### PR TITLE
feat: add CLI app with Stricli commands and fossilize native binary builds

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -20,7 +20,8 @@ artifactProvider:
         - "linux-builds"
         - "mac-builds"
         - "windows-builds"
+        - "cli-binaries"
 
 targets:
   - name: github
-    includeNames: /^.*\.(dmg|zip|exe|msi|AppImage|deb|snap|blockmap)$|^latest.*\.yml$/
+    includeNames: /^.*\.(dmg|zip|exe|msi|AppImage|deb|snap|blockmap)$|^latest.*\.yml$|^freestyle-.*/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,10 @@ jobs:
         working-directory: apps/electron
         run: pnpm run typecheck:web
 
+      - name: Typecheck CLI
+        working-directory: apps/cli
+        run: pnpm run typecheck
+
   build-linux:
     name: Build (Linux)
     needs: [lint, typecheck]
@@ -126,6 +130,39 @@ jobs:
             apps/electron/dist/*.zip
             apps/electron/dist/latest*.yml
             apps/electron/dist/*.blockmap
+          if-no-files-found: warn
+
+  build-cli:
+    name: Build CLI Binaries
+    needs: [lint, typecheck]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build server
+        run: pnpm --filter @freestyle/server build
+
+      - name: Build CLI native binaries
+        working-directory: apps/cli
+        run: pnpm run build:sea
+        env:
+          FOSSILIZE_PLATFORMS: linux-x64,linux-arm64,darwin-x64,darwin-arm64,win-x64
+          # TODO: add FOSSILIZE_SIGN + APPLE_* secrets for macOS codesigning
+
+      - name: Upload CLI binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-binaries
+          path: apps/cli/dist-bin/freestyle-*
           if-no-files-found: warn
 
   build-windows:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@freestyle/cli",
+  "version": "0.0.2",
+  "type": "module",
+  "license": "FSL-1.1-ALv2",
+  "bin": {
+    "freestyle": "./dist/bin.cjs"
+  },
+  "main": "./dist/bin.cjs",
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "tsx src/bin.ts",
+    "build": "tsx script/bundle.ts",
+    "build:sea": "tsx script/build.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@freestyle/server": "workspace:*",
+    "@freestyle/validations": "workspace:*",
+    "@hono/node-server": "^2.0.4",
+    "@stricli/auto-complete": "^1.2.4",
+    "@stricli/core": "^1.2.4",
+    "@types/node": "latest",
+    "chalk": "^5.4.1",
+    "esbuild": "^0.25.0",
+    "fossilize": "^0.7.0",
+    "hono": "^4.12.22",
+    "tsx": "^4.22.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/cli/script/build.ts
+++ b/apps/cli/script/build.ts
@@ -1,0 +1,45 @@
+/**
+ * Build native binaries for all platforms using fossilize (Node SEA).
+ *
+ * Step 1: esbuild bundles src/bin.ts into a single CJS file.
+ * Step 2: fossilize compiles that into native binaries for each platform.
+ *
+ * Usage:
+ *   tsx script/build.ts                 # Build for current platform
+ *   FOSSILIZE_PLATFORMS=linux-x64,darwin-arm64 tsx script/build.ts
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { build } from "esbuild";
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+);
+
+const outfile = "dist/bundle.cjs";
+
+await build({
+  entryPoints: ["./src/bin.ts"],
+  bundle: true,
+  platform: "node",
+  target: "node22",
+  format: "cjs",
+  outfile,
+  treeShaking: true,
+  minify: true,
+  sourcemap: "linked",
+  define: {
+    FREESTYLE_CLI_VERSION: JSON.stringify(pkg.version),
+  },
+  external: ["node:*"],
+});
+
+console.log(`Bundled → ${outfile}`);
+
+const fossilizeCmd = `npx fossilize --no-bundle -o freestyle ${outfile}`;
+
+console.log(`Running: ${fossilizeCmd}`);
+execSync(fossilizeCmd, { stdio: "inherit" });
+
+console.log("Native binaries built → dist-bin/");

--- a/apps/cli/script/bundle.ts
+++ b/apps/cli/script/bundle.ts
@@ -1,0 +1,55 @@
+/**
+ * Bundle the CLI for npm distribution.
+ *
+ * Produces dist/bin.cjs (a single CJS file with all dependencies bundled)
+ * and dist/index.cjs (a thin wrapper with Node version check + shebang).
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { build } from "esbuild";
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+);
+
+await build({
+  entryPoints: ["./src/bin.ts"],
+  bundle: true,
+  platform: "node",
+  target: "node22",
+  format: "cjs",
+  outfile: "dist/index.cjs",
+  treeShaking: true,
+  minify: true,
+  sourcemap: "linked",
+  define: {
+    FREESTYLE_CLI_VERSION: JSON.stringify(pkg.version),
+  },
+  banner: {
+    js: "/* @freestyle/cli */",
+  },
+  external: ["node:*"],
+});
+
+mkdirSync("dist", { recursive: true });
+
+const binWrapper = `#!/usr/bin/env node
+{
+  const v = process.versions.node.split(".").map(Number);
+  if (v[0] < 22) {
+    console.error("Freestyle CLI requires Node.js >= 22. Current: " + process.version);
+    process.exit(1);
+  }
+}
+{
+  const e = process.emit;
+  process.emit = function (n, ...a) {
+    return n === "warning" ? false : e.apply(this, [n, ...a]);
+  };
+}
+require("./index.cjs");
+`;
+
+writeFileSync("dist/bin.cjs", binWrapper);
+
+console.log(`Bundled @freestyle/cli v${pkg.version} → dist/`);

--- a/apps/cli/src/app.ts
+++ b/apps/cli/src/app.ts
@@ -1,0 +1,31 @@
+import { buildApplication as stricliBuildApplication } from "@stricli/core";
+import { dictRoute } from "./commands/dict/index.js";
+import { formatRoute } from "./commands/format/index.js";
+import { historyRoute } from "./commands/history/index.js";
+import { serveCommand } from "./commands/serve.js";
+import { versionCommand } from "./commands/version.js";
+import { VERSION } from "./lib/constants.js";
+import { buildRouteMap } from "./lib/route-map.js";
+
+const routes = buildRouteMap({
+  routes: {
+    version: versionCommand,
+    serve: serveCommand,
+    format: formatRoute,
+    formats: formatRoute,
+    history: historyRoute,
+    dict: dictRoute,
+  },
+  docs: {
+    brief: "Freestyle CLI - voice dictation from the command line",
+  },
+});
+
+export function buildApplication() {
+  return stricliBuildApplication(routes, {
+    name: "freestyle",
+    versionInfo: {
+      currentVersion: VERSION,
+    },
+  });
+}

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -1,0 +1,33 @@
+// Suppress experimental warnings (node:sqlite, etc.)
+const originalEmit = process.emit;
+process.emit = function (
+  this: typeof process,
+  name: string | symbol,
+  ...args: unknown[]
+) {
+  if (name === "warning") return false;
+  return originalEmit.apply(this, [name, ...args] as Parameters<
+    typeof originalEmit
+  >);
+} as typeof process.emit;
+
+// Handle broken pipes gracefully
+process.stdout.on("error", (err: NodeJS.ErrnoException) => {
+  if (err.code === "EPIPE" || err.code === "EIO") {
+    process.exit(0);
+  }
+  throw err;
+});
+
+process.stderr.on("error", (err: NodeJS.ErrnoException) => {
+  if (err.code === "EPIPE" || err.code === "EIO") {
+    process.exit(0);
+  }
+  throw err;
+});
+
+import { startCli } from "./cli.js";
+
+startCli(process.argv.slice(2)).catch(() => {
+  process.exitCode = 1;
+});

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -1,0 +1,13 @@
+import { run } from "@stricli/core";
+import { buildApplication } from "./app.js";
+import type { FreestyleContext } from "./context.js";
+
+export async function startCli(args: string[]): Promise<void> {
+  const context: FreestyleContext = {
+    process,
+    env: process.env,
+  };
+
+  const app = buildApplication();
+  await run(app, args, context);
+}

