### PR TITLE
fix(ci): prevent electron-builder from attempting implicit publish

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -14,9 +14,9 @@
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps && node scripts/fix-keylistener.mjs",
     "build:unpack": "npm run build && electron-builder --dir",
-    "build:win": "electron-vite build && electron-builder --win",
-    "build:mac": "electron-vite build && electron-builder --mac",
-    "build:linux": "electron-vite build && electron-builder --linux"
+    "build:win": "electron-vite build && electron-builder --win --publish never",
+    "build:mac": "electron-vite build && electron-builder --mac --publish never",
+    "build:linux": "electron-vite build && electron-builder --linux --publish never"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",


### PR DESCRIPTION
## Summary

- The macOS CI build was failing because `electron-builder` auto-detects CI and tries to publish artifacts to GitHub Releases, but `GH_TOKEN` isn't set
- The build itself succeeds — only the implicit publish step fails
- Add `--publish never` to all three platform build scripts (`build:mac`, `build:win`, `build:linux`)
- The `publish.provider: github` in `electron-builder.yml` is kept — it's only used by `electron-updater` at runtime to know where to check for updates, not for CI publishing
- Artifact upload is already handled by `actions/upload-artifact` in the workflow

Matches the pattern used by [getsentry/spotlight](https://github.com/getsentry/spotlight).