### PR TITLE
fix(ci): set Craft publish_repo to self

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,5 +41,6 @@ jobs:
           version: ${{ inputs.version }}
           force: ${{ inputs.force }}
           merge_target: ${{ inputs.merge_target }}
+          publish_repo: self
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Craft defaults to creating publish request issues in `{owner}/publish` (`freestyle-voice/publish`), which doesn't exist. Set `publish_repo: self` so publish request issues are created in the source repo instead.