--- a/apps/cli/src/commands/dict/create.ts
+++ b/apps/cli/src/commands/dict/create.ts
@@ -1,0 +1,55 @@
+import chalk from "chalk";
+import { apiPost } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl } from "../../lib/constants.js";
+import { CommandOutput } from "../../lib/output.js";
+import { formatKeyValue } from "../../lib/table.js";
+
+interface CreateDictResult {
+  id: number;
+  key: string;
+  value: string;
+}
+
+export const dictCreateCommand = buildCommand<CreateDictResult>({
+  docs: { brief: "Create a dictionary entry" },
+  parameters: {
+    flags: {
+      key: {
+        kind: "parsed",
+        parse: String,
+        brief: "Word or phrase to match",
+      },
+      value: {
+        kind: "parsed",
+        parse: String,
+        brief: "Replacement text",
+      },
+    },
+  },
+  output: {
+    human: (data) => {
+      const header = chalk.green(
+        `Created dictionary entry #${String(data.id)}`,
+      );
+      const details = formatKeyValue([
+        ["Key", data.key],
+        ["Value", data.value],
+      ]);
+      return `${header}\n${details}`;
+    },
+    json: (data) => data,
+  },
+  async *func(flags) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+
+    const result = await apiPost<CreateDictResult>(
+      { baseUrl: base, port },
+      "/api/dictionary",
+      { key: flags.key, value: flags.value },
+    );
+
+    yield new CommandOutput(result);
+  },
+});

--- a/apps/cli/src/commands/dict/delete.ts
+++ b/apps/cli/src/commands/dict/delete.ts
@@ -1,0 +1,40 @@
+import chalk from "chalk";
+import { apiDelete } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl } from "../../lib/constants.js";
+import { CommandOutput } from "../../lib/output.js";
+
+interface DeleteResult {
+  ok: boolean;
+  id: string;
+}
+
+export const dictDeleteCommand = buildCommand<DeleteResult>({
+  docs: { brief: "Delete a dictionary entry" },
+  parameters: {
+    positional: {
+      kind: "tuple",
+      parameters: [
+        {
+          brief: "Dictionary entry ID",
+          parse: String,
+        },
+      ],
+    },
+  },
+  output: {
+    human: (data) => chalk.green(`Deleted dictionary entry #${data.id}`),
+    json: (data) => data,
+  },
+  async *func(flags, id) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+
+    await apiDelete<{ ok: boolean }>(
+      { baseUrl: base, port },
+      `/api/dictionary/${id}`,
+    );
+
+    yield new CommandOutput({ ok: true, id });
+  },
+});

--- a/apps/cli/src/commands/dict/index.ts
+++ b/apps/cli/src/commands/dict/index.ts
@@ -1,0 +1,18 @@
+import { buildRouteMap } from "../../lib/route-map.js";
+import { dictCreateCommand } from "./create.js";
+import { dictDeleteCommand } from "./delete.js";
+import { dictListCommand } from "./list.js";
+import { dictUpdateCommand } from "./update.js";
+import { dictViewCommand } from "./view.js";
+
+export const dictRoute = buildRouteMap({
+  routes: {
+    list: dictListCommand,
+    view: dictViewCommand,
+    create: dictCreateCommand,
+    update: dictUpdateCommand,
+    delete: dictDeleteCommand,
+  },
+  docs: { brief: "Manage the word dictionary" },
+  defaultCommand: "list",
+});

--- a/apps/cli/src/commands/dict/list.ts
+++ b/apps/cli/src/commands/dict/list.ts
@@ -1,0 +1,93 @@
+import chalk from "chalk";
+import { apiGet } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl } from "../../lib/constants.js";
+import { CommandOutput } from "../../lib/output.js";
+import { formatTable } from "../../lib/table.js";
+
+interface DictionaryRow {
+  id: number;
+  key: string;
+  value: string;
+  usage_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface DictListResponse {
+  items: DictionaryRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export const dictListCommand = buildCommand<DictListResponse>({
+  docs: { brief: "List dictionary entries" },
+  parameters: {
+    flags: {
+      limit: {
+        kind: "parsed",
+        parse: Number,
+        brief: "Maximum number of results",
+        default: "50",
+      },
+      offset: {
+        kind: "parsed",
+        parse: Number,
+        brief: "Offset for pagination",
+        default: "0",
+      },
+      search: {
+        kind: "parsed",
+        parse: String,
+        brief: "Search by key or value",
+        optional: true,
+        default: undefined,
+      },
+      "order-by": {
+        kind: "parsed",
+        parse: String,
+        brief: "Order by column (prefix with - for DESC)",
+        default: "-created_at",
+      },
+    },
+  },
+  output: {
+    human: (data) => {
+      const header = chalk.dim(
+        `Showing ${String(data.items.length)} of ${String(data.total)} dictionary entries`,
+      );
+      const table = formatTable(data.items as any, [
+        { key: "id", label: "ID", width: 6 },
+        { key: "key", label: "Key", width: 25 },
+        { key: "value", label: "Value", width: 30 },
+        {
+          key: "usage_count",
+          label: "Uses",
+          width: 8,
+          transform: (v) => String(v),
+        },
+        { key: "created_at", label: "Created", width: 20 },
+      ]);
+      return `${header}\n${table}`;
+    },
+    json: (data) => data,
+  },
+  async *func(flags) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+    const params = new URLSearchParams({
+      limit: String(flags.limit),
+      offset: String(flags.offset),
+      orderBy: flags["order-by"],
+    });
+    if (flags.search) params.set("search", flags.search);
+
+    const data = await apiGet<DictListResponse>(
+      { baseUrl: base, port },
+      `/api/dictionary?${params.toString()}`,
+    );
+
+    yield new CommandOutput(data);
+  },
+});

--- a/apps/cli/src/commands/dict/update.ts
+++ b/apps/cli/src/commands/dict/update.ts
@@ -1,0 +1,63 @@
+import chalk from "chalk";
+import { apiPut } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl } from "../../lib/constants.js";
+import { CommandOutput } from "../../lib/output.js";
+
+interface UpdateResult {
+  id: number;
+  key: string;
+  value: string;
+}
+
+export const dictUpdateCommand = buildCommand<UpdateResult>({
+  docs: { brief: "Update a dictionary entry" },
+  parameters: {
+    flags: {
+      key: {
+        kind: "parsed",
+        parse: String,
+        brief: "New key",
+        optional: true,
+        default: undefined,
+      },
+      value: {
+        kind: "parsed",
+        parse: String,
+        brief: "New value",
+        optional: true,
+        default: undefined,
+      },
+    },
+    positional: {
+      kind: "tuple",
+      parameters: [
+        {
+          brief: "Dictionary entry ID",
+          parse: String,
+        },
+      ],
+    },
+  },
+  output: {
+    human: (data) =>
+      chalk.green(`Updated dictionary entry #${String(data.id)}`),
+    json: (data) => data,
+  },
+  async *func(flags, id) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+
+    const body: Record<string, string> = {};
+    if (flags.key !== undefined) body.key = flags.key;
+    if (flags.value !== undefined) body.value = flags.value;
+
+    const result = await apiPut<UpdateResult>(
+      { baseUrl: base, port },
+      `/api/dictionary/${id}`,
+      body,
+    );
+
+    yield new CommandOutput(result);
+  },
+});

