### PR TITLE
feat: add Windows cloud-only support

### DIFF
--- a/apps/electron/electron.vite.config.ts
+++ b/apps/electron/electron.vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
   },
   preload: {},
   renderer: {
+    define: {
+      "process.platform": JSON.stringify(process.platform),
+    },
     resolve: {
       alias: {
         "@renderer": resolve("src/renderer/src"),

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -175,6 +175,7 @@ function getAppWindowPosition(): { x: number; y: number } {
 function createAppWindow(): void {
   const { x, y } = getAppWindowPosition();
 
+  winToggleActive = false;
   mainWindow = new BrowserWindow({
     width: APP_WIDTH,
     height: APP_HEIGHT,
@@ -715,14 +716,11 @@ app.whenReady().then(() => {
       }
       keyListener = null;
     }
-    if (process.platform === "win32") {
-      globalShortcut.unregisterAll();
-      winToggleActive = false;
-    }
-
     // GlobalKeyboardListener requires WinKeyServer.exe which isn't shipped on Windows.
     // Hotkey recording is not supported on Windows — cancel and re-register.
     if (process.platform === "win32") {
+      globalShortcut.unregisterAll();
+      winToggleActive = false;
       settingsWindow?.webContents.send("hotkey-record:cancel");
       registerHotkey(currentHotkeyAccel ?? undefined);
       return;

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -8,6 +8,7 @@ import { serve } from "@hono/node-server";
 import {
   app,
   BrowserWindow,
+  globalShortcut,
   ipcMain,
   Menu,
   nativeImage,
@@ -41,6 +42,7 @@ let settingsWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let keyListener: GlobalKeyboardListener | null = null;
 let hotkeyPressed = false;
+let winToggleActive = false;
 let currentHotkeyAccel: string | null = null;
 
 /**
@@ -218,8 +220,9 @@ function createSettingsWindow(): void {
     height: 560,
     show: false,
     autoHideMenuBar: true,
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 16, y: 16 },
+    titleBarStyle: process.platform === "darwin" ? "hiddenInset" : "default",
+    trafficLightPosition:
+      process.platform === "darwin" ? { x: 16, y: 16 } : undefined,
     ...(process.platform === "linux" ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, "../preload/index.js"),
@@ -644,6 +647,18 @@ app.whenReady().then(() => {
       }
       keyListener = null;
     }
+    if (process.platform === "win32") {
+      globalShortcut.unregisterAll();
+      winToggleActive = false;
+    }
+
+    // GlobalKeyboardListener requires WinKeyServer.exe which isn't shipped on Windows.
+    // Hotkey recording is not supported on Windows — cancel and re-register.
+    if (process.platform === "win32") {
+      settingsWindow?.webContents.send("hotkey-record:cancel");
+      registerHotkey(currentHotkeyAccel ?? undefined);
+      return;
+    }
 
     // Ensure binary is executable / signed before starting recording listener
     ensureMacKeyServerExecutable();
@@ -1038,6 +1053,10 @@ function registerHotkey(hotkey?: string): void {
     keyListener = null;
   }
   hotkeyPressed = false;
+  if (process.platform === "win32") {
+    globalShortcut.unregisterAll();
+    winToggleActive = false;
+  }
 
   if (!hotkey) {
     hotkey = loadHotkeyFromDB();
@@ -1045,6 +1064,30 @@ function registerHotkey(hotkey?: string): void {
 
   const accel = hotkey && isValidAccelerator(hotkey) ? hotkey : DEFAULT_HOTKEY;
   currentHotkeyAccel = accel;
+
+  // Windows: WinKeyServer.exe is not reliably available, fall back to
+  // Electron's globalShortcut in toggle mode (press once to start, press again to stop).
+  if (process.platform === "win32") {
+    const registered = globalShortcut.register(accel, () => {
+      if (!winToggleActive) {
+        winToggleActive = true;
+        showPill();
+        mainWindow?.webContents.send("hotkey:down");
+      } else {
+        winToggleActive = false;
+        mainWindow?.webContents.send("hotkey:up");
+      }
+    });
+    if (!registered) {
+      const errorPayload = {
+        message: `Could not register hotkey "${accel}". Try a different key combination in Settings.`,
+      };
+      mainWindow?.webContents.send("hotkey:error", errorPayload);
+      settingsWindow?.webContents.send("hotkey:error", errorPayload);
+    }
+    return;
+  }
+
   const { modifiers, key: triggerKey } = parseAccelerator(accel);
 
   try {
@@ -1109,6 +1152,9 @@ app.on("will-quit", () => {
       /* ignore */
     }
     keyListener = null;
+  }
+  if (process.platform === "win32") {
+    globalShortcut.unregisterAll();
   }
 });
 

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -8,8 +8,8 @@ import { serve } from "@hono/node-server";
 import {
   app,
   BrowserWindow,
-  globalShortcut,
   dialog,
+  globalShortcut,
   ipcMain,
   Menu,
   nativeImage,

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -283,8 +283,9 @@ export default function OnboardingPage(): React.JSX.Element {
                       Default Hotkey: Alt + Space
                     </div>
                     <p className="text-muted-foreground text-xs">
-                      Hold to record, release to transcribe. You can change this
-                      in Settings later.
+                      {process.platform === "win32"
+                        ? "Press once to start recording, press again to stop and transcribe. You can change this in Settings later."
+                        : "Hold to record, release to transcribe. You can change this in Settings later."}
                     </p>
                   </div>
                 </div>

--- a/apps/server/src/lib/streaming-stt.ts
+++ b/apps/server/src/lib/streaming-stt.ts
@@ -135,12 +135,13 @@ export function openStreamingSession(opts: {
 /**
  * Check if a model supports realtime streaming transcription.
  * Only OpenAI's gpt-4o-transcribe variants support the Realtime API.
- * whisper-1 does NOT support streaming.
+ * On Windows, WinKeyServer and Realtime API are unavailable so streaming is disabled.
  */
 export function supportsStreaming(
   providerId: string,
   modelId: string,
 ): boolean {
+  if (process.platform === "win32") return false;
   if (providerId !== "openai") return false;
   const short = modelId.includes("/") ? modelId.split("/").pop()! : modelId;
   return short.includes("transcribe");


### PR DESCRIPTION
Closes #24 

Adds a Windows-compatible path for global hotkey handling and platform-aware UI/STT behavior, while leaving the existing macOS hold-to-record flow untouched.

- main: on Windows, fall back to Electron's globalShortcut in toggle mode (press to start, press again to stop) since WinKeyServer.exe is not shipped on Windows; cancel hotkey recording on Windows and re-register the current accel since key-up detection is unavailable.
- main: make settings window titleBarStyle/trafficLightPosition macOS-only; default chrome on Windows.
- vite: expose process.platform to the renderer as a build-time constant so the renderer can branch on platform.
- onboarding: show platform-aware hotkey instructions (press-to-toggle on Windows, hold-to-record on macOS).
- streaming-stt: disable realtime streaming on Windows since the toggle hotkey flow doesn't pair with the Realtime API the same way the macOS push-to-talk flow does.

## Demo 

https://github.com/user-attachments/assets/74e06960-b87c-467d-92dc-50845e982215

