### PR TITLE
fix(ci): add publish workflow and GitHub App token for release flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,89 @@
+# Publish workflow — runs when the "accepted" label is added to a
+# Craft publish request issue.  Downloads build artifacts from the
+# CI run on the release branch and creates a GitHub Release.
+
+name: Publish
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  publish:
+    if: github.event.label.name == 'accepted' && github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    name: Publish release
+    environment: production
+    steps:
+      - name: Generate GitHub App token
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Parse version from issue title
+        id: version
+        run: |
+          TITLE="${{ github.event.issue.title }}"
+          VERSION=$(echo "$TITLE" | grep -oP '\d+\.\d+\.\d+(-\S+)?$' || true)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not parse version from issue title: $TITLE"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: release/${{ steps.version.outputs.version }}
+          token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+
+      - name: Install Craft
+        run: |
+          CRAFT_VERSION=$(curl -sL https://api.github.com/repos/getsentry/craft/releases/latest | jq -r .tag_name)
+          curl -sL "https://github.com/getsentry/craft/releases/download/${CRAFT_VERSION}/craft-linux" -o /usr/local/bin/craft
+          chmod +x /usr/local/bin/craft
+
+      - name: Wait for CI on release branch
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          BRANCH="release/${{ steps.version.outputs.version }}"
+          echo "Waiting for CI on $BRANCH..."
+          RUN_ID=$(gh run list --branch "$BRANCH" --workflow "Build & Test" --limit 1 --json databaseId --jq '.[0].databaseId')
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::No CI run found for $BRANCH"
+            exit 1
+          fi
+          gh run watch "$RUN_ID" --exit-status
+
+      - name: Publish with Craft
+        env:
+          GITHUB_API_TOKEN: ${{ steps.token.outputs.token }}
+        run: craft publish ${{ steps.version.outputs.version }} --no-input --no-status-check
+
+      - name: Close issue on success
+        if: success()
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh issue close ${{ github.event.issue.number }} --comment "Published ${{ steps.version.outputs.version }}."
+
+      - name: Handle failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} --body "Publish failed. See [run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          gh issue edit ${{ github.event.issue.number }} --remove-label accepted

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,17 +19,28 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
   issues: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
     name: Release a new version
     steps:
+      - name: Generate GitHub App token
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.token.outputs.token }}
 
       - uses: pnpm/action-setup@v4
 
@@ -45,4 +56,4 @@ jobs:
           merge_target: ${{ inputs.merge_target }}
           publish_repo: self
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
## Summary

The release flow was broken because:
1. `release.yml` used `GITHUB_TOKEN` which doesn't trigger subsequent workflows when pushing the release branch — CI never ran on `release/X.Y.Z`
2. There was no `publish.yml` to handle the `accepted` label on publish request issues

## Changes

### `release.yml` (updated)
- Uses a GitHub App token (`APP_ID` + `APP_PRIVATE_KEY`) via `actions/create-github-app-token` so the release branch push triggers CI
- Added `concurrency: release` to prevent parallel releases
- Removed `pull-requests: write` (not needed)

### `publish.yml` (new)
- Triggers on `issues.labeled` with `accepted` label
- Parses version from the issue title
- Checks out the `release/X.Y.Z` branch
- Waits for CI to complete on the release branch (`gh run watch`)
- Runs `craft publish` to download artifacts from CI and create the GitHub Release
- Closes the issue on success; comments with logs link and removes label on failure

## Required Setup

You need a GitHub App installed on this repo:

### 1. Create the GitHub App
- Go to https://github.com/settings/apps/new (or org settings)
- **Name**: `freestyle-release` (or similar)
- **Homepage URL**: `https://github.com/freestyle-voice/freestyle`
- **Webhook**: Uncheck "Active" (no webhook needed)
- **Permissions**:
  - Repository permissions:
    - **Contents**: Read and write
    - **Issues**: Read and write
  - No organization permissions needed
- Click "Create GitHub App"

### 2. Generate a private key
- On the App's settings page, click "Generate a private key"
- Download the `.pem` file

### 3. Install the App
- Go to the App's "Install App" tab
- Install it on the `freestyle-voice` org, selecting only the `freestyle` repository

### 4. Add secrets/variables to the repo
| Name | Type | Value |
|------|------|-------|
| `APP_ID` | **Repository variable** (`Settings > Secrets and variables > Actions > Variables`) | The App ID from the App's settings page (a number like `123456`) |
| `APP_PRIVATE_KEY` | **Repository secret** (`Settings > Secrets and variables > Actions > Secrets`) | The contents of the `.pem` file |

### 5. Create the `accepted` label
- Go to `Settings > Labels` and create a label named `accepted`

### 6. (Optional) Create the `production` environment
- Go to `Settings > Environments > New environment > "production"`
- Optionally add protection rules (required reviewers, etc.)

After setup, the release flow is:
1. Trigger "Release" workflow manually
2. Craft creates `release/X.Y.Z` branch and a publish request issue
3. CI builds artifacts on the release branch
4. Add `accepted` label to the issue
5. `publish.yml` runs Craft publish → GitHub Release with binaries