--- a/apps/cli/src/commands/dict/view.ts
+++ b/apps/cli/src/commands/dict/view.ts
@@ -1,0 +1,52 @@
+import { apiGet } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl } from "../../lib/constants.js";
+import { CommandOutput } from "../../lib/output.js";
+import { formatKeyValue } from "../../lib/table.js";
+
+interface DictionaryRow {
+  id: number;
+  key: string;
+  value: string;
+  usage_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export const dictViewCommand = buildCommand<DictionaryRow>({
+  docs: { brief: "View a dictionary entry" },
+  parameters: {
+    positional: {
+      kind: "tuple",
+      parameters: [
+        {
+          brief: "Dictionary entry ID",
+          parse: String,
+        },
+      ],
+    },
+  },
+  output: {
+    human: (data) =>
+      formatKeyValue([
+        ["ID", String(data.id)],
+        ["Key", data.key],
+        ["Value", data.value],
+        ["Usage Count", String(data.usage_count)],
+        ["Created", data.created_at],
+        ["Updated", data.updated_at],
+      ]),
+    json: (data) => data,
+  },
+  async *func(flags, id) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+
+    const data = await apiGet<DictionaryRow>(
+      { baseUrl: base, port },
+      `/api/dictionary/${id}`,
+    );
+
+    yield new CommandOutput(data);
+  },
+});

--- a/apps/cli/src/commands/format/create.ts
+++ b/apps/cli/src/commands/format/create.ts
@@ -1,0 +1,64 @@
+import chalk from "chalk";
+import { apiPost } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl } from "../../lib/constants.js";
+import { CommandOutput } from "../../lib/output.js";
+import { formatKeyValue } from "../../lib/table.js";
+
+interface CreateFormatResult {
+  id: number;
+  app_pattern: string;
+  label: string;
+  instructions: string;
+}
+
+export const formatCreateCommand = buildCommand<CreateFormatResult>({
+  docs: { brief: "Create a formatting rule" },
+  parameters: {
+    flags: {
+      "app-pattern": {
+        kind: "parsed",
+        parse: String,
+        brief: "App pattern to match (e.g. 'slack|discord')",
+      },
+      label: {
+        kind: "parsed",
+        parse: String,
+        brief: "Display label for this rule",
+      },
+      instructions: {
+        kind: "parsed",
+        parse: String,
+        brief: "Formatting instructions for the LLM",
+      },
+    },
+  },
+  output: {
+    human: (data) => {
+      const header = chalk.green(`Created format rule #${String(data.id)}`);
+      const details = formatKeyValue([
+        ["Label", data.label],
+        ["Pattern", data.app_pattern],
+        ["Instructions", data.instructions],
+      ]);
+      return `${header}\n${details}`;
+    },
+    json: (data) => data,
+  },
+  async *func(flags) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+
+    const result = await apiPost<CreateFormatResult>(
+      { baseUrl: base, port },
+      "/api/formats",
+      {
+        app_pattern: flags["app-pattern"],
+        label: flags.label,
+        instructions: flags.instructions,
+      },
+    );
+
+    yield new CommandOutput(result);
+  },
+});

--- a/apps/cli/src/commands/format/delete.ts
+++ b/apps/cli/src/commands/format/delete.ts
@@ -1,0 +1,40 @@
+import chalk from "chalk";
+import { apiDelete } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl } from "../../lib/constants.js";
+import { CommandOutput } from "../../lib/output.js";
+
+interface DeleteResult {
+  ok: boolean;
+  id: string;
+}
+
+export const formatDeleteCommand = buildCommand<DeleteResult>({
+  docs: { brief: "Delete a formatting rule" },
+  parameters: {
+    positional: {
+      kind: "tuple",
+      parameters: [
+        {
+          brief: "Format rule ID",
+          parse: String,
+        },
+      ],
+    },
+  },
+  output: {
+    human: (data) => chalk.green(`Deleted format rule #${data.id}`),
+    json: (data) => data,
+  },
+  async *func(flags, id) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+
+    await apiDelete<{ ok: boolean }>(
+      { baseUrl: base, port },
+      `/api/formats/${id}`,
+    );
+
+    yield new CommandOutput({ ok: true, id });
+  },
+});

--- a/apps/cli/src/commands/format/index.ts
+++ b/apps/cli/src/commands/format/index.ts
@@ -1,0 +1,18 @@
+import { buildRouteMap } from "../../lib/route-map.js";
+import { formatCreateCommand } from "./create.js";
+import { formatDeleteCommand } from "./delete.js";
+import { formatListCommand } from "./list.js";
+import { formatUpdateCommand } from "./update.js";
+import { formatViewCommand } from "./view.js";
+
+export const formatRoute = buildRouteMap({
+  routes: {
+    list: formatListCommand,
+    view: formatViewCommand,
+    create: formatCreateCommand,
+    update: formatUpdateCommand,
+    delete: formatDeleteCommand,
+  },
+  docs: { brief: "Manage formatting rules" },
+  defaultCommand: "list",
+});

--- a/apps/cli/src/commands/format/list.ts
+++ b/apps/cli/src/commands/format/list.ts
@@ -1,0 +1,86 @@
+import chalk from "chalk";
+import { apiGet } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl } from "../../lib/constants.js";
+import { CommandOutput } from "../../lib/output.js";
+import { formatTable } from "../../lib/table.js";
+
+interface FormatRow {
+  id: number;
+  app_pattern: string;
+  label: string;
+  instructions: string;
+  is_default: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface FormatListResponse {
+  items: FormatRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export const formatListCommand = buildCommand<FormatListResponse>({
+  docs: { brief: "List formatting rules" },
+  parameters: {
+    flags: {
+      limit: {
+        kind: "parsed",
+        parse: Number,
+        brief: "Maximum number of results",
+        default: "50",
+      },
+      offset: {
+        kind: "parsed",
+        parse: Number,
+        brief: "Offset for pagination",
+        default: "0",
+      },
+      search: {
+        kind: "parsed",
+        parse: String,
+        brief: "Search by label, pattern, or instructions",
+        optional: true,
+        default: undefined,
+      },
+    },
+  },
+  output: {
+    human: (data) => {
+      const header = chalk.dim(
+        `Showing ${String(data.items.length)} of ${String(data.total)} format rules`,
+      );
+      const table = formatTable(data.items as any, [
+        { key: "id", label: "ID", width: 6 },
+        { key: "label", label: "Label", width: 20 },
+        { key: "app_pattern", label: "Pattern", width: 30 },
+        {
+          key: "is_default",
+          label: "Type",
+          width: 10,
+          transform: (v) => (v === 1 ? "default" : "custom"),
+        },
+      ]);
+      return `${header}\n${table}`;
+    },
+    json: (data) => data,
+  },
+  async *func(flags) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+    const params = new URLSearchParams({
+      limit: String(flags.limit),
+      offset: String(flags.offset),
+    });
+    if (flags.search) params.set("search", flags.search);
+
+    const data = await apiGet<FormatListResponse>(
+      { baseUrl: base, port },
+      `/api/formats?${params.toString()}`,
+    );
+
+    yield new CommandOutput(data);
+  },
+});

--- a/apps/cli/src/commands/format/update.ts
+++ b/apps/cli/src/commands/format/update.ts
@@ -1,0 +1,71 @@
+import chalk from "chalk";
+import { apiPut } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl } from "../../lib/constants.js";
+import { CommandOutput } from "../../lib/output.js";
+
+interface UpdateResult {
+  ok: boolean;
+  id: string;
+}
+
+export const formatUpdateCommand = buildCommand<UpdateResult>({
+  docs: { brief: "Update a formatting rule" },
+  parameters: {
+    flags: {
+      "app-pattern": {
+        kind: "parsed",
+        parse: String,
+        brief: "New app pattern",
+        optional: true,
+        default: undefined,
+      },
+      label: {
+        kind: "parsed",
+        parse: String,
+        brief: "New label",
+        optional: true,
+        default: undefined,
+      },
+      instructions: {
+        kind: "parsed",
+        parse: String,
+        brief: "New formatting instructions",
+        optional: true,
+        default: undefined,
+      },
+    },
+    positional: {
+      kind: "tuple",
+      parameters: [
+        {
+          brief: "Format rule ID",
+          parse: String,
+        },
+      ],
+    },
+  },
+  output: {
+    human: (data) => chalk.green(`Updated format rule #${data.id}`),
+    json: (data) => data,
+  },
+  async *func(flags, id) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+
+    const body: Record<string, string> = {};
+    if (flags["app-pattern"] !== undefined)
+      body.app_pattern = flags["app-pattern"];
+    if (flags.label !== undefined) body.label = flags.label;
+    if (flags.instructions !== undefined)
+      body.instructions = flags.instructions;
+
+    await apiPut<{ ok: boolean }>(
+      { baseUrl: base, port },
+      `/api/formats/${id}`,
+      body,
+    );
+
+    yield new CommandOutput({ ok: true, id });
+  },
+});

