### PR TITLE
fix: idle-timeout mic release and first-run pill disappearing

### DIFF
--- a/apps/electron/src/renderer/src/lib/recorder.ts
+++ b/apps/electron/src/renderer/src/lib/recorder.ts
@@ -2,11 +2,14 @@ import { encodeWavFromFloat32 } from "./wav";
 
 const TARGET_RATE = 16000;
 
+const RELEASE_DELAY_MS = 30_000;
+
 export class Recorder {
   private stream: MediaStream | null = null;
   private mediaRecorder: MediaRecorder | null = null;
   private chunks: Blob[] = [];
   private mimeType = "";
+  private releaseTimer: ReturnType<typeof setTimeout> | null = null;
 
   private hasLiveStream(): boolean {
     return (
@@ -23,6 +26,7 @@ export class Recorder {
    * avoid the costly getUserMedia() round-trip on repeated calls.
    */
   async acquireStream(deviceId?: string | null): Promise<MediaStream> {
+    this.cancelScheduledRelease();
     this.chunks = [];
     this.mediaRecorder = null;
 
@@ -112,8 +116,24 @@ export class Recorder {
 
   /** Stop all mic tracks so the OS mic indicator turns off. */
   releaseStream(): void {
+    this.cancelScheduledRelease();
     for (const t of this.stream?.getTracks() ?? []) t.stop();
     this.stream = null;
+  }
+
+  /** Release the mic stream after a delay so rapid re-recordings stay fast. */
+  scheduleRelease(delayMs = RELEASE_DELAY_MS): void {
+    this.cancelScheduledRelease();
+    this.releaseTimer = setTimeout(() => {
+      this.releaseStream();
+    }, delayMs);
+  }
+
+  cancelScheduledRelease(): void {
+    if (this.releaseTimer !== null) {
+      clearTimeout(this.releaseTimer);
+      this.releaseTimer = null;
+    }
   }
 
   /** Full cleanup — release the mic stream. Call on unmount only. */

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -123,7 +123,7 @@ export default function AppPage(): React.JSX.Element {
           wantsMicRef.current = false;
           stopVisualization();
           recorderRef.current.cancel();
-          recorderRef.current.releaseStream();
+          recorderRef.current.scheduleRelease();
           if (import.meta.env.DEV) {
             console.log("[app] onFinal:", JSON.stringify(text));
           }
@@ -134,10 +134,14 @@ export default function AppPage(): React.JSX.Element {
           hidePill();
         },
         onError: (msg) => {
+          // Only tear down recording state if we're actually recording.
+          // Connection errors (no API key, no model) fire before the
+          // user starts a session and must not reset the UI.
+          if (!wantsMicRef.current) return;
           wantsMicRef.current = false;
           stopVisualization();
           recorderRef.current.cancel();
-          recorderRef.current.releaseStream();
+          recorderRef.current.scheduleRelease();
           setState("error");
           setMessage(msg);
           setTimeout(() => hidePill(), 2000);
@@ -312,7 +316,7 @@ export default function AppPage(): React.JSX.Element {
     } catch (err) {
       wantsMicRef.current = false;
       pendingCommitRef.current = false;
-      recorderRef.current.releaseStream();
+      recorderRef.current.scheduleRelease();
       setState("error");
       setMessage(err instanceof Error ? err.message : "Mic access denied");
       setTimeout(() => hidePill(), 2000);
@@ -328,7 +332,7 @@ export default function AppPage(): React.JSX.Element {
     const recordingDuration = Date.now() - startTimeRef.current;
     if (recordingDuration < 1000) {
       recorderRef.current.cancel();
-      recorderRef.current.releaseStream();
+      recorderRef.current.scheduleRelease();
       streamerRef.current?.cancel();
       hidePill();
       return;
@@ -338,7 +342,7 @@ export default function AppPage(): React.JSX.Element {
     if (useStreamingRef.current && streamerRef.current) {
       setState("transcribing");
       recorderRef.current.cancel();
-      recorderRef.current.releaseStream();
+      recorderRef.current.scheduleRelease();
       streamerRef.current.commit();
       return;
     }
@@ -357,13 +361,13 @@ export default function AppPage(): React.JSX.Element {
       }
 
       if (!wavBlob) {
-        recorderRef.current.releaseStream();
+        recorderRef.current.scheduleRelease();
         hidePill();
         return;
       }
 
       recorderRef.current.cancel();
-      recorderRef.current.releaseStream();
+      recorderRef.current.scheduleRelease();
 
       const headers: Record<string, string> = {
         "Content-Type": "audio/wav",
@@ -406,7 +410,7 @@ export default function AppPage(): React.JSX.Element {
     stopVisualization();
     streamerRef.current?.cancel();
     recorderRef.current.cancel();
-    recorderRef.current.releaseStream();
+    recorderRef.current.scheduleRelease();
     hidePill();
   }, [stopVisualization, hidePill]);
 


### PR DESCRIPTION
## Summary

Two fixes: restores fast recording start and fixes the first-run pill flash.

## Changes

### 1. Idle-timeout mic release (fixes recording start lag)
After PR #35, every recording session called `releaseStream()` immediately, forcing a full `getUserMedia()` call (~100-300ms) on the next hotkey press. This undid the speed gains.

Now uses `scheduleRelease(30000)` instead — the mic stream stays alive for 30 seconds after recording ends. If the user presses the hotkey again within 30s, `hasLiveStream()` returns true and `acquireStream()` skips `getUserMedia()` entirely (0ms). After 30s idle, the stream is released and the OS mic indicator turns off.

- `Recorder.scheduleRelease(delayMs)` — starts a timer that calls `releaseStream()` after the delay
- `Recorder.cancelScheduledRelease()` — clears the timer (called by `acquireStream()`)
- `acquireStream()` cancels any pending release before checking the stream
- Abort paths (user cancelled during init) still use immediate `releaseStream()`

### 2. First-run pill disappearing
On the very first hotkey press, the Streamer singleton is created and opens a WebSocket to the server. If the server has no voice model configured or no API key, it sends an `error` message and closes the connection. The `onError` callback (after PR #36 fixes) would reset `wantsMicRef = false`, call `stopVisualization()`, and `hidePill()` — tearing down the recording that was just starting.

Fixed by guarding `onError`: only tear down recording state when `wantsMicRef.current` is true (i.e., during an active recording). Connection-time errors are silently ignored — the recording flow continues using the REST fallback path.

## Verification
- `pnpm run build` — passes (typecheck node + web, electron-vite build)
- `pnpm biome check` — passes
- Test: first hotkey press should show pill and enter recording (no flash/disappear)
- Test: repeated recordings within 30s should start instantly (no "initializing" state)
- Test: wait >30s after a recording, then press hotkey — should show "initializing" briefly, then record
- Test: check macOS menu bar — mic indicator should turn off ~30s after last recording