### PR TITLE
fix: improve responsive layout across Today, Formats, and History sections

### DIFF
--- a/apps/electron/src/renderer/src/pages/settings/formats.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/formats.tsx
@@ -328,12 +328,10 @@ function FormatRuleCard({
     <div className="group flex items-start gap-3 px-4 py-3">
       <FileText className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">{rule.label}</span>
-          <span className="bg-secondary text-muted-foreground rounded px-1.5 py-0.5 font-mono text-[10px]">
-            {rule.app_pattern.length > 40
-              ? `${rule.app_pattern.slice(0, 40)}...`
-              : rule.app_pattern}
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="shrink-0 text-sm font-medium">{rule.label}</span>
+          <span className="bg-secondary text-muted-foreground truncate rounded px-1.5 py-0.5 font-mono text-[10px]">
+            {rule.app_pattern}
           </span>
         </div>
         <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs">

--- a/apps/electron/src/renderer/src/pages/settings/history.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/history.tsx
@@ -175,7 +175,7 @@ export default function HistoryPage(): React.JSX.Element {
 
       {/* Stats cards */}
       {stats && (
-        <div className="grid grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 gap-3 min-[700px]:grid-cols-4">
           <StatCard
             label="Total Sessions"
             value={String(stats.total_sessions)}

--- a/apps/electron/src/renderer/src/pages/settings/history.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/history.tsx
@@ -175,7 +175,7 @@ export default function HistoryPage(): React.JSX.Element {
 
       {/* Stats cards */}
       {stats && (
-        <div className="grid grid-cols-2 gap-3 min-[700px]:grid-cols-4">
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
           <StatCard
             label="Total Sessions"
             value={String(stats.total_sessions)}

--- a/apps/electron/src/renderer/src/pages/today.tsx
+++ b/apps/electron/src/renderer/src/pages/today.tsx
@@ -222,7 +222,7 @@ export default function TodayPage(): React.JSX.Element {
       </div>
 
       {/* Right rail — day summary */}
-      <aside className="border-border bg-sidebar hidden min-[750px]:flex w-[280px] shrink-0 flex-col gap-7 border-l px-7 pt-[44px] pb-9 overflow-auto">
+      <aside className="border-border bg-sidebar hidden min-[1024px]:flex w-[280px] shrink-0 flex-col gap-7 border-l px-7 pt-[44px] pb-9 overflow-auto">
         <section>
           <RailLabel>In numbers</RailLabel>
           <RailStat

--- a/apps/electron/src/renderer/src/pages/today.tsx
+++ b/apps/electron/src/renderer/src/pages/today.tsx
@@ -222,7 +222,7 @@ export default function TodayPage(): React.JSX.Element {
       </div>
 
       {/* Right rail — day summary */}
-      <aside className="border-border bg-sidebar hidden min-[1024px]:flex w-[280px] shrink-0 flex-col gap-7 border-l px-7 pt-[44px] pb-9 overflow-auto">
+      <aside className="border-border bg-sidebar hidden lg:flex w-[280px] shrink-0 flex-col gap-7 border-l px-7 pt-[44px] pb-9 overflow-auto">
         <section>
           <RailLabel>In numbers</RailLabel>
           <RailStat


### PR DESCRIPTION
Closes #31 

- Today: raise right-rail breakpoint from 750px to 1024px so the analysis panel only shows when there is enough room for the center column
- Formats: replace JS-based 40-char truncation on app_pattern badge with CSS truncate; add min-w-0 to inner flex container and shrink-0 to label so the badge clips responsively instead of overflowing
- History: change stats grid from fixed grid-cols-4 to grid-cols-2 with min-[700px]:grid-cols-4 so cards reflow to a 2x2 layout on narrow windows

## Before 
<img width="1520" height="1008" alt="1_before" src="https://github.com/user-attachments/assets/9b24578a-0e18-478c-b0b5-a1cc5351001e" />
<img width="1531" height="1019" alt="2_before" src="https://github.com/user-attachments/assets/bc032eb1-8542-47f8-907a-1d14327128d9" />
<img width="1439" height="1005" alt="3_before" src="https://github.com/user-attachments/assets/23927a69-c09d-486a-b868-44377da9aa1e" />

## After

<img width="1516" height="912" alt="1_after" src="https://github.com/user-attachments/assets/0abcb55b-1987-499d-b9bc-d06c893b342f" />
<img width="1502" height="1026" alt="2_after" src="https://github.com/user-attachments/assets/0254746e-989d-4d17-b632-122687ed838e" />
<img width="1534" height="1022" alt="3_after" src="https://github.com/user-attachments/assets/0b3cb26d-a516-41fe-96a6-3b5c44510670" />