--- a/apps/cli/src/commands/format/view.ts
+++ b/apps/cli/src/commands/format/view.ts
@@ -1,0 +1,54 @@
+import { apiGet } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl } from "../../lib/constants.js";
+import { CommandOutput } from "../../lib/output.js";
+import { formatKeyValue } from "../../lib/table.js";
+
+interface FormatRow {
+  id: number;
+  app_pattern: string;
+  label: string;
+  instructions: string;
+  is_default: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export const formatViewCommand = buildCommand<FormatRow>({
+  docs: { brief: "View a formatting rule" },
+  parameters: {
+    positional: {
+      kind: "tuple",
+      parameters: [
+        {
+          brief: "Format rule ID",
+          parse: String,
+        },
+      ],
+    },
+  },
+  output: {
+    human: (data) =>
+      formatKeyValue([
+        ["ID", String(data.id)],
+        ["Label", data.label],
+        ["Pattern", data.app_pattern],
+        ["Instructions", data.instructions],
+        ["Type", data.is_default === 1 ? "default" : "custom"],
+        ["Created", data.created_at],
+        ["Updated", data.updated_at],
+      ]),
+    json: (data) => data,
+  },
+  async *func(flags, id) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+
+    const row = await apiGet<FormatRow>(
+      { baseUrl: base, port },
+      `/api/formats/${id}`,
+    );
+
+    yield new CommandOutput(row);
+  },
+});

--- a/apps/cli/src/commands/history/index.ts
+++ b/apps/cli/src/commands/history/index.ts
@@ -1,0 +1,10 @@
+import { buildRouteMap } from "../../lib/route-map.js";
+import { historyListCommand } from "./list.js";
+
+export const historyRoute = buildRouteMap({
+  routes: {
+    list: historyListCommand,
+  },
+  docs: { brief: "View transcription history" },
+  defaultCommand: "list",
+});

