### PR TITLE
fix: apply post-processing to streaming transcription path

### DIFF
--- a/apps/electron/src/main/paste.ts
+++ b/apps/electron/src/main/paste.ts
@@ -20,7 +20,6 @@ async function pasteWindows(): Promise<void> {
 }
 
 async function pasteLinux(): Promise<void> {
-  // Try xdotool first (X11), fall back to wtype (Wayland)
   try {
     await execAsync("xdotool key ctrl+v");
   } catch {
@@ -35,7 +34,7 @@ export async function pasteIntoFocusedApp(text: string): Promise<void> {
   clipboard.writeText(text);
 
   try {
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => setTimeout(r, 15));
 
     switch (process.platform) {
       case "darwin":
@@ -49,7 +48,7 @@ export async function pasteIntoFocusedApp(text: string): Promise<void> {
         break;
     }
 
-    await new Promise((r) => setTimeout(r, 200));
+    await new Promise((r) => setTimeout(r, 80));
   } finally {
     clipboard.writeText(prior);
   }

--- a/apps/electron/src/renderer/src/App.tsx
+++ b/apps/electron/src/renderer/src/App.tsx
@@ -1,31 +1,39 @@
 import AppPage from "@renderer/pages/app";
-import NotFoundPage from "@renderer/pages/not-found";
-import OnboardingPage from "@renderer/pages/onboarding";
-import DictionaryPage from "@renderer/pages/settings/dictionary";
-import FeedbackPage from "@renderer/pages/settings/feedback";
-import FormatsPage from "@renderer/pages/settings/formats";
-import GeneralSettingsPage from "@renderer/pages/settings/general";
-import HistoryPage from "@renderer/pages/settings/history";
-import SettingsLayout from "@renderer/pages/settings/layout";
-import ModelsPage from "@renderer/pages/settings/models";
+import { lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router";
+
+const OnboardingPage = lazy(() => import("@renderer/pages/onboarding"));
+const NotFoundPage = lazy(() => import("@renderer/pages/not-found"));
+const SettingsLayout = lazy(() => import("@renderer/pages/settings/layout"));
+const GeneralSettingsPage = lazy(
+  () => import("@renderer/pages/settings/general"),
+);
+const ModelsPage = lazy(() => import("@renderer/pages/settings/models"));
+const DictionaryPage = lazy(
+  () => import("@renderer/pages/settings/dictionary"),
+);
+const FormatsPage = lazy(() => import("@renderer/pages/settings/formats"));
+const HistoryPage = lazy(() => import("@renderer/pages/settings/history"));
+const FeedbackPage = lazy(() => import("@renderer/pages/settings/feedback"));
 
 export default function App(): React.JSX.Element {
   return (
-    <Routes>
-      <Route path="/" element={<Navigate to="/app" replace />} />
-      <Route path="/app" element={<AppPage />} />
-      <Route path="/onboarding" element={<OnboardingPage />} />
-      <Route path="/settings" element={<SettingsLayout />}>
-        <Route index element={<Navigate to="general" replace />} />
-        <Route path="general" element={<GeneralSettingsPage />} />
-        <Route path="models" element={<ModelsPage />} />
-        <Route path="dictionary" element={<DictionaryPage />} />
-        <Route path="formats" element={<FormatsPage />} />
-        <Route path="history" element={<HistoryPage />} />
-        <Route path="feedback" element={<FeedbackPage />} />
-      </Route>
-      <Route path="*" element={<NotFoundPage />} />
-    </Routes>
+    <Suspense fallback={null}>
+      <Routes>
+        <Route path="/" element={<Navigate to="/app" replace />} />
+        <Route path="/app" element={<AppPage />} />
+        <Route path="/onboarding" element={<OnboardingPage />} />
+        <Route path="/settings" element={<SettingsLayout />}>
+          <Route index element={<Navigate to="general" replace />} />
+          <Route path="general" element={<GeneralSettingsPage />} />
+          <Route path="models" element={<ModelsPage />} />
+          <Route path="dictionary" element={<DictionaryPage />} />
+          <Route path="formats" element={<FormatsPage />} />
+          <Route path="history" element={<HistoryPage />} />
+          <Route path="feedback" element={<FeedbackPage />} />
+        </Route>
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
+    </Suspense>
   );
 }

--- a/apps/electron/src/renderer/src/components/ui/orb.tsx
+++ b/apps/electron/src/renderer/src/components/ui/orb.tsx
@@ -1,7 +1,8 @@
 import { useTexture } from "@react-three/drei";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { useEffect, useMemo, useRef } from "react";
-import * as THREE from "three";
+import type { CircleGeometry, Mesh, ShaderMaterial } from "three";
+import { Color, RepeatWrapping, Uniform } from "three";
 
 export type AgentState = null | "thinking" | "listening" | "talking";
 
@@ -90,11 +91,10 @@ function Scene({
   getOutputVolume?: () => number;
 }) {
   const { gl } = useThree();
-  const circleRef =
-    useRef<THREE.Mesh<THREE.CircleGeometry, THREE.ShaderMaterial>>(null);
+  const circleRef = useRef<Mesh<CircleGeometry, ShaderMaterial>>(null);
   const initialColorsRef = useRef<[string, string]>(colors);
-  const targetColor1Ref = useRef(new THREE.Color(colors[0]));
-  const targetColor2Ref = useRef(new THREE.Color(colors[1]));
+  const targetColor1Ref = useRef(new Color(colors[0]));
+  const targetColor2Ref = useRef(new Color(colors[1]));
   const animSpeedRef = useRef(0.1);
   const perlinNoiseTexture = useTexture(
     "https://storage.googleapis.com/eleven-public-cdn/images/perlin-noise.png",
@@ -138,8 +138,8 @@ function Scene({
   );
 
   useEffect(() => {
-    targetColor1Ref.current = new THREE.Color(colors[0]);
-    targetColor2Ref.current = new THREE.Color(colors[1]);
+    targetColor1Ref.current = new Color(colors[0]);
+    targetColor2Ref.current = new Color(colors[1]);
   }, [colors]);
 
   useEffect(() => {
@@ -229,22 +229,22 @@ function Scene({
   }, [gl]);
 
   const uniforms = useMemo(() => {
-    perlinNoiseTexture.wrapS = THREE.RepeatWrapping;
-    perlinNoiseTexture.wrapT = THREE.RepeatWrapping;
+    perlinNoiseTexture.wrapS = RepeatWrapping;
+    perlinNoiseTexture.wrapT = RepeatWrapping;
     const isDark =
       typeof document !== "undefined" &&
       document.documentElement.classList.contains("dark");
     return {
-      uColor1: new THREE.Uniform(new THREE.Color(initialColorsRef.current[0])),
-      uColor2: new THREE.Uniform(new THREE.Color(initialColorsRef.current[1])),
+      uColor1: new Uniform(new Color(initialColorsRef.current[0])),
+      uColor2: new Uniform(new Color(initialColorsRef.current[1])),
       uOffsets: { value: offsets },
-      uPerlinTexture: new THREE.Uniform(perlinNoiseTexture),
-      uTime: new THREE.Uniform(0),
-      uAnimation: new THREE.Uniform(0.1),
-      uInverted: new THREE.Uniform(isDark ? 1 : 0),
-      uInputVolume: new THREE.Uniform(0),
-      uOutputVolume: new THREE.Uniform(0),
-      uOpacity: new THREE.Uniform(0),
+      uPerlinTexture: new Uniform(perlinNoiseTexture),
+      uTime: new Uniform(0),
+      uAnimation: new Uniform(0.1),
+      uInverted: new Uniform(isDark ? 1 : 0),
+      uInputVolume: new Uniform(0),
+      uOutputVolume: new Uniform(0),
+      uOpacity: new Uniform(0),
     };
   }, [perlinNoiseTexture, offsets]);
 

--- a/apps/electron/src/renderer/src/lib/pcm-processor.ts
+++ b/apps/electron/src/renderer/src/lib/pcm-processor.ts
@@ -2,9 +2,8 @@
  * AudioWorklet processor that buffers, downsamples and encodes audio
  * to 16 kHz PCM16 chunks ready to send over the wire.
  *
- * The main thread sends { type: 'init', sampleRate: number } once to
- * configure the resampling ratio.  After that the worklet posts
- * Int16Array buffers (~80 ms each) as transferable ArrayBuffers.
+ * Uses the AudioWorkletGlobalScope `sampleRate` to compute the
+ * downsampling ratio.  Posts ~80 ms Int16Array buffers as transferables.
  */
 
 const PROCESSOR_CODE = `
@@ -14,15 +13,10 @@ const TARGET_CHUNK_MS = 80;
 class PCMProcessor extends AudioWorkletProcessor {
   constructor() {
     super();
-    this.ratio = 1;
+    // sampleRate is a global in AudioWorkletGlobalScope
+    this.ratio = sampleRate / TARGET_RATE;
     this.targetChunkSamples = (TARGET_RATE * TARGET_CHUNK_MS) / 1000;
     this.buf = new Float32Array(0);
-
-    this.port.onmessage = (e) => {
-      if (e.data && e.data.type === 'init') {
-        this.ratio = e.data.sampleRate / TARGET_RATE;
-      }
-    };
   }
 
   process(inputs) {

--- a/apps/electron/src/renderer/src/lib/pcm-processor.ts
+++ b/apps/electron/src/renderer/src/lib/pcm-processor.ts
@@ -1,13 +1,61 @@
-// AudioWorklet processor for PCM16 extraction
-// This file is loaded via audioContext.audioWorklet.addModule()
+/**
+ * AudioWorklet processor that buffers, downsamples and encodes audio
+ * to 16 kHz PCM16 chunks ready to send over the wire.
+ *
+ * The main thread sends { type: 'init', sampleRate: number } once to
+ * configure the resampling ratio.  After that the worklet posts
+ * Int16Array buffers (~80 ms each) as transferable ArrayBuffers.
+ */
 
 const PROCESSOR_CODE = `
+const TARGET_RATE = 16000;
+const TARGET_CHUNK_MS = 80;
+
 class PCMProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.ratio = 1;
+    this.targetChunkSamples = (TARGET_RATE * TARGET_CHUNK_MS) / 1000;
+    this.buf = new Float32Array(0);
+
+    this.port.onmessage = (e) => {
+      if (e.data && e.data.type === 'init') {
+        this.ratio = e.data.sampleRate / TARGET_RATE;
+      }
+    };
+  }
+
   process(inputs) {
     const input = inputs[0];
-    if (!input || !input[0]) return true;
-    const copy = new Float32Array(input[0]);
-    this.port.postMessage(copy.buffer, [copy.buffer]);
+    if (!input || !input[0] || input[0].length === 0) return true;
+
+    const raw = input[0];
+
+    // Append to internal buffer
+    const prev = this.buf;
+    const next = new Float32Array(prev.length + raw.length);
+    next.set(prev);
+    next.set(raw, prev.length);
+    this.buf = next;
+
+    // Flush when we have enough for one target chunk
+    const samplesNeeded = Math.ceil(this.targetChunkSamples * this.ratio);
+    while (this.buf.length >= samplesNeeded) {
+      const slice = this.buf.subarray(0, samplesNeeded);
+      this.buf = this.buf.slice(samplesNeeded);
+
+      // Downsample + encode to PCM16
+      const outLen = Math.round(slice.length / this.ratio);
+      const pcm16 = new Int16Array(outLen);
+      for (let i = 0; i < outLen; i++) {
+        const idx = Math.round(i * this.ratio);
+        const s = Math.max(-1, Math.min(1, slice[idx] || 0));
+        pcm16[i] = s < 0 ? s * 0x8000 : s * 0x7FFF;
+      }
+
+      this.port.postMessage(pcm16.buffer, [pcm16.buffer]);
+    }
+
     return true;
   }
 }

--- a/apps/electron/src/renderer/src/lib/recorder.ts
+++ b/apps/electron/src/renderer/src/lib/recorder.ts
@@ -1,3 +1,5 @@
+import { encodeWavFromFloat32 } from "./wav";
+
 const TARGET_RATE = 16000;
 
 export class Recorder {
@@ -12,6 +14,8 @@ export class Recorder {
    * need the stream for visualization.
    */
   async acquireStream(deviceId?: string | null): Promise<MediaStream> {
+    this.chunks = [];
+    this.mediaRecorder = null;
     const processing = {
       echoCancellation: false,
       noiseSuppression: false,
@@ -128,8 +132,9 @@ async function blobToWav16k(blob: Blob): Promise<Blob> {
 
   const mono = mixToMono(decoded);
   const resampled = await resample(mono, decoded.sampleRate, TARGET_RATE);
-  const wavBuf = encodeWav16(resampled, TARGET_RATE);
-  return new Blob([wavBuf], { type: "audio/wav" });
+  return new Blob([encodeWavFromFloat32(resampled, TARGET_RATE)], {
+    type: "audio/wav",
+  });
 }
 
 function mixToMono(buf: AudioBuffer): Float32Array {
@@ -160,38 +165,4 @@ async function resample(
   node.start(0);
   const rendered = await offline.startRendering();
   return rendered.getChannelData(0);
-}
-
-function encodeWav16(samples: Float32Array, sampleRate: number): ArrayBuffer {
-  const bytesPerSample = 2;
-  const blockAlign = 1 * bytesPerSample;
-  const byteRate = sampleRate * blockAlign;
-  const dataSize = samples.length * bytesPerSample;
-  const buf = new ArrayBuffer(44 + dataSize);
-  const view = new DataView(buf);
-
-  writeString(view, 0, "RIFF");
-  view.setUint32(4, 36 + dataSize, true);
-  writeString(view, 8, "WAVE");
-  writeString(view, 12, "fmt ");
-  view.setUint32(16, 16, true);
-  view.setUint16(20, 1, true);
-  view.setUint16(22, 1, true);
-  view.setUint32(24, sampleRate, true);
-  view.setUint32(28, byteRate, true);
-  view.setUint16(32, blockAlign, true);
-  view.setUint16(34, 16, true);
-  writeString(view, 36, "data");
-  view.setUint32(40, dataSize, true);
-
-  let offset = 44;
-  for (let i = 0; i < samples.length; i++, offset += 2) {
-    const s = Math.max(-1, Math.min(1, samples[i]));
-    view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true);
-  }
-  return buf;
-}
-
-function writeString(view: DataView, offset: number, s: string): void {
-  for (let i = 0; i < s.length; i++) view.setUint8(offset + i, s.charCodeAt(i));
 }

--- a/apps/electron/src/renderer/src/lib/recorder.ts
+++ b/apps/electron/src/renderer/src/lib/recorder.ts
@@ -6,8 +6,12 @@ export class Recorder {
   private chunks: Blob[] = [];
   private mimeType = "";
 
-  async start(deviceId?: string | null): Promise<MediaStream> {
-    this.chunks = [];
+  /**
+   * Acquire the microphone stream without starting a MediaRecorder.
+   * Use this when the Streamer handles audio capture and you only
+   * need the stream for visualization.
+   */
+  async acquireStream(deviceId?: string | null): Promise<MediaStream> {
     const processing = {
       echoCancellation: false,
       noiseSuppression: false,
@@ -32,16 +36,26 @@ export class Recorder {
         throw e;
       }
     }
+    return this.stream;
+  }
+
+  /**
+   * Acquire the mic AND start a MediaRecorder for the REST fallback
+   * path (when streaming is unavailable).
+   */
+  async start(deviceId?: string | null): Promise<MediaStream> {
+    this.chunks = [];
+    const stream = await this.acquireStream(deviceId);
     this.mimeType = pickSupportedMime();
     this.mediaRecorder = new MediaRecorder(
-      this.stream,
+      stream,
       this.mimeType ? { mimeType: this.mimeType } : undefined,
     );
     this.mediaRecorder.ondataavailable = (e) => {
       if (e.data.size > 0) this.chunks.push(e.data);
     };
     this.mediaRecorder.start();
-    return this.stream;
+    return stream;
   }
 
   getStream(): MediaStream | null {

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -1,6 +1,11 @@
 /**
- * WebSocket-based audio streamer for real-time STT.
- * Sends raw PCM16 audio chunks to the server, receives partial/final transcripts.
+ * Persistent WebSocket-based audio streamer for real-time STT.
+ *
+ * A single Streamer instance stays alive across recording sessions.
+ * The WebSocket to the server (and through it the OpenAI Realtime
+ * upstream) remains open, eliminating reconnection overhead on each
+ * hotkey press.  Recording sessions are delimited by startCapture /
+ * commit / cancel rather than connect / disconnect.
  */
 
 import { getPCMProcessorUrl } from "./pcm-processor";
@@ -11,72 +16,72 @@ export interface StreamerCallbacks {
   onPartial: (text: string) => void;
   onFinal: (text: string) => void;
   onError: (message: string) => void;
-  onReady: (model: string) => void;
+  onReady: () => void;
   onConfig: (config: { streaming: boolean; model: string }) => void;
 }
 
 export class Streamer {
   private ws: WebSocket | null = null;
-  private stream: MediaStream | null = null;
-  private ctx: AudioContext | null = null;
-  private source: MediaStreamAudioSourceNode | null = null;
-  private workletNode: AudioWorkletNode | null = null;
   private sessionReady = false;
   private pendingChunks: ArrayBuffer[] = [];
-  private closed = false;
+  private destroyed = false;
   private readonly callbacks: StreamerCallbacks;
   private readonly wsUrl: string;
+
+  // Capture pipeline — reused across sessions when possible
+  private ctx: AudioContext | null = null;
+  private workletReady = false;
+  private source: MediaStreamAudioSourceNode | null = null;
+  private workletNode: AudioWorkletNode | null = null;
+  private capturing = false;
 
   constructor(baseUrl: string, callbacks: StreamerCallbacks) {
     this.wsUrl = `${baseUrl.replace(/^http/, "ws")}/stream`;
     this.callbacks = callbacks;
+    this.openWebSocket();
   }
+
+  // ------- public API -------
 
   setContext(context: string): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({ type: "context", context }));
-    }
+    this.sendJSON({ type: "context", context });
   }
 
-  async start(deviceId?: string | null): Promise<MediaStream> {
-    // Open WebSocket
-    this.openWebSocket();
+  /**
+   * Begin capturing audio from the given stream and feeding it to the
+   * server.  The stream is typically the one already acquired by the
+   * Recorder so no extra getUserMedia call is needed.
+   */
+  async startCapture(
+    stream: MediaStream,
+    sharedCtx?: AudioContext,
+  ): Promise<void> {
+    this.capturing = true;
+    this.pendingChunks = [];
+    this.sendJSON({ type: "start" });
 
-    // Acquire mic
-    const processing = {
-      echoCancellation: false,
-      noiseSuppression: false,
-      autoGainControl: false,
-    };
-
-    try {
-      this.stream = await navigator.mediaDevices.getUserMedia({
-        audio: deviceId
-          ? { deviceId: { exact: deviceId }, ...processing }
-          : processing,
-      });
-    } catch (e) {
-      const name = e instanceof Error ? e.name : "";
-      if (
-        deviceId &&
-        (name === "OverconstrainedError" || name === "NotFoundError")
-      ) {
-        this.stream = await navigator.mediaDevices.getUserMedia({
-          audio: processing,
-        });
-      } else {
-        throw e;
+    if (sharedCtx && sharedCtx.state !== "closed") {
+      if (this.ctx && this.ctx !== sharedCtx) {
+        try {
+          this.ctx.close();
+        } catch {}
       }
+      this.ctx = sharedCtx;
+    }
+    if (!this.ctx || this.ctx.state === "closed") {
+      this.ctx = new AudioContext();
+    }
+    if (this.ctx.state === "suspended") await this.ctx.resume();
+
+    if (!this.workletReady) {
+      await this.ctx.audioWorklet.addModule(getPCMProcessorUrl());
+      this.workletReady = true;
     }
 
-    // Set up audio processing: downsample to 16kHz mono PCM16
-    this.ctx = new AudioContext();
-    this.source = this.ctx.createMediaStreamSource(this.stream);
-
-    await this.ctx.audioWorklet.addModule(getPCMProcessorUrl());
+    this.source = this.ctx.createMediaStreamSource(stream);
     this.workletNode = new AudioWorkletNode(this.ctx, "pcm-processor");
     this.workletNode.port.onmessage = (e: MessageEvent) => {
-      if (this.closed) return;
+      if (!this.capturing) return;
       const input = new Float32Array(e.data);
       const pcm16 = downsampleAndEncode(
         input,
@@ -85,35 +90,51 @@ export class Streamer {
       );
       this.sendAudio(pcm16.buffer as ArrayBuffer);
     };
-
     this.source.connect(this.workletNode);
     this.workletNode.connect(this.ctx.destination);
-
-    return this.stream;
   }
 
   commit(): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({ type: "commit" }));
-    }
+    this.stopCapture();
+    this.sendJSON({ type: "commit" });
   }
 
   cancel(): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({ type: "cancel" }));
-    }
-    this.close();
+    this.stopCapture();
+    this.sendJSON({ type: "cancel" });
   }
 
-  close(): void {
-    this.closed = true;
+  /** Tear down everything — only call on app unmount. */
+  destroy(): void {
+    this.destroyed = true;
     this.stopCapture();
     if (this.ws && this.ws.readyState <= WebSocket.OPEN) this.ws.close();
     this.ws = null;
+    if (this.ctx) {
+      try {
+        this.ctx.close();
+      } catch {}
+      this.ctx = null;
+      this.workletReady = false;
+    }
   }
 
-  getStream(): MediaStream | null {
-    return this.stream;
+  getAudioContext(): AudioContext | null {
+    return this.ctx;
+  }
+
+  // ------- internals -------
+
+  private stopCapture(): void {
+    this.capturing = false;
+    try {
+      this.workletNode?.disconnect();
+    } catch {}
+    try {
+      this.source?.disconnect();
+    } catch {}
+    this.workletNode = null;
+    this.source = null;
   }
 
   private sendAudio(chunk: ArrayBuffer): void {
@@ -121,6 +142,12 @@ export class Streamer {
       this.ws.send(chunk);
     } else {
       this.pendingChunks.push(chunk);
+    }
+  }
+
+  private sendJSON(obj: Record<string, unknown>): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(obj));
     }
   }
 
@@ -133,6 +160,7 @@ export class Streamer {
   }
 
   private openWebSocket(): void {
+    if (this.destroyed) return;
     const ws = new WebSocket(this.wsUrl);
     ws.binaryType = "arraybuffer";
     this.ws = ws;
@@ -157,15 +185,14 @@ export class Streamer {
             streaming: msg.streaming ?? false,
             model: msg.model ?? "",
           });
-          // If not streaming, server closed the WS -- client should use REST
           if (!msg.streaming) {
-            this.close();
+            this.destroy();
           }
           break;
         case "session.ready":
           this.sessionReady = true;
           this.flushPendingChunks();
-          this.callbacks.onReady(msg.model ?? "");
+          this.callbacks.onReady();
           break;
         case "partial":
           this.callbacks.onPartial(msg.text ?? "");
@@ -179,38 +206,17 @@ export class Streamer {
       }
     });
 
-    ws.addEventListener("error", () => {
-      this.callbacks.onError("WebSocket connection failed");
-    });
+    ws.addEventListener("error", () => {});
 
     ws.addEventListener("close", () => {
-      if (!this.closed) {
-        this.sessionReady = false;
-        this.pendingChunks = [];
+      this.sessionReady = false;
+      this.pendingChunks = [];
+      if (!this.destroyed) {
         setTimeout(() => {
-          if (!this.closed) this.openWebSocket();
+          if (!this.destroyed) this.openWebSocket();
         }, 1000);
       }
     });
-  }
-
-  private stopCapture(): void {
-    try {
-      this.workletNode?.disconnect();
-    } catch {}
-    try {
-      this.source?.disconnect();
-    } catch {}
-    this.workletNode = null;
-    this.source = null;
-    this.stream?.getTracks().forEach((t) => t.stop());
-    this.stream = null;
-    if (this.ctx) {
-      try {
-        this.ctx.close();
-      } catch {}
-      this.ctx = null;
-    }
   }
 }
 

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -9,13 +9,14 @@
  */
 
 import { getPCMProcessorUrl } from "./pcm-processor";
+import { encodeWavFromInt16 } from "./wav";
 
 const TARGET_RATE = 16000;
-const WAV_HEADER_SIZE = 44;
 
 export interface StreamerCallbacks {
   onPartial: (text: string) => void;
   onFinal: (text: string) => void;
+  onCleaned?: (text: string) => void;
   onError: (message: string) => void;
   onReady: () => void;
   onConfig: (config: { streaming: boolean; model: string }) => void;
@@ -82,14 +83,6 @@ export class Streamer {
 
     this.source = this.ctx.createMediaStreamSource(stream);
     this.workletNode = new AudioWorkletNode(this.ctx, "pcm-processor");
-
-    // Tell the worklet the native sample rate so it can compute the
-    // downsampling ratio.
-    this.workletNode.port.postMessage({
-      type: "init",
-      sampleRate: this.ctx.sampleRate,
-    });
-
     this.workletNode.port.onmessage = (e: MessageEvent) => {
       if (!this.capturing) return;
       const chunk = e.data as ArrayBuffer;
@@ -114,43 +107,16 @@ export class Streamer {
     this.sendJSON({ type: "cancel" });
   }
 
-  /**
-   * Build a WAV blob from the PCM16 chunks accumulated during capture.
-   * This bypasses the expensive MediaRecorder → decode → resample chain.
-   */
   getWavBlob(): Blob | null {
     if (this.pcmSampleCount === 0) return null;
-
-    const dataSize = this.pcmSampleCount * 2;
-    const buf = new ArrayBuffer(WAV_HEADER_SIZE + dataSize);
-    const view = new DataView(buf);
-
-    // RIFF/WAVE header
-    writeStr(view, 0, "RIFF");
-    view.setUint32(4, 36 + dataSize, true);
-    writeStr(view, 8, "WAVE");
-    writeStr(view, 12, "fmt ");
-    view.setUint32(16, 16, true);
-    view.setUint16(20, 1, true); // PCM
-    view.setUint16(22, 1, true); // mono
-    view.setUint32(24, TARGET_RATE, true);
-    view.setUint32(28, TARGET_RATE * 2, true); // byte rate
-    view.setUint16(32, 2, true); // block align
-    view.setUint16(34, 16, true); // bits per sample
-    writeStr(view, 36, "data");
-    view.setUint32(40, dataSize, true);
-
-    // Copy PCM samples
-    let offset = WAV_HEADER_SIZE;
-    for (const chunk of this.pcmChunks) {
-      for (let i = 0; i < chunk.length; i++, offset += 2) {
-        view.setInt16(offset, chunk[i], true);
-      }
-    }
-
+    const blob = encodeWavFromInt16(
+      this.pcmChunks,
+      this.pcmSampleCount,
+      TARGET_RATE,
+    );
     this.pcmChunks = [];
     this.pcmSampleCount = 0;
-    return new Blob([buf], { type: "audio/wav" });
+    return blob;
   }
 
   destroy(): void {
@@ -165,10 +131,6 @@ export class Streamer {
       this.ctx = null;
       this.workletReady = false;
     }
-  }
-
-  getAudioContext(): AudioContext | null {
-    return this.ctx;
   }
 
   // ------- internals -------
@@ -233,9 +195,6 @@ export class Streamer {
             streaming: msg.streaming ?? false,
             model: msg.model ?? "",
           });
-          if (!msg.streaming) {
-            this.destroy();
-          }
           break;
         case "session.ready":
           this.sessionReady = true;
@@ -247,6 +206,9 @@ export class Streamer {
           break;
         case "final":
           this.callbacks.onFinal(msg.text ?? "");
+          break;
+        case "cleaned":
+          this.callbacks.onCleaned?.(msg.text ?? "");
           break;
         case "error":
           this.callbacks.onError(msg.message ?? "Unknown error");
@@ -265,11 +227,5 @@ export class Streamer {
         }, 1000);
       }
     });
-  }
-}
-
-function writeStr(view: DataView, offset: number, s: string): void {
-  for (let i = 0; i < s.length; i++) {
-    view.setUint8(offset + i, s.charCodeAt(i));
   }
 }

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -32,6 +32,12 @@ export class Streamer {
     this.callbacks = callbacks;
   }
 
+  setContext(context: string): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ type: "context", context }));
+    }
+  }
+
   async start(deviceId?: string | null): Promise<MediaStream> {
     // Open WebSocket
     this.openWebSocket();

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -11,6 +11,7 @@
 import { getPCMProcessorUrl } from "./pcm-processor";
 
 const TARGET_RATE = 16000;
+const WAV_HEADER_SIZE = 44;
 
 export interface StreamerCallbacks {
   onPartial: (text: string) => void;
@@ -35,6 +36,10 @@ export class Streamer {
   private workletNode: AudioWorkletNode | null = null;
   private capturing = false;
 
+  // PCM accumulator for REST fallback WAV generation
+  private pcmChunks: Int16Array[] = [];
+  private pcmSampleCount = 0;
+
   constructor(baseUrl: string, callbacks: StreamerCallbacks) {
     this.wsUrl = `${baseUrl.replace(/^http/, "ws")}/stream`;
     this.callbacks = callbacks;
@@ -47,17 +52,14 @@ export class Streamer {
     this.sendJSON({ type: "context", context });
   }
 
-  /**
-   * Begin capturing audio from the given stream and feeding it to the
-   * server.  The stream is typically the one already acquired by the
-   * Recorder so no extra getUserMedia call is needed.
-   */
   async startCapture(
     stream: MediaStream,
     sharedCtx?: AudioContext,
   ): Promise<void> {
     this.capturing = true;
     this.pendingChunks = [];
+    this.pcmChunks = [];
+    this.pcmSampleCount = 0;
     this.sendJSON({ type: "start" });
 
     if (sharedCtx && sharedCtx.state !== "closed") {
@@ -80,15 +82,23 @@ export class Streamer {
 
     this.source = this.ctx.createMediaStreamSource(stream);
     this.workletNode = new AudioWorkletNode(this.ctx, "pcm-processor");
+
+    // Tell the worklet the native sample rate so it can compute the
+    // downsampling ratio.
+    this.workletNode.port.postMessage({
+      type: "init",
+      sampleRate: this.ctx.sampleRate,
+    });
+
     this.workletNode.port.onmessage = (e: MessageEvent) => {
       if (!this.capturing) return;
-      const input = new Float32Array(e.data);
-      const pcm16 = downsampleAndEncode(
-        input,
-        this.ctx!.sampleRate,
-        TARGET_RATE,
-      );
-      this.sendAudio(pcm16.buffer as ArrayBuffer);
+      const chunk = e.data as ArrayBuffer;
+      this.sendAudio(chunk);
+
+      // Accumulate for REST fallback
+      const pcm16 = new Int16Array(chunk);
+      this.pcmChunks.push(pcm16);
+      this.pcmSampleCount += pcm16.length;
     };
     this.source.connect(this.workletNode);
     this.workletNode.connect(this.ctx.destination);
@@ -104,7 +114,45 @@ export class Streamer {
     this.sendJSON({ type: "cancel" });
   }
 
-  /** Tear down everything — only call on app unmount. */
+  /**
+   * Build a WAV blob from the PCM16 chunks accumulated during capture.
+   * This bypasses the expensive MediaRecorder → decode → resample chain.
+   */
+  getWavBlob(): Blob | null {
+    if (this.pcmSampleCount === 0) return null;
+
+    const dataSize = this.pcmSampleCount * 2;
+    const buf = new ArrayBuffer(WAV_HEADER_SIZE + dataSize);
+    const view = new DataView(buf);
+
+    // RIFF/WAVE header
+    writeStr(view, 0, "RIFF");
+    view.setUint32(4, 36 + dataSize, true);
+    writeStr(view, 8, "WAVE");
+    writeStr(view, 12, "fmt ");
+    view.setUint32(16, 16, true);
+    view.setUint16(20, 1, true); // PCM
+    view.setUint16(22, 1, true); // mono
+    view.setUint32(24, TARGET_RATE, true);
+    view.setUint32(28, TARGET_RATE * 2, true); // byte rate
+    view.setUint16(32, 2, true); // block align
+    view.setUint16(34, 16, true); // bits per sample
+    writeStr(view, 36, "data");
+    view.setUint32(40, dataSize, true);
+
+    // Copy PCM samples
+    let offset = WAV_HEADER_SIZE;
+    for (const chunk of this.pcmChunks) {
+      for (let i = 0; i < chunk.length; i++, offset += 2) {
+        view.setInt16(offset, chunk[i], true);
+      }
+    }
+
+    this.pcmChunks = [];
+    this.pcmSampleCount = 0;
+    return new Blob([buf], { type: "audio/wav" });
+  }
+
   destroy(): void {
     this.destroyed = true;
     this.stopCapture();
@@ -220,23 +268,8 @@ export class Streamer {
   }
 }
 
-/**
- * Downsample float32 audio to target rate and encode as PCM16.
- */
-function downsampleAndEncode(
-  input: Float32Array,
-  fromRate: number,
-  toRate: number,
-): Int16Array {
-  const ratio = fromRate / toRate;
-  const outLength = Math.round(input.length / ratio);
-  const output = new Int16Array(outLength);
-
-  for (let i = 0; i < outLength; i++) {
-    const srcIndex = Math.round(i * ratio);
-    const sample = Math.max(-1, Math.min(1, input[srcIndex] ?? 0));
-    output[i] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+function writeStr(view: DataView, offset: number, s: string): void {
+  for (let i = 0; i < s.length; i++) {
+    view.setUint8(offset + i, s.charCodeAt(i));
   }
-
-  return output;
 }

--- a/apps/electron/src/renderer/src/lib/wav.ts
+++ b/apps/electron/src/renderer/src/lib/wav.ts
@@ -1,0 +1,67 @@
+const HEADER_SIZE = 44;
+
+export function encodeWavFromInt16(
+  chunks: Int16Array[],
+  sampleCount: number,
+  sampleRate: number,
+): Blob {
+  const dataSize = sampleCount * 2;
+  const buf = new ArrayBuffer(HEADER_SIZE + dataSize);
+  const view = new DataView(buf);
+
+  writeHeader(view, dataSize, sampleRate);
+
+  let offset = HEADER_SIZE;
+  for (const chunk of chunks) {
+    for (let i = 0; i < chunk.length; i++, offset += 2) {
+      view.setInt16(offset, chunk[i], true);
+    }
+  }
+
+  return new Blob([buf], { type: "audio/wav" });
+}
+
+export function encodeWavFromFloat32(
+  samples: Float32Array,
+  sampleRate: number,
+): ArrayBuffer {
+  const dataSize = samples.length * 2;
+  const buf = new ArrayBuffer(HEADER_SIZE + dataSize);
+  const view = new DataView(buf);
+
+  writeHeader(view, dataSize, sampleRate);
+
+  let offset = HEADER_SIZE;
+  for (let i = 0; i < samples.length; i++, offset += 2) {
+    const s = Math.max(-1, Math.min(1, samples[i]));
+    view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+  }
+
+  return buf;
+}
+
+function writeHeader(
+  view: DataView,
+  dataSize: number,
+  sampleRate: number,
+): void {
+  writeStr(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeStr(view, 8, "WAVE");
+  writeStr(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeStr(view, 36, "data");
+  view.setUint32(40, dataSize, true);
+}
+
+function writeStr(view: DataView, offset: number, s: string): void {
+  for (let i = 0; i < s.length; i++) {
+    view.setUint8(offset + i, s.charCodeAt(i));
+  }
+}

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -90,7 +90,7 @@ export default function AppPage(): React.JSX.Element {
   const [elapsed, setElapsed] = useState(0);
   const [message, setMessage] = useState("");
   const [partialText, setPartialText] = useState("");
-  const [useStreaming, setUseStreaming] = useState(false);
+  const useStreamingRef = useRef(false);
 
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
@@ -112,7 +112,7 @@ export default function AppPage(): React.JSX.Element {
     if (!streamerRef.current) {
       streamerRef.current = new Streamer(getApiBase(), {
         onConfig: (config) => {
-          setUseStreaming(config.streaming);
+          useStreamingRef.current = config.streaming;
         },
         onReady: () => {},
         onPartial: (text) => setPartialText(text),
@@ -235,7 +235,7 @@ export default function AppPage(): React.JSX.Element {
     try {
       // When streaming is active, skip MediaRecorder entirely — the
       // Streamer accumulates PCM16 and can produce a WAV if needed.
-      const stream = useStreaming
+      const stream = useStreamingRef.current
         ? await recorderRef.current.acquireStream()
         : await recorderRef.current.start();
 
@@ -289,7 +289,7 @@ export default function AppPage(): React.JSX.Element {
     }
 
     // If streaming mode is active, commit via WebSocket
-    if (useStreaming && streamerRef.current) {
+    if (useStreamingRef.current && streamerRef.current) {
       setState("transcribing");
       recorderRef.current.cancel();
       streamerRef.current.commit();
@@ -345,7 +345,7 @@ export default function AppPage(): React.JSX.Element {
       setMessage(err instanceof Error ? err.message : "Transcription failed");
       setTimeout(() => hidePill(), 2000);
     }
-  }, [useStreaming, stopVisualization, hidePill]);
+  }, [stopVisualization, hidePill]);
 
   const cancelRecording = useCallback(() => {
     wantsMicRef.current = false;
@@ -448,6 +448,24 @@ export default function AppPage(): React.JSX.Element {
           .glow-transcribing { animation: glow-pulse-blue 1.5s ease-in-out infinite; }
           .glow-error { animation: glow-pulse-red 1.5s ease-in-out infinite; }
           .glow-idle { box-shadow: 0 0 6px 2px rgba(161,161,170,0.05); transition: box-shadow 300ms ease; }
+          @keyframes shimmer {
+            0% { background-position: 100% center; }
+            100% { background-position: 0% center; }
+          }
+          .shimmer-text {
+            font-style: italic;
+            background: linear-gradient(
+              90deg,
+              #71717a calc(50% - 40px),
+              #d4d4d8,
+              #71717a calc(50% + 40px)
+            );
+            background-size: 250% 100%;
+            background-clip: text;
+            -webkit-background-clip: text;
+            color: transparent;
+            animation: shimmer 2s linear infinite;
+          }
         `}
       </style>
       <div
@@ -517,7 +535,7 @@ export default function AppPage(): React.JSX.Element {
           {/* Right-side content changes per state */}
           {state === "initializing" && (
             <span style={pillTextStyle}>
-              <span style={{ opacity: 0.7 }}>Listening...</span>
+              <span className="shimmer-text">Listening...</span>
             </span>
           )}
 
@@ -584,7 +602,11 @@ export default function AppPage(): React.JSX.Element {
 
           {state === "transcribing" && (
             <span style={pillTextStyle}>
-              {partialText ? partialText.slice(-30) : "Transcribing..."}
+              {partialText ? (
+                partialText.slice(-30)
+              ) : (
+                <span className="shimmer-text">Transcribing...</span>
+              )}
             </span>
           )}
 

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -2,7 +2,6 @@ import { Orb } from "@renderer/components/ui/orb";
 import { getApiBase } from "@renderer/lib/api";
 import { Recorder } from "@renderer/lib/recorder";
 import { Streamer } from "@renderer/lib/streamer";
-import { Mic } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const BARS = 14;
@@ -454,7 +453,13 @@ export default function AppPage(): React.JSX.Element {
           .glow-idle { box-shadow: 0 0 6px 2px rgba(161,161,170,0.05); transition: box-shadow 300ms ease; }
         `}
       </style>
-      <div className={glowState} style={{ borderRadius: 28 }}>
+      <div
+        className={glowState}
+        style={{
+          borderRadius: 28,
+          visibility: state === "idle" ? "hidden" : "visible",
+        }}
+      >
         <div
           className="inline-flex items-center gap-3"
           style={
@@ -590,17 +595,9 @@ export default function AppPage(): React.JSX.Element {
             <span style={pillTextStyle}>{message || "Error"}</span>
           )}
 
-          {state === "idle" && (
-            <div
-              className="inline-flex items-center gap-2"
-              style={{ padding: "0 8px" }}
-            >
-              <Mic size={17} style={{ opacity: 0.5, color: "#a1a1aa" }} />
-              <span style={{ opacity: 0.5, color: "#a1a1aa" }}>
-                Hold hotkey to record
-              </span>
-            </div>
-          )}
+          {/* idle: render nothing — the pill window is hidden when idle, so any
+               content here would only flash during the race between showPill()
+               and the hotkey:down IPC reaching the renderer. */}
         </div>
       </div>
     </div>

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -29,11 +29,19 @@ type PillState =
   | "error";
 
 // ---------------------------------------------------------------------------
-// Sound system — generates short sine-wave tones via Web Audio API.
-// Sounds can be muted globally via the `sound_enabled` setting.
+// Sound system — single persistent AudioContext, avoids creating a new one
+// per tone.
 // ---------------------------------------------------------------------------
 
-let _soundEnabled = true; // cached; updated from settings on mount
+let _soundEnabled = true;
+let _toneCtx: AudioContext | null = null;
+
+function getToneCtx(): AudioContext {
+  if (!_toneCtx || _toneCtx.state === "closed") {
+    _toneCtx = new AudioContext();
+  }
+  return _toneCtx;
+}
 
 type TonePreset = "start" | "stop";
 const TONE_PRESETS: Record<TonePreset, { freq: number; ms: number }> = {
@@ -45,8 +53,7 @@ async function playTone(preset: TonePreset, volume = 0.3): Promise<void> {
   if (!_soundEnabled) return;
   const { freq, ms } = TONE_PRESETS[preset];
   try {
-    const ctx = new AudioContext();
-    // Resume context in case Chromium's autoplay policy suspended it
+    const ctx = getToneCtx();
     if (ctx.state === "suspended") await ctx.resume();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
@@ -58,7 +65,6 @@ async function playTone(preset: TonePreset, volume = 0.3): Promise<void> {
     gain.connect(ctx.destination);
     osc.start();
     osc.stop(ctx.currentTime + ms / 1000);
-    setTimeout(() => ctx.close(), ms + 200);
   } catch {
     // ignore audio errors
   }
@@ -88,7 +94,7 @@ export default function AppPage(): React.JSX.Element {
 
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
-  const ctxRef = useRef<AudioContext | null>(null);
+  const analyserCtxRef = useRef<AudioContext | null>(null);
   const barsRef = useRef<number[]>(new Array(BARS).fill(0));
   const barsSvgRef = useRef<SVGSVGElement>(null);
   const volumeRef = useRef(0);
@@ -97,14 +103,43 @@ export default function AppPage(): React.JSX.Element {
   const timerRef = useRef<number>(0);
   const wantsMicRef = useRef(false);
   const appContextRef = useRef<string | null>(null);
-  const micWarmedUp = useRef(false); // true after first successful getUserMedia
+  const micWarmedUp = useRef(false);
 
   const getInputVolume = useCallback(() => volumeRef.current, []);
 
+  // -- Lazy singleton Streamer --
+  const getStreamer = useCallback((): Streamer => {
+    if (!streamerRef.current) {
+      streamerRef.current = new Streamer(getApiBase(), {
+        onConfig: (config) => {
+          setUseStreaming(config.streaming);
+        },
+        onReady: () => {},
+        onPartial: (text) => setPartialText(text),
+        onFinal: async (text) => {
+          recorderRef.current.cancel();
+          if (text.trim()) {
+            await window.api.pasteText(text);
+          }
+          hidePill();
+        },
+        onError: (msg) => {
+          recorderRef.current.cancel();
+          setState("error");
+          setMessage(msg);
+          setTimeout(() => hidePill(), 2000);
+        },
+      });
+    }
+    return streamerRef.current;
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   // -- Audio visualization (from a MediaStream) --
   const startVisualization = useCallback((stream: MediaStream) => {
-    const ctx = new AudioContext();
-    ctxRef.current = ctx;
+    if (!analyserCtxRef.current || analyserCtxRef.current.state === "closed") {
+      analyserCtxRef.current = new AudioContext();
+    }
+    const ctx = analyserCtxRef.current;
     const source = ctx.createMediaStreamSource(stream);
     const analyser = ctx.createAnalyser();
     analyser.fftSize = 256;
@@ -115,7 +150,10 @@ export default function AppPage(): React.JSX.Element {
     const sliceSize = Math.floor(analyser.frequencyBinCount / BARS);
 
     const update = () => {
-      if (!wantsMicRef.current) return;
+      if (!wantsMicRef.current) {
+        source.disconnect();
+        return;
+      }
       analyser.getByteFrequencyData(dataArray);
       const raw: number[] = [];
       let totalSum = 0;
@@ -130,7 +168,6 @@ export default function AppPage(): React.JSX.Element {
       }
       barsRef.current = smoothBars(barsRef.current, raw);
       volumeRef.current = Math.min(1, (totalSum / BARS) * 2.5);
-      // Direct DOM update — avoids 60fps React re-renders (rerender-use-ref-transient-values)
       const svg = barsSvgRef.current;
       if (svg) {
         const lines = svg.querySelectorAll("line");
@@ -152,14 +189,7 @@ export default function AppPage(): React.JSX.Element {
     rafRef.current = 0;
     cancelAnimationFrame(timerRef.current);
     timerRef.current = 0;
-    if (ctxRef.current) {
-      try {
-        ctxRef.current.close();
-      } catch (_) {
-        /* ignore */
-      }
-      ctxRef.current = null;
-    }
+    // Don't close analyserCtxRef — we reuse it across sessions
     barsRef.current = new Array(BARS).fill(0);
     volumeRef.current = 0;
     setElapsed(0);
@@ -175,23 +205,25 @@ export default function AppPage(): React.JSX.Element {
 
   // -- Start recording --
   const startRecording = useCallback(async () => {
-    if (wantsMicRef.current) return; // Already recording
+    if (wantsMicRef.current) return;
     wantsMicRef.current = true;
     setMessage("");
     setPartialText("");
 
-    // Capture frontmost app in parallel with mic acquisition (don't block on it)
     window.api
       ?.getFrontmostApp()
       .then((app) => {
         appContextRef.current = app;
-        if (app) streamerRef.current?.setContext(app);
+        if (app) {
+          try {
+            getStreamer().setContext(app);
+          } catch {}
+        }
       })
       .catch(() => {
         appContextRef.current = null;
       });
 
-    // Show initializing only on the very first press (mic not yet warmed up)
     const isFirstPress = !micWarmedUp.current;
     if (isFirstPress) {
       setState("initializing");
@@ -201,7 +233,6 @@ export default function AppPage(): React.JSX.Element {
     }
 
     try {
-      // Start the recorder (captures audio for REST transcription)
       const stream = await recorderRef.current.start();
 
       if (!wantsMicRef.current) {
@@ -209,7 +240,6 @@ export default function AppPage(): React.JSX.Element {
         return;
       }
 
-      // Mark mic as warmed up after first successful acquisition
       if (isFirstPress) {
         micWarmedUp.current = true;
         playTone("start");
@@ -225,88 +255,47 @@ export default function AppPage(): React.JSX.Element {
       };
       timerRef.current = requestAnimationFrame(updateTimer);
 
-      // Start visualization from the recorder's stream
       startVisualization(stream);
 
-      // Try to also open a streaming connection for real-time partial text
       try {
-        const streamer = new Streamer(getApiBase(), {
-          onConfig: (config) => {
-            setUseStreaming(config.streaming);
-          },
-          onReady: () => {},
-          onPartial: (text) => setPartialText(text),
-          onFinal: async (text) => {
-            // Always clean up streamer and recorder after streaming completes
-            streamerRef.current?.close();
-            streamerRef.current = null;
-            recorderRef.current.cancel();
-
-            if (text.trim()) {
-              await window.api.pasteText(text);
-            }
-            hidePill();
-          },
-          onError: (msg) => {
-            // Clean up on streaming error
-            streamerRef.current?.close();
-            streamerRef.current = null;
-            recorderRef.current.cancel();
-            setState("error");
-            setMessage(msg);
-            setTimeout(() => hidePill(), 2000);
-          },
-        });
-        streamerRef.current = streamer;
-        // Start the streamer's mic separately (it gets its own stream)
-        await streamer.start();
-      } catch {
-        // Streaming is optional -- REST fallback always works
-        // Close the streamer if it partially initialized (e.g. WebSocket opened but mic failed)
-        streamerRef.current?.close();
-        streamerRef.current = null;
-      }
+        await getStreamer().startCapture(
+          stream,
+          analyserCtxRef.current ?? undefined,
+        );
+      } catch {}
     } catch (err) {
       wantsMicRef.current = false;
       setState("error");
       setMessage(err instanceof Error ? err.message : "Mic access denied");
       setTimeout(() => hidePill(), 2000);
     }
-  }, [startVisualization, hidePill]);
+  }, [startVisualization, hidePill, getStreamer]);
 
   // -- Commit: stop recording and transcribe --
   const commitRecording = useCallback(async () => {
     wantsMicRef.current = false;
     stopVisualization();
-    // Audio feedback: descending tone on stop
     playTone("stop");
 
-    // Skip recordings shorter than 1 second (likely accidental trigger)
     const recordingDuration = Date.now() - startTimeRef.current;
     if (recordingDuration < 1000) {
       recorderRef.current.cancel();
       streamerRef.current?.cancel();
-      streamerRef.current = null;
       hidePill();
       return;
     }
 
-    const streamer = streamerRef.current;
-
-    // If streaming mode is active, just commit via WebSocket
-    if (useStreaming && streamer) {
+    // If streaming mode is active, commit via WebSocket
+    if (useStreaming && streamerRef.current) {
       setState("transcribing");
-      // Stop the recorder's mic stream (the streamer has its own)
       recorderRef.current.cancel();
-      streamer.commit();
-      // The onFinal callback will handle the paste and cleanup
+      streamerRef.current.commit();
       return;
     }
 
     // REST fallback: stop recorder, send WAV
     setState("transcribing");
-    streamer?.close();
-    streamerRef.current = null;
+    streamerRef.current?.cancel();
 
     try {
       let wavBlob: Blob;
@@ -317,7 +306,6 @@ export default function AppPage(): React.JSX.Element {
         return;
       }
 
-      // Use the frontmost app captured at recording start
       const headers: Record<string, string> = {
         "Content-Type": "audio/wav",
       };
@@ -353,7 +341,6 @@ export default function AppPage(): React.JSX.Element {
     wantsMicRef.current = false;
     stopVisualization();
     streamerRef.current?.cancel();
-    streamerRef.current = null;
     recorderRef.current.cancel();
     hidePill();
   }, [stopVisualization, hidePill]);
@@ -380,7 +367,6 @@ export default function AppPage(): React.JSX.Element {
   useEffect(() => {
     const removeDown = window.api.onHotkeyDown(() => {
       const s = stateRef.current;
-      // Allow starting from idle or terminal states (transcribing/error)
       if (s === "idle" || s === "transcribing" || s === "error") {
         startRecording();
       }
@@ -403,6 +389,8 @@ export default function AppPage(): React.JSX.Element {
   useEffect(() => {
     return () => {
       cancelRecording();
+      streamerRef.current?.destroy();
+      streamerRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cancelRecording]);
@@ -411,7 +399,6 @@ export default function AppPage(): React.JSX.Element {
   const gap = SVG_WIDTH / BARS;
   const barWidth = Math.min(gap * 0.55, 5);
 
-  // Animated glow uses CSS animation via a class
   const glowState =
     state === "initializing"
       ? "glow-initializing"
@@ -594,10 +581,6 @@ export default function AppPage(): React.JSX.Element {
           {state === "error" && (
             <span style={pillTextStyle}>{message || "Error"}</span>
           )}
-
-          {/* idle: render nothing — the pill window is hidden when idle, so any
-               content here would only flash during the race between showPill()
-               and the hotkey:down IPC reaching the renderer. */}
         </div>
       </div>
     </div>

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -166,8 +166,11 @@ export default function AppPage(): React.JSX.Element {
     setElapsed(0);
   }, []);
 
-  // Hide the pill immediately
+  // Hide the pill and reset to idle so the next show starts clean
   const hidePill = useCallback(() => {
+    setState("idle");
+    setPartialText("");
+    setMessage("");
     window.api.hidePill();
   }, []);
 
@@ -285,7 +288,7 @@ export default function AppPage(): React.JSX.Element {
       recorderRef.current.cancel();
       streamerRef.current?.cancel();
       streamerRef.current = null;
-      window.api.hidePill();
+      hidePill();
       return;
     }
 
@@ -353,8 +356,8 @@ export default function AppPage(): React.JSX.Element {
     streamerRef.current?.cancel();
     streamerRef.current = null;
     recorderRef.current.cancel();
-    window.api.hidePill();
-  }, [stopVisualization]);
+    hidePill();
+  }, [stopVisualization, hidePill]);
 
   // Load sound preference from server settings
   useEffect(() => {

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -183,6 +183,7 @@ export default function AppPage(): React.JSX.Element {
       ?.getFrontmostApp()
       .then((app) => {
         appContextRef.current = app;
+        if (app) streamerRef.current?.setContext(app);
       })
       .catch(() => {
         appContextRef.current = null;

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -233,7 +233,11 @@ export default function AppPage(): React.JSX.Element {
     }
 
     try {
-      const stream = await recorderRef.current.start();
+      // When streaming is active, skip MediaRecorder entirely — the
+      // Streamer accumulates PCM16 and can produce a WAV if needed.
+      const stream = useStreaming
+        ? await recorderRef.current.acquireStream()
+        : await recorderRef.current.start();
 
       if (!wantsMicRef.current) {
         recorderRef.current.cancel();
@@ -246,7 +250,6 @@ export default function AppPage(): React.JSX.Element {
         setState("recording");
       }
 
-      // Start timer
       startTimeRef.current = Date.now();
       const updateTimer = () => {
         if (!wantsMicRef.current) return;
@@ -293,18 +296,25 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
-    // REST fallback: stop recorder, send WAV
     setState("transcribing");
     streamerRef.current?.cancel();
 
     try {
-      let wavBlob: Blob;
-      if (recorderRef.current.isRecording()) {
+      // Prefer the Streamer's pre-encoded WAV (already 16kHz PCM16,
+      // no decode/resample overhead).  Fall back to MediaRecorder path
+      // only when the Streamer has no accumulated audio.
+      let wavBlob: Blob | null = streamerRef.current?.getWavBlob() ?? null;
+
+      if (!wavBlob && recorderRef.current.isRecording()) {
         wavBlob = await recorderRef.current.stop();
-      } else {
+      }
+
+      if (!wavBlob) {
         hidePill();
         return;
       }
+
+      recorderRef.current.cancel();
 
       const headers: Record<string, string> = {
         "Content-Type": "audio/wav",

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -99,6 +99,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
   const [language, setLanguage] = useState("auto");
   const [pillPosition, setPillPosition] = useState("bottom-center");
   const [soundEnabled, setSoundEnabled] = useState(true);
+  const [transcriptionPrompt, setTranscriptionPrompt] = useState("");
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null);
   const [updateDownloaded, setUpdateDownloaded] = useState(false);
   const [downloading, setDownloading] = useState(false);
@@ -172,6 +173,12 @@ export default function GeneralSettingsPage(): React.JSX.Element {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data?.value === "false") setSoundEnabled(false);
+      })
+      .catch(() => {});
+    fetch(`${getApiBase()}/api/settings/transcription_prompt`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value) setTranscriptionPrompt(data.value);
       })
       .catch(() => {});
 
@@ -379,6 +386,31 @@ export default function GeneralSettingsPage(): React.JSX.Element {
               </select>
             </div>
           </div>
+        </div>
+
+        {/* Transcription prompt hint */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Transcription Prompt</label>
+          <p className="text-muted-foreground text-xs">
+            Hint for the speech model — list domain terms, names, or jargon to
+            improve accuracy.
+          </p>
+          <input
+            type="text"
+            value={transcriptionPrompt}
+            onChange={(e) => {
+              setTranscriptionPrompt(e.target.value);
+            }}
+            onBlur={() => {
+              fetch(`${getApiBase()}/api/settings/transcription_prompt`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ value: transcriptionPrompt }),
+              }).catch(() => {});
+            }}
+            placeholder="e.g. TypeScript, React, Kubernetes, JIRA..."
+            className="border-border bg-card text-foreground w-full rounded-lg border px-3 py-2 text-sm"
+          />
         </div>
 
         {/* Sound toggle - inline row */}

--- a/apps/server/src/lib/post-process.ts
+++ b/apps/server/src/lib/post-process.ts
@@ -1,0 +1,187 @@
+import { generateText } from "ai";
+import { getModelCost } from "../routes/models.js";
+import { getDb } from "./db.js";
+import { createChatModel, getDefaultModels } from "./providers.js";
+
+/** Build a context string from the raw x-app-context header for matching */
+function buildMatchContext(rawContext: string | null): string {
+  if (!rawContext) return "";
+
+  try {
+    const ctx = JSON.parse(rawContext) as {
+      app?: string;
+      url?: string;
+      title?: string;
+      windowTitle?: string;
+    };
+
+    const parts: string[] = [];
+    if (ctx.url) parts.push(ctx.url);
+    if (ctx.title) parts.push(ctx.title);
+    if (ctx.windowTitle) parts.push(ctx.windowTitle);
+    if (ctx.app) parts.push(ctx.app);
+    return parts.join(" ");
+  } catch {
+    return rawContext;
+  }
+}
+
+/** Look up formatting instructions from the format_rules table */
+function getContextHint(
+  rawContext: string | null,
+  db: ReturnType<typeof getDb>,
+): string {
+  if (!rawContext) return "";
+
+  const matchStr = buildMatchContext(rawContext);
+  if (!matchStr) return "";
+
+  try {
+    const rows = db
+      .prepare(
+        "SELECT app_pattern, instructions FROM format_rules ORDER BY is_default ASC, id DESC",
+      )
+      .all() as { app_pattern: string; instructions: string }[];
+
+    for (const row of rows) {
+      const patterns = row.app_pattern.split("|").map((p) => p.trim());
+      for (const pattern of patterns) {
+        if (pattern && matchStr.toLowerCase().includes(pattern.toLowerCase())) {
+          return row.instructions;
+        }
+      }
+    }
+  } catch {
+    // format_rules table may not exist yet
+  }
+
+  try {
+    const ctx = JSON.parse(rawContext) as { app?: string };
+    if (ctx.app) return `The user is dictating in ${ctx.app}.`;
+  } catch {
+    // not JSON
+  }
+
+  return "";
+}
+
+export interface PostProcessResult {
+  cleaned: string;
+  llmProvider: string | null;
+  llmModel: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
+/**
+ * Run LLM cleanup and dictionary replacements on transcribed text.
+ * Returns the cleaned text plus metadata for history tracking.
+ */
+export async function postProcess(
+  rawText: string,
+  appContext: string | null,
+): Promise<PostProcessResult> {
+  const db = getDb();
+  const defaults = getDefaultModels();
+  let cleaned = rawText;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let llmProvider: string | null = null;
+  let llmModel: string | null = null;
+  let costUsd = 0;
+
+  // LLM cleanup
+  const llmSetting = db
+    .prepare("SELECT value FROM settings WHERE key = 'llm_cleanup'")
+    .get() as { value: string } | undefined;
+  const llmEnabled = llmSetting?.value === "true";
+
+  if (llmEnabled && defaults.llm) {
+    const contextHint = getContextHint(appContext, db);
+    const systemPrompt = `You are an intelligent voice-to-text post-processor that transforms raw dictated speech into clean, polished writing.
+${contextHint ? `\nContext: ${contextHint}\n` : ""}
+Your job:
+- Remove filler words (um, uh, like, you know, basically, so, I mean, etc.)
+- Remove false starts, repeated words, and self-corrections (keep only the final intended version)
+- Fix grammar, spelling, punctuation, and capitalization
+- Convert spoken numbers, dates, and abbreviations to their written forms where appropriate
+- Structure run-on sentences into clear, well-punctuated prose
+- Preserve the speaker's original meaning, intent, tone, and personality exactly
+- Keep technical terms, names, and domain-specific vocabulary intact
+- Do NOT add information that wasn't spoken
+- Do NOT change the meaning or rewrite beyond what's needed for clarity
+- Do NOT add greetings, sign-offs, or any framing text
+
+Output ONLY the cleaned text. No explanations, no quotes, no prefixes.`;
+
+    try {
+      const chatModel = createChatModel(
+        defaults.llm.provider,
+        defaults.llm.model_id,
+      );
+      const result = await generateText({
+        model: chatModel,
+        system: systemPrompt,
+        prompt: rawText,
+      });
+      cleaned = result.text;
+      inputTokens = result.usage?.inputTokens ?? 0;
+      outputTokens = result.usage?.outputTokens ?? 0;
+      llmProvider = defaults.llm.provider;
+      llmModel = defaults.llm.model_id;
+    } catch (err) {
+      console.error("LLM cleanup failed:", err);
+    }
+  }
+
+  // Dictionary replacements
+  try {
+    const dictRows = db
+      .prepare(
+        "SELECT id, key, value FROM dictionary ORDER BY length(key) DESC",
+      )
+      .all() as { id: number; key: string; value: string }[];
+
+    if (dictRows.length > 0) {
+      const matchedIds: number[] = [];
+      for (const { id, key, value } of dictRows) {
+        const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const regex = new RegExp(`\\b${escaped}\\b`, "gi");
+        if (regex.test(cleaned)) {
+          matchedIds.push(id);
+          cleaned = cleaned.replace(
+            new RegExp(`\\b${escaped}\\b`, "gi"),
+            value,
+          );
+        }
+      }
+      if (matchedIds.length > 0) {
+        const updateStmt = db.prepare(
+          "UPDATE dictionary SET usage_count = usage_count + 1 WHERE id = ?",
+        );
+        for (const id of matchedIds) {
+          updateStmt.run(id);
+        }
+      }
+    }
+  } catch {
+    // Dictionary table may not exist yet
+  }
+
+  // Calculate cost
+  if (inputTokens > 0 || outputTokens > 0) {
+    try {
+      if (llmModel) {
+        const pricing = await getModelCost(llmModel);
+        if (pricing) {
+          costUsd = inputTokens * pricing.input + outputTokens * pricing.output;
+        }
+      }
+    } catch {
+      // ignore pricing errors
+    }
+  }
+
+  return { cleaned, llmProvider, llmModel, inputTokens, outputTokens, costUsd };
+}

--- a/apps/server/src/lib/streaming-stt.ts
+++ b/apps/server/src/lib/streaming-stt.ts
@@ -5,7 +5,7 @@ import { getDb } from "./db.js";
 export interface StreamCallbacks {
   onReady: (model: string) => void;
   onPartial: (text: string) => void;
-  onFinal: (text: string) => void | Promise<void>;
+  onFinal: (text: string) => void;
   onError: (message: string) => void;
   onClose: () => void;
 }
@@ -13,6 +13,7 @@ export interface StreamCallbacks {
 export interface StreamSession {
   sendAudio(chunk: ArrayBuffer): void;
   commit(): void;
+  cancel(): void;
   close(): void;
 }
 
@@ -21,7 +22,6 @@ const REALTIME_URL = "wss://api.openai.com/v1/realtime?intent=transcription";
 /**
  * Opens a streaming transcription session via OpenAI's Realtime API.
  * Supports models like gpt-4o-transcribe, gpt-4o-mini-transcribe.
- * Falls back gracefully if the model doesn't support streaming.
  */
 export function openStreamingSession(opts: {
   apiKey: string;
@@ -79,6 +79,7 @@ export function openStreamingSession(opts: {
         const text =
           typeof evt.transcript === "string" ? evt.transcript : partialText;
         callbacks.onFinal(text.trim());
+        partialText = "";
         return;
       }
       case "error": {
@@ -115,6 +116,12 @@ export function openStreamingSession(opts: {
       if (ws.readyState !== WebSocket.OPEN) return;
       ws.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
     },
+    cancel(): void {
+      if (ws.readyState !== WebSocket.OPEN) return;
+      // Clear the audio buffer without triggering a transcription
+      ws.send(JSON.stringify({ type: "input_audio_buffer.clear" }));
+      partialText = "";
+    },
     close(): void {
       if (ws.readyState <= WebSocket.OPEN) ws.close();
     },
@@ -132,7 +139,6 @@ export function supportsStreaming(
 ): boolean {
   if (providerId !== "openai") return false;
   const short = modelId.includes("/") ? modelId.split("/").pop()! : modelId;
-  // whisper-1 doesn't support streaming, gpt-4o-transcribe variants do
   return short.includes("transcribe");
 }
 

--- a/apps/server/src/lib/streaming-stt.ts
+++ b/apps/server/src/lib/streaming-stt.ts
@@ -26,9 +26,10 @@ const REALTIME_URL = "wss://api.openai.com/v1/realtime?intent=transcription";
 export function openStreamingSession(opts: {
   apiKey: string;
   model: string;
+  prompt?: string;
   callbacks: StreamCallbacks;
 }): StreamSession {
-  const { apiKey, model, callbacks } = opts;
+  const { apiKey, model, prompt, callbacks } = opts;
   let partialText = "";
   let configured = false;
 
@@ -40,12 +41,15 @@ export function openStreamingSession(opts: {
   });
 
   ws.on("open", () => {
+    const transcription: Record<string, unknown> = { model };
+    if (prompt) transcription.prompt = prompt;
+
     ws.send(
       JSON.stringify({
         type: "transcription_session.update",
         session: {
           input_audio_format: "pcm16",
-          input_audio_transcription: { model },
+          input_audio_transcription: transcription,
           turn_detection: null,
         },
       }),

--- a/apps/server/src/lib/streaming-stt.ts
+++ b/apps/server/src/lib/streaming-stt.ts
@@ -5,7 +5,7 @@ import { getDb } from "./db.js";
 export interface StreamCallbacks {
   onReady: (model: string) => void;
   onPartial: (text: string) => void;
-  onFinal: (text: string) => void;
+  onFinal: (text: string) => void | Promise<void>;
   onError: (message: string) => void;
   onClose: () => void;
 }

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -6,6 +6,7 @@ import { getDefaultModels } from "../lib/providers.js";
 import {
   getApiKeyForProvider,
   openStreamingSession,
+  type StreamSession,
   supportsStreaming,
 } from "../lib/streaming-stt.js";
 
@@ -14,80 +15,86 @@ const stream = new Hono();
 stream.get(
   "/",
   upgradeWebSocket(() => {
-    let upstream: ReturnType<typeof openStreamingSession> | null = null;
+    let upstream: StreamSession | null = null;
     let closed = false;
-    const startTime = Date.now();
+    let sessionStartTime = Date.now();
     let voiceDefaults: { provider: string; model_id: string } | null = null;
     let appContext: string | null = null;
 
-    return {
-      onOpen(_event, ws) {
-        const defaults = getDefaultModels();
-        if (!defaults.voice) {
-          ws.send(
-            JSON.stringify({
-              type: "error",
-              message: "No voice model configured",
-            }),
-          );
-          ws.close();
-          return;
-        }
-        voiceDefaults = defaults.voice;
-
-        const apiKey = getApiKeyForProvider(defaults.voice.provider);
-        if (!apiKey) {
-          ws.send(
-            JSON.stringify({
-              type: "error",
-              message: `No API key for ${defaults.voice.provider}`,
-            }),
-          );
-          ws.close();
-          return;
-        }
-
-        const modelShort = defaults.voice.model_id.includes("/")
-          ? defaults.voice.model_id.split("/").pop()!
-          : defaults.voice.model_id;
-
-        const canStream = supportsStreaming(
-          defaults.voice.provider,
-          defaults.voice.model_id,
-        );
-
+    function connectUpstream(ws: {
+      send: (data: string) => void;
+      close: () => void;
+    }): void {
+      const defaults = getDefaultModels();
+      if (!defaults.voice) {
         ws.send(
           JSON.stringify({
-            type: "config",
-            model: modelShort,
-            streaming: canStream,
+            type: "error",
+            message: "No voice model configured",
           }),
         );
+        ws.close();
+        return;
+      }
+      voiceDefaults = defaults.voice;
 
-        if (!canStream) {
-          ws.close();
-          return;
-        }
+      const apiKey = getApiKeyForProvider(defaults.voice.provider);
+      if (!apiKey) {
+        ws.send(
+          JSON.stringify({
+            type: "error",
+            message: `No API key for ${defaults.voice.provider}`,
+          }),
+        );
+        ws.close();
+        return;
+      }
 
-        try {
-          upstream = openStreamingSession({
-            apiKey,
-            model: modelShort,
-            callbacks: {
-              onReady: (model) => {
-                ws.send(JSON.stringify({ type: "session.ready", model }));
-              },
-              onPartial: (text) => {
-                ws.send(JSON.stringify({ type: "partial", text }));
-              },
-              onFinal: async (rawText) => {
-                const durationMs = Date.now() - startTime;
+      const modelShort = defaults.voice.model_id.includes("/")
+        ? defaults.voice.model_id.split("/").pop()!
+        : defaults.voice.model_id;
 
-                const pp = await postProcess(rawText, appContext);
+      const canStream = supportsStreaming(
+        defaults.voice.provider,
+        defaults.voice.model_id,
+      );
+
+      ws.send(
+        JSON.stringify({
+          type: "config",
+          model: modelShort,
+          streaming: canStream,
+        }),
+      );
+
+      if (!canStream) {
+        ws.close();
+        return;
+      }
+
+      upstream = openStreamingSession({
+        apiKey,
+        model: modelShort,
+        callbacks: {
+          onReady: (model) => {
+            ws.send(JSON.stringify({ type: "session.ready", model }));
+          },
+          onPartial: (text) => {
+            ws.send(JSON.stringify({ type: "partial", text }));
+          },
+          onFinal: (rawText) => {
+            const durationMs = Date.now() - sessionStartTime;
+
+            // Send raw text immediately so the client can paste without waiting
+            ws.send(JSON.stringify({ type: "final", text: rawText }));
+
+            // Run post-processing in the background for history
+            postProcess(rawText, appContext)
+              .then((pp) => {
                 const finalText = pp.cleaned;
-
-                ws.send(JSON.stringify({ type: "final", text: finalText }));
-
+                if (finalText !== rawText) {
+                  ws.send(JSON.stringify({ type: "cleaned", text: finalText }));
+                }
                 try {
                   const db = getDb();
                   db.prepare(
@@ -109,33 +116,48 @@ stream.get(
                 } catch (err) {
                   console.error("Failed to save history:", err);
                 }
+              })
+              .catch((err) => {
+                console.error("Post-processing failed:", err);
+                try {
+                  const db = getDb();
+                  db.prepare(
+                    `INSERT INTO transcription_history
+                     (raw_text, voice_provider, voice_model, duration_ms)
+                     VALUES (?, ?, ?, ?)`,
+                  ).run(
+                    rawText,
+                    voiceDefaults!.provider,
+                    voiceDefaults!.model_id,
+                    durationMs,
+                  );
+                } catch {}
+              });
+          },
+          onError: (message) => {
+            ws.send(JSON.stringify({ type: "error", message }));
+            upstream = null;
+          },
+          onClose: () => {
+            upstream = null;
+            if (!closed) {
+              try {
+                connectUpstream(ws);
+              } catch {}
+            }
+          },
+        },
+      });
+    }
 
-                cleanup();
-              },
-              onError: (message) => {
-                ws.send(JSON.stringify({ type: "error", message }));
-                cleanup();
-              },
-              onClose: () => {
-                if (!closed) cleanup();
-              },
-            },
-          });
+    return {
+      onOpen(_event, ws) {
+        try {
+          connectUpstream(ws);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           ws.send(JSON.stringify({ type: "error", message }));
           ws.close();
-        }
-
-        function cleanup(): void {
-          if (closed) return;
-          closed = true;
-          try {
-            upstream?.close();
-          } catch {}
-          try {
-            ws.close();
-          } catch {}
         }
       },
 
@@ -158,37 +180,42 @@ stream.get(
           return;
         }
 
-        if (msg.type === "context") {
-          appContext = msg.context ?? null;
-        } else if (msg.type === "commit") {
-          upstream?.commit();
-        } else if (msg.type === "cancel") {
-          closed = true;
-          try {
-            upstream?.close();
-          } catch {}
-          try {
-            ws.close();
-          } catch {}
+        switch (msg.type) {
+          case "context":
+            appContext = msg.context ?? null;
+            break;
+          case "start":
+            sessionStartTime = Date.now();
+            appContext = null;
+            if (!upstream) {
+              try {
+                connectUpstream(ws);
+              } catch {}
+            }
+            break;
+          case "commit":
+            upstream?.commit();
+            break;
+          case "cancel":
+            upstream?.cancel();
+            break;
         }
       },
 
       onClose() {
-        if (!closed) {
-          closed = true;
-          try {
-            upstream?.close();
-          } catch {}
-        }
+        closed = true;
+        try {
+          upstream?.close();
+        } catch {}
+        upstream = null;
       },
 
       onError() {
-        if (!closed) {
-          closed = true;
-          try {
-            upstream?.close();
-          } catch {}
-        }
+        closed = true;
+        try {
+          upstream?.close();
+        } catch {}
+        upstream = null;
       },
     };
   }),

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -104,7 +104,7 @@ stream.get(
             postProcess(rawText, appContext)
               .then((pp) => {
                 const finalText = pp.cleaned;
-                if (finalText !== rawText) {
+                if (finalText !== rawText && !closed) {
                   ws.send(JSON.stringify({ type: "cleaned", text: finalText }));
                 }
                 try {

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -1,6 +1,7 @@
 import { upgradeWebSocket } from "@hono/node-server";
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
+import { postProcess } from "../lib/post-process.js";
 import { getDefaultModels } from "../lib/providers.js";
 import {
   getApiKeyForProvider,
@@ -17,6 +18,7 @@ stream.get(
     let closed = false;
     const startTime = Date.now();
     let voiceDefaults: { provider: string; model_id: string } | null = null;
+    let appContext: string | null = null;
 
     return {
       onOpen(_event, ws) {
@@ -78,21 +80,31 @@ stream.get(
               onPartial: (text) => {
                 ws.send(JSON.stringify({ type: "partial", text }));
               },
-              onFinal: (text) => {
-                ws.send(JSON.stringify({ type: "final", text }));
+              onFinal: async (rawText) => {
+                const durationMs = Date.now() - startTime;
 
-                // Save to history
+                const pp = await postProcess(rawText, appContext);
+                const finalText = pp.cleaned;
+
+                ws.send(JSON.stringify({ type: "final", text: finalText }));
+
                 try {
                   const db = getDb();
                   db.prepare(
                     `INSERT INTO transcription_history
-                     (raw_text, voice_provider, voice_model, duration_ms)
-                     VALUES (?, ?, ?, ?)`,
+                     (raw_text, cleaned_text, voice_provider, voice_model, llm_provider, llm_model, duration_ms, input_tokens, output_tokens, cost_usd)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
                   ).run(
-                    text,
+                    rawText,
+                    finalText !== rawText ? finalText : null,
                     voiceDefaults!.provider,
                     voiceDefaults!.model_id,
-                    Date.now() - startTime,
+                    pp.llmProvider,
+                    pp.llmModel,
+                    durationMs,
+                    pp.inputTokens,
+                    pp.outputTokens,
+                    pp.costUsd,
                   );
                 } catch (err) {
                   console.error("Failed to save history:", err);
@@ -128,16 +140,14 @@ stream.get(
       },
 
       onMessage(event, ws) {
-        if (!upstream) return;
-
         // Binary data = audio chunk
         if (event.data instanceof ArrayBuffer) {
-          upstream.sendAudio(event.data);
+          upstream?.sendAudio(event.data);
           return;
         }
 
         // Text data = JSON command
-        let msg: { type: string };
+        let msg: { type: string; context?: string };
         try {
           msg = JSON.parse(
             typeof event.data === "string"
@@ -148,12 +158,14 @@ stream.get(
           return;
         }
 
-        if (msg.type === "commit") {
-          upstream.commit();
+        if (msg.type === "context") {
+          appContext = msg.context ?? null;
+        } else if (msg.type === "commit") {
+          upstream?.commit();
         } else if (msg.type === "cancel") {
           closed = true;
           try {
-            upstream.close();
+            upstream?.close();
           } catch {}
           try {
             ws.close();

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -72,9 +72,21 @@ stream.get(
         return;
       }
 
+      let prompt: string | undefined;
+      try {
+        const db = getDb();
+        const row = db
+          .prepare(
+            "SELECT value FROM settings WHERE key = 'transcription_prompt'",
+          )
+          .get() as { value: string } | undefined;
+        if (row?.value) prompt = row.value;
+      } catch {}
+
       upstream = openStreamingSession({
         apiKey,
         model: modelShort,
+        prompt,
         callbacks: {
           onReady: (model) => {
             ws.send(JSON.stringify({ type: "session.ready", model }));

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -1,87 +1,13 @@
-import { generateText, experimental_transcribe as transcribe } from "ai";
+import { experimental_transcribe as transcribe } from "ai";
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
+import { postProcess } from "../lib/post-process.js";
 import {
-  createChatModel,
   createTranscriptionModel,
   getDefaultModels,
 } from "../lib/providers.js";
-import { getModelCost } from "../routes/models.js";
 
 const transcribeRoute = new Hono();
-
-// ---------------------------------------------------------------------------
-// Context detection — uses format_rules from DB
-// ---------------------------------------------------------------------------
-
-/** Build a context string from the raw x-app-context header for matching */
-function buildMatchContext(rawContext: string | null): string {
-  if (!rawContext) return "";
-
-  try {
-    const ctx = JSON.parse(rawContext) as {
-      app?: string;
-      url?: string;
-      title?: string;
-      windowTitle?: string;
-    };
-
-    // Build a combined string for pattern matching
-    const parts: string[] = [];
-    if (ctx.url) parts.push(ctx.url);
-    if (ctx.title) parts.push(ctx.title);
-    if (ctx.windowTitle) parts.push(ctx.windowTitle);
-    if (ctx.app) parts.push(ctx.app);
-    return parts.join(" ");
-  } catch {
-    return rawContext;
-  }
-}
-
-/** Look up formatting instructions from the format_rules table */
-function getContextHint(
-  rawContext: string | null,
-  db: ReturnType<typeof getDb>,
-): string {
-  if (!rawContext) return "";
-
-  const matchStr = buildMatchContext(rawContext);
-  if (!matchStr) return "";
-
-  try {
-    // User rules (is_default=0) first, then defaults (is_default=1)
-    const rows = db
-      .prepare(
-        "SELECT app_pattern, instructions FROM format_rules ORDER BY is_default ASC, id DESC",
-      )
-      .all() as { app_pattern: string; instructions: string }[];
-
-    for (const row of rows) {
-      const patterns = row.app_pattern.split("|").map((p) => p.trim());
-      for (const pattern of patterns) {
-        if (pattern && matchStr.toLowerCase().includes(pattern.toLowerCase())) {
-          return row.instructions;
-        }
-      }
-    }
-  } catch {
-    // format_rules table may not exist yet
-  }
-
-  // Fallback: extract app name for a generic hint
-  try {
-    const ctx = JSON.parse(rawContext) as { app?: string };
-    if (ctx.app) return `The user is dictating in ${ctx.app}.`;
-  } catch {
-    // not JSON
-  }
-
-  return "";
-}
-
-// ---------------------------------------------------------------------------
-// Route
-// ---------------------------------------------------------------------------
 
 transcribeRoute.post("/", async (c) => {
   const start = Date.now();
@@ -121,7 +47,6 @@ transcribeRoute.post("/", async (c) => {
 
   // Step 1: Transcribe
   const db = getDb();
-  const contextHint = getContextHint(appContext, db);
   let rawText: string;
 
   const langSetting = db
@@ -159,103 +84,9 @@ transcribeRoute.post("/", async (c) => {
     });
   }
 
-  // Step 2: LLM post-processing (optional)
-  let cleanedText = rawText;
-  let inputTokens = 0;
-  let outputTokens = 0;
-
-  const llmSetting = db
-    .prepare("SELECT value FROM settings WHERE key = 'llm_cleanup'")
-    .get() as { value: string } | undefined;
-  const llmEnabled = llmSetting?.value === "true";
-
-  if (llmEnabled && defaults.llm) {
-    const systemPrompt = `You are an intelligent voice-to-text post-processor that transforms raw dictated speech into clean, polished writing.
-${contextHint ? `\nContext: ${contextHint}\n` : ""}
-Your job:
-- Remove filler words (um, uh, like, you know, basically, so, I mean, etc.)
-- Remove false starts, repeated words, and self-corrections (keep only the final intended version)
-- Fix grammar, spelling, punctuation, and capitalization
-- Convert spoken numbers, dates, and abbreviations to their written forms where appropriate
-- Structure run-on sentences into clear, well-punctuated prose
-- Preserve the speaker's original meaning, intent, tone, and personality exactly
-- Keep technical terms, names, and domain-specific vocabulary intact
-- Do NOT add information that wasn't spoken
-- Do NOT change the meaning or rewrite beyond what's needed for clarity
-- Do NOT add greetings, sign-offs, or any framing text
-
-Output ONLY the cleaned text. No explanations, no quotes, no prefixes.`;
-
-    try {
-      const chatModel = createChatModel(
-        defaults.llm.provider,
-        defaults.llm.model_id,
-      );
-      const result = await generateText({
-        model: chatModel,
-        system: systemPrompt,
-        prompt: rawText,
-      });
-      cleanedText = result.text;
-      inputTokens = result.usage?.inputTokens ?? 0;
-      outputTokens = result.usage?.outputTokens ?? 0;
-    } catch (err) {
-      console.error("LLM cleanup failed:", err);
-    }
-  }
-
-  // Step 3: Dictionary replacements
-  try {
-    const dictRows = db
-      .prepare(
-        "SELECT id, key, value FROM dictionary ORDER BY length(key) DESC",
-      )
-      .all() as { id: number; key: string; value: string }[];
-
-    if (dictRows.length > 0) {
-      const matchedIds: number[] = [];
-      for (const { id, key, value } of dictRows) {
-        const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const regex = new RegExp(`\\b${escaped}\\b`, "gi");
-        if (regex.test(cleanedText)) {
-          matchedIds.push(id);
-          cleanedText = cleanedText.replace(
-            new RegExp(`\\b${escaped}\\b`, "gi"),
-            value,
-          );
-        }
-      }
-      if (matchedIds.length > 0) {
-        const updateStmt = db.prepare(
-          "UPDATE dictionary SET usage_count = usage_count + 1 WHERE id = ?",
-        );
-        for (const id of matchedIds) {
-          updateStmt.run(id);
-        }
-      }
-    }
-  } catch {
-    // Dictionary table may not exist yet
-  }
-
+  // Step 2: LLM post-processing + dictionary replacements
+  const pp = await postProcess(rawText, appContext);
   const durationMs = Date.now() - start;
-
-  // Calculate cost from models.dev pricing
-  let costUsd = 0;
-  if (inputTokens > 0 || outputTokens > 0) {
-    try {
-      const llmModelId =
-        llmEnabled && defaults.llm ? defaults.llm.model_id : null;
-      if (llmModelId) {
-        const pricing = await getModelCost(llmModelId);
-        if (pricing) {
-          costUsd = inputTokens * pricing.input + outputTokens * pricing.output;
-        }
-      }
-    } catch {
-      // ignore pricing errors
-    }
-  }
 
   // Save to history
   try {
@@ -265,15 +96,15 @@ Output ONLY the cleaned text. No explanations, no quotes, no prefixes.`;
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       rawText,
-      cleanedText !== rawText ? cleanedText : null,
+      pp.cleaned !== rawText ? pp.cleaned : null,
       defaults.voice.provider,
       defaults.voice.model_id,
-      llmEnabled && defaults.llm ? defaults.llm.provider : null,
-      llmEnabled && defaults.llm ? defaults.llm.model_id : null,
+      pp.llmProvider,
+      pp.llmModel,
       durationMs,
-      inputTokens,
-      outputTokens,
-      costUsd,
+      pp.inputTokens,
+      pp.outputTokens,
+      pp.costUsd,
     );
   } catch (err) {
     console.error("Failed to save history:", err);
@@ -281,7 +112,7 @@ Output ONLY the cleaned text. No explanations, no quotes, no prefixes.`;
 
   return c.json({
     raw: rawText,
-    cleaned: cleanedText,
+    cleaned: pp.cleaned,
     model: defaults.voice.model_id,
     durationMs,
   });


### PR DESCRIPTION
## Summary

- The WebSocket streaming path was bypassing LLM cleanup, dictionary replacements, and per-app format rules — sending raw transcription text straight to the client while the REST path applied all three
- History entries from streaming sessions were also missing `cleaned_text`, LLM metadata, token counts, and cost tracking

## Changes

- **Extract** post-processing into a shared `apps/server/src/lib/post-process.ts` module (LLM cleanup, dictionary replacements, context-aware formatting, cost calculation)
- **Refactor** `transcribe.ts` to use the shared module instead of inline logic
- **Apply** post-processing in `stream.ts` on the final text before sending it to the client
- **Add** a `context` WebSocket message type so the renderer can forward the frontmost app context (used for per-app format rule matching)
- **Update** streaming history inserts to populate all fields (`cleaned_text`, `llm_provider`, `llm_model`, `input_tokens`, `output_tokens`, `cost_usd`)
- **Widen** the `StreamCallbacks.onFinal` type to accept `Promise<void>` since the streaming handler is now async