### PR TITLE
release: merge 0.0.1 release branch back into main

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestyle/electron",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Voice-to-text that works everywhere",
   "author": "freestyle-voice",
   "homepage": "https://github.com/freestyle-voice/freestyle",


### PR DESCRIPTION
Merge the 0.0.1 release branch back into main so the tag is reachable from main's history. Without this, `git describe` fails on main because no tag is an ancestor of HEAD, which breaks Craft's changelog generation for subsequent releases.