--- a/apps/cli/src/commands/history/list.ts
+++ b/apps/cli/src/commands/history/list.ts
@@ -1,0 +1,121 @@
+import chalk from "chalk";
+import { apiGet } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl } from "../../lib/constants.js";
+import { CommandOutput } from "../../lib/output.js";
+import { formatTable } from "../../lib/table.js";
+
+interface HistoryRow {
+  id: number;
+  raw_text: string;
+  cleaned_text: string | null;
+  voice_provider: string;
+  voice_model: string;
+  llm_provider: string | null;
+  llm_model: string | null;
+  duration_ms: number;
+  audio_duration_ms: number;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+  created_at: string;
+}
+
+interface HistoryListResponse {
+  items: HistoryRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+function truncate(str: string, len: number): string {
+  if (str.length <= len) return str;
+  return `${str.slice(0, len - 1)}\u2026`;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${String(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export const historyListCommand = buildCommand<HistoryListResponse>({
+  docs: { brief: "List transcription history" },
+  parameters: {
+    flags: {
+      limit: {
+        kind: "parsed",
+        parse: Number,
+        brief: "Maximum number of results",
+        default: "20",
+      },
+      offset: {
+        kind: "parsed",
+        parse: Number,
+        brief: "Offset for pagination",
+        default: "0",
+      },
+      search: {
+        kind: "parsed",
+        parse: String,
+        brief: "Search transcription text",
+        optional: true,
+        default: undefined,
+      },
+      "order-by": {
+        kind: "parsed",
+        parse: String,
+        brief: "Order by column (prefix with - for DESC)",
+        default: "-created_at",
+      },
+    },
+  },
+  output: {
+    human: (data) => {
+      const header = chalk.dim(
+        `Showing ${String(data.items.length)} of ${String(data.total)} transcriptions`,
+      );
+      const table = formatTable(data.items as any, [
+        { key: "id", label: "ID", width: 6 },
+        {
+          key: "cleaned_text",
+          label: "Text",
+          width: 40,
+          transform: (v) => truncate((v as string) ?? "(no text)", 40),
+        },
+        { key: "voice_model", label: "Model", width: 20 },
+        {
+          key: "duration_ms",
+          label: "Duration",
+          width: 10,
+          transform: (v) => formatDuration(v as number),
+        },
+        {
+          key: "cost_usd",
+          label: "Cost",
+          width: 10,
+          transform: (v) => `$${(v as number).toFixed(4)}`,
+        },
+        { key: "created_at", label: "Date", width: 20 },
+      ]);
+      return `${header}\n${table}`;
+    },
+    json: (data) => data,
+  },
+  async *func(flags) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+    const params = new URLSearchParams({
+      limit: String(flags.limit),
+      offset: String(flags.offset),
+      orderBy: flags["order-by"],
+    });
+    if (flags.search) params.set("search", flags.search);
+
+    const data = await apiGet<HistoryListResponse>(
+      { baseUrl: base, port },
+      `/api/history?${params.toString()}`,
+    );
+
+    yield new CommandOutput(data);
+  },
+});

--- a/apps/cli/src/commands/serve.ts
+++ b/apps/cli/src/commands/serve.ts
@@ -1,0 +1,52 @@
+import chalk from "chalk";
+import { buildCommand } from "../lib/command.js";
+import { DEFAULT_PORT } from "../lib/constants.js";
+import { CommandOutput } from "../lib/output.js";
+
+interface ServeData {
+  port: number;
+  message: string;
+}
+
+export const serveCommand = buildCommand<ServeData>({
+  docs: { brief: "Start the Freestyle server" },
+  output: {
+    human: (data) => data.message,
+    json: (data) => ({ port: data.port }),
+  },
+  async *func(flags) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const proc = this.process;
+
+    const { serve } = await import("@hono/node-server");
+    const { default: app } = await import("@freestyle/server");
+
+    yield new CommandOutput({
+      port,
+      message: chalk.green(
+        `Freestyle server listening on port ${String(port)}`,
+      ),
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const server = serve({ fetch: app.fetch, port }, () => {
+        proc.stdout.write(
+          `  ${chalk.dim("Local:")}  http://localhost:${String(port)}\n`,
+        );
+        proc.stdout.write(
+          `  ${chalk.dim("Press")}  ${chalk.bold("Ctrl+C")} to stop\n`,
+        );
+      });
+
+      proc.on("SIGINT", () => {
+        server.close();
+        resolve();
+      });
+      proc.on("SIGTERM", () => {
+        server.close();
+        resolve();
+      });
+      server.on("error", reject);
+    });
+  },
+});

--- a/apps/cli/src/commands/version.ts
+++ b/apps/cli/src/commands/version.ts
@@ -1,0 +1,38 @@
+import { apiGetText } from "../lib/api-client.js";
+import { buildCommand } from "../lib/command.js";
+import { DEFAULT_PORT, getBaseUrl, VERSION } from "../lib/constants.js";
+import { CommandOutput } from "../lib/output.js";
+import { formatKeyValue } from "../lib/table.js";
+
+interface VersionData {
+  cli: string;
+  server: string | null;
+}
+
+export const versionCommand = buildCommand<VersionData>({
+  docs: { brief: "Show CLI and server version" },
+  output: {
+    human: (data) => {
+      const pairs: [string, string][] = [["CLI", data.cli]];
+      if (data.server) {
+        pairs.push(["Server", data.server]);
+      } else {
+        pairs.push(["Server", "(not reachable)"]);
+      }
+      return formatKeyValue(pairs);
+    },
+    json: (data) => data,
+  },
+  async *func(flags) {
+    const port = flags.port ?? DEFAULT_PORT;
+    const base = getBaseUrl(port);
+    let serverVersion: string | null = null;
+    try {
+      serverVersion = await apiGetText({ baseUrl: base, port }, "/");
+    } catch {
+      // Server unreachable -- not an error for version command
+    }
+
+    yield new CommandOutput({ cli: VERSION, server: serverVersion });
+  },
+});

--- a/apps/cli/src/context.ts
+++ b/apps/cli/src/context.ts
@@ -1,0 +1,13 @@
+import type { CommandContext } from "@stricli/core";
+
+/**
+ * Extended command context for Freestyle CLI.
+ *
+ * Stricli's CommandContext requires `process: { stdout, stderr }`.
+ * We extend it to expose the full Node process and env for commands that
+ * need more (e.g. `serve` registers signal handlers).
+ */
+export interface FreestyleContext extends CommandContext {
+  readonly process: NodeJS.Process;
+  readonly env: NodeJS.ProcessEnv;
+}

--- a/apps/cli/src/lib/api-client.ts
+++ b/apps/cli/src/lib/api-client.ts
@@ -1,0 +1,82 @@
+import { ApiError, ConnectionError } from "./errors.js";
+
+export interface ApiClientOptions {
+  baseUrl: string;
+  port: number;
+}
+
+async function request<T>(
+  opts: ApiClientOptions,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(`${opts.baseUrl}${path}`, {
+      method,
+      headers: body ? { "Content-Type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch {
+    throw new ConnectionError(opts.port);
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new ApiError(res.status, text);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+async function requestText(
+  opts: ApiClientOptions,
+  method: string,
+  path: string,
+): Promise<string> {
+  let res: Response;
+  try {
+    res = await fetch(`${opts.baseUrl}${path}`, { method });
+  } catch {
+    throw new ConnectionError(opts.port);
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new ApiError(res.status, text);
+  }
+
+  return res.text();
+}
+
+export function apiGet<T>(opts: ApiClientOptions, path: string): Promise<T> {
+  return request(opts, "GET", path);
+}
+
+export function apiGetText(
+  opts: ApiClientOptions,
+  path: string,
+): Promise<string> {
+  return requestText(opts, "GET", path);
+}
+
+export function apiPost<T>(
+  opts: ApiClientOptions,
+  path: string,
+  body: unknown,
+): Promise<T> {
+  return request(opts, "POST", path, body);
+}
+
+export function apiPut<T>(
+  opts: ApiClientOptions,
+  path: string,
+  body: unknown,
+): Promise<T> {
+  return request(opts, "PUT", path, body);
+}
+
+export function apiDelete<T>(opts: ApiClientOptions, path: string): Promise<T> {
+  return request(opts, "DELETE", path);
+}

--- a/apps/cli/src/lib/command.ts
+++ b/apps/cli/src/lib/command.ts
@@ -1,0 +1,89 @@
+import {
+  type CommandContext,
+  buildCommand as stricliBuildCommand,
+} from "@stricli/core";
+import type { FreestyleContext } from "../context.js";
+import { CliError } from "./errors.js";
+import { CommandOutput, type OutputConfig, renderOutput } from "./output.js";
+
+const GLOBAL_FLAGS = {
+  json: {
+    kind: "boolean",
+    brief: "Output as JSON",
+    default: false,
+  },
+  port: {
+    kind: "parsed",
+    parse: Number,
+    brief: "Server port",
+    optional: true,
+    default: undefined,
+  },
+} as const;
+
+/**
+ * Wrapper around Stricli's buildCommand that injects global --json and --port
+ * flags and handles output rendering + error formatting.
+ *
+ * Commands yield CommandOutput instances from an async generator. The wrapper
+ * iterates the generator and renders each output in human or JSON mode.
+ */
+export function buildCommand<TData>(config: {
+  docs: { brief: string };
+  output: OutputConfig<TData>;
+  parameters?: {
+    flags?: Record<string, any>;
+    positional?: any;
+  };
+  func: (
+    this: FreestyleContext,
+    flags: any,
+    ...args: any[]
+  ) => AsyncGenerator<CommandOutput<TData>, void, unknown>;
+}) {
+  const { func: commandFunc, output: outputConfig, ...rest } = config;
+
+  const mergedFlags = {
+    ...config.parameters?.flags,
+    ...GLOBAL_FLAGS,
+  };
+
+  const parameters: any = { flags: mergedFlags };
+  if (config.parameters?.positional) {
+    parameters.positional = config.parameters.positional;
+  }
+
+  return stricliBuildCommand({
+    ...rest,
+    parameters,
+    async func(
+      this: CommandContext,
+      flags: any,
+      ...args: any[]
+    ): Promise<undefined | Error> {
+      const ctx = this as unknown as FreestyleContext;
+      try {
+        const gen = commandFunc.call(ctx, flags, ...args);
+        for await (const value of gen) {
+          if (value instanceof CommandOutput) {
+            renderOutput(value, outputConfig, ctx, flags.json);
+          }
+        }
+      } catch (err) {
+        if (err instanceof CliError) {
+          if (flags.json) {
+            ctx.process.stdout.write(
+              JSON.stringify({ error: err.message }, null, 2),
+            );
+            ctx.process.stdout.write("\n");
+          } else {
+            ctx.process.stderr.write(`Error: ${err.message}\n`);
+          }
+          ctx.process.exitCode = err.exitCode;
+          return;
+        }
+        throw err;
+      }
+    },
+  });
+}

--- a/apps/cli/src/lib/constants.ts
+++ b/apps/cli/src/lib/constants.ts
@@ -1,0 +1,12 @@
+declare const FREESTYLE_CLI_VERSION: string | undefined;
+
+export const VERSION =
+  typeof FREESTYLE_CLI_VERSION === "string"
+    ? FREESTYLE_CLI_VERSION
+    : "0.0.0-dev";
+
+export const DEFAULT_PORT = 4649;
+
+export function getBaseUrl(port: number): string {
+  return `http://localhost:${String(port)}`;
+}

--- a/apps/cli/src/lib/errors.ts
+++ b/apps/cli/src/lib/errors.ts
@@ -1,0 +1,30 @@
+export class CliError extends Error {
+  readonly exitCode: number;
+
+  constructor(message: string, exitCode = 1) {
+    super(message);
+    this.name = "CliError";
+    this.exitCode = exitCode;
+  }
+}
+
+export class ApiError extends CliError {
+  readonly status: number;
+
+  constructor(status: number, body: string) {
+    super(`API error (${String(status)}): ${body}`, 30);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+export class ConnectionError extends CliError {
+  constructor(port: number) {
+    super(
+      `Could not connect to Freestyle server on port ${String(port)}.\n` +
+        "Make sure the Freestyle app is running, or start the server with: freestyle serve",
+      31,
+    );
+    this.name = "ConnectionError";
+  }
+}

--- a/apps/cli/src/lib/output.ts
+++ b/apps/cli/src/lib/output.ts
@@ -1,0 +1,28 @@
+import type { FreestyleContext } from "../context.js";
+
+export class CommandOutput<T> {
+  constructor(public readonly data: T) {}
+}
+
+export interface OutputConfig<T> {
+  human: (data: T, ctx: FreestyleContext) => string;
+  json: (data: T) => unknown;
+}
+
+export function renderOutput<T>(
+  output: CommandOutput<T>,
+  config: OutputConfig<T>,
+  ctx: FreestyleContext,
+  jsonMode: boolean,
+): void {
+  if (jsonMode) {
+    ctx.process.stdout.write(JSON.stringify(config.json(output.data), null, 2));
+    ctx.process.stdout.write("\n");
+  } else {
+    const text = config.human(output.data, ctx);
+    if (text) {
+      ctx.process.stdout.write(text);
+      ctx.process.stdout.write("\n");
+    }
+  }
+}

--- a/apps/cli/src/lib/route-map.ts
+++ b/apps/cli/src/lib/route-map.ts
@@ -1,0 +1,53 @@
+import {
+  type Command,
+  type CommandContext,
+  type RouteMap,
+  buildRouteMap as stricliBuildRouteMap,
+} from "@stricli/core";
+
+type RoutingTarget = Command<CommandContext> | RouteMap<CommandContext>;
+
+const ALIASES: Record<string, string[]> = {
+  list: ["ls"],
+  view: ["show"],
+  create: ["new"],
+  delete: ["rm", "remove"],
+};
+
+/**
+ * Wrapper around Stricli's buildRouteMap that auto-injects standard aliases
+ * (list->ls, view->show, create->new, delete->rm/remove) and hides them
+ * from help output.
+ */
+export function buildRouteMap(config: {
+  routes: Record<string, RoutingTarget>;
+  docs: { brief: string };
+  defaultCommand?: string;
+}) {
+  const routeNames = Object.keys(config.routes);
+  const aliasMap: Record<string, string> = {};
+
+  for (const name of routeNames) {
+    const aliasList = ALIASES[name];
+    if (aliasList) {
+      for (const alias of aliasList) {
+        aliasMap[alias] = name;
+      }
+    }
+  }
+
+  const hideRoute: Record<string, boolean> = {};
+  for (const alias of Object.keys(aliasMap)) {
+    hideRoute[alias] = true;
+  }
+
+  return stricliBuildRouteMap({
+    routes: config.routes as any,
+    docs: {
+      ...config.docs,
+      hideRoute,
+    },
+    defaultCommand: config.defaultCommand as any,
+    aliases: Object.keys(aliasMap).length > 0 ? (aliasMap as any) : undefined,
+  });
+}

--- a/apps/cli/src/lib/table.ts
+++ b/apps/cli/src/lib/table.ts
@@ -1,0 +1,55 @@
+import chalk from "chalk";
+
+interface Column {
+  key: string;
+  label: string;
+  width?: number;
+  transform?: (value: unknown) => string;
+}
+
+export function formatTable(
+  rows: Record<string, any>[],
+  columns: Column[],
+): string {
+  if (rows.length === 0) {
+    return chalk.dim("No results found.");
+  }
+
+  const widths = columns.map((col) => {
+    const headerLen = col.label.length;
+    const maxDataLen = rows.reduce((max, row) => {
+      const val = col.transform
+        ? col.transform(row[col.key])
+        : String(row[col.key] ?? "");
+      return Math.max(max, val.length);
+    }, 0);
+    return col.width ?? Math.max(headerLen, Math.min(maxDataLen, 60));
+  });
+
+  const header = columns
+    .map((col, i) => chalk.bold(col.label.padEnd(widths[i]!)))
+    .join("  ");
+
+  const separator = widths.map((w) => chalk.dim("-".repeat(w))).join("  ");
+
+  const body = rows.map((row) =>
+    columns
+      .map((col, i) => {
+        const val = col.transform
+          ? col.transform(row[col.key])
+          : String(row[col.key] ?? "");
+        return val.padEnd(widths[i]!);
+      })
+      .join("  "),
+  );
+
+  return [header, separator, ...body].join("\n");
+}
+
+export function formatKeyValue(pairs: [string, string][]): string {
+  const maxKeyLen = pairs.reduce((max, [key]) => Math.max(max, key.length), 0);
+
+  return pairs
+    .map(([key, value]) => `${chalk.bold(key.padEnd(maxKeyLen))}  ${value}`)
+    .join("\n");
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "@freestyle/validations": ["../../packages/validations/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "script/**/*.ts"]
+}

--- a/apps/server/src/routes/formats.ts
+++ b/apps/server/src/routes/formats.ts
@@ -59,6 +59,16 @@ const formats = new Hono()
       offset,
     });
   })
+  .get("/:id{[0-9]+}", (c) => {
+    const db = getDb();
+    const id = Number(c.req.param("id"));
+    const row = db.prepare("SELECT * FROM format_rules WHERE id = ?").get(id) as
+      | FormatRow
+      | undefined;
+
+    if (!row) return c.json({ error: "Not found" }, 404);
+    return c.json(row);
+  })
   .get("/match", (c) => {
     const db = getDb();
     const context = c.req.query("context") ?? "";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,45 @@ importers:
         specifier: ^2.9.14
         version: 2.9.14
 
+  apps/cli:
+    devDependencies:
+      '@freestyle/server':
+        specifier: workspace:*
+        version: link:../server
+      '@freestyle/validations':
+        specifier: workspace:*
+        version: link:../../packages/validations
+      '@hono/node-server':
+        specifier: ^2.0.4
+        version: 2.0.4(hono@4.12.22)
+      '@stricli/auto-complete':
+        specifier: ^1.2.4
+        version: 1.2.7
+      '@stricli/core':
+        specifier: ^1.2.4
+        version: 1.2.7
+      '@types/node':
+        specifier: latest
+        version: 25.9.1
+      chalk:
+        specifier: ^5.4.1
+        version: 5.6.2
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      fossilize:
+        specifier: ^0.7.0
+        version: 0.7.0
+      hono:
+        specifier: ^4.12.22
+        version: 4.12.22
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   apps/electron:
     dependencies:
       '@electron-toolkit/preload':
@@ -110,7 +149,7 @@ importers:
         version: 2.0.0(@types/node@22.19.19)
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 4.3.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
       '@types/node':
         specifier: ^22.19.1
         version: 22.19.19
@@ -128,7 +167,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.2.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 5.2.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
       electron:
         specifier: ^39.2.6
         version: 39.8.10
@@ -137,7 +176,7 @@ importers:
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 5.0.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
       react:
         specifier: ^19.2.1
         version: 19.2.6
@@ -152,7 +191,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.2.6
-        version: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+        version: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
   apps/server:
     dependencies:
@@ -210,7 +249,7 @@ importers:
         version: 8.18.1
       pkgroll:
         specifier: ^2.27.0
-        version: 2.27.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 2.27.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -576,6 +615,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -590,6 +635,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -612,6 +663,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -626,6 +683,12 @@ packages:
 
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -648,6 +711,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
@@ -662,6 +731,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -684,6 +759,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
@@ -698,6 +779,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -720,6 +807,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
@@ -734,6 +827,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -756,6 +855,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
@@ -770,6 +875,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -792,6 +903,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
@@ -806,6 +923,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -828,6 +951,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -842,6 +971,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -864,6 +999,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -878,6 +1019,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -900,6 +1047,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
@@ -914,6 +1067,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -936,6 +1095,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
@@ -950,6 +1115,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -972,6 +1143,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
@@ -986,6 +1163,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1008,6 +1191,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
@@ -1022,6 +1211,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2441,6 +2636,13 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
+  '@stricli/auto-complete@1.2.7':
+    resolution: {integrity: sha512-i7tuoYJvBLRVxvjVhzmZJjPPq1f6jVHU118EgVNW82rkbRuSOjTlUH6DY/d8BXfrDg9DemuDtaGmiL1OvPwcPA==}
+    hasBin: true
+
+  '@stricli/core@1.2.7':
+    resolution: {integrity: sha512-a0HxA/cSWjqHj/9GM+cfc/zGNmBdxVTQQpHIEvY1AbDEgo4ZU84cTCbtywYEQOHw2wIc6Vu+PKv+ZQoqZwkHnQ==}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -2823,12 +3025,61 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.3:
+    resolution: {integrity: sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.3:
+    resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -3313,6 +3564,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3338,6 +3594,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
@@ -3379,6 +3638,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -3453,6 +3715,11 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  fossilize@0.7.0:
+    resolution: {integrity: sha512-DMY/j38pRnMgAjz+2PzOGn0WlDQ4Aa5/gQMgrsBLSv1LK+eSH51IIyxjMEvonv1Xs9LpIdJIGlVVXPmZGJR8Qg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -3982,6 +4249,10 @@ packages:
       '@types/three': '>=0.134.0'
       three: '>=0.134.0'
 
+  macho-unsign@2.0.6:
+    resolution: {integrity: sha512-YkIVGFnpVHJMMwfy4bHo79Vy05ddVk/PZGSCmmiCT4zepx+FMP/JAt9hOoXuc31s2bbcOtnzznOGca5fRhgZOg==}
+    engines: {node: '>=18.12.0'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -4225,6 +4496,10 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@6.2.0:
+    resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
+    engines: {node: '>=18'}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4315,6 +4590,10 @@ packages:
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
+
+  portable-executable-signature@2.0.6:
+    resolution: {integrity: sha512-VV+1GuJca0cJ0PFwnCW/xK8Ro9DDX38e4iUDh6ngPjd9vj7VLiemh9rSlqquvcVGtClkVzYaV/UseMVnUrxS/Q==}
+    engines: {node: '>=18.12.0'}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -4729,6 +5008,9 @@ packages:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
 
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
@@ -4799,9 +5081,15 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
   tar@7.5.15:
     resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
     engines: {node: '>=18'}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
@@ -4809,6 +5097,9 @@ packages:
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
     engines: {node: '>=6.0.0'}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   three-mesh-bvh@0.8.3:
     resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
@@ -4887,6 +5178,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tunnel-rat@0.1.2:
     resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
@@ -5101,6 +5397,10 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  xz-decompress@0.2.3:
+    resolution: {integrity: sha512-O8v6HG8T0PrKBcpyWA13GkSYWFvncwzuzcLx5A7++l3HsE3atmoetXjIxrZ/JV/nbvSZ7WS4+3XvREZuVn+rEA==}
+    engines: {node: '>=16'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -5131,9 +5431,17 @@ packages:
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
+  yauzl@3.3.1:
+    resolution: {integrity: sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   yocto-spinner@1.2.0:
     resolution: {integrity: sha512-Yw0hUB6UA3o4YUgKy3oSe9a4cxoaZ9sBfYDw+JSxo6Id0KoJGoxzPA24qqUXYKBWABs/zDSGTz9kww7t3F0XGw==}
@@ -5622,6 +5930,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
@@ -5629,6 +5940,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
@@ -5640,6 +5954,9 @@ snapshots:
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
     optional: true
 
@@ -5647,6 +5964,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
@@ -5658,6 +5978,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
@@ -5665,6 +5988,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
@@ -5676,6 +6002,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
@@ -5683,6 +6012,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
@@ -5694,6 +6026,9 @@ snapshots:
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
@@ -5701,6 +6036,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
@@ -5712,6 +6050,9 @@ snapshots:
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
@@ -5719,6 +6060,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
@@ -5730,6 +6074,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
@@ -5737,6 +6084,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
@@ -5748,6 +6098,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
@@ -5755,6 +6108,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -5766,6 +6122,9 @@ snapshots:
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
@@ -5773,6 +6132,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
@@ -5784,6 +6146,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
@@ -5791,6 +6156,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -5802,6 +6170,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
@@ -5809,6 +6180,9 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
@@ -5820,6 +6194,9 @@ snapshots:
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
@@ -5827,6 +6204,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
@@ -5838,6 +6218,9 @@ snapshots:
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
@@ -5845,6 +6228,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)':
@@ -7371,6 +7757,12 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
+  '@stricli/auto-complete@1.2.7':
+    dependencies:
+      '@stricli/core': 1.2.7
+
+  '@stricli/core@1.2.7': {}
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -7436,12 +7828,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@ts-morph/common@0.27.0':
     dependencies:
@@ -7494,7 +7886,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       '@types/responselike': 1.0.3
 
   '@types/connect@3.4.38':
@@ -7511,7 +7903,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
 
   '@types/http-cache-semantics@4.2.0': {}
 
@@ -7519,7 +7911,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
 
   '@types/ms@2.1.0': {}
 
@@ -7549,7 +7941,7 @@ snapshots:
 
   '@types/plist@3.0.5':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
       xmlbuilder: 15.1.1
     optional: true
 
@@ -7569,11 +7961,11 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
 
   '@types/stats.js@0.17.4': {}
 
@@ -7605,7 +7997,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.9.1
     optional: true
 
   '@use-gesture/core@10.3.1': {}
@@ -7617,7 +8009,7 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -7625,7 +8017,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7760,9 +8152,43 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  b4a@1.8.1: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.8.3: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.3
+      bare-path: 3.0.0
+      bare-stream: 2.13.1(bare-events@2.8.3)
+      bare-url: 2.4.3
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.1: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.1
+
+  bare-stream@2.13.1(bare-events@2.8.3):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.3
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.3:
+    dependencies:
+      bare-path: 3.0.0
 
   base64-js@1.5.1: {}
 
@@ -7960,8 +8386,7 @@ snapshots:
 
   commander@5.1.0: {}
 
-  commander@9.5.0:
-    optional: true
+  commander@9.5.0: {}
 
   commondir@1.0.1: {}
 
@@ -8190,7 +8615,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
+  electron-vite@5.0.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -8198,7 +8623,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8355,6 +8780,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -8369,6 +8823,12 @@ snapshots:
   estree-walker@2.0.2: {}
 
   etag@1.8.1: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.3
+    transitivePeerDependencies:
+      - bare-abort-controller
 
   eventsource-parser@3.0.8: {}
 
@@ -8458,6 +8918,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-fifo@1.3.2: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8539,6 +9001,23 @@ snapshots:
   forwarded-parse@2.1.2: {}
 
   forwarded@0.2.0: {}
+
+  fossilize@0.7.0:
+    dependencies:
+      '@stricli/auto-complete': 1.2.7
+      '@stricli/core': 1.2.7
+      esbuild: 0.25.12
+      macho-unsign: 2.0.6
+      p-limit: 6.2.0
+      portable-executable-signature: 2.0.6
+      postject: 1.0.0-alpha.6
+      tar-stream: 3.2.0
+      xz-decompress: 0.2.3
+      yauzl: 3.3.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
 
   fresh@2.0.0: {}
 
@@ -9004,6 +9483,8 @@ snapshots:
       '@types/three': 0.184.1
       three: 0.184.0
 
+  macho-unsign@2.0.6: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -9233,6 +9714,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@6.2.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -9286,7 +9771,7 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  pkgroll@2.27.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
+  pkgroll@2.27.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.4)
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.60.4)
@@ -9297,7 +9782,7 @@ snapshots:
       esbuild: 0.26.0
       magic-string: 0.30.21
       rollup: 4.60.4
-      rollup-plugin-import-trace: 1.0.1(rollup@4.60.4)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      rollup-plugin-import-trace: 1.0.1(rollup@4.60.4)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
       rollup-pluginutils: 2.8.2
       yaml: 2.9.0
     optionalDependencies:
@@ -9317,6 +9802,8 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
     optional: true
+
+  portable-executable-signature@2.0.6: {}
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -9342,7 +9829,6 @@ snapshots:
   postject@1.0.0-alpha.6:
     dependencies:
       commander: 9.5.0
-    optional: true
 
   potpack@1.0.2: {}
 
@@ -9597,10 +10083,10 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
-  rollup-plugin-import-trace@1.0.1(rollup@4.60.4)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
+  rollup-plugin-import-trace@1.0.1(rollup@4.60.4)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)):
     optionalDependencies:
       rollup: 4.60.4
-      vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
   rollup-pluginutils@2.8.2:
     dependencies:
@@ -9832,6 +10318,15 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
@@ -9892,6 +10387,17 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar@7.5.15:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -9899,6 +10405,13 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   temp-file@3.4.0:
     dependencies:
@@ -9909,6 +10422,12 @@ snapshots:
     dependencies:
       mkdirp: 0.5.6
       rimraf: 2.6.3
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   three-mesh-bvh@0.8.3(three@0.184.0):
     dependencies:
@@ -9991,6 +10510,12 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel-rat@0.1.2(@types/react@19.2.15)(react@19.2.6):
     dependencies:
@@ -10088,7 +10613,7 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
+  vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -10101,9 +10626,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
+  vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -10116,6 +10642,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
+      tsx: 4.22.3
       yaml: 2.9.0
     optional: true
 
@@ -10160,6 +10687,8 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  xz-decompress@0.2.3: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
@@ -10187,7 +10716,14 @@ snapshots:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
 
+  yauzl@3.3.1:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0
+
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   yocto-spinner@1.2.0:
     dependencies:

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -16,4 +16,9 @@ cd apps/electron
 pnpm version "$NEW_VERSION" --no-git-tag-version
 cd ../..
 
+# Bump the CLI app version
+cd apps/cli
+pnpm version "$NEW_VERSION" --no-git-tag-version
+cd ../..
+
 echo "Version bump complete"

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", "build/**"]
+      "outputs": ["dist/**", "build/**", "dist-bin/**"],
+      "env": ["FOSSILIZE_PLATFORMS"]
     },
     "dev": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Introduces `@freestyle/cli`, a new terminal interface for Freestyle that talks to the local server over HTTP. Ships as both an npm package (`freestyle` binary) and cross-platform native binaries via fossilize (Node SEA).

## Commands

| Command | Description |
|---------|-------------|
| `freestyle version` | Show CLI + server version |
| `freestyle serve` | Start the Freestyle server standalone |
| `freestyle format list\|view\|create\|update\|delete` | Manage formatting rules (CRUD) |
| `freestyle history list` | List transcription history |
| `freestyle dict list\|view\|create\|update\|delete` | Manage word dictionary (CRUD) |

All commands support `--json` for machine-readable output and `--port` to override the server port (default 4649). Route maps auto-inject aliases (`ls`, `show`, `new`, `rm`).

## Architecture

- **Framework**: [Stricli](https://bloomberg.github.io/stricli/) (same as getsentry/cli)
- **Build**: esbuild (CJS bundle) + fossilize (Node SEA native binaries)
- **API client**: Plain `fetch` against `localhost:4649`
- **Output**: Dual human/JSON rendering via `CommandOutput` + `OutputConfig`

## Changes to existing code

- `apps/server/src/routes/formats.ts` — added `GET /api/formats/:id` endpoint (matching the existing dictionary pattern)
- `.craft.yml` — added `cli-binaries` artifact + updated `includeNames` regex
- `turbo.json` — added `dist-bin/**` outputs + `FOSSILIZE_PLATFORMS` env passthrough
- `scripts/bump-version.sh` — added CLI version bump alongside electron
- `.github/workflows/build.yml` — added CLI typecheck step + `build-cli` job

## Testing

Verified with `pnpm --filter @freestyle/cli run typecheck` (clean) and `pnpm biome check apps/cli` (clean). Self-reviewed for bugs and AI slop.

<!--
## Plan

### New files (31 files under apps/cli/)
- package.json, tsconfig.json
- src/bin.ts (entry point: suppress warnings, register error handlers, call startCli)
- src/cli.ts (CLI runner: create FreestyleContext, dispatch to Stricli app)
- src/app.ts (Stricli application + top-level route map)
- src/context.ts (FreestyleContext extends CommandContext)
- src/lib/constants.ts (VERSION, DEFAULT_PORT, getBaseUrl)
- src/lib/errors.ts (CliError, ApiError, ConnectionError)
- src/lib/api-client.ts (fetch wrapper: apiGet, apiGetText, apiPost, apiPut, apiDelete)
- src/lib/command.ts (buildCommand wrapper: injects --json/--port, handles output + errors)
- src/lib/route-map.ts (buildRouteMap wrapper: auto-injects aliases)
- src/lib/output.ts (CommandOutput class + renderOutput)
- src/lib/table.ts (terminal table + key-value formatting with chalk)
- src/commands/version.ts, serve.ts
- src/commands/format/{index,list,view,create,update,delete}.ts
- src/commands/history/{index,list}.ts
- src/commands/dict/{index,list,view,create,update,delete}.ts
- script/bundle.ts (npm package: esbuild → CJS)
- script/build.ts (native binary: esbuild → CJS → fossilize → SEA)

### Review findings fixed
1. version command was calling res.json() on a text/plain response → added apiGetText
2. format/view.ts was fetching all formats and filtering client-side → added GET /:id to server
3. serve.ts used bare `process` global for signal handlers → captured `this.process` as `proc`
4. build.ts used fake FOSSILIZE_OUTPUT env var → removed, using default dist-bin/
5. build.ts was double-bundling → added --no-bundle flag to fossilize
6. CI macOS signing → added TODO comment for follow-up
-->