### PR TITLE
fix: reduce main-process event-loop pressure to prevent typing lag on macOS

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -324,16 +324,39 @@ function showPill(): void {
   }
 }
 
-// -- macOS: Get frontmost app + browser tab context via AppleScript --
-function getMacFrontmostApp(): string | null {
-  try {
-    const { execSync } = require("node:child_process");
-    const appName = execSync(
-      `osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true'`,
-      { encoding: "utf-8", timeout: 2000 },
-    ).trim();
+// -- Async helper: run a command without blocking the main thread --
+function execAsync(
+  cmd: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<string> {
+  const { execFile } =
+    require("node:child_process") as typeof import("node:child_process");
+  return new Promise((resolve, reject) => {
+    execFile(
+      cmd,
+      args,
+      { encoding: "utf-8", timeout: timeoutMs },
+      (err, stdout) => {
+        if (err) reject(err);
+        else resolve((stdout as string).trim());
+      },
+    );
+  });
+}
 
-    // For browsers, try to get the active tab URL and title
+// -- macOS: Get frontmost app + browser tab context via AppleScript --
+async function getMacFrontmostApp(): Promise<string | null> {
+  try {
+    const appName = await execAsync(
+      "osascript",
+      [
+        "-e",
+        'tell application "System Events" to get name of first application process whose frontmost is true',
+      ],
+      2000,
+    );
+
     const chromiumBrowsers = [
       "Google Chrome",
       "Arc",
@@ -343,10 +366,14 @@ function getMacFrontmostApp(): string | null {
 
     try {
       if (appName === "Safari") {
-        const result = execSync(
-          `osascript -e 'tell application "Safari" to return {URL of current tab of front window, name of current tab of front window}'`,
-          { encoding: "utf-8", timeout: 2000 },
-        ).trim();
+        const result = await execAsync(
+          "osascript",
+          [
+            "-e",
+            'tell application "Safari" to return {URL of current tab of front window, name of current tab of front window}',
+          ],
+          2000,
+        );
         const idx = result.indexOf(", ");
         if (idx > 0) {
           return JSON.stringify({
@@ -356,16 +383,24 @@ function getMacFrontmostApp(): string | null {
           });
         }
       } else if (appName === "Firefox") {
-        const title = execSync(
-          `osascript -e 'tell application "System Events" to get name of front window of application process "Firefox"'`,
-          { encoding: "utf-8", timeout: 2000 },
-        ).trim();
+        const title = await execAsync(
+          "osascript",
+          [
+            "-e",
+            'tell application "System Events" to get name of front window of application process "Firefox"',
+          ],
+          2000,
+        );
         return JSON.stringify({ app: appName, windowTitle: title });
       } else if (chromiumBrowsers.includes(appName)) {
-        const result = execSync(
-          `osascript -e 'tell application "${appName}" to return {URL of active tab of front window, title of active tab of front window}'`,
-          { encoding: "utf-8", timeout: 2000 },
-        ).trim();
+        const result = await execAsync(
+          "osascript",
+          [
+            "-e",
+            `tell application "${appName}" to return {URL of active tab of front window, title of active tab of front window}`,
+          ],
+          2000,
+        );
         const idx = result.indexOf(", ");
         if (idx > 0) {
           return JSON.stringify({
@@ -386,10 +421,8 @@ function getMacFrontmostApp(): string | null {
 }
 
 // -- Windows: Get foreground window process name + title via PowerShell --
-function getWindowsFrontmostApp(): string | null {
+async function getWindowsFrontmostApp(): Promise<string | null> {
   try {
-    const { execSync } = require("node:child_process");
-    // Get foreground window title and process name
     const script = `
       Add-Type @"
         using System;
@@ -410,10 +443,11 @@ function getWindowsFrontmostApp(): string | null {
       $proc = Get-Process -Id $pid -ErrorAction SilentlyContinue
       "$($proc.ProcessName)|$title"
     `;
-    const result = execSync(
-      `powershell -NoProfile -Command "${script.replace(/"/g, '\\"')}"`,
-      { encoding: "utf-8", timeout: 3000 },
-    ).trim();
+    const result = await execAsync(
+      "powershell",
+      ["-NoProfile", "-Command", script],
+      3000,
+    );
 
     const pipeIdx = result.indexOf("|");
     if (pipeIdx > 0) {
@@ -428,25 +462,22 @@ function getWindowsFrontmostApp(): string | null {
 }
 
 // -- Linux (X11): Get active window name + title via xdotool --
-function getLinuxFrontmostApp(): string | null {
+async function getLinuxFrontmostApp(): Promise<string | null> {
   try {
-    const { execSync } = require("node:child_process");
-    const windowTitle = execSync("xdotool getactivewindow getwindowname", {
-      encoding: "utf-8",
-      timeout: 2000,
-    }).trim();
+    const windowTitle = await execAsync(
+      "xdotool",
+      ["getactivewindow", "getwindowname"],
+      2000,
+    );
 
-    // Try to get the process name
     let processName = "";
     try {
-      const pid = execSync("xdotool getactivewindow getwindowpid", {
-        encoding: "utf-8",
-        timeout: 2000,
-      }).trim();
-      processName = execSync(`cat /proc/${pid}/comm`, {
-        encoding: "utf-8",
-        timeout: 1000,
-      }).trim();
+      const pid = await execAsync(
+        "xdotool",
+        ["getactivewindow", "getwindowpid"],
+        2000,
+      );
+      processName = await execAsync("cat", [`/proc/${pid}/comm`], 1000);
     } catch {
       // some windows don't expose PID
     }
@@ -984,13 +1015,13 @@ app.whenReady().then(() => {
   ipcMain.handle("system:frontmost-app", async () => {
     try {
       if (process.platform === "darwin") {
-        return getMacFrontmostApp();
+        return await getMacFrontmostApp();
       }
       if (process.platform === "win32") {
-        return getWindowsFrontmostApp();
+        return await getWindowsFrontmostApp();
       }
       if (process.platform === "linux") {
-        return getLinuxFrontmostApp();
+        return await getLinuxFrontmostApp();
       }
     } catch {
       // graceful fallback

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -5,7 +5,7 @@ Sentry.init({
   enabled: process.env.NODE_ENV === "production",
 });
 
-import { spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import { chmodSync, existsSync, realpathSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -330,8 +330,6 @@ function execAsync(
   args: string[],
   timeoutMs: number,
 ): Promise<string> {
-  const { execFile } =
-    require("node:child_process") as typeof import("node:child_process");
   return new Promise((resolve, reject) => {
     execFile(
       cmd,

--- a/apps/electron/src/renderer/src/lib/pcm-processor.ts
+++ b/apps/electron/src/renderer/src/lib/pcm-processor.ts
@@ -13,10 +13,15 @@ const TARGET_CHUNK_MS = 80;
 class PCMProcessor extends AudioWorkletProcessor {
   constructor() {
     super();
-    // sampleRate is a global in AudioWorkletGlobalScope
     this.ratio = sampleRate / TARGET_RATE;
     this.targetChunkSamples = (TARGET_RATE * TARGET_CHUNK_MS) / 1000;
-    this.buf = new Float32Array(0);
+    this.samplesNeeded = Math.ceil(this.targetChunkSamples * this.ratio);
+    // Pre-allocated ring buffer — sized for ~200ms of audio at the native
+    // sample rate, which is well above the ~80ms flush interval.
+    this.ringLen = this.samplesNeeded * 4;
+    this.ring = new Float32Array(this.ringLen);
+    this.writePos = 0;
+    this.available = 0;
   }
 
   process(inputs) {
@@ -24,29 +29,27 @@ class PCMProcessor extends AudioWorkletProcessor {
     if (!input || !input[0] || input[0].length === 0) return true;
 
     const raw = input[0];
+    const len = raw.length;
 
-    // Append to internal buffer
-    const prev = this.buf;
-    const next = new Float32Array(prev.length + raw.length);
-    next.set(prev);
-    next.set(raw, prev.length);
-    this.buf = next;
+    // Write incoming samples into the ring buffer
+    for (let i = 0; i < len; i++) {
+      this.ring[this.writePos] = raw[i];
+      this.writePos = (this.writePos + 1) % this.ringLen;
+    }
+    this.available += len;
 
     // Flush when we have enough for one target chunk
-    const samplesNeeded = Math.ceil(this.targetChunkSamples * this.ratio);
-    while (this.buf.length >= samplesNeeded) {
-      const slice = this.buf.subarray(0, samplesNeeded);
-      this.buf = this.buf.slice(samplesNeeded);
-
-      // Downsample + encode to PCM16
-      const outLen = Math.round(slice.length / this.ratio);
+    while (this.available >= this.samplesNeeded) {
+      const readPos = (this.writePos - this.available + this.ringLen) % this.ringLen;
+      const outLen = Math.round(this.samplesNeeded / this.ratio);
       const pcm16 = new Int16Array(outLen);
       for (let i = 0; i < outLen; i++) {
-        const idx = Math.round(i * this.ratio);
-        const s = Math.max(-1, Math.min(1, slice[idx] || 0));
-        pcm16[i] = s < 0 ? s * 0x8000 : s * 0x7FFF;
+        const srcIdx = Math.round(i * this.ratio);
+        const ringIdx = (readPos + srcIdx) % this.ringLen;
+        const s = Math.max(-1, Math.min(1, this.ring[ringIdx] || 0));
+        pcm16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
       }
-
+      this.available -= this.samplesNeeded;
       this.port.postMessage(pcm16.buffer, [pcm16.buffer]);
     }
 

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -150,6 +150,7 @@ export default function AppPage(): React.JSX.Element {
 
     const dataArray = new Uint8Array(analyser.frequencyBinCount);
     const sliceSize = Math.floor(analyser.frequencyBinCount / BARS);
+    let lastIpcTime = 0;
 
     const update = () => {
       if (!wantsMicRef.current) {
@@ -171,8 +172,12 @@ export default function AppPage(): React.JSX.Element {
       barsRef.current = smoothBars(barsRef.current, raw);
       const volume = Math.min(1, (totalSum / BARS) * 2.5);
       volumeRef.current = volume;
-      // Broadcast for other windows (Today tutorial wave) — fire-and-forget IPC
-      window.api?.sendAudioLevel(volume);
+      // Throttle IPC to ~10fps to reduce main-process event-loop pressure
+      const now = performance.now();
+      if (now - lastIpcTime >= 100) {
+        lastIpcTime = now;
+        window.api?.sendAudioLevel(volume);
+      }
       // Direct DOM update — avoids 60fps React re-renders (rerender-use-ref-transient-values)
       const svg = barsSvgRef.current;
       if (svg) {
@@ -193,7 +198,7 @@ export default function AppPage(): React.JSX.Element {
   const stopVisualization = useCallback(() => {
     cancelAnimationFrame(rafRef.current);
     rafRef.current = 0;
-    cancelAnimationFrame(timerRef.current);
+    clearInterval(timerRef.current);
     timerRef.current = 0;
     // Don't close analyserCtxRef — we reuse it across sessions
     barsRef.current = new Array(BARS).fill(0);
@@ -257,12 +262,10 @@ export default function AppPage(): React.JSX.Element {
       }
 
       startTimeRef.current = Date.now();
-      const updateTimer = () => {
+      timerRef.current = window.setInterval(() => {
         if (!wantsMicRef.current) return;
         setElapsed(Date.now() - startTimeRef.current);
-        timerRef.current = requestAnimationFrame(updateTimer);
-      };
-      timerRef.current = requestAnimationFrame(updateTimer);
+      }, 100);
 
       startVisualization(stream);
 


### PR DESCRIPTION
## Summary

Freestyle's `node-global-key-listener` intercepts **every keystroke system-wide** via a native binary (MacKeyServer) that blocks on the Node.js event loop for each event response. When the main process event loop is busy, keystroke responses are delayed, causing perceptible typing lag across all applications.

This PR reduces event-loop pressure through four targeted fixes:

## Changes

### 1. Replace `execSync` with async `execFile` for frontmost-app detection (P0)
`getMacFrontmostApp()`, `getWindowsFrontmostApp()`, and `getLinuxFrontmostApp()` previously used `execSync` which **blocked the entire main thread** for up to 2-3 seconds on every hotkey press. During this time, the MacKeyServer binary would be waiting for keystroke responses that couldn't be processed, freezing all keyboard input system-wide.

Now uses an async `execFile` wrapper so the event loop remains free to process key events while the child process runs.

### 2. Throttle audio-level IPC from 60 fps to ~10 fps (P1)
During recording, `sendAudioLevel()` fired an IPC message on every `requestAnimationFrame` callback (~60/sec). The main process received each one and forwarded it to the settings window — 60 IPC serialization/deserialization cycles per second competing with the key listener's event responses.

Now throttled to ~10 fps (every 100ms), reducing IPC pressure by 6x with no visible difference to audio visualization.

### 3. Replace 60 fps RAF timer with 100ms setInterval (P1)
The recording timer called `setElapsed()` via `requestAnimationFrame` at ~60 fps, triggering a full React re-render each frame. A timer display only needs ~10 updates/sec.

Replaced with `setInterval` at 100ms, also fixed cleanup to use `clearInterval` instead of `cancelAnimationFrame`.

### 4. Ring buffer for AudioWorklet PCM processor (P1)
The `process()` callback runs ~344 times/sec and previously allocated a **new `Float32Array`** on every call, copying the old buffer + new data into it. This created heavy GC pressure on the audio thread.

Replaced with a pre-allocated ring buffer (~200ms capacity) that writes samples in-place with zero allocations during steady-state operation.

## Not included (future work)
- Replacing `node-global-key-listener` with an in-process native addon (eliminates the stdio round-trip entirely)
- Moving the Hono server to a UtilityProcess (isolates DB/network from the key listener event loop)

## How to verify
1. Launch Freestyle on macOS
2. Type in any application — keystrokes should feel responsive with no perceptible lag
3. Hold the hotkey to record — visualization, timer, and streaming should work normally
4. Release and verify transcription completes and pastes correctly