### PR TITLE
fix: critical state bugs — streaming callbacks, audio node leaks, dev-only logging

### DIFF
--- a/apps/electron/src/main/paste.ts
+++ b/apps/electron/src/main/paste.ts
@@ -37,7 +37,9 @@ const PASTE_SETTLE_MS: Record<string, number> = {
 };
 
 export async function pasteIntoFocusedApp(text: string): Promise<void> {
-  console.log("[paste] text:", JSON.stringify(text));
+  if (process.env.NODE_ENV !== "production") {
+    console.log("[paste] text:", JSON.stringify(text));
+  }
   if (!text?.trim()) return;
 
   const prior = clipboard.readText();

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -95,6 +95,8 @@ export default function AppPage(): React.JSX.Element {
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
   const analyserCtxRef = useRef<AudioContext | null>(null);
+  const audioSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const analyserNodeRef = useRef<AnalyserNode | null>(null);
   const barsRef = useRef<number[]>(new Array(BARS).fill(0));
   const barsSvgRef = useRef<SVGSVGElement>(null);
   const volumeRef = useRef(0);
@@ -118,9 +120,13 @@ export default function AppPage(): React.JSX.Element {
         onReady: () => {},
         onPartial: (text) => setPartialText(text),
         onFinal: async (text) => {
+          wantsMicRef.current = false;
+          stopVisualization();
           recorderRef.current.cancel();
           recorderRef.current.releaseStream();
-          console.log("[app] onFinal:", JSON.stringify(text));
+          if (import.meta.env.DEV) {
+            console.log("[app] onFinal:", JSON.stringify(text));
+          }
           if (text.trim()) {
             await window.api.pasteText(text);
             window.api?.sendTranscriptionDone();
@@ -128,6 +134,8 @@ export default function AppPage(): React.JSX.Element {
           hidePill();
         },
         onError: (msg) => {
+          wantsMicRef.current = false;
+          stopVisualization();
           recorderRef.current.cancel();
           recorderRef.current.releaseStream();
           setState("error");
@@ -145,11 +153,22 @@ export default function AppPage(): React.JSX.Element {
       analyserCtxRef.current = new AudioContext();
     }
     const ctx = analyserCtxRef.current;
+
+    // Disconnect previous nodes to avoid leaking them on the AudioContext
+    try {
+      audioSourceRef.current?.disconnect();
+    } catch {}
+    try {
+      analyserNodeRef.current?.disconnect();
+    } catch {}
+
     const source = ctx.createMediaStreamSource(stream);
     const analyser = ctx.createAnalyser();
     analyser.fftSize = 256;
     analyser.smoothingTimeConstant = 0.4;
     source.connect(analyser);
+    audioSourceRef.current = source;
+    analyserNodeRef.current = analyser;
 
     const dataArray = new Uint8Array(analyser.frequencyBinCount);
     const sliceSize = Math.floor(analyser.frequencyBinCount / BARS);
@@ -157,7 +176,6 @@ export default function AppPage(): React.JSX.Element {
 
     const update = () => {
       if (!wantsMicRef.current) {
-        source.disconnect();
         return;
       }
       analyser.getByteFrequencyData(dataArray);
@@ -203,6 +221,15 @@ export default function AppPage(): React.JSX.Element {
     rafRef.current = 0;
     clearInterval(timerRef.current);
     timerRef.current = 0;
+    // Disconnect audio nodes to prevent accumulation on the AudioContext
+    try {
+      audioSourceRef.current?.disconnect();
+    } catch {}
+    try {
+      analyserNodeRef.current?.disconnect();
+    } catch {}
+    audioSourceRef.current = null;
+    analyserNodeRef.current = null;
     // Don't close analyserCtxRef — we reuse it across sessions
     barsRef.current = new Array(BARS).fill(0);
     volumeRef.current = 0;
@@ -358,7 +385,9 @@ export default function AppPage(): React.JSX.Element {
 
       const data = await res.json();
       const text = data.cleaned || data.raw || "";
-      console.log("[app] transcribe response:", JSON.stringify(data));
+      if (import.meta.env.DEV) {
+        console.log("[app] transcribe response:", JSON.stringify(data));
+      }
 
       if (text.trim()) {
         await window.api.pasteText(text);

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -96,9 +96,11 @@ const stream = new Hono().get(
           onFinal: (rawText) => {
             const durationMs = Date.now() - sessionStartTime;
 
-            console.log(
-              `[stream] onFinal: rawText=${JSON.stringify(rawText)}, audioDurationMs=${audioDurationMs}, durationMs=${durationMs}`,
-            );
+            if (process.env.NODE_ENV !== "production") {
+              console.log(
+                `[stream] onFinal: rawText=${JSON.stringify(rawText)}, audioDurationMs=${audioDurationMs}, durationMs=${durationMs}`,
+              );
+            }
 
             // Skip empty transcriptions entirely — don't send to client
             if (!rawText?.trim()) {

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -75,9 +75,11 @@ const transcribeRoute = new Hono().post("/", async (c) => {
       ...(language && language !== "auto" ? { language } : {}),
     });
     rawText = result.text;
-    console.log(
-      `[transcribe] rawText=${JSON.stringify(rawText)}, audioDurationMs=${audioDurationMs}`,
-    );
+    if (process.env.NODE_ENV !== "production") {
+      console.log(
+        `[transcribe] rawText=${JSON.stringify(rawText)}, audioDurationMs=${audioDurationMs}`,
+      );
+    }
   } catch (err) {
     return c.json(
       {


### PR DESCRIPTION
## Summary

Three critical fixes found during post-merge review of PR #35. Build and typecheck pass.

## Changes

### 1. CRITICAL: Streaming `onFinal`/`onError` never reset recording state
The `onFinal` and `onError` callbacks in the Streamer singleton never called `wantsMicRef.current = false` or `stopVisualization()`. After the first streaming transcription:
- `wantsMicRef` stayed `true` permanently
- `startRecording()` bailed out on its first line (`if (wantsMicRef.current) return`)
- The setInterval timer and RAF visualization loop kept running indefinitely
- **The app was completely bricked after one use** — no further recordings possible

This is the root cause of the "pill appears and immediately disappears on first click" issue — the previous session's `onFinal` left the state dirty.

### 2. Progressive slowdown — Web Audio node leak
Each `startVisualization()` call created a new `MediaStreamAudioSourceNode` + `AnalyserNode` pair on the shared `AudioContext` without disconnecting the previous ones. The only disconnect code was inside the RAF callback, but `stopVisualization()` calls `cancelAnimationFrame` which could prevent that callback from ever running.

Over repeated sessions, orphaned audio node pairs accumulated on the AudioContext, causing progressive slowdown.

Fixed by storing audio nodes in refs (`audioSourceRef`, `analyserNodeRef`) and explicitly disconnecting them in both `startVisualization` (before creating new ones) and `stopVisualization`.

### 3. Diagnostic logging leaked to production
All `console.log` statements added in PR #35 ran unconditionally. Now gated behind:
- `process.env.NODE_ENV !== "production"` for server/main process code
- `import.meta.env.DEV` for renderer code

## Verification
- `pnpm run build` — passes (typecheck node + web, electron-vite build)
- `pnpm biome check` — passes on all changed files