### PR TITLE
fix(ci): add issues permission and default merge target for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,12 @@ on:
       merge_target:
         description: Target branch to merge into
         required: false
+        default: "main"
 
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   release:


### PR DESCRIPTION
Two fixes for the release workflow:

1. **Add `issues: write` permission** — Craft with `publish_repo: self` needs to create issues in the source repo for publish requests. The `GITHUB_TOKEN` only had `contents: write` and `pull-requests: write`.

2. **Default `merge_target` to `main`** — so it doesn't need to be specified manually on every dispatch.

Also deleted the stale `release/0.0.1` branch from previous failed attempts.