### PR TITLE
feat: improve post-processing and add re-record during transcription

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -339,6 +339,19 @@ function showPill(): void {
     mainWindow.setPosition(x, y);
     mainWindow.showInactive();
   }
+
+  // On Windows, register Escape as a global shortcut while the pill
+  // is visible so the user can cancel recording/transcription.
+  // (On macOS/Linux, Escape is detected via the GlobalKeyboardListener.)
+  if (process.platform === "win32") {
+    if (!globalShortcut.isRegistered("Escape")) {
+      globalShortcut.register("Escape", () => {
+        if (mainWindow?.isVisible()) {
+          mainWindow.webContents.send("pill:cancel");
+        }
+      });
+    }
+  }
 }
 
 // -- Async helper: run a command without blocking the main thread --
@@ -509,6 +522,12 @@ async function getLinuxFrontmostApp(): Promise<string | null> {
 function hidePill(): void {
   if (mainWindow?.isVisible()) {
     mainWindow.hide();
+  }
+  // Unregister Escape shortcut when pill is hidden (Windows only)
+  if (process.platform === "win32") {
+    try {
+      globalShortcut.unregister("Escape");
+    } catch {}
   }
 }
 
@@ -1269,6 +1288,12 @@ function registerHotkey(hotkey?: string): void {
     e: IGlobalKeyEvent,
     isDown: IGlobalKeyDownMap,
   ): boolean | undefined => {
+    // Escape cancels recording/transcription when the pill is visible
+    if (e.name === "ESCAPE" && e.state === "DOWN" && mainWindow?.isVisible()) {
+      mainWindow?.webContents.send("pill:cancel");
+      return undefined;
+    }
+
     if (e.name !== triggerKey) return undefined;
 
     if (e.state === "DOWN" && !hotkeyPressed) {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -687,11 +687,6 @@ app.whenReady().then(async () => {
     optimizer.watchWindowShortcuts(window);
   });
 
-  // IPC: debug log from pill renderer → main process stdout
-  ipcMain.on("debug:log", (_event, msg: string) => {
-    console.log(`[pill] ${msg}`);
-  });
-
   // IPC: paste text at cursor
   ipcMain.handle("paste:text", async (_event, text: string) => {
     await pasteIntoFocusedApp(text);

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -687,6 +687,11 @@ app.whenReady().then(async () => {
     optimizer.watchWindowShortcuts(window);
   });
 
+  // IPC: debug log from pill renderer → main process stdout
+  ipcMain.on("debug:log", (_event, msg: string) => {
+    console.log(`[pill] ${msg}`);
+  });
+
   // IPC: paste text at cursor
   ipcMain.handle("paste:text", async (_event, text: string) => {
     await pasteIntoFocusedApp(text);

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -10,6 +10,7 @@ declare global {
       getServerPort: () => Promise<number>;
       onHotkeyDown: (callback: () => void) => () => void;
       onHotkeyUp: (callback: () => void) => () => void;
+      onPillCancel: (callback: () => void) => () => void;
       checkMicPermission: () => Promise<string>;
       requestMicPermission: () => Promise<string>;
       checkAccessibilityPermission: () => Promise<boolean>;

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -4,7 +4,6 @@ declare global {
   interface Window {
     electron: ElectronAPI;
     api: {
-      debugLog: (msg: string) => void;
       pasteText: (text: string) => Promise<void>;
       updateHotkey: (hotkey: string) => void;
       hidePill: () => void;

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     electron: ElectronAPI;
     api: {
+      debugLog: (msg: string) => void;
       pasteText: (text: string) => Promise<void>;
       updateHotkey: (hotkey: string) => void;
       hidePill: () => void;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -19,6 +19,11 @@ const api = {
     ipcRenderer.on("hotkey:up", handler);
     return () => ipcRenderer.removeListener("hotkey:up", handler);
   },
+  onPillCancel: (callback: () => void): (() => void) => {
+    const handler = (): void => callback();
+    ipcRenderer.on("pill:cancel", handler);
+    return () => ipcRenderer.removeListener("pill:cancel", handler);
+  },
   checkMicPermission: (): Promise<string> =>
     ipcRenderer.invoke("permissions:check-mic"),
   requestMicPermission: (): Promise<string> =>

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -3,6 +3,7 @@ import { contextBridge, ipcRenderer } from "electron";
 
 // Custom APIs for renderer
 const api = {
+  debugLog: (msg: string): void => ipcRenderer.send("debug:log", msg),
   pasteText: (text: string): Promise<void> =>
     ipcRenderer.invoke("paste:text", text),
   updateHotkey: (hotkey: string): void =>

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -3,7 +3,6 @@ import { contextBridge, ipcRenderer } from "electron";
 
 // Custom APIs for renderer
 const api = {
-  debugLog: (msg: string): void => ipcRenderer.send("debug:log", msg),
   pasteText: (text: string): Promise<void> =>
     ipcRenderer.invoke("paste:text", text),
   updateHotkey: (hotkey: string): void =>

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -112,12 +112,16 @@ export class Streamer {
     this.source.connect(this.workletNode);
   }
 
-  commit(): void {
+  commit(previousText?: string): void {
     const audioDurationMs = Math.round(
       (this.pcmSampleCount / TARGET_RATE) * 1000,
     );
     this.stopCapture();
-    this.sendJSON({ type: "commit", audioDurationMs });
+    const msg: Record<string, unknown> = { type: "commit", audioDurationMs };
+    if (previousText) {
+      msg.previousText = previousText;
+    }
+    this.sendJSON(msg);
   }
 
   cancel(): void {

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -112,16 +112,12 @@ export class Streamer {
     this.source.connect(this.workletNode);
   }
 
-  commit(previousText?: string): void {
+  commit(): void {
     const audioDurationMs = Math.round(
       (this.pcmSampleCount / TARGET_RATE) * 1000,
     );
     this.stopCapture();
-    const msg: Record<string, unknown> = { type: "commit", audioDurationMs };
-    if (previousText) {
-      msg.previousText = previousText;
-    }
-    this.sendJSON(msg);
+    this.sendJSON({ type: "commit", audioDurationMs });
   }
 
   cancel(): void {

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -124,6 +124,7 @@ export default function AppPage(): React.JSX.Element {
   // `deferredCommitRef` holds a callback to execute the deferred commit
   // once the first result arrives.
   const [isReRecording, setIsReRecording] = useState(false);
+  const isReRecordingRef = useRef(false);
   const previousTextRef = useRef<string | null>(null);
   const awaitingFirstResultRef = useRef(false);
   const deferredCommitRef = useRef<((prevText: string) => void) | null>(null);
@@ -335,6 +336,7 @@ export default function AppPage(): React.JSX.Element {
     setPartialText("");
     setMessage("");
     setIsReRecording(false);
+    isReRecordingRef.current = false;
     sessionIdRef.current = 0;
     previousTextRef.current = null;
     awaitingFirstResultRef.current = false;
@@ -354,8 +356,10 @@ export default function AppPage(): React.JSX.Element {
       setPartialText("");
 
       if (forReRecord) {
+        isReRecordingRef.current = true;
         setIsReRecording(true);
       } else {
+        isReRecordingRef.current = false;
         setIsReRecording(false);
         previousTextRef.current = null;
         awaitingFirstResultRef.current = false;
@@ -425,6 +429,7 @@ export default function AppPage(): React.JSX.Element {
       } catch (err) {
         wantsMicRef.current = false;
         pendingCommitRef.current = false;
+        isReRecordingRef.current = false;
         setIsReRecording(false);
         awaitingFirstResultRef.current = false;
         deferredCommitRef.current = null;
@@ -440,7 +445,8 @@ export default function AppPage(): React.JSX.Element {
   // -- Commit: stop recording and transcribe --
   const commitRecording = useCallback(async () => {
     wantsMicRef.current = false;
-    const wasReRecording = isReRecording;
+    const wasReRecording = isReRecordingRef.current;
+    isReRecordingRef.current = false;
     setIsReRecording(false);
     stopVisualization();
     playTone("stop");
@@ -551,11 +557,12 @@ export default function AppPage(): React.JSX.Element {
       setMessage(err instanceof Error ? err.message : "Transcription failed");
       setTimeout(() => hidePill(), 2000);
     }
-  }, [stopVisualization, hidePill, isReRecording]);
+  }, [stopVisualization, hidePill]);
 
   const cancelRecording = useCallback(() => {
     wantsMicRef.current = false;
     sessionIdRef.current = 0;
+    isReRecordingRef.current = false;
     setIsReRecording(false);
     previousTextRef.current = null;
     awaitingFirstResultRef.current = false;

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -213,9 +213,7 @@ export default function AppPage(): React.JSX.Element {
 
           // Normal path — this is the final result.
           dbg("[onFinal] → paste and hide");
-          sessionIdRef.current = 0;
-          commitSessionRef.current = 0;
-          wantsMicRef.current = false;
+          const mySid = sid;
           stopVisualization();
           recorderRef.current.cancel();
           recorderRef.current.releaseStream();
@@ -223,7 +221,10 @@ export default function AppPage(): React.JSX.Element {
             await window.api.pasteText(text);
             window.api?.sendTranscriptionDone();
           }
-          hidePill();
+          // A new session may have started during the paste await.
+          if (isCurrentSession(mySid)) {
+            hidePill();
+          }
         },
         onCleaned: (text) => {
           dbg(
@@ -487,12 +488,12 @@ export default function AppPage(): React.JSX.Element {
       if (wasReRecording && previousTextRef.current?.trim()) {
         const text = previousTextRef.current;
         previousTextRef.current = null;
-        sessionIdRef.current = 0;
-        commitSessionRef.current = 0;
         await window.api.pasteText(text);
         window.api?.sendTranscriptionDone();
       }
-      hidePill();
+      if (isCurrentSession(mySession)) {
+        hidePill();
+      }
       return;
     }
 
@@ -542,12 +543,12 @@ export default function AppPage(): React.JSX.Element {
       if (!wavBlob) {
         recorderRef.current.releaseStream();
         if (prevText?.trim()) {
-          sessionIdRef.current = 0;
-          commitSessionRef.current = 0;
           await window.api.pasteText(prevText);
           window.api?.sendTranscriptionDone();
         }
-        hidePill();
+        if (isCurrentSession(mySession)) {
+          hidePill();
+        }
         return;
       }
 
@@ -625,13 +626,18 @@ export default function AppPage(): React.JSX.Element {
         );
       }
 
-      sessionIdRef.current = 0;
-      commitSessionRef.current = 0;
       if (text.trim()) {
         await window.api.pasteText(text);
         window.api?.sendTranscriptionDone();
       }
-      hidePill();
+      // A new session may have started during the paste await.
+      if (isCurrentSession(mySession)) {
+        hidePill();
+      } else {
+        dbg(
+          `[commitRecording] skipping hidePill, new session started during paste`,
+        );
+      }
     } catch (err) {
       // Only show error if we're still the active session
       if (isCurrentSession(mySession)) {

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -392,12 +392,12 @@ export default function AppPage(): React.JSX.Element {
       } catch (err) {
         wantsMicRef.current = false;
         pendingCommitRef.current = false;
+        reRecordingRef.current = false;
+        setIsReRecording(false);
         recorderRef.current.releaseStream();
-        if (!forReRecord) {
-          setState("error");
-          setMessage(err instanceof Error ? err.message : "Mic access denied");
-          setTimeout(() => hidePill(), 2000);
-        }
+        setState("error");
+        setMessage(err instanceof Error ? err.message : "Mic access denied");
+        setTimeout(() => hidePill(), 2000);
       }
     },
     [startVisualization, hidePill, getStreamer],
@@ -425,12 +425,8 @@ export default function AppPage(): React.JSX.Element {
         previousTextRef.current = null;
         await window.api.pasteText(text);
         window.api?.sendTranscriptionDone();
-        hidePill();
-        return;
       }
-      if (!wasReRecording) {
-        hidePill();
-      }
+      hidePill();
       return;
     }
 

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -98,13 +98,13 @@ const pillInnerStyle: React.CSSProperties = {
   WebkitAppRegion: "no-drag",
 } as React.CSSProperties;
 
-// ---------------------------------------------------------------------------
-// Transcription queue entry.  Each recording produces one of these.
-// The `promise` resolves with the transcribed (and individually
-// post-processed) text once the server responds.
-// ---------------------------------------------------------------------------
+interface TranscribeResult {
+  raw: string;
+  cleaned: string;
+}
+
 interface QueueEntry {
-  promise: Promise<string>;
+  promise: Promise<TranscribeResult>;
 }
 
 export default function AppPage(): React.JSX.Element {
@@ -117,6 +117,7 @@ export default function AppPage(): React.JSX.Element {
   const [isReRecording, setIsReRecording] = useState(false);
   const isReRecordingRef = useRef(false);
   const [pendingCount, setPendingCount] = useState(0);
+  const [pillLabel, setPillLabel] = useState("Transcribing...");
 
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
@@ -171,48 +172,59 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
+    // If the user started recording again while we were awaiting,
+    // stash results and exit — next commitRecording will re-drain.
     if (wantsMicRef.current || queueRef.current.length > 0) {
       const resolved = results
-        .filter((t) => t.trim())
-        .map((t) => ({ promise: Promise.resolve(t) }));
+        .filter((r) => r.raw.trim())
+        .map((r) => ({ promise: Promise.resolve(r) }));
       queueRef.current = [...resolved, ...queueRef.current];
       drainingRef.current = false;
       return;
     }
 
-    const nonEmpty = results.filter((t) => t.trim());
+    const nonEmpty = results.filter((r) => r.raw.trim());
     if (nonEmpty.length === 0) {
       drainingRef.current = false;
       hidePill();
       return;
     }
 
-    const combined = nonEmpty.join(" ");
-    dbg(
-      `[drainQueue] post-processing ${nonEmpty.length} result(s) via /api/post-process`,
-    );
     let finalText: string;
-    try {
-      const res = await fetch(`${getApiBase()}/api/post-process`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          text: combined,
-          appContext: appContextRef.current,
-        }),
-      });
-      if (!pillActiveRef.current) {
-        drainingRef.current = false;
-        return;
-      }
-      if (res.ok) {
-        const data = await res.json();
-        finalText = data.cleaned || combined;
-      } else {
+
+    if (nonEmpty.length === 1) {
+      // Single recording — use the already-post-processed cleaned text.
+      finalText = nonEmpty[0].cleaned.trim() || nonEmpty[0].raw.trim();
+      dbg("[drainQueue] single result, using cleaned text");
+    } else {
+      // Multiple recordings — stitch raw texts and post-process together.
+      const combined = nonEmpty.map((r) => r.raw).join(" ");
+      dbg(
+        `[drainQueue] stitching ${nonEmpty.length} results, calling /api/post-process`,
+      );
+      setPillLabel("Processing...");
+      try {
+        const res = await fetch(`${getApiBase()}/api/post-process`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            text: combined,
+            appContext: appContextRef.current,
+          }),
+        });
+        if (!pillActiveRef.current) {
+          drainingRef.current = false;
+          return;
+        }
+        if (res.ok) {
+          const data = await res.json();
+          finalText = data.cleaned || combined;
+        } else {
+          finalText = combined;
+        }
+      } catch {
         finalText = combined;
       }
-    } catch {
-      finalText = combined;
     }
 
     if (!pillActiveRef.current) {
@@ -222,7 +234,7 @@ export default function AppPage(): React.JSX.Element {
 
     if (wantsMicRef.current || queueRef.current.length > 0) {
       queueRef.current = [
-        { promise: Promise.resolve(finalText) },
+        { promise: Promise.resolve({ raw: finalText, cleaned: finalText }) },
         ...queueRef.current,
       ];
       drainingRef.current = false;
@@ -368,6 +380,7 @@ export default function AppPage(): React.JSX.Element {
     setIsReRecording(false);
     isReRecordingRef.current = false;
     setPendingCount(0);
+    setPillLabel("Transcribing...");
     wantsMicRef.current = false;
     pillActiveRef.current = false;
     queueRef.current = [];
@@ -390,6 +403,7 @@ export default function AppPage(): React.JSX.Element {
       pendingCommitRef.current = false;
       setMessage("");
       setPartialText("");
+      setPillLabel("Transcribing...");
 
       if (forReRecord) {
         isReRecordingRef.current = true;
@@ -514,25 +528,31 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
-    // Build the transcription promise
+    // Skip post-processing on subsequent recordings — the raw texts
+    // will be stitched and post-processed together in drainQueue.
+    const isSubsequent = queueRef.current.length > 0 || drainingRef.current;
     const headers: Record<string, string> = {
       "Content-Type": "audio/wav",
       "x-audio-duration-ms": String(recordingDuration),
     };
     if (appContextRef.current) headers["x-app-context"] = appContextRef.current;
+    if (isSubsequent) headers["x-skip-post-process"] = "true";
 
     setPendingCount((c) => c + 1);
-    const transcribePromise = fetch(`${getApiBase()}/api/transcribe`, {
-      method: "POST",
-      body: wavBlob,
-      headers,
-    })
+    const empty: TranscribeResult = { raw: "", cleaned: "" };
+    const transcribePromise: Promise<TranscribeResult> = fetch(
+      `${getApiBase()}/api/transcribe`,
+      { method: "POST", body: wavBlob, headers },
+    )
       .then(async (res) => {
-        if (!res.ok) return "";
+        if (!res.ok) return empty;
         const data = await res.json();
-        return (data.raw || "").trim();
+        return {
+          raw: (data.raw || "").trim(),
+          cleaned: (data.cleaned || data.raw || "").trim(),
+        };
       })
-      .catch(() => "");
+      .catch(() => empty);
 
     // Push to queue
     queueRef.current.push({ promise: transcribePromise });
@@ -861,7 +881,7 @@ export default function AppPage(): React.JSX.Element {
                 {partialText ? (
                   partialText.slice(-30)
                 ) : (
-                  <span className="shimmer-text">Transcribing...</span>
+                  <span className="shimmer-text">{pillLabel}</span>
                 )}
               </span>
             )}

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -85,12 +85,40 @@ function formatTimer(ms: number): string {
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
+// ---------------------------------------------------------------------------
+// Pill inner content — extracted so it can be rendered in both the main pill
+// and the background transcribing pill during re-record.
+// ---------------------------------------------------------------------------
+
+const pillInnerStyle: React.CSSProperties = {
+  height: 48,
+  padding: "0 10px",
+  borderRadius: 28,
+  background: "var(--card)",
+  color: "var(--foreground)",
+  border: "1px solid var(--border)",
+  fontFamily: "'DM Sans', sans-serif",
+  fontSize: 14,
+  fontWeight: 500,
+  minWidth: 200,
+  maxWidth: 420,
+  WebkitAppRegion: "no-drag",
+} as React.CSSProperties;
+
 export default function AppPage(): React.JSX.Element {
   const [state, setState] = useState<PillState>("idle");
   const [elapsed, setElapsed] = useState(0);
   const [message, setMessage] = useState("");
   const [partialText, setPartialText] = useState("");
   const useStreamingRef = useRef(false);
+
+  // Re-record state: when the user presses the hotkey during transcription,
+  // we start a new recording while the previous transcription finishes in
+  // the background.  The finished text is stored here so it can be combined
+  // with the new transcription.
+  const [isReRecording, setIsReRecording] = useState(false);
+  const previousTextRef = useRef<string | null>(null);
+  const reRecordingRef = useRef(false);
 
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
@@ -123,6 +151,14 @@ export default function AppPage(): React.JSX.Element {
         onFinal: async (text) => {
           if (sessionIdRef.current === 0) return;
 
+          // If the user started a re-recording while we were transcribing,
+          // store the text instead of pasting — it will be combined with the
+          // new transcription when that finishes.
+          if (reRecordingRef.current) {
+            previousTextRef.current = text.trim() || null;
+            return;
+          }
+
           wantsMicRef.current = false;
           sessionIdRef.current = 0;
           stopVisualization();
@@ -134,8 +170,31 @@ export default function AppPage(): React.JSX.Element {
           }
           hidePill();
         },
+        onCleaned: (text) => {
+          // If the user is re-recording, update previousText with the
+          // cleaned version so the final combine uses the best text.
+          if (reRecordingRef.current) {
+            if (text.trim()) {
+              previousTextRef.current = text.trim();
+            }
+            return;
+          }
+
+          // Normal flow: paste the cleaned text (replaces the raw text
+          // that was already pasted by onFinal).
+          if (text.trim()) {
+            window.api.pasteText(text);
+          }
+        },
         onError: (msg) => {
           if (sessionIdRef.current === 0) return;
+
+          // If re-recording, don't hide — let the recording continue
+          if (reRecordingRef.current) {
+            previousTextRef.current = null;
+            return;
+          }
+
           wantsMicRef.current = false;
           sessionIdRef.current = 0;
           stopVisualization();
@@ -244,89 +303,112 @@ export default function AppPage(): React.JSX.Element {
     setState("idle");
     setPartialText("");
     setMessage("");
+    setIsReRecording(false);
+    reRecordingRef.current = false;
+    previousTextRef.current = null;
     window.api.hidePill();
   }, []);
 
   // -- Start recording --
-  const startRecording = useCallback(async () => {
-    if (wantsMicRef.current) return;
-    wantsMicRef.current = true;
-    pendingCommitRef.current = false;
-    setMessage("");
-    setPartialText("");
+  // When `forReRecord` is true, we're starting a new recording while the
+  // previous transcription is still in progress.
+  const startRecording = useCallback(
+    async (forReRecord = false) => {
+      if (wantsMicRef.current) return;
+      wantsMicRef.current = true;
+      pendingCommitRef.current = false;
+      setMessage("");
+      setPartialText("");
 
-    window.api
-      ?.getFrontmostApp()
-      .then((app) => {
-        appContextRef.current = app;
-        if (app) {
-          try {
-            getStreamer().setContext(app);
-          } catch {}
-        }
-      })
-      .catch(() => {
-        appContextRef.current = null;
-      });
-
-    setState("initializing");
-
-    try {
-      // When streaming is active, skip MediaRecorder entirely — the
-      // Streamer accumulates PCM16 and can produce a WAV if needed.
-      const stream = useStreamingRef.current
-        ? await recorderRef.current.acquireStream()
-        : await recorderRef.current.start();
-
-      if (!wantsMicRef.current) {
-        recorderRef.current.cancel();
-        recorderRef.current.releaseStream();
-        return;
+      if (forReRecord) {
+        reRecordingRef.current = true;
+        setIsReRecording(true);
+      } else {
+        reRecordingRef.current = false;
+        setIsReRecording(false);
+        previousTextRef.current = null;
       }
 
-      // User already released the hotkey while mic was initializing —
-      // treat as an aborted press: release the mic and hide the pill
-      // without flashing the recording state or playing a tone.
-      if (pendingCommitRef.current) {
-        pendingCommitRef.current = false;
-        recorderRef.current.cancel();
-        recorderRef.current.releaseStream();
-        streamerRef.current?.cancel();
-        hidePill();
-        return;
+      window.api
+        ?.getFrontmostApp()
+        .then((app) => {
+          appContextRef.current = app;
+          if (app) {
+            try {
+              getStreamer().setContext(app);
+            } catch {}
+          }
+        })
+        .catch(() => {
+          appContextRef.current = null;
+        });
+
+      // When re-recording, skip the initializing state — go straight to
+      // recording so the UI doesn't flash the amber "Listening..." pill
+      // on top of the blue transcribing pill.
+      if (!forReRecord) {
+        setState("initializing");
       }
-
-      sessionIdRef.current++;
-      playTone("start");
-      setState("recording");
-      startTimeRef.current = Date.now();
-      timerRef.current = window.setInterval(() => {
-        if (!wantsMicRef.current) return;
-        setElapsed(Date.now() - startTimeRef.current);
-      }, 100);
-
-      startVisualization(stream);
 
       try {
-        await getStreamer().startCapture(
-          stream,
-          analyserCtxRef.current ?? undefined,
-        );
-      } catch {}
-    } catch (err) {
-      wantsMicRef.current = false;
-      pendingCommitRef.current = false;
-      recorderRef.current.releaseStream();
-      setState("error");
-      setMessage(err instanceof Error ? err.message : "Mic access denied");
-      setTimeout(() => hidePill(), 2000);
-    }
-  }, [startVisualization, hidePill, getStreamer]);
+        const stream = useStreamingRef.current
+          ? await recorderRef.current.acquireStream()
+          : await recorderRef.current.start();
+
+        if (!wantsMicRef.current) {
+          recorderRef.current.cancel();
+          recorderRef.current.releaseStream();
+          return;
+        }
+
+        if (pendingCommitRef.current) {
+          pendingCommitRef.current = false;
+          recorderRef.current.cancel();
+          recorderRef.current.releaseStream();
+          streamerRef.current?.cancel();
+          if (!forReRecord) {
+            hidePill();
+          }
+          return;
+        }
+
+        sessionIdRef.current++;
+        playTone("start");
+        setState("recording");
+        startTimeRef.current = Date.now();
+        timerRef.current = window.setInterval(() => {
+          if (!wantsMicRef.current) return;
+          setElapsed(Date.now() - startTimeRef.current);
+        }, 100);
+
+        startVisualization(stream);
+
+        try {
+          await getStreamer().startCapture(
+            stream,
+            analyserCtxRef.current ?? undefined,
+          );
+        } catch {}
+      } catch (err) {
+        wantsMicRef.current = false;
+        pendingCommitRef.current = false;
+        recorderRef.current.releaseStream();
+        if (!forReRecord) {
+          setState("error");
+          setMessage(err instanceof Error ? err.message : "Mic access denied");
+          setTimeout(() => hidePill(), 2000);
+        }
+      }
+    },
+    [startVisualization, hidePill, getStreamer],
+  );
 
   // -- Commit: stop recording and transcribe --
   const commitRecording = useCallback(async () => {
     wantsMicRef.current = false;
-    sessionIdRef.current = 0;
+    const wasReRecording = reRecordingRef.current;
+    reRecordingRef.current = false;
+    setIsReRecording(false);
     stopVisualization();
     playTone("stop");
 
@@ -335,16 +417,32 @@ export default function AppPage(): React.JSX.Element {
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
       streamerRef.current?.cancel();
-      hidePill();
+      // If this was a re-record that was too short, and we already have
+      // previousText from the first transcription, paste that instead.
+      if (wasReRecording && previousTextRef.current?.trim()) {
+        sessionIdRef.current = 0;
+        const text = previousTextRef.current;
+        previousTextRef.current = null;
+        await window.api.pasteText(text);
+        window.api?.sendTranscriptionDone();
+        hidePill();
+        return;
+      }
+      if (!wasReRecording) {
+        hidePill();
+      }
       return;
     }
+
+    const prevText = previousTextRef.current;
+    previousTextRef.current = null;
 
     // If streaming mode is active, commit via WebSocket
     if (useStreamingRef.current && streamerRef.current) {
       setState("transcribing");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
-      streamerRef.current.commit();
+      streamerRef.current.commit(prevText ?? undefined);
       return;
     }
 
@@ -352,9 +450,6 @@ export default function AppPage(): React.JSX.Element {
     streamerRef.current?.cancel();
 
     try {
-      // Prefer the Streamer's pre-encoded WAV (already 16kHz PCM16,
-      // no decode/resample overhead).  Fall back to MediaRecorder path
-      // only when the Streamer has no accumulated audio.
       let wavBlob: Blob | null = streamerRef.current?.getWavBlob() ?? null;
 
       if (!wavBlob && recorderRef.current.isRecording()) {
@@ -363,6 +458,12 @@ export default function AppPage(): React.JSX.Element {
 
       if (!wavBlob) {
         recorderRef.current.releaseStream();
+        // If we had previous text, paste it
+        if (prevText?.trim()) {
+          sessionIdRef.current = 0;
+          await window.api.pasteText(prevText);
+          window.api?.sendTranscriptionDone();
+        }
         hidePill();
         return;
       }
@@ -376,6 +477,7 @@ export default function AppPage(): React.JSX.Element {
       };
       if (appContextRef.current)
         headers["x-app-context"] = appContextRef.current;
+      if (prevText) headers["x-previous-text"] = prevText;
 
       const res = await fetch(`${getApiBase()}/api/transcribe`, {
         method: "POST",
@@ -394,6 +496,7 @@ export default function AppPage(): React.JSX.Element {
         console.log("[app] transcribe response:", JSON.stringify(data));
       }
 
+      sessionIdRef.current = 0;
       if (text.trim()) {
         await window.api.pasteText(text);
         window.api?.sendTranscriptionDone();
@@ -409,6 +512,9 @@ export default function AppPage(): React.JSX.Element {
   const cancelRecording = useCallback(() => {
     wantsMicRef.current = false;
     sessionIdRef.current = 0;
+    reRecordingRef.current = false;
+    setIsReRecording(false);
+    previousTextRef.current = null;
     stopVisualization();
     streamerRef.current?.cancel();
     recorderRef.current.cancel();
@@ -435,8 +541,11 @@ export default function AppPage(): React.JSX.Element {
   useEffect(() => {
     const removeDown = window.api.onHotkeyDown(() => {
       const s = stateRef.current;
-      if (s === "idle" || s === "transcribing" || s === "error") {
-        startRecording();
+      if (s === "idle" || s === "error") {
+        startRecording(false);
+      } else if (s === "transcribing") {
+        // Re-record: start a new recording while transcription finishes
+        startRecording(true);
       }
     });
     const removeUp = window.api.onHotkeyUp(() => {
@@ -535,153 +644,197 @@ export default function AppPage(): React.JSX.Element {
             color: transparent;
             animation: shimmer 2s linear infinite;
           }
+          @keyframes slide-up-in {
+            from {
+              opacity: 0;
+              transform: translateY(8px);
+            }
+            to {
+              opacity: 1;
+              transform: translateY(0);
+            }
+          }
+          .pill-slide-up {
+            animation: slide-up-in 250ms ease-out both;
+          }
         `}
       </style>
-      <div
-        className={glowState}
-        style={{
-          borderRadius: 28,
-          visibility: state === "idle" ? "hidden" : "visible",
-        }}
-      >
-        <div
-          className="inline-flex items-center gap-3"
-          style={
-            {
-              height: 48,
-              padding: "0 10px",
+
+      <div style={{ position: "relative" }}>
+        {/* Background transcribing pill — visible during re-record */}
+        {isReRecording && (
+          <div
+            className="glow-transcribing"
+            style={{
               borderRadius: 28,
-              background: "var(--card)",
-              color: "var(--foreground)",
-              border: "1px solid var(--border)",
-              fontFamily: "'DM Sans', sans-serif",
-              fontSize: 14,
-              fontWeight: 500,
-              minWidth: 200,
-              maxWidth: 420,
-              WebkitAppRegion: "no-drag",
-            } as React.CSSProperties
-          }
-        >
-          {/* Orb — conditionally rendered per state */}
-          {state !== "idle" && (
+              position: "absolute",
+              bottom: -6,
+              left: 8,
+              right: 8,
+              opacity: 0.55,
+              transform: "scale(0.95)",
+              pointerEvents: "none",
+              zIndex: 0,
+            }}
+          >
             <div
-              style={{
-                width: 32,
-                height: 32,
-                borderRadius: "50%",
-                overflow: "hidden",
-                flexShrink: 0,
-              }}
+              className="inline-flex items-center gap-3"
+              style={pillInnerStyle}
             >
-              <Orb
-                colors={
-                  state === "error"
-                    ? ["#DD6E4E", "#B85C3A"]
-                    : state === "transcribing"
-                      ? ["#60A5FA", "#3B82F6"]
-                      : state === "initializing"
-                        ? ["#FBBF24", "#F59E0B"]
-                        : ["#8AB62A", "#6B8F12"]
-                }
-                agentState={
-                  state === "initializing"
-                    ? "talking"
-                    : state === "recording"
-                      ? "listening"
-                      : state === "transcribing"
-                        ? "talking"
-                        : null
-                }
-                getInputVolume={
-                  state === "recording" ? getInputVolume : undefined
-                }
-                className="h-full w-full"
-              />
-            </div>
-          )}
-
-          {/* Right-side content changes per state */}
-          {state === "initializing" && (
-            <span style={pillTextStyle}>
-              <span className="shimmer-text">Listening...</span>
-            </span>
-          )}
-
-          {state === "recording" && (
-            <>
-              {partialText ? (
-                <span
-                  style={{
-                    flex: 1,
-                    fontSize: 12,
-                    color: "var(--foreground)",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                    direction: "rtl",
-                    textAlign: "left",
-                  }}
-                >
-                  {partialText}
-                </span>
-              ) : (
-                <svg
-                  ref={barsSvgRef}
-                  width={SVG_WIDTH}
-                  height={SVG_HEIGHT}
-                  viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
-                  style={{ display: "block", flex: 1 }}
-                  role="img"
-                  aria-label="Audio levels"
-                >
-                  {Array.from({ length: BARS }, (_, i) => {
-                    const x = gap * (i + 0.5);
-                    return (
-                      <line
-                        key={i}
-                        x1={x}
-                        y1={SVG_HEIGHT / 2 + 1}
-                        x2={x}
-                        y2={SVG_HEIGHT / 2 - 1}
-                        stroke="var(--muted-foreground)"
-                        strokeWidth={barWidth}
-                        strokeLinecap="round"
-                        style={{ opacity: 0.5 }}
-                      />
-                    );
-                  })}
-                </svg>
-              )}
-              <span
-                className="mono"
+              <div
                 style={{
-                  fontSize: 11,
-                  letterSpacing: "0.06em",
-                  opacity: 0.6,
+                  width: 32,
+                  height: 32,
+                  borderRadius: "50%",
+                  overflow: "hidden",
                   flexShrink: 0,
-                  color: "var(--muted-foreground)",
-                  paddingRight: 6,
                 }}
               >
-                {formatTimer(elapsed)}
-              </span>
-            </>
-          )}
-
-          {state === "transcribing" && (
-            <span style={pillTextStyle}>
-              {partialText ? (
-                partialText.slice(-30)
-              ) : (
+                <Orb
+                  colors={["#60A5FA", "#3B82F6"]}
+                  agentState="talking"
+                  className="h-full w-full"
+                />
+              </div>
+              <span style={pillTextStyle}>
                 <span className="shimmer-text">Transcribing...</span>
-              )}
-            </span>
-          )}
+              </span>
+            </div>
+          </div>
+        )}
 
-          {state === "error" && (
-            <span style={pillTextStyle}>{message || "Error"}</span>
-          )}
+        {/* Primary pill */}
+        <div
+          className={`${glowState}${isReRecording ? " pill-slide-up" : ""}`}
+          style={{
+            borderRadius: 28,
+            visibility: state === "idle" ? "hidden" : "visible",
+            position: "relative",
+            zIndex: 1,
+          }}
+        >
+          <div
+            className="inline-flex items-center gap-3"
+            style={pillInnerStyle}
+          >
+            {state !== "idle" && (
+              <div
+                style={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: "50%",
+                  overflow: "hidden",
+                  flexShrink: 0,
+                }}
+              >
+                <Orb
+                  colors={
+                    state === "error"
+                      ? ["#DD6E4E", "#B85C3A"]
+                      : state === "transcribing"
+                        ? ["#60A5FA", "#3B82F6"]
+                        : state === "initializing"
+                          ? ["#FBBF24", "#F59E0B"]
+                          : ["#8AB62A", "#6B8F12"]
+                  }
+                  agentState={
+                    state === "initializing"
+                      ? "talking"
+                      : state === "recording"
+                        ? "listening"
+                        : state === "transcribing"
+                          ? "talking"
+                          : null
+                  }
+                  getInputVolume={
+                    state === "recording" ? getInputVolume : undefined
+                  }
+                  className="h-full w-full"
+                />
+              </div>
+            )}
+
+            {state === "initializing" && (
+              <span style={pillTextStyle}>
+                <span className="shimmer-text">Listening...</span>
+              </span>
+            )}
+
+            {state === "recording" && (
+              <>
+                {partialText ? (
+                  <span
+                    style={{
+                      flex: 1,
+                      fontSize: 12,
+                      color: "var(--foreground)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      direction: "rtl",
+                      textAlign: "left",
+                    }}
+                  >
+                    {partialText}
+                  </span>
+                ) : (
+                  <svg
+                    ref={barsSvgRef}
+                    width={SVG_WIDTH}
+                    height={SVG_HEIGHT}
+                    viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+                    style={{ display: "block", flex: 1 }}
+                    role="img"
+                    aria-label="Audio levels"
+                  >
+                    {Array.from({ length: BARS }, (_, i) => {
+                      const x = gap * (i + 0.5);
+                      return (
+                        <line
+                          key={i}
+                          x1={x}
+                          y1={SVG_HEIGHT / 2 + 1}
+                          x2={x}
+                          y2={SVG_HEIGHT / 2 - 1}
+                          stroke="var(--muted-foreground)"
+                          strokeWidth={barWidth}
+                          strokeLinecap="round"
+                          style={{ opacity: 0.5 }}
+                        />
+                      );
+                    })}
+                  </svg>
+                )}
+                <span
+                  className="mono"
+                  style={{
+                    fontSize: 11,
+                    letterSpacing: "0.06em",
+                    opacity: 0.6,
+                    flexShrink: 0,
+                    color: "var(--muted-foreground)",
+                    paddingRight: 6,
+                  }}
+                >
+                  {formatTimer(elapsed)}
+                </span>
+              </>
+            )}
+
+            {state === "transcribing" && (
+              <span style={pillTextStyle}>
+                {partialText ? (
+                  partialText.slice(-30)
+                ) : (
+                  <span className="shimmer-text">Transcribing...</span>
+                )}
+              </span>
+            )}
+
+            {state === "error" && (
+              <span style={pillTextStyle}>{message || "Error"}</span>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -497,9 +497,13 @@ export default function AppPage(): React.JSX.Element {
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
       streamerRef.current?.cancel();
-      // If queue is empty (no previous recordings), just hide.
-      if (queueRef.current.length === 0) {
+      // Only hide if nothing else is in-flight (no queue entries and
+      // no active drain processing previous results).
+      if (queueRef.current.length === 0 && !drainingRef.current) {
         hidePill();
+      } else {
+        // Go back to transcribing — the drain will handle paste/hide.
+        setState("transcribing");
       }
       return;
     }
@@ -692,11 +696,11 @@ export default function AppPage(): React.JSX.Element {
             color: transparent;
             animation: shimmer 2s linear infinite;
           }
-          @keyframes slide-up-in {
-            from { opacity: 0; transform: translateY(8px); }
-            to { opacity: 1; transform: translateY(0); }
+          @keyframes fade-in {
+            from { opacity: 0; }
+            to { opacity: 1; }
           }
-          .pill-slide-up { animation: slide-up-in 250ms ease-out both; }
+          .pill-fade-in { animation: fade-in 200ms ease-out both; }
         `}
       </style>
 
@@ -760,7 +764,7 @@ export default function AppPage(): React.JSX.Element {
 
         {/* Primary (topmost) pill — gets the flare */}
         <div
-          className={`${topGlow}${isReRecording ? " pill-slide-up" : ""}`}
+          className={`${topGlow}${isReRecording ? " pill-fade-in" : ""}`}
           style={{
             borderRadius: 28,
             visibility: state === "idle" ? "hidden" : "visible",

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -29,8 +29,7 @@ type PillState =
   | "error";
 
 // ---------------------------------------------------------------------------
-// Sound system — single persistent AudioContext, avoids creating a new one
-// per tone.
+// Sound system
 // ---------------------------------------------------------------------------
 
 let _soundEnabled = true;
@@ -85,9 +84,12 @@ function formatTimer(ms: number): string {
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
+function dbg(msg: string): void {
+  window.api.debugLog(msg);
+}
+
 // ---------------------------------------------------------------------------
-// Pill inner content — extracted so it can be rendered in both the main pill
-// and the background transcribing pill during re-record.
+// Pill inner style — shared between primary and background pills.
 // ---------------------------------------------------------------------------
 
 const pillInnerStyle: React.CSSProperties = {
@@ -112,22 +114,22 @@ export default function AppPage(): React.JSX.Element {
   const [partialText, setPartialText] = useState("");
   const useStreamingRef = useRef(false);
 
-  // Re-record state: when the user presses the hotkey during transcription,
-  // we start a new recording while the previous transcription finishes in
-  // the background.
+  // Re-record state.
   //
-  // `awaitingFirstResultRef` is true when we've committed the second
-  // recording but the first transcription result hasn't arrived yet.
-  // When it's true, onFinal stores the first result AND immediately
-  // sends the deferred second commit with that text as previousText.
+  // `sessionIdRef` is the single source of truth for which commit "owns"
+  // the current session.  Every `startRecording` increments it.  After an
+  // async boundary (fetch, onFinal), a commit checks whether the session
+  // is still the one it started — if not, it's been superseded and must
+  // NOT paste or hide.  Instead it stores its result in `previousTextRef`
+  // for the newer session to pick up.
   //
-  // `deferredCommitRef` holds a callback to execute the deferred commit
-  // once the first result arrives.
+  // `commitSessionRef` records the sessionId that the currently in-flight
+  // commit belongs to.  It's set at the start of commitRecording and
+  // checked after every await.
   const [isReRecording, setIsReRecording] = useState(false);
   const isReRecordingRef = useRef(false);
   const previousTextRef = useRef<string | null>(null);
-  const awaitingFirstResultRef = useRef(false);
-  const deferredCommitRef = useRef<((prevText: string) => void) | null>(null);
+  const commitSessionRef = useRef(0);
 
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
@@ -147,8 +149,14 @@ export default function AppPage(): React.JSX.Element {
 
   const getInputVolume = useCallback(() => volumeRef.current, []);
 
+  /** Returns true if `mySession` is still the active session. */
+  const isCurrentSession = useCallback(
+    (mySession: number) => sessionIdRef.current === mySession && mySession > 0,
+    [],
+  );
+
   // -- Lazy singleton Streamer --
-  // biome-ignore lint/correctness/useExhaustiveDependencies: singleton must only be created once; hidePill is itself a stable useCallback declared below
+  // biome-ignore lint/correctness/useExhaustiveDependencies: singleton must only be created once
   const getStreamer = useCallback((): Streamer => {
     if (!streamerRef.current) {
       streamerRef.current = new Streamer(getApiBase(), {
@@ -158,38 +166,38 @@ export default function AppPage(): React.JSX.Element {
         onReady: () => {},
         onPartial: (text) => setPartialText(text),
         onFinal: async (text) => {
-          window.api.debugLog(
-            `[onFinal] text=${JSON.stringify(text?.slice(0, 60))}, sessionId=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}, awaitingFirst=${awaitingFirstResultRef.current}, isReRec=${isReRecordingRef.current}, hasDeferred=${!!deferredCommitRef.current}`,
+          const sid = sessionIdRef.current;
+          dbg(
+            `[onFinal] text=${JSON.stringify(text?.slice(0, 50))}, sid=${sid}, commitSid=${commitSessionRef.current}, wantsMic=${wantsMicRef.current}`,
           );
-          if (sessionIdRef.current === 0) return;
+          if (sid === 0) return;
 
-          if (awaitingFirstResultRef.current) {
-            window.api.debugLog(
-              "[onFinal] PATH: awaiting first → deferred commit",
-            );
-            awaitingFirstResultRef.current = false;
-            const stored = text.trim() || null;
-            previousTextRef.current = stored;
-
-            const deferred = deferredCommitRef.current;
-            deferredCommitRef.current = null;
-            if (deferred && stored) {
-              deferred(stored);
-            } else if (deferred) {
-              deferred("");
-            }
-            return;
-          }
-
+          // If the user is still recording a re-record, just store.
           if (wantsMicRef.current) {
-            window.api.debugLog("[onFinal] PATH: still recording → store");
+            dbg("[onFinal] → user still recording, storing");
             previousTextRef.current = text.trim() || null;
             return;
           }
 
-          window.api.debugLog("[onFinal] PATH: normal → paste and hide");
-          wantsMicRef.current = false;
+          // If this result belongs to a superseded commit (a newer
+          // session started since this commit was sent), store the
+          // result for the newer session and don't paste/hide.
+          if (
+            commitSessionRef.current !== 0 &&
+            sid !== commitSessionRef.current
+          ) {
+            dbg(
+              `[onFinal] → superseded (commit owns ${commitSessionRef.current}), storing`,
+            );
+            previousTextRef.current = text.trim() || null;
+            return;
+          }
+
+          // Normal path — this is the final result.
+          dbg("[onFinal] → paste and hide");
           sessionIdRef.current = 0;
+          commitSessionRef.current = 0;
+          wantsMicRef.current = false;
           stopVisualization();
           recorderRef.current.cancel();
           recorderRef.current.releaseStream();
@@ -200,16 +208,13 @@ export default function AppPage(): React.JSX.Element {
           hidePill();
         },
         onCleaned: (text) => {
-          window.api.debugLog(
-            `[onCleaned] sessionId=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}, awaitingFirst=${awaitingFirstResultRef.current}`,
+          dbg(
+            `[onCleaned] sid=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}`,
           );
-          // Guard: if the session was cancelled, ignore late arrivals
           if (sessionIdRef.current === 0) return;
 
-          if (wantsMicRef.current || awaitingFirstResultRef.current) {
-            if (text.trim()) {
-              previousTextRef.current = text.trim();
-            }
+          if (wantsMicRef.current) {
+            if (text.trim()) previousTextRef.current = text.trim();
             return;
           }
 
@@ -218,22 +223,19 @@ export default function AppPage(): React.JSX.Element {
           }
         },
         onError: (msg) => {
-          window.api.debugLog(
-            `[onError] msg=${msg}, sessionId=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}`,
+          dbg(
+            `[onError] msg=${msg}, sid=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}`,
           );
           if (sessionIdRef.current === 0) return;
 
           if (wantsMicRef.current) {
             previousTextRef.current = null;
-            awaitingFirstResultRef.current = false;
-            deferredCommitRef.current = null;
             return;
           }
 
-          wantsMicRef.current = false;
           sessionIdRef.current = 0;
-          awaitingFirstResultRef.current = false;
-          deferredCommitRef.current = null;
+          commitSessionRef.current = 0;
+          wantsMicRef.current = false;
           stopVisualization();
           recorderRef.current.cancel();
           recorderRef.current.releaseStream();
@@ -246,14 +248,13 @@ export default function AppPage(): React.JSX.Element {
     return streamerRef.current;
   }, []);
 
-  // -- Audio visualization (from a MediaStream) --
+  // -- Audio visualization --
   const startVisualization = useCallback((stream: MediaStream) => {
     if (!analyserCtxRef.current || analyserCtxRef.current.state === "closed") {
       analyserCtxRef.current = new AudioContext();
     }
     const ctx = analyserCtxRef.current;
 
-    // Disconnect previous nodes to avoid leaking them on the AudioContext
     try {
       audioSourceRef.current?.disconnect();
     } catch {}
@@ -274,9 +275,7 @@ export default function AppPage(): React.JSX.Element {
     let lastIpcTime = 0;
 
     const update = () => {
-      if (!wantsMicRef.current) {
-        return;
-      }
+      if (!wantsMicRef.current) return;
       analyser.getByteFrequencyData(dataArray);
       const raw: number[] = [];
       let totalSum = 0;
@@ -292,13 +291,11 @@ export default function AppPage(): React.JSX.Element {
       barsRef.current = smoothBars(barsRef.current, raw);
       const volume = Math.min(1, (totalSum / BARS) * 2.5);
       volumeRef.current = volume;
-      // Throttle IPC to ~10fps to reduce main-process event-loop pressure
       const now = performance.now();
       if (now - lastIpcTime >= 100) {
         lastIpcTime = now;
         window.api?.sendAudioLevel(volume);
       }
-      // Direct DOM update — avoids 60fps React re-renders (rerender-use-ref-transient-values)
       const svg = barsSvgRef.current;
       if (svg) {
         const lines = svg.querySelectorAll("line");
@@ -320,7 +317,6 @@ export default function AppPage(): React.JSX.Element {
     rafRef.current = 0;
     clearInterval(timerRef.current);
     timerRef.current = 0;
-    // Disconnect audio nodes to prevent accumulation on the AudioContext
     try {
       audioSourceRef.current?.disconnect();
     } catch {}
@@ -329,37 +325,34 @@ export default function AppPage(): React.JSX.Element {
     } catch {}
     audioSourceRef.current = null;
     analyserNodeRef.current = null;
-    // Don't close analyserCtxRef — we reuse it across sessions
     barsRef.current = new Array(BARS).fill(0);
     volumeRef.current = 0;
     setElapsed(0);
   }, []);
 
-  // Hide the pill and reset to idle so the next show starts clean
+  // Hide the pill and reset ALL state so the next show starts clean.
   const hidePill = useCallback(() => {
-    window.api.debugLog("[hidePill] called");
+    dbg("[hidePill]");
     setState("idle");
     setPartialText("");
     setMessage("");
     setIsReRecording(false);
     isReRecordingRef.current = false;
+    wantsMicRef.current = false;
     sessionIdRef.current = 0;
+    commitSessionRef.current = 0;
     previousTextRef.current = null;
-    awaitingFirstResultRef.current = false;
-    deferredCommitRef.current = null;
     window.api.hidePill();
   }, []);
 
   // -- Start recording --
-  // When `forReRecord` is true, we're starting a new recording while the
-  // previous transcription is still in progress.
   const startRecording = useCallback(
     async (forReRecord = false) => {
-      window.api.debugLog(
-        `[startRecording] forReRecord=${forReRecord}, wantsMic=${wantsMicRef.current}, sessionId=${sessionIdRef.current}`,
+      dbg(
+        `[startRecording] forReRecord=${forReRecord}, wantsMic=${wantsMicRef.current}, sid=${sessionIdRef.current}`,
       );
       if (wantsMicRef.current) {
-        window.api.debugLog("[startRecording] SKIP: wantsMic already true");
+        dbg("[startRecording] SKIP: wantsMic already true");
         return;
       }
       wantsMicRef.current = true;
@@ -374,8 +367,6 @@ export default function AppPage(): React.JSX.Element {
         isReRecordingRef.current = false;
         setIsReRecording(false);
         previousTextRef.current = null;
-        awaitingFirstResultRef.current = false;
-        deferredCommitRef.current = null;
       }
 
       window.api
@@ -392,9 +383,6 @@ export default function AppPage(): React.JSX.Element {
           appContextRef.current = null;
         });
 
-      // When re-recording, skip the initializing state — go straight to
-      // recording so the UI doesn't flash the amber "Listening..." pill
-      // on top of the blue transcribing pill.
       if (!forReRecord) {
         setState("initializing");
       }
@@ -415,13 +403,12 @@ export default function AppPage(): React.JSX.Element {
           recorderRef.current.cancel();
           recorderRef.current.releaseStream();
           streamerRef.current?.cancel();
-          if (!forReRecord) {
-            hidePill();
-          }
+          if (!forReRecord) hidePill();
           return;
         }
 
         sessionIdRef.current++;
+        dbg(`[startRecording] session started: sid=${sessionIdRef.current}`);
         playTone("start");
         setState("recording");
         startTimeRef.current = Date.now();
@@ -443,8 +430,6 @@ export default function AppPage(): React.JSX.Element {
         pendingCommitRef.current = false;
         isReRecordingRef.current = false;
         setIsReRecording(false);
-        awaitingFirstResultRef.current = false;
-        deferredCommitRef.current = null;
         recorderRef.current.releaseStream();
         setState("error");
         setMessage(err instanceof Error ? err.message : "Mic access denied");
@@ -457,9 +442,13 @@ export default function AppPage(): React.JSX.Element {
   // -- Commit: stop recording and transcribe --
   const commitRecording = useCallback(async () => {
     const wasReRecording = isReRecordingRef.current;
-    window.api.debugLog(
-      `[commitRecording] wasReRec=${wasReRecording}, wantsMic=${wantsMicRef.current}, sessionId=${sessionIdRef.current}, prevText=${!!previousTextRef.current}, awaitFirst=${awaitingFirstResultRef.current}`,
+    const mySession = sessionIdRef.current;
+    commitSessionRef.current = mySession;
+
+    dbg(
+      `[commitRecording] wasReRec=${wasReRecording}, sid=${mySession}, wantsMic=${wantsMicRef.current}, hasPrevText=${!!previousTextRef.current}`,
     );
+
     wantsMicRef.current = false;
     isReRecordingRef.current = false;
     setIsReRecording(false);
@@ -468,22 +457,18 @@ export default function AppPage(): React.JSX.Element {
 
     const recordingDuration = Date.now() - startTimeRef.current;
     if (recordingDuration < 1000) {
-      window.api.debugLog("[commitRecording] short recording (<1s)");
+      dbg("[commitRecording] short (<1s)");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
       streamerRef.current?.cancel();
       if (wasReRecording && previousTextRef.current?.trim()) {
-        // Short re-record with first result already available — paste it.
-        sessionIdRef.current = 0;
         const text = previousTextRef.current;
         previousTextRef.current = null;
-        awaitingFirstResultRef.current = false;
-        deferredCommitRef.current = null;
+        sessionIdRef.current = 0;
+        commitSessionRef.current = 0;
         await window.api.pasteText(text);
         window.api?.sendTranscriptionDone();
       }
-      // If the first result hasn't arrived yet, onFinal will
-      // see wantsMicRef=false and paste when it does arrive.
       hidePill();
       return;
     }
@@ -491,30 +476,18 @@ export default function AppPage(): React.JSX.Element {
     const prevText = previousTextRef.current;
     previousTextRef.current = null;
 
-    // If streaming mode is active, commit via WebSocket
+    // --- Streaming path ---
     if (useStreamingRef.current && streamerRef.current) {
       setState("transcribing");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
-
-      if (wasReRecording && !prevText) {
-        window.api.debugLog("[commitRecording] streaming: deferring commit");
-        awaitingFirstResultRef.current = true;
-        deferredCommitRef.current = (firstText: string) => {
-          window.api.debugLog(
-            `[deferredCommit] firing, hasText=${!!firstText}`,
-          );
-          streamerRef.current?.commit(firstText || undefined);
-        };
-      } else {
-        window.api.debugLog(
-          `[commitRecording] streaming: immediate commit, hasPrev=${!!prevText}`,
-        );
-        streamerRef.current.commit(prevText ?? undefined);
-      }
+      dbg(`[commitRecording] streaming commit, hasPrev=${!!prevText}`);
+      streamerRef.current.commit(prevText ?? undefined);
+      // onFinal will handle paste/hide, using sessionId checks.
       return;
     }
 
+    // --- REST path ---
     setState("transcribing");
     streamerRef.current?.cancel();
 
@@ -529,6 +502,7 @@ export default function AppPage(): React.JSX.Element {
         recorderRef.current.releaseStream();
         if (prevText?.trim()) {
           sessionIdRef.current = 0;
+          commitSessionRef.current = 0;
           await window.api.pasteText(prevText);
           window.api?.sendTranscriptionDone();
         }
@@ -539,9 +513,6 @@ export default function AppPage(): React.JSX.Element {
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
 
-      // For the REST path, if the first result hasn't arrived yet we
-      // must wait for it.  This is only possible in streaming mode
-      // which already returned above, so prevText is reliable here.
       const headers: Record<string, string> = {
         "Content-Type": "audio/wav",
         "x-audio-duration-ms": String(recordingDuration),
@@ -556,6 +527,25 @@ export default function AppPage(): React.JSX.Element {
         headers,
       });
 
+      // ---- After async: check if we're still the active session ----
+      if (!isCurrentSession(mySession)) {
+        // A newer session started while we were waiting for the API.
+        // Store our result for the newer session to combine with.
+        dbg(
+          `[commitRecording] REST response arrived but superseded (my=${mySession}, current=${sessionIdRef.current})`,
+        );
+        if (res.ok) {
+          try {
+            const data = await res.json();
+            const text = data.cleaned || data.raw || "";
+            if (text.trim()) {
+              previousTextRef.current = text.trim();
+            }
+          } catch {}
+        }
+        return;
+      }
+
       if (!res.ok) {
         const err = await res.json().catch(() => ({ error: "Request failed" }));
         throw new Error(err.error || `HTTP ${res.status}`);
@@ -564,30 +554,36 @@ export default function AppPage(): React.JSX.Element {
       const data = await res.json();
       const text = data.cleaned || data.raw || "";
       if (import.meta.env.DEV) {
-        console.log("[app] transcribe response:", JSON.stringify(data));
+        dbg(
+          `[commitRecording] REST response: ${JSON.stringify(text?.slice(0, 50))}`,
+        );
       }
 
       sessionIdRef.current = 0;
+      commitSessionRef.current = 0;
       if (text.trim()) {
         await window.api.pasteText(text);
         window.api?.sendTranscriptionDone();
       }
       hidePill();
     } catch (err) {
-      setState("error");
-      setMessage(err instanceof Error ? err.message : "Transcription failed");
-      setTimeout(() => hidePill(), 2000);
+      // Only show error if we're still the active session
+      if (isCurrentSession(mySession)) {
+        setState("error");
+        setMessage(err instanceof Error ? err.message : "Transcription failed");
+        setTimeout(() => hidePill(), 2000);
+      }
     }
-  }, [stopVisualization, hidePill]);
+  }, [stopVisualization, hidePill, isCurrentSession]);
 
   const cancelRecording = useCallback(() => {
+    dbg("[cancelRecording]");
     wantsMicRef.current = false;
     sessionIdRef.current = 0;
+    commitSessionRef.current = 0;
     isReRecordingRef.current = false;
     setIsReRecording(false);
     previousTextRef.current = null;
-    awaitingFirstResultRef.current = false;
-    deferredCommitRef.current = null;
     stopVisualization();
     streamerRef.current?.cancel();
     recorderRef.current.cancel();
@@ -595,7 +591,7 @@ export default function AppPage(): React.JSX.Element {
     hidePill();
   }, [stopVisualization, hidePill]);
 
-  // Load sound preference from server settings
+  // Load sound preference
   useEffect(() => {
     getClient()
       .api.settings[":key"].$get({ param: { key: "sound_enabled" } })
@@ -606,17 +602,14 @@ export default function AppPage(): React.JSX.Element {
       .catch(() => {});
   }, []);
 
-  // Track state in a ref so event handlers don't need state in their deps
   const stateRef = useRef(state);
   stateRef.current = state;
 
-  // Hold-to-record: hotkey down = start, hotkey up = commit
+  // Hotkey handlers
   useEffect(() => {
     const removeDown = window.api.onHotkeyDown(() => {
       const s = stateRef.current;
-      window.api.debugLog(
-        `[hotkeyDown] state=${s}, wantsMic=${wantsMicRef.current}`,
-      );
+      dbg(`[hotkeyDown] state=${s}, wantsMic=${wantsMicRef.current}`);
       if (s === "idle" || s === "error") {
         startRecording(false);
       } else if (s === "transcribing") {
@@ -624,7 +617,7 @@ export default function AppPage(): React.JSX.Element {
       }
     });
     const removeUp = window.api.onHotkeyUp(() => {
-      window.api.debugLog(
+      dbg(
         `[hotkeyUp] state=${stateRef.current}, wantsMic=${wantsMicRef.current}`,
       );
       if (stateRef.current === "recording") {
@@ -634,8 +627,7 @@ export default function AppPage(): React.JSX.Element {
       }
     });
     const removeCancel = window.api.onPillCancel(() => {
-      const s = stateRef.current;
-      if (s !== "idle") {
+      if (stateRef.current !== "idle") {
         cancelRecording();
       }
     });
@@ -646,16 +638,12 @@ export default function AppPage(): React.JSX.Element {
     };
   }, [startRecording, commitRecording, cancelRecording]);
 
-  // Cleanup on unmount — fully release mic + audio resources.
-  // Use a ref to avoid StrictMode double-invoke calling cancelRecording
-  // on the simulated unmount (which hides the pill spuriously).
+  // Cleanup on unmount
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
-      // Delay cleanup slightly so StrictMode's immediate remount
-      // can cancel it before resources are destroyed.
       setTimeout(() => {
         if (!mountedRef.current) {
           cancelRecording();
@@ -746,7 +734,6 @@ export default function AppPage(): React.JSX.Element {
       </style>
 
       <div style={{ position: "relative" }}>
-        {/* Background transcribing pill — visible during re-record */}
         {isReRecording && (
           <div
             className="glow-transcribing"
@@ -788,7 +775,6 @@ export default function AppPage(): React.JSX.Element {
           </div>
         )}
 
-        {/* Primary pill */}
         <div
           className={`${glowState}${isReRecording ? " pill-slide-up" : ""}`}
           style={{

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -10,7 +10,6 @@ const FALL = 0.22;
 const SVG_WIDTH = 140;
 const SVG_HEIGHT = 28;
 
-/** Shared style for right-side text content in the pill */
 const pillTextStyle: React.CSSProperties = {
   color: "var(--muted-foreground)",
   fontSize: 13,
@@ -29,16 +28,14 @@ type PillState =
   | "error";
 
 // ---------------------------------------------------------------------------
-// Sound system
+// Sound
 // ---------------------------------------------------------------------------
 
 let _soundEnabled = true;
 let _toneCtx: AudioContext | null = null;
 
 function getToneCtx(): AudioContext {
-  if (!_toneCtx || _toneCtx.state === "closed") {
-    _toneCtx = new AudioContext();
-  }
+  if (!_toneCtx || _toneCtx.state === "closed") _toneCtx = new AudioContext();
   return _toneCtx;
 }
 
@@ -64,9 +61,7 @@ async function playTone(preset: TonePreset, volume = 0.3): Promise<void> {
     gain.connect(ctx.destination);
     osc.start();
     osc.stop(ctx.currentTime + ms / 1000);
-  } catch {
-    // ignore audio errors
-  }
+  } catch {}
 }
 
 function smoothBars(prev: number[], next: number[]): number[] {
@@ -88,10 +83,6 @@ function dbg(msg: string): void {
   window.api.debugLog(msg);
 }
 
-// ---------------------------------------------------------------------------
-// Pill inner style — shared between primary and background pills.
-// ---------------------------------------------------------------------------
-
 const pillInnerStyle: React.CSSProperties = {
   height: 48,
   padding: "0 10px",
@@ -107,6 +98,15 @@ const pillInnerStyle: React.CSSProperties = {
   WebkitAppRegion: "no-drag",
 } as React.CSSProperties;
 
+// ---------------------------------------------------------------------------
+// Transcription queue entry.  Each recording produces one of these.
+// The `promise` resolves with the transcribed (and individually
+// post-processed) text once the server responds.
+// ---------------------------------------------------------------------------
+interface QueueEntry {
+  promise: Promise<string>;
+}
+
 export default function AppPage(): React.JSX.Element {
   const [state, setState] = useState<PillState>("idle");
   const [elapsed, setElapsed] = useState(0);
@@ -114,31 +114,8 @@ export default function AppPage(): React.JSX.Element {
   const [partialText, setPartialText] = useState("");
   const useStreamingRef = useRef(false);
 
-  // Re-record state.
-  //
-  // `sessionIdRef` is the single source of truth for which commit "owns"
-  // the current session.  Every `startRecording` increments it.  After an
-  // async boundary (fetch, onFinal), a commit checks whether the session
-  // is still the one it started — if not, it's been superseded and must
-  // NOT paste or hide.  Instead it stores its result in `previousTextRef`
-  // for the newer session to pick up.
-  //
-  // `commitSessionRef` records the sessionId that the currently in-flight
-  // commit belongs to.  It's set at the start of commitRecording and
-  // checked after every await.
-  //
-  // `resolvePreviousTextRef` holds a Promise resolve function.  When a
-  // re-record commit needs the first result but it hasn't arrived yet,
-  // it awaits a promise.  The superseded commit resolves it when its
-  // fetch returns, delivering the text.
   const [isReRecording, setIsReRecording] = useState(false);
   const isReRecordingRef = useRef(false);
-  const previousTextRef = useRef<string | null>(null);
-  const commitSessionRef = useRef(0);
-  const pillActiveRef = useRef(false);
-  const resolvePreviousTextRef = useRef<((text: string | null) => void) | null>(
-    null,
-  );
 
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
@@ -154,18 +131,103 @@ export default function AppPage(): React.JSX.Element {
   const wantsMicRef = useRef(false);
   const appContextRef = useRef<string | null>(null);
   const pendingCommitRef = useRef(false);
-  const sessionIdRef = useRef(0);
+  const pillActiveRef = useRef(false);
+
+  // ---- Transcription queue ----
+  // Each commitRecording pushes a QueueEntry.  The drainQueue function
+  // waits for all entries, stitches the results, post-processes if
+  // needed, then pastes.  No session-id coordination required.
+  const queueRef = useRef<QueueEntry[]>([]);
+  const drainingRef = useRef(false);
+  const cancelledRef = useRef(false);
 
   const getInputVolume = useCallback(() => volumeRef.current, []);
 
-  /** Returns true if `mySession` is still the active session. */
-  const isCurrentSession = useCallback(
-    (mySession: number) => sessionIdRef.current === mySession && mySession > 0,
-    [],
-  );
+  // ---- Queue drain ----
+  const drainQueue = useCallback(async () => {
+    if (drainingRef.current) return;
+    drainingRef.current = true;
 
-  // -- Lazy singleton Streamer --
-  // biome-ignore lint/correctness/useExhaustiveDependencies: singleton must only be created once
+    // Keep draining as long as there are entries.  New entries may be
+    // pushed while we're awaiting, so re-check after each batch.
+    while (queueRef.current.length > 0 && !cancelledRef.current) {
+      // Snapshot the current queue and clear it so new recordings
+      // can push fresh entries while we await.
+      const batch = [...queueRef.current];
+      queueRef.current = [];
+
+      dbg(`[drainQueue] waiting for ${batch.length} result(s)`);
+      const results = await Promise.all(batch.map((e) => e.promise));
+
+      if (cancelledRef.current) break;
+
+      // If more entries arrived while we were awaiting, loop again
+      // to include them in the final stitch.
+      if (queueRef.current.length > 0) {
+        // Put the resolved results back as immediately-resolved entries
+        // so the next iteration can combine everything.
+        const resolved = results
+          .filter((t) => t.trim())
+          .map((t) => ({ promise: Promise.resolve(t) }));
+        queueRef.current = [...resolved, ...queueRef.current];
+        continue;
+      }
+
+      // All results are in.  Stitch and paste.
+      const nonEmpty = results.filter((t) => t.trim());
+      if (nonEmpty.length === 0 || cancelledRef.current) break;
+
+      let finalText: string;
+      if (nonEmpty.length === 1) {
+        finalText = nonEmpty[0];
+      } else {
+        // Multiple recordings — stitch and re-post-process.
+        const combined = nonEmpty.join(" ");
+        dbg(
+          `[drainQueue] stitching ${nonEmpty.length} results, calling /api/post-process`,
+        );
+        try {
+          const res = await fetch(`${getApiBase()}/api/post-process`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              text: combined,
+              appContext: appContextRef.current,
+            }),
+          });
+          if (cancelledRef.current) break;
+          if (res.ok) {
+            const data = await res.json();
+            finalText = data.cleaned || combined;
+          } else {
+            finalText = combined;
+          }
+        } catch {
+          finalText = combined;
+        }
+      }
+
+      if (cancelledRef.current) break;
+
+      dbg(`[drainQueue] pasting final text (${finalText.length} chars)`);
+      await window.api.pasteText(finalText);
+      window.api?.sendTranscriptionDone();
+    }
+
+    drainingRef.current = false;
+
+    // If not cancelled and no new entries arrived, we're done — hide.
+    if (!cancelledRef.current && queueRef.current.length === 0) {
+      // Only hide if the user isn't currently recording another segment
+      if (!wantsMicRef.current) {
+        dbg("[drainQueue] done, hiding pill");
+        hidePill();
+      }
+    }
+  }, []);
+
+  // ---- Streamer (lazy singleton) ----
+  // biome-ignore lint/correctness/useExhaustiveDependencies: singleton
   const getStreamer = useCallback((): Streamer => {
     if (!streamerRef.current) {
       streamerRef.current = new Streamer(getApiBase(), {
@@ -174,90 +236,22 @@ export default function AppPage(): React.JSX.Element {
         },
         onReady: () => {},
         onPartial: (text) => setPartialText(text),
-        onFinal: async (text) => {
-          const sid = sessionIdRef.current;
-          dbg(
-            `[onFinal] text=${JSON.stringify(text?.slice(0, 50))}, sid=${sid}, commitSid=${commitSessionRef.current}, wantsMic=${wantsMicRef.current}, active=${pillActiveRef.current}`,
-          );
-          if (!pillActiveRef.current) return;
-
-          // If the user is still recording a re-record, just store.
-          if (wantsMicRef.current) {
-            dbg("[onFinal] → user still recording, storing");
-            const stored = text.trim() || null;
-            previousTextRef.current = stored;
-            if (resolvePreviousTextRef.current) {
-              resolvePreviousTextRef.current(stored);
-              resolvePreviousTextRef.current = null;
-            }
-            return;
-          }
-
-          // If this result belongs to a superseded commit (a newer
-          // session started since this commit was sent), store the
-          // result for the newer session and don't paste/hide.
-          if (
-            commitSessionRef.current !== 0 &&
-            sid !== commitSessionRef.current
-          ) {
-            dbg(
-              `[onFinal] → superseded (commit owns ${commitSessionRef.current}), storing`,
-            );
-            const stored = text.trim() || null;
-            previousTextRef.current = stored;
-            if (resolvePreviousTextRef.current) {
-              resolvePreviousTextRef.current(stored);
-              resolvePreviousTextRef.current = null;
-            }
-            return;
-          }
-
-          // Normal path — this is the final result.
-          dbg("[onFinal] → paste and hide");
-          const mySid = sid;
-          stopVisualization();
-          recorderRef.current.cancel();
-          recorderRef.current.releaseStream();
-          if (text.trim()) {
-            await window.api.pasteText(text);
-            window.api?.sendTranscriptionDone();
-          }
-          // A new session may have started during the paste await.
-          if (isCurrentSession(mySid)) {
-            hidePill();
-          }
+        onFinal: async (_text) => {
+          dbg(`[onFinal] active=${pillActiveRef.current}`);
+          // Streaming onFinal is not used in the queue model for the
+          // REST path.  For streaming mode it would need to resolve a
+          // promise — but the current user is on REST, so this is a
+          // no-op safety net.  The queue handles everything.
         },
-        onCleaned: (text) => {
-          dbg(
-            `[onCleaned] active=${pillActiveRef.current}, wantsMic=${wantsMicRef.current}`,
-          );
-          if (!pillActiveRef.current) return;
-
-          if (wantsMicRef.current) {
-            if (text.trim()) previousTextRef.current = text.trim();
-            return;
-          }
-
-          if (text.trim()) {
-            window.api.pasteText(text);
-          }
+        onCleaned: (_text) => {
+          dbg(`[onCleaned] active=${pillActiveRef.current}`);
+          // Cleaned results are handled by the transcribe endpoint
+          // response directly.  No action needed here.
         },
         onError: (msg) => {
-          dbg(
-            `[onError] msg=${msg}, active=${pillActiveRef.current}, wantsMic=${wantsMicRef.current}`,
-          );
+          dbg(`[onError] msg=${msg}, active=${pillActiveRef.current}`);
           if (!pillActiveRef.current) return;
-
-          if (wantsMicRef.current) {
-            previousTextRef.current = null;
-            return;
-          }
-
-          commitSessionRef.current = 0;
-          wantsMicRef.current = false;
-          stopVisualization();
-          recorderRef.current.cancel();
-          recorderRef.current.releaseStream();
+          if (wantsMicRef.current) return;
           setState("error");
           setMessage(msg);
           setTimeout(() => hidePill(), 2000);
@@ -267,13 +261,12 @@ export default function AppPage(): React.JSX.Element {
     return streamerRef.current;
   }, []);
 
-  // -- Audio visualization --
+  // ---- Visualization ----
   const startVisualization = useCallback((stream: MediaStream) => {
     if (!analyserCtxRef.current || analyserCtxRef.current.state === "closed") {
       analyserCtxRef.current = new AudioContext();
     }
     const ctx = analyserCtxRef.current;
-
     try {
       audioSourceRef.current?.disconnect();
     } catch {}
@@ -300,9 +293,7 @@ export default function AppPage(): React.JSX.Element {
       let totalSum = 0;
       for (let i = 0; i < BARS; i++) {
         let sum = 0;
-        for (let j = 0; j < sliceSize; j++) {
-          sum += dataArray[i * sliceSize + j];
-        }
+        for (let j = 0; j < sliceSize; j++) sum += dataArray[i * sliceSize + j];
         const val = sum / sliceSize / 255;
         raw.push(val);
         totalSum += val;
@@ -349,9 +340,7 @@ export default function AppPage(): React.JSX.Element {
     setElapsed(0);
   }, []);
 
-  // Hide the pill and reset ALL state so the next show starts clean.
-  // Note: sessionIdRef is NOT reset — it monotonically increases so
-  // that stale async callbacks can never collide with a new session.
+  // ---- Hide pill ----
   const hidePill = useCallback(() => {
     dbg("[hidePill]");
     setState("idle");
@@ -361,20 +350,17 @@ export default function AppPage(): React.JSX.Element {
     isReRecordingRef.current = false;
     wantsMicRef.current = false;
     pillActiveRef.current = false;
-    commitSessionRef.current = 0;
-    previousTextRef.current = null;
-    if (resolvePreviousTextRef.current) {
-      resolvePreviousTextRef.current(null);
-      resolvePreviousTextRef.current = null;
-    }
+    cancelledRef.current = false;
+    queueRef.current = [];
+    drainingRef.current = false;
     window.api.hidePill();
   }, []);
 
-  // -- Start recording --
+  // ---- Start recording ----
   const startRecording = useCallback(
     async (forReRecord = false) => {
       dbg(
-        `[startRecording] forReRecord=${forReRecord}, wantsMic=${wantsMicRef.current}, sid=${sessionIdRef.current}`,
+        `[startRecording] forReRec=${forReRecord}, wantsMic=${wantsMicRef.current}`,
       );
       if (wantsMicRef.current) {
         dbg("[startRecording] SKIP: wantsMic already true");
@@ -382,6 +368,7 @@ export default function AppPage(): React.JSX.Element {
       }
       wantsMicRef.current = true;
       pillActiveRef.current = true;
+      cancelledRef.current = false;
       pendingCommitRef.current = false;
       setMessage("");
       setPartialText("");
@@ -392,7 +379,6 @@ export default function AppPage(): React.JSX.Element {
       } else {
         isReRecordingRef.current = false;
         setIsReRecording(false);
-        previousTextRef.current = null;
       }
 
       window.api
@@ -409,9 +395,7 @@ export default function AppPage(): React.JSX.Element {
           appContextRef.current = null;
         });
 
-      if (!forReRecord) {
-        setState("initializing");
-      }
+      if (!forReRecord) setState("initializing");
 
       try {
         const stream = useStreamingRef.current
@@ -423,7 +407,6 @@ export default function AppPage(): React.JSX.Element {
           recorderRef.current.releaseStream();
           return;
         }
-
         if (pendingCommitRef.current) {
           pendingCommitRef.current = false;
           recorderRef.current.cancel();
@@ -433,8 +416,6 @@ export default function AppPage(): React.JSX.Element {
           return;
         }
 
-        sessionIdRef.current++;
-        dbg(`[startRecording] session started: sid=${sessionIdRef.current}`);
         playTone("start");
         setState("recording");
         startTimeRef.current = Date.now();
@@ -444,7 +425,6 @@ export default function AppPage(): React.JSX.Element {
         }, 100);
 
         startVisualization(stream);
-
         try {
           await getStreamer().startCapture(
             stream,
@@ -465,16 +445,13 @@ export default function AppPage(): React.JSX.Element {
     [startVisualization, hidePill, getStreamer],
   );
 
-  // -- Commit: stop recording and transcribe --
+  // ---- Commit recording ----
+  // Fires a transcription request and pushes the result promise into the
+  // queue.  Does NOT paste or hide — the queue drain handles that.
   const commitRecording = useCallback(async () => {
-    const wasReRecording = isReRecordingRef.current;
-    const mySession = sessionIdRef.current;
-    commitSessionRef.current = mySession;
-
     dbg(
-      `[commitRecording] wasReRec=${wasReRecording}, sid=${mySession}, wantsMic=${wantsMicRef.current}, hasPrevText=${!!previousTextRef.current}`,
+      `[commitRecording] wantsMic=${wantsMicRef.current}, queueLen=${queueRef.current.length}`,
     );
-
     wantsMicRef.current = false;
     isReRecordingRef.current = false;
     setIsReRecording(false);
@@ -483,185 +460,68 @@ export default function AppPage(): React.JSX.Element {
 
     const recordingDuration = Date.now() - startTimeRef.current;
     if (recordingDuration < 1000) {
-      dbg("[commitRecording] short (<1s)");
+      dbg("[commitRecording] short (<1s), skipping");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
       streamerRef.current?.cancel();
-      if (wasReRecording && previousTextRef.current?.trim()) {
-        const text = previousTextRef.current;
-        previousTextRef.current = null;
-        await window.api.pasteText(text);
-        window.api?.sendTranscriptionDone();
-      }
-      if (isCurrentSession(mySession)) {
+      // If queue is empty (no previous recordings), just hide.
+      if (queueRef.current.length === 0) {
         hidePill();
       }
       return;
     }
 
-    let prevText = previousTextRef.current;
-    previousTextRef.current = null;
-
-    // --- Streaming path ---
-    if (useStreamingRef.current && streamerRef.current) {
-      setState("transcribing");
-      recorderRef.current.cancel();
-      recorderRef.current.releaseStream();
-
-      // If the first result hasn't arrived yet, wait for it.
-      if (wasReRecording && !prevText) {
-        dbg("[commitRecording] streaming: waiting for first result...");
-        prevText = await new Promise<string | null>((resolve) => {
-          if (previousTextRef.current) {
-            const t = previousTextRef.current;
-            previousTextRef.current = null;
-            resolve(t);
-            return;
-          }
-          resolvePreviousTextRef.current = resolve;
-        });
-        dbg(
-          `[commitRecording] streaming: got first result, len=${prevText?.length ?? 0}`,
-        );
-        if (!isCurrentSession(mySession)) return;
-      }
-
-      dbg(`[commitRecording] streaming commit, hasPrev=${!!prevText}`);
-      streamerRef.current.commit(prevText ?? undefined);
-      return;
-    }
-
-    // --- REST path ---
     setState("transcribing");
-    streamerRef.current?.cancel();
 
-    try {
-      let wavBlob: Blob | null = streamerRef.current?.getWavBlob() ?? null;
-
-      if (!wavBlob && recorderRef.current.isRecording()) {
-        wavBlob = await recorderRef.current.stop();
-      }
-
-      if (!wavBlob) {
-        recorderRef.current.releaseStream();
-        if (prevText?.trim()) {
-          await window.api.pasteText(prevText);
-          window.api?.sendTranscriptionDone();
-        }
-        if (isCurrentSession(mySession)) {
-          hidePill();
-        }
-        return;
-      }
-
-      recorderRef.current.cancel();
-      recorderRef.current.releaseStream();
-
-      // If this is a re-record and the first result hasn't arrived yet,
-      // wait for the superseded commit to deliver it.
-      if (wasReRecording && !prevText) {
-        dbg("[commitRecording] REST: waiting for first result...");
-        prevText = await new Promise<string | null>((resolve) => {
-          // If the first result already landed while we were getting
-          // the WAV blob, grab it now.
-          if (previousTextRef.current) {
-            const t = previousTextRef.current;
-            previousTextRef.current = null;
-            resolve(t);
-            return;
-          }
-          resolvePreviousTextRef.current = resolve;
-        });
-        dbg(
-          `[commitRecording] REST: got first result, len=${prevText?.length ?? 0}`,
-        );
-
-        // Re-check session after the wait
-        if (!isCurrentSession(mySession)) return;
-      }
-
-      const headers: Record<string, string> = {
-        "Content-Type": "audio/wav",
-        "x-audio-duration-ms": String(recordingDuration),
-      };
-      if (appContextRef.current)
-        headers["x-app-context"] = appContextRef.current;
-      if (prevText) headers["x-previous-text"] = prevText;
-
-      const res = await fetch(`${getApiBase()}/api/transcribe`, {
-        method: "POST",
-        body: wavBlob,
-        headers,
-      });
-
-      // ---- After async: check if we're still the active session ----
-      if (!isCurrentSession(mySession)) {
-        dbg(
-          `[commitRecording] superseded (my=${mySession}, cur=${sessionIdRef.current})`,
-        );
-        let resultText: string | null = null;
-        if (res.ok) {
-          try {
-            const data = await res.json();
-            resultText = (data.cleaned || data.raw || "").trim() || null;
-          } catch {}
-        }
-        // Store the result AND wake up the newer commit if it's waiting.
-        previousTextRef.current = resultText;
-        if (resolvePreviousTextRef.current) {
-          resolvePreviousTextRef.current(resultText);
-          resolvePreviousTextRef.current = null;
-        }
-        return;
-      }
-
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ error: "Request failed" }));
-        throw new Error(err.error || `HTTP ${res.status}`);
-      }
-
-      const data = await res.json();
-      const text = data.cleaned || data.raw || "";
-      if (import.meta.env.DEV) {
-        dbg(
-          `[commitRecording] REST response: ${JSON.stringify(text?.slice(0, 50))}`,
-        );
-      }
-
-      if (text.trim()) {
-        await window.api.pasteText(text);
-        window.api?.sendTranscriptionDone();
-      }
-      // A new session may have started during the paste await.
-      if (isCurrentSession(mySession)) {
-        hidePill();
-      } else {
-        dbg(
-          `[commitRecording] skipping hidePill, new session started during paste`,
-        );
-      }
-    } catch (err) {
-      // Only show error if we're still the active session
-      if (isCurrentSession(mySession)) {
-        setState("error");
-        setMessage(err instanceof Error ? err.message : "Transcription failed");
-        setTimeout(() => hidePill(), 2000);
-      }
+    // Get the audio blob
+    let wavBlob: Blob | null = streamerRef.current?.getWavBlob() ?? null;
+    if (!wavBlob && recorderRef.current.isRecording()) {
+      wavBlob = await recorderRef.current.stop();
     }
-  }, [stopVisualization, hidePill, isCurrentSession]);
+    recorderRef.current.cancel();
+    recorderRef.current.releaseStream();
 
+    if (!wavBlob) {
+      if (queueRef.current.length === 0) hidePill();
+      return;
+    }
+
+    // Build the transcription promise
+    const headers: Record<string, string> = {
+      "Content-Type": "audio/wav",
+      "x-audio-duration-ms": String(recordingDuration),
+    };
+    if (appContextRef.current) headers["x-app-context"] = appContextRef.current;
+
+    const transcribePromise = fetch(`${getApiBase()}/api/transcribe`, {
+      method: "POST",
+      body: wavBlob,
+      headers,
+    })
+      .then(async (res) => {
+        if (!res.ok) return "";
+        const data = await res.json();
+        return (data.cleaned || data.raw || "").trim();
+      })
+      .catch(() => "");
+
+    // Push to queue
+    queueRef.current.push({ promise: transcribePromise });
+    dbg(`[commitRecording] pushed to queue, len=${queueRef.current.length}`);
+
+    // Start draining if not already draining
+    drainQueue();
+  }, [stopVisualization, hidePill, drainQueue]);
+
+  // ---- Cancel ----
   const cancelRecording = useCallback(() => {
     dbg("[cancelRecording]");
+    cancelledRef.current = true;
     wantsMicRef.current = false;
     pillActiveRef.current = false;
-    commitSessionRef.current = 0;
     isReRecordingRef.current = false;
     setIsReRecording(false);
-    previousTextRef.current = null;
-    if (resolvePreviousTextRef.current) {
-      resolvePreviousTextRef.current(null);
-      resolvePreviousTextRef.current = null;
-    }
+    queueRef.current = [];
     stopVisualization();
     streamerRef.current?.cancel();
     recorderRef.current.cancel();
@@ -669,7 +529,7 @@ export default function AppPage(): React.JSX.Element {
     hidePill();
   }, [stopVisualization, hidePill]);
 
-  // Load sound preference
+  // ---- Sound preference ----
   useEffect(() => {
     getClient()
       .api.settings[":key"].$get({ param: { key: "sound_enabled" } })
@@ -683,7 +543,7 @@ export default function AppPage(): React.JSX.Element {
   const stateRef = useRef(state);
   stateRef.current = state;
 
-  // Hotkey handlers
+  // ---- Hotkey handlers ----
   useEffect(() => {
     const removeDown = window.api.onHotkeyDown(() => {
       const s = stateRef.current;
@@ -705,9 +565,7 @@ export default function AppPage(): React.JSX.Element {
       }
     });
     const removeCancel = window.api.onPillCancel(() => {
-      if (stateRef.current !== "idle") {
-        cancelRecording();
-      }
+      if (stateRef.current !== "idle") cancelRecording();
     });
     return () => {
       removeDown();
@@ -716,7 +574,7 @@ export default function AppPage(): React.JSX.Element {
     };
   }, [startRecording, commitRecording, cancelRecording]);
 
-  // Cleanup on unmount
+  // ---- Cleanup on unmount ----
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
@@ -734,7 +592,7 @@ export default function AppPage(): React.JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cancelRecording]);
 
-  // -- Render --
+  // ---- Render ----
   const gap = SVG_WIDTH / BARS;
   const barWidth = Math.min(gap * 0.55, 5);
 
@@ -783,12 +641,7 @@ export default function AppPage(): React.JSX.Element {
           }
           .shimmer-text {
             font-style: italic;
-            background: linear-gradient(
-              90deg,
-              var(--muted-foreground) calc(50% - 40px),
-              var(--foreground),
-              var(--muted-foreground) calc(50% + 40px)
-            );
+            background: linear-gradient(90deg, var(--muted-foreground) calc(50% - 40px), var(--foreground), var(--muted-foreground) calc(50% + 40px));
             background-size: 250% 100%;
             background-clip: text;
             -webkit-background-clip: text;
@@ -796,18 +649,10 @@ export default function AppPage(): React.JSX.Element {
             animation: shimmer 2s linear infinite;
           }
           @keyframes slide-up-in {
-            from {
-              opacity: 0;
-              transform: translateY(8px);
-            }
-            to {
-              opacity: 1;
-              transform: translateY(0);
-            }
+            from { opacity: 0; transform: translateY(8px); }
+            to { opacity: 1; transform: translateY(0); }
           }
-          .pill-slide-up {
-            animation: slide-up-in 250ms ease-out both;
-          }
+          .pill-slide-up { animation: slide-up-in 250ms ease-out both; }
         `}
       </style>
 

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -116,6 +116,7 @@ export default function AppPage(): React.JSX.Element {
 
   const [isReRecording, setIsReRecording] = useState(false);
   const isReRecordingRef = useRef(false);
+  const [pendingCount, setPendingCount] = useState(0);
 
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
@@ -379,6 +380,7 @@ export default function AppPage(): React.JSX.Element {
     setMessage("");
     setIsReRecording(false);
     isReRecordingRef.current = false;
+    setPendingCount(0);
     wantsMicRef.current = false;
     pillActiveRef.current = false;
     cancelledRef.current = false;
@@ -524,10 +526,7 @@ export default function AppPage(): React.JSX.Element {
     };
     if (appContextRef.current) headers["x-app-context"] = appContextRef.current;
 
-    // Always grab raw transcription text.  Post-processing is done
-    // once on the combined result in drainQueue — this avoids
-    // individual LLM cleanup that would hide corrections like
-    // "scratch that" from the final post-processing pass.
+    setPendingCount((c) => c + 1);
     const transcribePromise = fetch(`${getApiBase()}/api/transcribe`, {
       method: "POST",
       body: wavBlob,
@@ -538,7 +537,8 @@ export default function AppPage(): React.JSX.Element {
         const data = await res.json();
         return (data.raw || "").trim();
       })
-      .catch(() => "");
+      .catch(() => "")
+      .finally(() => setPendingCount((c) => Math.max(0, c - 1)));
 
     // Push to queue
     queueRef.current.push({ promise: transcribePromise });
@@ -631,16 +631,25 @@ export default function AppPage(): React.JSX.Element {
   const gap = SVG_WIDTH / BARS;
   const barWidth = Math.min(gap * 0.55, 5);
 
-  const glowState =
+  // Flare only on the topmost pill.
+  const topGlow =
     state === "initializing"
       ? "glow-initializing"
       : state === "recording"
         ? "glow-recording"
-        : state === "transcribing"
+        : state === "transcribing" && !isReRecording
           ? "glow-transcribing"
           : state === "error"
             ? "glow-error"
             : "glow-idle";
+
+  // Right-side badge: timer during recording, xN during transcribing.
+  const badge =
+    state === "recording"
+      ? formatTimer(elapsed)
+      : state === "transcribing" && pendingCount > 0
+        ? `x${pendingCount}`
+        : null;
 
   return (
     <div
@@ -692,16 +701,17 @@ export default function AppPage(): React.JSX.Element {
       </style>
 
       <div style={{ position: "relative" }}>
+        {/* Background stacked pill — visible during re-record.
+            No flare, slightly scaled down for depth effect. */}
         {isReRecording && (
           <div
-            className="glow-transcribing"
             style={{
               borderRadius: 28,
               position: "absolute",
-              bottom: -14,
+              bottom: -10,
               left: "50%",
-              transform: "translateX(-50%) scale(0.92)",
-              opacity: 0.5,
+              transform: "translateX(-50%) scale(0.97)",
+              opacity: 0.45,
               pointerEvents: "none",
               zIndex: 0,
               width: "100%",
@@ -729,12 +739,28 @@ export default function AppPage(): React.JSX.Element {
               <span style={pillTextStyle}>
                 <span className="shimmer-text">Transcribing...</span>
               </span>
+              {pendingCount > 0 && (
+                <span
+                  className="mono"
+                  style={{
+                    fontSize: 11,
+                    letterSpacing: "0.06em",
+                    opacity: 0.6,
+                    flexShrink: 0,
+                    color: "var(--muted-foreground)",
+                    paddingRight: 6,
+                  }}
+                >
+                  x{pendingCount}
+                </span>
+              )}
             </div>
           </div>
         )}
 
+        {/* Primary (topmost) pill — gets the flare */}
         <div
-          className={`${glowState}${isReRecording ? " pill-slide-up" : ""}`}
+          className={`${topGlow}${isReRecording ? " pill-slide-up" : ""}`}
           style={{
             borderRadius: 28,
             visibility: state === "idle" ? "hidden" : "visible",
@@ -834,19 +860,6 @@ export default function AppPage(): React.JSX.Element {
                     })}
                   </svg>
                 )}
-                <span
-                  className="mono"
-                  style={{
-                    fontSize: 11,
-                    letterSpacing: "0.06em",
-                    opacity: 0.6,
-                    flexShrink: 0,
-                    color: "var(--muted-foreground)",
-                    paddingRight: 6,
-                  }}
-                >
-                  {formatTimer(elapsed)}
-                </span>
               </>
             )}
 
@@ -862,6 +875,23 @@ export default function AppPage(): React.JSX.Element {
 
             {state === "error" && (
               <span style={pillTextStyle}>{message || "Error"}</span>
+            )}
+
+            {/* Right-side badge: timer or xN counter */}
+            {badge && (
+              <span
+                className="mono"
+                style={{
+                  fontSize: 11,
+                  letterSpacing: "0.06em",
+                  opacity: 0.6,
+                  flexShrink: 0,
+                  color: "var(--muted-foreground)",
+                  paddingRight: 6,
+                }}
+              >
+                {badge}
+              </span>
             )}
           </div>
         </div>

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -126,10 +126,18 @@ export default function AppPage(): React.JSX.Element {
   // `commitSessionRef` records the sessionId that the currently in-flight
   // commit belongs to.  It's set at the start of commitRecording and
   // checked after every await.
+  //
+  // `resolvePreviousTextRef` holds a Promise resolve function.  When a
+  // re-record commit needs the first result but it hasn't arrived yet,
+  // it awaits a promise.  The superseded commit resolves it when its
+  // fetch returns, delivering the text.
   const [isReRecording, setIsReRecording] = useState(false);
   const isReRecordingRef = useRef(false);
   const previousTextRef = useRef<string | null>(null);
   const commitSessionRef = useRef(0);
+  const resolvePreviousTextRef = useRef<((text: string | null) => void) | null>(
+    null,
+  );
 
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
@@ -175,7 +183,12 @@ export default function AppPage(): React.JSX.Element {
           // If the user is still recording a re-record, just store.
           if (wantsMicRef.current) {
             dbg("[onFinal] → user still recording, storing");
-            previousTextRef.current = text.trim() || null;
+            const stored = text.trim() || null;
+            previousTextRef.current = stored;
+            if (resolvePreviousTextRef.current) {
+              resolvePreviousTextRef.current(stored);
+              resolvePreviousTextRef.current = null;
+            }
             return;
           }
 
@@ -189,7 +202,12 @@ export default function AppPage(): React.JSX.Element {
             dbg(
               `[onFinal] → superseded (commit owns ${commitSessionRef.current}), storing`,
             );
-            previousTextRef.current = text.trim() || null;
+            const stored = text.trim() || null;
+            previousTextRef.current = stored;
+            if (resolvePreviousTextRef.current) {
+              resolvePreviousTextRef.current(stored);
+              resolvePreviousTextRef.current = null;
+            }
             return;
           }
 
@@ -342,6 +360,11 @@ export default function AppPage(): React.JSX.Element {
     sessionIdRef.current = 0;
     commitSessionRef.current = 0;
     previousTextRef.current = null;
+    // Wake up any waiting commit so it can exit cleanly
+    if (resolvePreviousTextRef.current) {
+      resolvePreviousTextRef.current(null);
+      resolvePreviousTextRef.current = null;
+    }
     window.api.hidePill();
   }, []);
 
@@ -473,7 +496,7 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
-    const prevText = previousTextRef.current;
+    let prevText = previousTextRef.current;
     previousTextRef.current = null;
 
     // --- Streaming path ---
@@ -481,9 +504,27 @@ export default function AppPage(): React.JSX.Element {
       setState("transcribing");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
+
+      // If the first result hasn't arrived yet, wait for it.
+      if (wasReRecording && !prevText) {
+        dbg("[commitRecording] streaming: waiting for first result...");
+        prevText = await new Promise<string | null>((resolve) => {
+          if (previousTextRef.current) {
+            const t = previousTextRef.current;
+            previousTextRef.current = null;
+            resolve(t);
+            return;
+          }
+          resolvePreviousTextRef.current = resolve;
+        });
+        dbg(
+          `[commitRecording] streaming: got first result, len=${prevText?.length ?? 0}`,
+        );
+        if (!isCurrentSession(mySession)) return;
+      }
+
       dbg(`[commitRecording] streaming commit, hasPrev=${!!prevText}`);
       streamerRef.current.commit(prevText ?? undefined);
-      // onFinal will handle paste/hide, using sessionId checks.
       return;
     }
 
@@ -513,6 +554,29 @@ export default function AppPage(): React.JSX.Element {
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
 
+      // If this is a re-record and the first result hasn't arrived yet,
+      // wait for the superseded commit to deliver it.
+      if (wasReRecording && !prevText) {
+        dbg("[commitRecording] REST: waiting for first result...");
+        prevText = await new Promise<string | null>((resolve) => {
+          // If the first result already landed while we were getting
+          // the WAV blob, grab it now.
+          if (previousTextRef.current) {
+            const t = previousTextRef.current;
+            previousTextRef.current = null;
+            resolve(t);
+            return;
+          }
+          resolvePreviousTextRef.current = resolve;
+        });
+        dbg(
+          `[commitRecording] REST: got first result, len=${prevText?.length ?? 0}`,
+        );
+
+        // Re-check session after the wait
+        if (!isCurrentSession(mySession)) return;
+      }
+
       const headers: Record<string, string> = {
         "Content-Type": "audio/wav",
         "x-audio-duration-ms": String(recordingDuration),
@@ -529,19 +593,21 @@ export default function AppPage(): React.JSX.Element {
 
       // ---- After async: check if we're still the active session ----
       if (!isCurrentSession(mySession)) {
-        // A newer session started while we were waiting for the API.
-        // Store our result for the newer session to combine with.
         dbg(
-          `[commitRecording] REST response arrived but superseded (my=${mySession}, current=${sessionIdRef.current})`,
+          `[commitRecording] superseded (my=${mySession}, cur=${sessionIdRef.current})`,
         );
+        let resultText: string | null = null;
         if (res.ok) {
           try {
             const data = await res.json();
-            const text = data.cleaned || data.raw || "";
-            if (text.trim()) {
-              previousTextRef.current = text.trim();
-            }
+            resultText = (data.cleaned || data.raw || "").trim() || null;
           } catch {}
+        }
+        // Store the result AND wake up the newer commit if it's waiting.
+        previousTextRef.current = resultText;
+        if (resolvePreviousTextRef.current) {
+          resolvePreviousTextRef.current(resultText);
+          resolvePreviousTextRef.current = null;
         }
         return;
       }
@@ -584,6 +650,10 @@ export default function AppPage(): React.JSX.Element {
     isReRecordingRef.current = false;
     setIsReRecording(false);
     previousTextRef.current = null;
+    if (resolvePreviousTextRef.current) {
+      resolvePreviousTextRef.current(null);
+      resolvePreviousTextRef.current = null;
+    }
     stopVisualization();
     streamerRef.current?.cancel();
     recorderRef.current.cancel();

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -811,10 +811,11 @@ export default function AppPage(): React.JSX.Element {
               borderRadius: 28,
               position: "absolute",
               bottom: -14,
-              left: 6,
-              right: 6,
+              left: 0,
+              right: 0,
               opacity: 0.5,
               transform: "scale(0.92)",
+              transformOrigin: "center center",
               pointerEvents: "none",
               zIndex: 0,
             }}

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -114,13 +114,19 @@ export default function AppPage(): React.JSX.Element {
 
   // Re-record state: when the user presses the hotkey during transcription,
   // we start a new recording while the previous transcription finishes in
-  // the background.  `pendingResultsRef` counts how many streaming `final`
-  // messages we still expect before the very last result can be pasted.
-  // When it drops to zero on a `final` arrival, that result is the one to
-  // paste.  The `isReRecording` state drives the stacked-pill visual.
+  // the background.
+  //
+  // `awaitingFirstResultRef` is true when we've committed the second
+  // recording but the first transcription result hasn't arrived yet.
+  // When it's true, onFinal stores the first result AND immediately
+  // sends the deferred second commit with that text as previousText.
+  //
+  // `deferredCommitRef` holds a callback to execute the deferred commit
+  // once the first result arrives.
   const [isReRecording, setIsReRecording] = useState(false);
   const previousTextRef = useRef<string | null>(null);
-  const pendingResultsRef = useRef(0);
+  const awaitingFirstResultRef = useRef(false);
+  const deferredCommitRef = useRef<((prevText: string) => void) | null>(null);
 
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
@@ -153,16 +159,32 @@ export default function AppPage(): React.JSX.Element {
         onFinal: async (text) => {
           if (sessionIdRef.current === 0) return;
 
-          // More results expected (a re-record was started) — store the
-          // text so it can be combined with the next transcription.
-          if (pendingResultsRef.current > 1) {
-            pendingResultsRef.current--;
+          // If we are awaiting the first result before sending the
+          // deferred second commit, handle it here.
+          if (awaitingFirstResultRef.current) {
+            awaitingFirstResultRef.current = false;
+            const stored = text.trim() || null;
+            previousTextRef.current = stored;
+
+            // Fire the deferred commit now that we have the first text.
+            const deferred = deferredCommitRef.current;
+            deferredCommitRef.current = null;
+            if (deferred && stored) {
+              deferred(stored);
+            } else if (deferred) {
+              deferred("");
+            }
+            return;
+          }
+
+          // If the user is still recording (re-record in progress),
+          // store the text and wait for them to finish.
+          if (wantsMicRef.current) {
             previousTextRef.current = text.trim() || null;
             return;
           }
 
-          // This is the last expected result — paste and close.
-          pendingResultsRef.current = 0;
+          // Normal path — this is the final result; paste and close.
           wantsMicRef.current = false;
           sessionIdRef.current = 0;
           stopVisualization();
@@ -175,9 +197,9 @@ export default function AppPage(): React.JSX.Element {
           hidePill();
         },
         onCleaned: (text) => {
-          // If more results are pending, update previousText with the
-          // cleaned version so the final combine uses the best text.
-          if (pendingResultsRef.current > 0) {
+          // If the user is still recording or we're waiting for the
+          // first result, update previousText with the cleaned version.
+          if (wantsMicRef.current || awaitingFirstResultRef.current) {
             if (text.trim()) {
               previousTextRef.current = text.trim();
             }
@@ -193,17 +215,19 @@ export default function AppPage(): React.JSX.Element {
         onError: (msg) => {
           if (sessionIdRef.current === 0) return;
 
-          // If more results are pending (re-recording in progress),
-          // don't hide — let the recording continue.
-          if (pendingResultsRef.current > 1) {
-            pendingResultsRef.current--;
+          // If the user is still recording, don't hide — let the
+          // recording continue. Clear the stored text since it errored.
+          if (wantsMicRef.current) {
             previousTextRef.current = null;
+            awaitingFirstResultRef.current = false;
+            deferredCommitRef.current = null;
             return;
           }
 
-          pendingResultsRef.current = 0;
           wantsMicRef.current = false;
           sessionIdRef.current = 0;
+          awaitingFirstResultRef.current = false;
+          deferredCommitRef.current = null;
           stopVisualization();
           recorderRef.current.cancel();
           recorderRef.current.releaseStream();
@@ -311,8 +335,10 @@ export default function AppPage(): React.JSX.Element {
     setPartialText("");
     setMessage("");
     setIsReRecording(false);
-    pendingResultsRef.current = 0;
+    sessionIdRef.current = 0;
     previousTextRef.current = null;
+    awaitingFirstResultRef.current = false;
+    deferredCommitRef.current = null;
     window.api.hidePill();
   }, []);
 
@@ -328,14 +354,12 @@ export default function AppPage(): React.JSX.Element {
       setPartialText("");
 
       if (forReRecord) {
-        // The previous commit already set pendingResultsRef to 1;
-        // bump it so onFinal knows to store that result rather than paste.
-        pendingResultsRef.current++;
         setIsReRecording(true);
       } else {
-        pendingResultsRef.current = 0;
         setIsReRecording(false);
         previousTextRef.current = null;
+        awaitingFirstResultRef.current = false;
+        deferredCommitRef.current = null;
       }
 
       window.api
@@ -401,8 +425,9 @@ export default function AppPage(): React.JSX.Element {
       } catch (err) {
         wantsMicRef.current = false;
         pendingCommitRef.current = false;
-        pendingResultsRef.current = 0;
         setIsReRecording(false);
+        awaitingFirstResultRef.current = false;
+        deferredCommitRef.current = null;
         recorderRef.current.releaseStream();
         setState("error");
         setMessage(err instanceof Error ? err.message : "Mic access denied");
@@ -425,28 +450,19 @@ export default function AppPage(): React.JSX.Element {
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
       streamerRef.current?.cancel();
-      if (wasReRecording) {
-        // Short re-record — decrement the pending counter since we
-        // won't be sending a second commit.  If the first result
-        // already arrived, paste it; otherwise let the pending
-        // onFinal handle the paste when it drops to zero.
-        pendingResultsRef.current = Math.max(0, pendingResultsRef.current - 1);
-        if (
-          pendingResultsRef.current === 0 &&
-          previousTextRef.current?.trim()
-        ) {
-          sessionIdRef.current = 0;
-          const text = previousTextRef.current;
-          previousTextRef.current = null;
-          await window.api.pasteText(text);
-          window.api?.sendTranscriptionDone();
-          hidePill();
-        }
-        // If pendingResultsRef > 0 the first result hasn't arrived yet;
-        // onFinal will handle paste when it arrives since pending == 1.
-      } else {
-        hidePill();
+      if (wasReRecording && previousTextRef.current?.trim()) {
+        // Short re-record with first result already available — paste it.
+        sessionIdRef.current = 0;
+        const text = previousTextRef.current;
+        previousTextRef.current = null;
+        awaitingFirstResultRef.current = false;
+        deferredCommitRef.current = null;
+        await window.api.pasteText(text);
+        window.api?.sendTranscriptionDone();
       }
+      // If the first result hasn't arrived yet, onFinal will
+      // see wantsMicRef=false and paste when it does arrive.
+      hidePill();
       return;
     }
 
@@ -455,11 +471,20 @@ export default function AppPage(): React.JSX.Element {
 
     // If streaming mode is active, commit via WebSocket
     if (useStreamingRef.current && streamerRef.current) {
-      pendingResultsRef.current = Math.max(1, pendingResultsRef.current);
       setState("transcribing");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
-      streamerRef.current.commit(prevText ?? undefined);
+
+      if (wasReRecording && !prevText) {
+        // The first result hasn't arrived yet. Defer the commit
+        // until onFinal delivers it, so the server can combine them.
+        awaitingFirstResultRef.current = true;
+        deferredCommitRef.current = (firstText: string) => {
+          streamerRef.current?.commit(firstText || undefined);
+        };
+      } else {
+        streamerRef.current.commit(prevText ?? undefined);
+      }
       return;
     }
 
@@ -475,7 +500,6 @@ export default function AppPage(): React.JSX.Element {
 
       if (!wavBlob) {
         recorderRef.current.releaseStream();
-        // If we had previous text, paste it
         if (prevText?.trim()) {
           sessionIdRef.current = 0;
           await window.api.pasteText(prevText);
@@ -488,6 +512,9 @@ export default function AppPage(): React.JSX.Element {
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
 
+      // For the REST path, if the first result hasn't arrived yet we
+      // must wait for it.  This is only possible in streaming mode
+      // which already returned above, so prevText is reliable here.
       const headers: Record<string, string> = {
         "Content-Type": "audio/wav",
         "x-audio-duration-ms": String(recordingDuration),
@@ -524,14 +551,15 @@ export default function AppPage(): React.JSX.Element {
       setMessage(err instanceof Error ? err.message : "Transcription failed");
       setTimeout(() => hidePill(), 2000);
     }
-  }, [stopVisualization, hidePill]);
+  }, [stopVisualization, hidePill, isReRecording]);
 
   const cancelRecording = useCallback(() => {
     wantsMicRef.current = false;
     sessionIdRef.current = 0;
-    pendingResultsRef.current = 0;
     setIsReRecording(false);
     previousTextRef.current = null;
+    awaitingFirstResultRef.current = false;
+    deferredCommitRef.current = null;
     stopVisualization();
     streamerRef.current?.cancel();
     recorderRef.current.cancel();

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -158,16 +158,22 @@ export default function AppPage(): React.JSX.Element {
         onReady: () => {},
         onPartial: (text) => setPartialText(text),
         onFinal: async (text) => {
-          if (sessionIdRef.current === 0) return;
+          console.log(
+            `[onFinal] text=${JSON.stringify(text?.slice(0, 60))}, sessionId=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}, awaitingFirst=${awaitingFirstResultRef.current}, isReRecording=${isReRecordingRef.current}, hasDeferredCommit=${!!deferredCommitRef.current}`,
+          );
+          if (sessionIdRef.current === 0) {
+            console.log("[onFinal] SKIP: sessionId is 0");
+            return;
+          }
 
-          // If we are awaiting the first result before sending the
-          // deferred second commit, handle it here.
           if (awaitingFirstResultRef.current) {
+            console.log(
+              "[onFinal] PATH: awaiting first result → store + fire deferred commit",
+            );
             awaitingFirstResultRef.current = false;
             const stored = text.trim() || null;
             previousTextRef.current = stored;
 
-            // Fire the deferred commit now that we have the first text.
             const deferred = deferredCommitRef.current;
             deferredCommitRef.current = null;
             if (deferred && stored) {
@@ -178,14 +184,13 @@ export default function AppPage(): React.JSX.Element {
             return;
           }
 
-          // If the user is still recording (re-record in progress),
-          // store the text and wait for them to finish.
           if (wantsMicRef.current) {
+            console.log("[onFinal] PATH: user still recording → store text");
             previousTextRef.current = text.trim() || null;
             return;
           }
 
-          // Normal path — this is the final result; paste and close.
+          console.log("[onFinal] PATH: normal → paste and hide");
           wantsMicRef.current = false;
           sessionIdRef.current = 0;
           stopVisualization();
@@ -198,8 +203,9 @@ export default function AppPage(): React.JSX.Element {
           hidePill();
         },
         onCleaned: (text) => {
-          // If the user is still recording or we're waiting for the
-          // first result, update previousText with the cleaned version.
+          console.log(
+            `[onCleaned] text=${JSON.stringify(text?.slice(0, 60))}, wantsMic=${wantsMicRef.current}, awaitingFirst=${awaitingFirstResultRef.current}`,
+          );
           if (wantsMicRef.current || awaitingFirstResultRef.current) {
             if (text.trim()) {
               previousTextRef.current = text.trim();
@@ -207,17 +213,16 @@ export default function AppPage(): React.JSX.Element {
             return;
           }
 
-          // Normal flow: paste the cleaned text (replaces the raw text
-          // that was already pasted by onFinal).
           if (text.trim()) {
             window.api.pasteText(text);
           }
         },
         onError: (msg) => {
+          console.log(
+            `[onError] msg=${msg}, sessionId=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}`,
+          );
           if (sessionIdRef.current === 0) return;
 
-          // If the user is still recording, don't hide — let the
-          // recording continue. Clear the stored text since it errored.
           if (wantsMicRef.current) {
             previousTextRef.current = null;
             awaitingFirstResultRef.current = false;
@@ -332,6 +337,7 @@ export default function AppPage(): React.JSX.Element {
 
   // Hide the pill and reset to idle so the next show starts clean
   const hidePill = useCallback(() => {
+    console.log("[hidePill] called");
     setState("idle");
     setPartialText("");
     setMessage("");
@@ -349,7 +355,13 @@ export default function AppPage(): React.JSX.Element {
   // previous transcription is still in progress.
   const startRecording = useCallback(
     async (forReRecord = false) => {
-      if (wantsMicRef.current) return;
+      console.log(
+        `[startRecording] forReRecord=${forReRecord}, wantsMic=${wantsMicRef.current}, sessionId=${sessionIdRef.current}`,
+      );
+      if (wantsMicRef.current) {
+        console.log("[startRecording] SKIP: wantsMic already true");
+        return;
+      }
       wantsMicRef.current = true;
       pendingCommitRef.current = false;
       setMessage("");
@@ -444,8 +456,11 @@ export default function AppPage(): React.JSX.Element {
 
   // -- Commit: stop recording and transcribe --
   const commitRecording = useCallback(async () => {
-    wantsMicRef.current = false;
     const wasReRecording = isReRecordingRef.current;
+    console.log(
+      `[commitRecording] wasReRecording=${wasReRecording}, wantsMic=${wantsMicRef.current}, sessionId=${sessionIdRef.current}, previousText=${JSON.stringify(previousTextRef.current?.slice(0, 40))}, awaitingFirst=${awaitingFirstResultRef.current}`,
+    );
+    wantsMicRef.current = false;
     isReRecordingRef.current = false;
     setIsReRecording(false);
     stopVisualization();
@@ -453,6 +468,7 @@ export default function AppPage(): React.JSX.Element {
 
     const recordingDuration = Date.now() - startTimeRef.current;
     if (recordingDuration < 1000) {
+      console.log("[commitRecording] short recording (<1s), cancelling");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
       streamerRef.current?.cancel();
@@ -482,13 +498,20 @@ export default function AppPage(): React.JSX.Element {
       recorderRef.current.releaseStream();
 
       if (wasReRecording && !prevText) {
-        // The first result hasn't arrived yet. Defer the commit
-        // until onFinal delivers it, so the server can combine them.
+        console.log(
+          "[commitRecording] streaming: deferring commit — awaiting first result",
+        );
         awaitingFirstResultRef.current = true;
         deferredCommitRef.current = (firstText: string) => {
+          console.log(
+            `[deferredCommit] firing with firstText=${JSON.stringify(firstText?.slice(0, 40))}`,
+          );
           streamerRef.current?.commit(firstText || undefined);
         };
       } else {
+        console.log(
+          `[commitRecording] streaming: immediate commit, prevText=${JSON.stringify(prevText?.slice(0, 40))}`,
+        );
         streamerRef.current.commit(prevText ?? undefined);
       }
       return;
@@ -593,6 +616,7 @@ export default function AppPage(): React.JSX.Element {
   useEffect(() => {
     const removeDown = window.api.onHotkeyDown(() => {
       const s = stateRef.current;
+      console.log(`[hotkeyDown] state=${s}, wantsMic=${wantsMicRef.current}`);
       if (s === "idle" || s === "error") {
         startRecording(false);
       } else if (s === "transcribing") {
@@ -600,6 +624,9 @@ export default function AppPage(): React.JSX.Element {
       }
     });
     const removeUp = window.api.onHotkeyUp(() => {
+      console.log(
+        `[hotkeyUp] state=${stateRef.current}, wantsMic=${wantsMicRef.current}`,
+      );
       if (stateRef.current === "recording") {
         commitRecording();
       } else if (stateRef.current === "initializing") {

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -140,7 +140,6 @@ export default function AppPage(): React.JSX.Element {
   // needed, then pastes.  No session-id coordination required.
   const queueRef = useRef<QueueEntry[]>([]);
   const drainingRef = useRef(false);
-  const cancelledRef = useRef(false);
 
   const getInputVolume = useCallback(() => volumeRef.current, []);
 
@@ -152,44 +151,35 @@ export default function AppPage(): React.JSX.Element {
     if (drainingRef.current) return;
     drainingRef.current = true;
 
-    // Wait until the user finishes recording.  Each commitRecording
-    // calls drainQueue again after pushing, so if we're already
-    // draining we just return (the loop will pick up new entries).
-    while (wantsMicRef.current && !cancelledRef.current) {
+    while (wantsMicRef.current && pillActiveRef.current) {
       await new Promise((r) => setTimeout(r, 100));
     }
 
-    if (cancelledRef.current || queueRef.current.length === 0) {
+    if (!pillActiveRef.current || queueRef.current.length === 0) {
       drainingRef.current = false;
       return;
     }
 
-    // Take everything in the queue.
     const batch = [...queueRef.current];
     queueRef.current = [];
 
     dbg(`[drainQueue] waiting for ${batch.length} result(s)`);
     const results = await Promise.all(batch.map((e) => e.promise));
 
-    if (cancelledRef.current) {
+    if (!pillActiveRef.current) {
       drainingRef.current = false;
       return;
     }
 
-    // If the user started recording again while we were awaiting,
-    // put results back and loop.
     if (wantsMicRef.current || queueRef.current.length > 0) {
       const resolved = results
         .filter((t) => t.trim())
         .map((t) => ({ promise: Promise.resolve(t) }));
       queueRef.current = [...resolved, ...queueRef.current];
       drainingRef.current = false;
-      // The next commitRecording will call drainQueue again.
       return;
     }
 
-    // All results are in and user is not recording.  Stitch and
-    // post-process as one cohesive piece.
     const nonEmpty = results.filter((t) => t.trim());
     if (nonEmpty.length === 0) {
       drainingRef.current = false;
@@ -211,7 +201,7 @@ export default function AppPage(): React.JSX.Element {
           appContext: appContextRef.current,
         }),
       });
-      if (cancelledRef.current) {
+      if (!pillActiveRef.current) {
         drainingRef.current = false;
         return;
       }
@@ -225,13 +215,11 @@ export default function AppPage(): React.JSX.Element {
       finalText = combined;
     }
 
-    if (cancelledRef.current) {
+    if (!pillActiveRef.current) {
       drainingRef.current = false;
       return;
     }
 
-    // If the user started ANOTHER recording while we were post-
-    // processing, stash the result and let the next drain combine it.
     if (wantsMicRef.current || queueRef.current.length > 0) {
       queueRef.current = [
         { promise: Promise.resolve(finalText) },
@@ -247,11 +235,10 @@ export default function AppPage(): React.JSX.Element {
 
     drainingRef.current = false;
 
-    // Final check: if user started recording during paste, don't hide.
     if (
       !wantsMicRef.current &&
       queueRef.current.length === 0 &&
-      !cancelledRef.current
+      pillActiveRef.current
     ) {
       dbg("[drainQueue] done, hiding pill");
       hidePill();
@@ -383,7 +370,6 @@ export default function AppPage(): React.JSX.Element {
     setPendingCount(0);
     wantsMicRef.current = false;
     pillActiveRef.current = false;
-    cancelledRef.current = false;
     queueRef.current = [];
     drainingRef.current = false;
     window.api.hidePill();
@@ -401,7 +387,6 @@ export default function AppPage(): React.JSX.Element {
       }
       wantsMicRef.current = true;
       pillActiveRef.current = true;
-      cancelledRef.current = false;
       pendingCommitRef.current = false;
       setMessage("");
       setPartialText("");
@@ -518,8 +503,14 @@ export default function AppPage(): React.JSX.Element {
     recorderRef.current.cancel();
     recorderRef.current.releaseStream();
 
+    // If cancel/hide fired while we were getting the blob, bail out.
+    if (!pillActiveRef.current) {
+      dbg("[commitRecording] pill no longer active, bailing");
+      return;
+    }
+
     if (!wavBlob) {
-      if (queueRef.current.length === 0) hidePill();
+      if (queueRef.current.length === 0 && !drainingRef.current) hidePill();
       return;
     }
 
@@ -555,7 +546,6 @@ export default function AppPage(): React.JSX.Element {
   // ---- Cancel ----
   const cancelRecording = useCallback(() => {
     dbg("[cancelRecording]");
-    cancelledRef.current = true;
     wantsMicRef.current = false;
     pillActiveRef.current = false;
     isReRecordingRef.current = false;

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -187,7 +187,8 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
-    // All results are in and user is not recording.  Stitch and paste.
+    // All results are in and user is not recording.  Stitch and
+    // post-process as one cohesive piece.
     const nonEmpty = results.filter((t) => t.trim());
     if (nonEmpty.length === 0) {
       drainingRef.current = false;
@@ -195,36 +196,32 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
+    const combined = nonEmpty.join(" ");
+    dbg(
+      `[drainQueue] post-processing ${nonEmpty.length} result(s) via /api/post-process`,
+    );
     let finalText: string;
-    if (nonEmpty.length === 1) {
-      finalText = nonEmpty[0];
-    } else {
-      const combined = nonEmpty.join(" ");
-      dbg(
-        `[drainQueue] stitching ${nonEmpty.length} results via /api/post-process`,
-      );
-      try {
-        const res = await fetch(`${getApiBase()}/api/post-process`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            text: combined,
-            appContext: appContextRef.current,
-          }),
-        });
-        if (cancelledRef.current) {
-          drainingRef.current = false;
-          return;
-        }
-        if (res.ok) {
-          const data = await res.json();
-          finalText = data.cleaned || combined;
-        } else {
-          finalText = combined;
-        }
-      } catch {
+    try {
+      const res = await fetch(`${getApiBase()}/api/post-process`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text: combined,
+          appContext: appContextRef.current,
+        }),
+      });
+      if (cancelledRef.current) {
+        drainingRef.current = false;
+        return;
+      }
+      if (res.ok) {
+        const data = await res.json();
+        finalText = data.cleaned || combined;
+      } else {
         finalText = combined;
       }
+    } catch {
+      finalText = combined;
     }
 
     if (cancelledRef.current) {
@@ -527,6 +524,10 @@ export default function AppPage(): React.JSX.Element {
     };
     if (appContextRef.current) headers["x-app-context"] = appContextRef.current;
 
+    // Always grab raw transcription text.  Post-processing is done
+    // once on the combined result in drainQueue — this avoids
+    // individual LLM cleanup that would hide corrections like
+    // "scratch that" from the final post-processing pass.
     const transcribePromise = fetch(`${getApiBase()}/api/transcribe`, {
       method: "POST",
       body: wavBlob,
@@ -535,7 +536,7 @@ export default function AppPage(): React.JSX.Element {
       .then(async (res) => {
         if (!res.ok) return "";
         const data = await res.json();
-        return (data.cleaned || data.raw || "").trim();
+        return (data.raw || "").trim();
       })
       .catch(() => "");
 

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -158,17 +158,14 @@ export default function AppPage(): React.JSX.Element {
         onReady: () => {},
         onPartial: (text) => setPartialText(text),
         onFinal: async (text) => {
-          console.log(
-            `[onFinal] text=${JSON.stringify(text?.slice(0, 60))}, sessionId=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}, awaitingFirst=${awaitingFirstResultRef.current}, isReRecording=${isReRecordingRef.current}, hasDeferredCommit=${!!deferredCommitRef.current}`,
+          window.api.debugLog(
+            `[onFinal] text=${JSON.stringify(text?.slice(0, 60))}, sessionId=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}, awaitingFirst=${awaitingFirstResultRef.current}, isReRec=${isReRecordingRef.current}, hasDeferred=${!!deferredCommitRef.current}`,
           );
-          if (sessionIdRef.current === 0) {
-            console.log("[onFinal] SKIP: sessionId is 0");
-            return;
-          }
+          if (sessionIdRef.current === 0) return;
 
           if (awaitingFirstResultRef.current) {
-            console.log(
-              "[onFinal] PATH: awaiting first result → store + fire deferred commit",
+            window.api.debugLog(
+              "[onFinal] PATH: awaiting first → deferred commit",
             );
             awaitingFirstResultRef.current = false;
             const stored = text.trim() || null;
@@ -185,12 +182,12 @@ export default function AppPage(): React.JSX.Element {
           }
 
           if (wantsMicRef.current) {
-            console.log("[onFinal] PATH: user still recording → store text");
+            window.api.debugLog("[onFinal] PATH: still recording → store");
             previousTextRef.current = text.trim() || null;
             return;
           }
 
-          console.log("[onFinal] PATH: normal → paste and hide");
+          window.api.debugLog("[onFinal] PATH: normal → paste and hide");
           wantsMicRef.current = false;
           sessionIdRef.current = 0;
           stopVisualization();
@@ -203,9 +200,12 @@ export default function AppPage(): React.JSX.Element {
           hidePill();
         },
         onCleaned: (text) => {
-          console.log(
-            `[onCleaned] text=${JSON.stringify(text?.slice(0, 60))}, wantsMic=${wantsMicRef.current}, awaitingFirst=${awaitingFirstResultRef.current}`,
+          window.api.debugLog(
+            `[onCleaned] sessionId=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}, awaitingFirst=${awaitingFirstResultRef.current}`,
           );
+          // Guard: if the session was cancelled, ignore late arrivals
+          if (sessionIdRef.current === 0) return;
+
           if (wantsMicRef.current || awaitingFirstResultRef.current) {
             if (text.trim()) {
               previousTextRef.current = text.trim();
@@ -218,7 +218,7 @@ export default function AppPage(): React.JSX.Element {
           }
         },
         onError: (msg) => {
-          console.log(
+          window.api.debugLog(
             `[onError] msg=${msg}, sessionId=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}`,
           );
           if (sessionIdRef.current === 0) return;
@@ -337,7 +337,7 @@ export default function AppPage(): React.JSX.Element {
 
   // Hide the pill and reset to idle so the next show starts clean
   const hidePill = useCallback(() => {
-    console.log("[hidePill] called");
+    window.api.debugLog("[hidePill] called");
     setState("idle");
     setPartialText("");
     setMessage("");
@@ -355,11 +355,11 @@ export default function AppPage(): React.JSX.Element {
   // previous transcription is still in progress.
   const startRecording = useCallback(
     async (forReRecord = false) => {
-      console.log(
+      window.api.debugLog(
         `[startRecording] forReRecord=${forReRecord}, wantsMic=${wantsMicRef.current}, sessionId=${sessionIdRef.current}`,
       );
       if (wantsMicRef.current) {
-        console.log("[startRecording] SKIP: wantsMic already true");
+        window.api.debugLog("[startRecording] SKIP: wantsMic already true");
         return;
       }
       wantsMicRef.current = true;
@@ -457,8 +457,8 @@ export default function AppPage(): React.JSX.Element {
   // -- Commit: stop recording and transcribe --
   const commitRecording = useCallback(async () => {
     const wasReRecording = isReRecordingRef.current;
-    console.log(
-      `[commitRecording] wasReRecording=${wasReRecording}, wantsMic=${wantsMicRef.current}, sessionId=${sessionIdRef.current}, previousText=${JSON.stringify(previousTextRef.current?.slice(0, 40))}, awaitingFirst=${awaitingFirstResultRef.current}`,
+    window.api.debugLog(
+      `[commitRecording] wasReRec=${wasReRecording}, wantsMic=${wantsMicRef.current}, sessionId=${sessionIdRef.current}, prevText=${!!previousTextRef.current}, awaitFirst=${awaitingFirstResultRef.current}`,
     );
     wantsMicRef.current = false;
     isReRecordingRef.current = false;
@@ -468,7 +468,7 @@ export default function AppPage(): React.JSX.Element {
 
     const recordingDuration = Date.now() - startTimeRef.current;
     if (recordingDuration < 1000) {
-      console.log("[commitRecording] short recording (<1s), cancelling");
+      window.api.debugLog("[commitRecording] short recording (<1s)");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
       streamerRef.current?.cancel();
@@ -498,19 +498,17 @@ export default function AppPage(): React.JSX.Element {
       recorderRef.current.releaseStream();
 
       if (wasReRecording && !prevText) {
-        console.log(
-          "[commitRecording] streaming: deferring commit — awaiting first result",
-        );
+        window.api.debugLog("[commitRecording] streaming: deferring commit");
         awaitingFirstResultRef.current = true;
         deferredCommitRef.current = (firstText: string) => {
-          console.log(
-            `[deferredCommit] firing with firstText=${JSON.stringify(firstText?.slice(0, 40))}`,
+          window.api.debugLog(
+            `[deferredCommit] firing, hasText=${!!firstText}`,
           );
           streamerRef.current?.commit(firstText || undefined);
         };
       } else {
-        console.log(
-          `[commitRecording] streaming: immediate commit, prevText=${JSON.stringify(prevText?.slice(0, 40))}`,
+        window.api.debugLog(
+          `[commitRecording] streaming: immediate commit, hasPrev=${!!prevText}`,
         );
         streamerRef.current.commit(prevText ?? undefined);
       }
@@ -616,7 +614,9 @@ export default function AppPage(): React.JSX.Element {
   useEffect(() => {
     const removeDown = window.api.onHotkeyDown(() => {
       const s = stateRef.current;
-      console.log(`[hotkeyDown] state=${s}, wantsMic=${wantsMicRef.current}`);
+      window.api.debugLog(
+        `[hotkeyDown] state=${s}, wantsMic=${wantsMicRef.current}`,
+      );
       if (s === "idle" || s === "error") {
         startRecording(false);
       } else if (s === "transcribing") {
@@ -624,7 +624,7 @@ export default function AppPage(): React.JSX.Element {
       }
     });
     const removeUp = window.api.onHotkeyUp(() => {
-      console.log(
+      window.api.debugLog(
         `[hotkeyUp] state=${stateRef.current}, wantsMic=${wantsMicRef.current}`,
       );
       if (stateRef.current === "recording") {

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -79,10 +79,6 @@ function formatTimer(ms: number): string {
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
-function dbg(msg: string): void {
-  window.api.debugLog(msg);
-}
-
 const pillInnerStyle: React.CSSProperties = {
   height: 48,
   padding: "0 10px",
@@ -164,7 +160,6 @@ export default function AppPage(): React.JSX.Element {
     const batch = [...queueRef.current];
     queueRef.current = [];
 
-    dbg(`[drainQueue] waiting for ${batch.length} result(s)`);
     const results = await Promise.all(batch.map((e) => e.promise));
 
     if (!pillActiveRef.current) {
@@ -195,13 +190,9 @@ export default function AppPage(): React.JSX.Element {
     if (nonEmpty.length === 1) {
       // Single recording — use the already-post-processed cleaned text.
       finalText = nonEmpty[0].cleaned.trim() || nonEmpty[0].raw.trim();
-      dbg("[drainQueue] single result, using cleaned text");
     } else {
       // Multiple recordings — stitch raw texts and post-process together.
       const combined = nonEmpty.map((r) => r.raw).join(" ");
-      dbg(
-        `[drainQueue] stitching ${nonEmpty.length} results, calling /api/post-process`,
-      );
       setPillLabel("Processing...");
       try {
         const res = await fetch(`${getApiBase()}/api/post-process`, {
@@ -241,9 +232,8 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
-    dbg(`[drainQueue] pasting (${finalText.length} chars)`);
     await window.api.pasteText(finalText);
-    window.api?.sendTranscriptionDone();
+    window.api.sendTranscriptionDone();
 
     drainingRef.current = false;
 
@@ -252,7 +242,6 @@ export default function AppPage(): React.JSX.Element {
       queueRef.current.length === 0 &&
       pillActiveRef.current
     ) {
-      dbg("[drainQueue] done, hiding pill");
       hidePill();
     }
   }, []);
@@ -268,19 +257,16 @@ export default function AppPage(): React.JSX.Element {
         onReady: () => {},
         onPartial: (text) => setPartialText(text),
         onFinal: async (_text) => {
-          dbg(`[onFinal] active=${pillActiveRef.current}`);
           // Streaming onFinal is not used in the queue model for the
           // REST path.  For streaming mode it would need to resolve a
           // promise — but the current user is on REST, so this is a
           // no-op safety net.  The queue handles everything.
         },
         onCleaned: (_text) => {
-          dbg(`[onCleaned] active=${pillActiveRef.current}`);
           // Cleaned results are handled by the transcribe endpoint
           // response directly.  No action needed here.
         },
         onError: (msg) => {
-          dbg(`[onError] msg=${msg}, active=${pillActiveRef.current}`);
           if (!pillActiveRef.current) return;
           if (wantsMicRef.current) return;
           setState("error");
@@ -373,7 +359,6 @@ export default function AppPage(): React.JSX.Element {
 
   // ---- Hide pill ----
   const hidePill = useCallback(() => {
-    dbg("[hidePill]");
     setState("idle");
     setPartialText("");
     setMessage("");
@@ -391,11 +376,7 @@ export default function AppPage(): React.JSX.Element {
   // ---- Start recording ----
   const startRecording = useCallback(
     async (forReRecord = false) => {
-      dbg(
-        `[startRecording] forReRec=${forReRecord}, wantsMic=${wantsMicRef.current}`,
-      );
       if (wantsMicRef.current) {
-        dbg("[startRecording] SKIP: wantsMic already true");
         return;
       }
       wantsMicRef.current = true;
@@ -481,9 +462,6 @@ export default function AppPage(): React.JSX.Element {
   // Fires a transcription request and pushes the result promise into the
   // queue.  Does NOT paste or hide — the queue drain handles that.
   const commitRecording = useCallback(async () => {
-    dbg(
-      `[commitRecording] wantsMic=${wantsMicRef.current}, queueLen=${queueRef.current.length}`,
-    );
     wantsMicRef.current = false;
     isReRecordingRef.current = false;
     setIsReRecording(false);
@@ -492,7 +470,6 @@ export default function AppPage(): React.JSX.Element {
 
     const recordingDuration = Date.now() - startTimeRef.current;
     if (recordingDuration < 1000) {
-      dbg("[commitRecording] short (<1s), skipping");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
       streamerRef.current?.cancel();
@@ -519,7 +496,6 @@ export default function AppPage(): React.JSX.Element {
 
     // If cancel/hide fired while we were getting the blob, bail out.
     if (!pillActiveRef.current) {
-      dbg("[commitRecording] pill no longer active, bailing");
       return;
     }
 
@@ -556,7 +532,6 @@ export default function AppPage(): React.JSX.Element {
 
     // Push to queue
     queueRef.current.push({ promise: transcribePromise });
-    dbg(`[commitRecording] pushed to queue, len=${queueRef.current.length}`);
 
     // Start draining if not already draining
     drainQueue();
@@ -564,7 +539,6 @@ export default function AppPage(): React.JSX.Element {
 
   // ---- Cancel ----
   const cancelRecording = useCallback(() => {
-    dbg("[cancelRecording]");
     wantsMicRef.current = false;
     pillActiveRef.current = false;
     isReRecordingRef.current = false;
@@ -595,7 +569,6 @@ export default function AppPage(): React.JSX.Element {
   useEffect(() => {
     const removeDown = window.api.onHotkeyDown(() => {
       const s = stateRef.current;
-      dbg(`[hotkeyDown] state=${s}, wantsMic=${wantsMicRef.current}`);
       if (s === "idle" || s === "error") {
         startRecording(false);
       } else if (s === "transcribing") {
@@ -603,9 +576,6 @@ export default function AppPage(): React.JSX.Element {
       }
     });
     const removeUp = window.api.onHotkeyUp(() => {
-      dbg(
-        `[hotkeyUp] state=${stateRef.current}, wantsMic=${wantsMicRef.current}`,
-      );
       if (stateRef.current === "recording") {
         commitRecording();
       } else if (stateRef.current === "initializing") {

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -144,85 +144,119 @@ export default function AppPage(): React.JSX.Element {
   const getInputVolume = useCallback(() => volumeRef.current, []);
 
   // ---- Queue drain ----
+  // Called after each commit.  Waits until the user stops recording
+  // (wantsMicRef is false), then resolves all queued promises,
+  // stitches results, post-processes if needed, and pastes.
   const drainQueue = useCallback(async () => {
     if (drainingRef.current) return;
     drainingRef.current = true;
 
-    // Keep draining as long as there are entries.  New entries may be
-    // pushed while we're awaiting, so re-check after each batch.
-    while (queueRef.current.length > 0 && !cancelledRef.current) {
-      // Snapshot the current queue and clear it so new recordings
-      // can push fresh entries while we await.
-      const batch = [...queueRef.current];
-      queueRef.current = [];
+    // Wait until the user finishes recording.  Each commitRecording
+    // calls drainQueue again after pushing, so if we're already
+    // draining we just return (the loop will pick up new entries).
+    while (wantsMicRef.current && !cancelledRef.current) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
 
-      dbg(`[drainQueue] waiting for ${batch.length} result(s)`);
-      const results = await Promise.all(batch.map((e) => e.promise));
+    if (cancelledRef.current || queueRef.current.length === 0) {
+      drainingRef.current = false;
+      return;
+    }
 
-      if (cancelledRef.current) break;
+    // Take everything in the queue.
+    const batch = [...queueRef.current];
+    queueRef.current = [];
 
-      // If more entries arrived while we were awaiting, loop again
-      // to include them in the final stitch.
-      if (queueRef.current.length > 0) {
-        // Put the resolved results back as immediately-resolved entries
-        // so the next iteration can combine everything.
-        const resolved = results
-          .filter((t) => t.trim())
-          .map((t) => ({ promise: Promise.resolve(t) }));
-        queueRef.current = [...resolved, ...queueRef.current];
-        continue;
-      }
+    dbg(`[drainQueue] waiting for ${batch.length} result(s)`);
+    const results = await Promise.all(batch.map((e) => e.promise));
 
-      // All results are in.  Stitch and paste.
-      const nonEmpty = results.filter((t) => t.trim());
-      if (nonEmpty.length === 0 || cancelledRef.current) break;
+    if (cancelledRef.current) {
+      drainingRef.current = false;
+      return;
+    }
 
-      let finalText: string;
-      if (nonEmpty.length === 1) {
-        finalText = nonEmpty[0];
-      } else {
-        // Multiple recordings — stitch and re-post-process.
-        const combined = nonEmpty.join(" ");
-        dbg(
-          `[drainQueue] stitching ${nonEmpty.length} results, calling /api/post-process`,
-        );
-        try {
-          const res = await fetch(`${getApiBase()}/api/post-process`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              text: combined,
-              appContext: appContextRef.current,
-            }),
-          });
-          if (cancelledRef.current) break;
-          if (res.ok) {
-            const data = await res.json();
-            finalText = data.cleaned || combined;
-          } else {
-            finalText = combined;
-          }
-        } catch {
+    // If the user started recording again while we were awaiting,
+    // put results back and loop.
+    if (wantsMicRef.current || queueRef.current.length > 0) {
+      const resolved = results
+        .filter((t) => t.trim())
+        .map((t) => ({ promise: Promise.resolve(t) }));
+      queueRef.current = [...resolved, ...queueRef.current];
+      drainingRef.current = false;
+      // The next commitRecording will call drainQueue again.
+      return;
+    }
+
+    // All results are in and user is not recording.  Stitch and paste.
+    const nonEmpty = results.filter((t) => t.trim());
+    if (nonEmpty.length === 0) {
+      drainingRef.current = false;
+      hidePill();
+      return;
+    }
+
+    let finalText: string;
+    if (nonEmpty.length === 1) {
+      finalText = nonEmpty[0];
+    } else {
+      const combined = nonEmpty.join(" ");
+      dbg(
+        `[drainQueue] stitching ${nonEmpty.length} results via /api/post-process`,
+      );
+      try {
+        const res = await fetch(`${getApiBase()}/api/post-process`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            text: combined,
+            appContext: appContextRef.current,
+          }),
+        });
+        if (cancelledRef.current) {
+          drainingRef.current = false;
+          return;
+        }
+        if (res.ok) {
+          const data = await res.json();
+          finalText = data.cleaned || combined;
+        } else {
           finalText = combined;
         }
+      } catch {
+        finalText = combined;
       }
-
-      if (cancelledRef.current) break;
-
-      dbg(`[drainQueue] pasting final text (${finalText.length} chars)`);
-      await window.api.pasteText(finalText);
-      window.api?.sendTranscriptionDone();
     }
+
+    if (cancelledRef.current) {
+      drainingRef.current = false;
+      return;
+    }
+
+    // If the user started ANOTHER recording while we were post-
+    // processing, stash the result and let the next drain combine it.
+    if (wantsMicRef.current || queueRef.current.length > 0) {
+      queueRef.current = [
+        { promise: Promise.resolve(finalText) },
+        ...queueRef.current,
+      ];
+      drainingRef.current = false;
+      return;
+    }
+
+    dbg(`[drainQueue] pasting (${finalText.length} chars)`);
+    await window.api.pasteText(finalText);
+    window.api?.sendTranscriptionDone();
 
     drainingRef.current = false;
 
-    // If not cancelled and no new entries arrived, we're done — hide.
-    if (!cancelledRef.current && queueRef.current.length === 0) {
-      // Only hide if the user isn't currently recording another segment
-      if (!wantsMicRef.current) {
-        dbg("[drainQueue] done, hiding pill");
-        hidePill();
-      }
+    // Final check: if user started recording during paste, don't hide.
+    if (
+      !wantsMicRef.current &&
+      queueRef.current.length === 0 &&
+      !cancelledRef.current
+    ) {
+      dbg("[drainQueue] done, hiding pill");
+      hidePill();
     }
   }, []);
 

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -114,11 +114,13 @@ export default function AppPage(): React.JSX.Element {
 
   // Re-record state: when the user presses the hotkey during transcription,
   // we start a new recording while the previous transcription finishes in
-  // the background.  The finished text is stored here so it can be combined
-  // with the new transcription.
+  // the background.  `pendingResultsRef` counts how many streaming `final`
+  // messages we still expect before the very last result can be pasted.
+  // When it drops to zero on a `final` arrival, that result is the one to
+  // paste.  The `isReRecording` state drives the stacked-pill visual.
   const [isReRecording, setIsReRecording] = useState(false);
   const previousTextRef = useRef<string | null>(null);
-  const reRecordingRef = useRef(false);
+  const pendingResultsRef = useRef(0);
 
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
@@ -151,14 +153,16 @@ export default function AppPage(): React.JSX.Element {
         onFinal: async (text) => {
           if (sessionIdRef.current === 0) return;
 
-          // If the user started a re-recording while we were transcribing,
-          // store the text instead of pasting — it will be combined with the
-          // new transcription when that finishes.
-          if (reRecordingRef.current) {
+          // More results expected (a re-record was started) — store the
+          // text so it can be combined with the next transcription.
+          if (pendingResultsRef.current > 1) {
+            pendingResultsRef.current--;
             previousTextRef.current = text.trim() || null;
             return;
           }
 
+          // This is the last expected result — paste and close.
+          pendingResultsRef.current = 0;
           wantsMicRef.current = false;
           sessionIdRef.current = 0;
           stopVisualization();
@@ -171,9 +175,9 @@ export default function AppPage(): React.JSX.Element {
           hidePill();
         },
         onCleaned: (text) => {
-          // If the user is re-recording, update previousText with the
+          // If more results are pending, update previousText with the
           // cleaned version so the final combine uses the best text.
-          if (reRecordingRef.current) {
+          if (pendingResultsRef.current > 0) {
             if (text.trim()) {
               previousTextRef.current = text.trim();
             }
@@ -189,12 +193,15 @@ export default function AppPage(): React.JSX.Element {
         onError: (msg) => {
           if (sessionIdRef.current === 0) return;
 
-          // If re-recording, don't hide — let the recording continue
-          if (reRecordingRef.current) {
+          // If more results are pending (re-recording in progress),
+          // don't hide — let the recording continue.
+          if (pendingResultsRef.current > 1) {
+            pendingResultsRef.current--;
             previousTextRef.current = null;
             return;
           }
 
+          pendingResultsRef.current = 0;
           wantsMicRef.current = false;
           sessionIdRef.current = 0;
           stopVisualization();
@@ -304,7 +311,7 @@ export default function AppPage(): React.JSX.Element {
     setPartialText("");
     setMessage("");
     setIsReRecording(false);
-    reRecordingRef.current = false;
+    pendingResultsRef.current = 0;
     previousTextRef.current = null;
     window.api.hidePill();
   }, []);
@@ -321,10 +328,12 @@ export default function AppPage(): React.JSX.Element {
       setPartialText("");
 
       if (forReRecord) {
-        reRecordingRef.current = true;
+        // The previous commit already set pendingResultsRef to 1;
+        // bump it so onFinal knows to store that result rather than paste.
+        pendingResultsRef.current++;
         setIsReRecording(true);
       } else {
-        reRecordingRef.current = false;
+        pendingResultsRef.current = 0;
         setIsReRecording(false);
         previousTextRef.current = null;
       }
@@ -392,7 +401,7 @@ export default function AppPage(): React.JSX.Element {
       } catch (err) {
         wantsMicRef.current = false;
         pendingCommitRef.current = false;
-        reRecordingRef.current = false;
+        pendingResultsRef.current = 0;
         setIsReRecording(false);
         recorderRef.current.releaseStream();
         setState("error");
@@ -406,8 +415,7 @@ export default function AppPage(): React.JSX.Element {
   // -- Commit: stop recording and transcribe --
   const commitRecording = useCallback(async () => {
     wantsMicRef.current = false;
-    const wasReRecording = reRecordingRef.current;
-    reRecordingRef.current = false;
+    const wasReRecording = isReRecording;
     setIsReRecording(false);
     stopVisualization();
     playTone("stop");
@@ -417,16 +425,28 @@ export default function AppPage(): React.JSX.Element {
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
       streamerRef.current?.cancel();
-      // If this was a re-record that was too short, and we already have
-      // previousText from the first transcription, paste that instead.
-      if (wasReRecording && previousTextRef.current?.trim()) {
-        sessionIdRef.current = 0;
-        const text = previousTextRef.current;
-        previousTextRef.current = null;
-        await window.api.pasteText(text);
-        window.api?.sendTranscriptionDone();
+      if (wasReRecording) {
+        // Short re-record — decrement the pending counter since we
+        // won't be sending a second commit.  If the first result
+        // already arrived, paste it; otherwise let the pending
+        // onFinal handle the paste when it drops to zero.
+        pendingResultsRef.current = Math.max(0, pendingResultsRef.current - 1);
+        if (
+          pendingResultsRef.current === 0 &&
+          previousTextRef.current?.trim()
+        ) {
+          sessionIdRef.current = 0;
+          const text = previousTextRef.current;
+          previousTextRef.current = null;
+          await window.api.pasteText(text);
+          window.api?.sendTranscriptionDone();
+          hidePill();
+        }
+        // If pendingResultsRef > 0 the first result hasn't arrived yet;
+        // onFinal will handle paste when it arrives since pending == 1.
+      } else {
+        hidePill();
       }
-      hidePill();
       return;
     }
 
@@ -435,6 +455,7 @@ export default function AppPage(): React.JSX.Element {
 
     // If streaming mode is active, commit via WebSocket
     if (useStreamingRef.current && streamerRef.current) {
+      pendingResultsRef.current = Math.max(1, pendingResultsRef.current);
       setState("transcribing");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
@@ -508,7 +529,7 @@ export default function AppPage(): React.JSX.Element {
   const cancelRecording = useCallback(() => {
     wantsMicRef.current = false;
     sessionIdRef.current = 0;
-    reRecordingRef.current = false;
+    pendingResultsRef.current = 0;
     setIsReRecording(false);
     previousTextRef.current = null;
     stopVisualization();
@@ -540,7 +561,6 @@ export default function AppPage(): React.JSX.Element {
       if (s === "idle" || s === "error") {
         startRecording(false);
       } else if (s === "transcribing") {
-        // Re-record: start a new recording while transcription finishes
         startRecording(true);
       }
     });
@@ -551,11 +571,18 @@ export default function AppPage(): React.JSX.Element {
         pendingCommitRef.current = true;
       }
     });
+    const removeCancel = window.api.onPillCancel(() => {
+      const s = stateRef.current;
+      if (s !== "idle") {
+        cancelRecording();
+      }
+    });
     return () => {
       removeDown();
       removeUp();
+      removeCancel();
     };
-  }, [startRecording, commitRecording]);
+  }, [startRecording, commitRecording, cancelRecording]);
 
   // Cleanup on unmount — fully release mic + audio resources.
   // Use a ref to avoid StrictMode double-invoke calling cancelRecording
@@ -664,11 +691,11 @@ export default function AppPage(): React.JSX.Element {
             style={{
               borderRadius: 28,
               position: "absolute",
-              bottom: -6,
-              left: 8,
-              right: 8,
-              opacity: 0.55,
-              transform: "scale(0.95)",
+              bottom: -14,
+              left: 6,
+              right: 6,
+              opacity: 0.5,
+              transform: "scale(0.92)",
               pointerEvents: "none",
               zIndex: 0,
             }}

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -135,6 +135,7 @@ export default function AppPage(): React.JSX.Element {
   const isReRecordingRef = useRef(false);
   const previousTextRef = useRef<string | null>(null);
   const commitSessionRef = useRef(0);
+  const pillActiveRef = useRef(false);
   const resolvePreviousTextRef = useRef<((text: string | null) => void) | null>(
     null,
   );
@@ -176,9 +177,9 @@ export default function AppPage(): React.JSX.Element {
         onFinal: async (text) => {
           const sid = sessionIdRef.current;
           dbg(
-            `[onFinal] text=${JSON.stringify(text?.slice(0, 50))}, sid=${sid}, commitSid=${commitSessionRef.current}, wantsMic=${wantsMicRef.current}`,
+            `[onFinal] text=${JSON.stringify(text?.slice(0, 50))}, sid=${sid}, commitSid=${commitSessionRef.current}, wantsMic=${wantsMicRef.current}, active=${pillActiveRef.current}`,
           );
-          if (sid === 0) return;
+          if (!pillActiveRef.current) return;
 
           // If the user is still recording a re-record, just store.
           if (wantsMicRef.current) {
@@ -228,9 +229,9 @@ export default function AppPage(): React.JSX.Element {
         },
         onCleaned: (text) => {
           dbg(
-            `[onCleaned] sid=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}`,
+            `[onCleaned] active=${pillActiveRef.current}, wantsMic=${wantsMicRef.current}`,
           );
-          if (sessionIdRef.current === 0) return;
+          if (!pillActiveRef.current) return;
 
           if (wantsMicRef.current) {
             if (text.trim()) previousTextRef.current = text.trim();
@@ -243,16 +244,15 @@ export default function AppPage(): React.JSX.Element {
         },
         onError: (msg) => {
           dbg(
-            `[onError] msg=${msg}, sid=${sessionIdRef.current}, wantsMic=${wantsMicRef.current}`,
+            `[onError] msg=${msg}, active=${pillActiveRef.current}, wantsMic=${wantsMicRef.current}`,
           );
-          if (sessionIdRef.current === 0) return;
+          if (!pillActiveRef.current) return;
 
           if (wantsMicRef.current) {
             previousTextRef.current = null;
             return;
           }
 
-          sessionIdRef.current = 0;
           commitSessionRef.current = 0;
           wantsMicRef.current = false;
           stopVisualization();
@@ -350,6 +350,8 @@ export default function AppPage(): React.JSX.Element {
   }, []);
 
   // Hide the pill and reset ALL state so the next show starts clean.
+  // Note: sessionIdRef is NOT reset — it monotonically increases so
+  // that stale async callbacks can never collide with a new session.
   const hidePill = useCallback(() => {
     dbg("[hidePill]");
     setState("idle");
@@ -358,10 +360,9 @@ export default function AppPage(): React.JSX.Element {
     setIsReRecording(false);
     isReRecordingRef.current = false;
     wantsMicRef.current = false;
-    sessionIdRef.current = 0;
+    pillActiveRef.current = false;
     commitSessionRef.current = 0;
     previousTextRef.current = null;
-    // Wake up any waiting commit so it can exit cleanly
     if (resolvePreviousTextRef.current) {
       resolvePreviousTextRef.current(null);
       resolvePreviousTextRef.current = null;
@@ -380,6 +381,7 @@ export default function AppPage(): React.JSX.Element {
         return;
       }
       wantsMicRef.current = true;
+      pillActiveRef.current = true;
       pendingCommitRef.current = false;
       setMessage("");
       setPartialText("");
@@ -651,7 +653,7 @@ export default function AppPage(): React.JSX.Element {
   const cancelRecording = useCallback(() => {
     dbg("[cancelRecording]");
     wantsMicRef.current = false;
-    sessionIdRef.current = 0;
+    pillActiveRef.current = false;
     commitSessionRef.current = 0;
     isReRecordingRef.current = false;
     setIsReRecording(false);
@@ -817,13 +819,12 @@ export default function AppPage(): React.JSX.Element {
               borderRadius: 28,
               position: "absolute",
               bottom: -14,
-              left: 0,
-              right: 0,
+              left: "50%",
+              transform: "translateX(-50%) scale(0.92)",
               opacity: 0.5,
-              transform: "scale(0.92)",
-              transformOrigin: "center center",
               pointerEvents: "none",
               zIndex: 0,
+              width: "100%",
             }}
           >
             <div

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -532,8 +532,7 @@ export default function AppPage(): React.JSX.Element {
         const data = await res.json();
         return (data.raw || "").trim();
       })
-      .catch(() => "")
-      .finally(() => setPendingCount((c) => Math.max(0, c - 1)));
+      .catch(() => "");
 
     // Push to queue
     queueRef.current.push({ promise: transcribePromise });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,6 +8,7 @@ import formats from "./routes/formats.js";
 import history from "./routes/history.js";
 import mcp from "./routes/mcp.js";
 import models from "./routes/models.js";
+import postProcessRoute from "./routes/post-process-route.js";
 import settings from "./routes/settings.js";
 import stream from "./routes/stream.js";
 import transcribe from "./routes/transcribe.js";
@@ -38,6 +39,7 @@ const app = new Hono()
   .route("/api/history", history)
   .route("/api/dictionary", dictionary)
   .route("/api/formats", formats)
+  .route("/api/post-process", postProcessRoute)
   .route("/api/feedback", feedback)
   .route("/mcp", mcp)
   .route("/stream", stream);

--- a/apps/server/src/lib/post-process.ts
+++ b/apps/server/src/lib/post-process.ts
@@ -77,27 +77,34 @@ export interface PostProcessResult {
 /**
  * Run LLM cleanup and dictionary replacements on transcribed text.
  * Returns the cleaned text plus metadata for history tracking.
+ *
+ * When `previousText` is provided, the raw transcription is appended to it
+ * and the combined text is sent through post-processing as a whole.  This
+ * is used for the re-record flow where the user presses the hotkey again
+ * while the first transcription is still being processed.
  */
 export async function postProcess(
   rawText: string,
   appContext: string | null,
+  previousText?: string,
 ): Promise<PostProcessResult> {
   const db = getDb();
   const defaults = getDefaultModels();
-  let cleaned = rawText;
   let inputTokens = 0;
   let outputTokens = 0;
   let llmProvider: string | null = null;
   let llmModel: string | null = null;
   let costUsd = 0;
 
-  // If the raw text is purely filler words / punctuation, treat as empty
+  // If the raw text is purely filler words / punctuation, treat as empty.
+  // When there's previousText we still want to return it even if the new
+  // chunk was empty.
   const stripped = rawText
     .replace(/\b(um+|uh+|ah+|er+|hm+|hmm+|mm+|mhm+|you know|i mean)\b/gi, "")
     .replace(/[.…,!?\-–—\s]+/g, "");
   if (!stripped) {
     return {
-      cleaned: "",
+      cleaned: previousText?.trim() || "",
       llmProvider: null,
       llmModel: null,
       inputTokens: 0,
@@ -105,6 +112,15 @@ export async function postProcess(
       costUsd: 0,
     };
   }
+
+  // When appending to a previous transcription, combine the already-
+  // processed text with the new raw transcription so the LLM can
+  // produce a cohesive result.
+  const textToProcess = previousText
+    ? `${previousText.trim()} ${rawText.trim()}`
+    : rawText;
+
+  let cleaned = textToProcess;
 
   // LLM cleanup
   const llmSetting = db
@@ -114,20 +130,29 @@ export async function postProcess(
 
   if (llmEnabled && defaults.llm) {
     const contextHint = getContextHint(appContext, db);
-    const systemPrompt = `You clean up raw voice transcriptions with minimal edits.
-${contextHint ? `\nContext: ${contextHint}\n` : ""}
-Allowed edits:
-1. Remove filler words (um, uh, like, you know, basically, so, I mean)
-2. Remove repeated words and false starts — keep the final intended version
-3. Fix punctuation, capitalization, and minor grammar
-4. Convert spoken numbers/dates to written form when natural
+    const appendNote = previousText
+      ? `\nNote: The text below is a continuation — the first part was already cleaned and the second part is newly transcribed. Clean up the entire combined text so it reads as one cohesive piece.\n`
+      : "";
+
+    const systemPrompt = `You clean up raw voice transcriptions into polished, ready-to-send text.
+${contextHint ? `\nContext: ${contextHint}\n` : ""}${appendNote}
+Edits you MUST apply:
+1. Remove filler words (um, uh, like, you know, basically, so, I mean, right, actually, literally)
+2. Remove false starts, repeated words, and self-corrections — keep only the final intended version
+3. Fix punctuation, capitalization, and grammar
+4. Convert spoken numbers, dates, and units to their written form (e.g. "three hundred dollars" → "$300")
+5. Clean up spoken artifacts: "dot" → ".", "at sign" / "at" in emails → "@", "slash" → "/", "hashtag" → "#", "dash" → "-"
+6. Smooth awkward phrasing caused by speech-to-text without changing the meaning
+7. Break run-on sentences into proper sentences where the speaker clearly intended a pause
+8. Ensure the text reads naturally as written communication
 
 Rules:
-- Keep the speaker's exact words and sentence structure
-- NEVER rephrase, summarize, or rewrite
-- NEVER add words the speaker did not say
-- NEVER explain your edits or include commentary
-- If only filler words or silence, return an empty string
+- Preserve the speaker's meaning and tone faithfully
+- Do NOT add information the speaker did not convey
+- Do NOT summarize or omit content — keep everything the speaker said
+- Do NOT add greetings, sign-offs, or filler the speaker didn't say
+- Do NOT explain your edits or include any commentary
+- If the input is only filler words or silence, return an empty string
 
 IMPORTANT: Your entire response must be the cleaned text and nothing else. No quotes, no explanations, no reasoning, no prefixes.`;
 
@@ -139,7 +164,7 @@ IMPORTANT: Your entire response must be the cleaned text and nothing else. No qu
       const result = await generateText({
         model: chatModel,
         system: systemPrompt,
-        prompt: rawText,
+        prompt: textToProcess,
       });
       let llmText = result.text.trim();
       inputTokens = result.usage?.inputTokens ?? 0;
@@ -149,13 +174,13 @@ IMPORTANT: Your entire response must be the cleaned text and nothing else. No qu
 
       // Guard: if the LLM leaked reasoning/commentary, extract the
       // actual cleaned text.
-      if (llmText.includes("\n") && llmText.length > rawText.length * 2) {
+      if (llmText.includes("\n") && llmText.length > textToProcess.length * 2) {
         const quoted = llmText.match(/"([^"]+)"[^"]*$/);
         if (quoted) {
           llmText = quoted[1];
         } else {
           const lines = llmText.split("\n").filter((l) => l.trim());
-          llmText = lines[lines.length - 1]?.trim() ?? rawText;
+          llmText = lines[lines.length - 1]?.trim() ?? textToProcess;
         }
       }
 
@@ -163,7 +188,7 @@ IMPORTANT: Your entire response must be the cleaned text and nothing else. No qu
       if (
         llmText.startsWith('"') &&
         llmText.endsWith('"') &&
-        !rawText.startsWith('"')
+        !textToProcess.startsWith('"')
       ) {
         llmText = llmText.slice(1, -1);
       }

--- a/apps/server/src/lib/post-process.ts
+++ b/apps/server/src/lib/post-process.ts
@@ -77,16 +77,10 @@ export interface PostProcessResult {
 /**
  * Run LLM cleanup and dictionary replacements on transcribed text.
  * Returns the cleaned text plus metadata for history tracking.
- *
- * When `previousText` is provided, the raw transcription is appended to it
- * and the combined text is sent through post-processing as a whole.  This
- * is used for the re-record flow where the user presses the hotkey again
- * while the first transcription is still being processed.
  */
 export async function postProcess(
   rawText: string,
   appContext: string | null,
-  previousText?: string,
 ): Promise<PostProcessResult> {
   const db = getDb();
   const defaults = getDefaultModels();
@@ -96,15 +90,12 @@ export async function postProcess(
   let llmModel: string | null = null;
   let costUsd = 0;
 
-  // If the raw text is purely filler words / punctuation, treat as empty.
-  // When there's previousText we still want to return it even if the new
-  // chunk was empty.
   const stripped = rawText
     .replace(/\b(um+|uh+|ah+|er+|hm+|hmm+|mm+|mhm+|you know|i mean)\b/gi, "")
     .replace(/[.…,!?\-–—\s]+/g, "");
   if (!stripped) {
     return {
-      cleaned: previousText?.trim() || "",
+      cleaned: "",
       llmProvider: null,
       llmModel: null,
       inputTokens: 0,
@@ -113,14 +104,7 @@ export async function postProcess(
     };
   }
 
-  // When appending to a previous transcription, combine the already-
-  // processed text with the new raw transcription so the LLM can
-  // produce a cohesive result.
-  const textToProcess = previousText
-    ? `${previousText.trim()} ${rawText.trim()}`
-    : rawText;
-
-  let cleaned = textToProcess;
+  let cleaned = rawText;
 
   // LLM cleanup
   const llmSetting = db
@@ -130,12 +114,8 @@ export async function postProcess(
 
   if (llmEnabled && defaults.llm) {
     const contextHint = getContextHint(appContext, db);
-    const appendNote = previousText
-      ? `\nNote: The text below is a continuation — the first part was already cleaned and the second part is newly transcribed. Clean up the entire combined text so it reads as one cohesive piece.\n`
-      : "";
-
     const systemPrompt = `You clean up raw voice transcriptions into polished, ready-to-send text.
-${contextHint ? `\nContext: ${contextHint}\n` : ""}${appendNote}
+${contextHint ? `\nContext: ${contextHint}\n` : ""}
 Edits you MUST apply:
 1. Remove filler words (um, uh, like, you know, basically, so, I mean, right, actually, literally)
 2. Remove false starts, repeated words, and self-corrections — keep only the final intended version
@@ -164,7 +144,7 @@ IMPORTANT: Your entire response must be the cleaned text and nothing else. No qu
       const result = await generateText({
         model: chatModel,
         system: systemPrompt,
-        prompt: textToProcess,
+        prompt: rawText,
       });
       let llmText = result.text.trim();
       inputTokens = result.usage?.inputTokens ?? 0;
@@ -174,13 +154,13 @@ IMPORTANT: Your entire response must be the cleaned text and nothing else. No qu
 
       // Guard: if the LLM leaked reasoning/commentary, extract the
       // actual cleaned text.
-      if (llmText.includes("\n") && llmText.length > textToProcess.length * 2) {
+      if (llmText.includes("\n") && llmText.length > rawText.length * 2) {
         const quoted = llmText.match(/"([^"]+)"[^"]*$/);
         if (quoted) {
           llmText = quoted[1];
         } else {
           const lines = llmText.split("\n").filter((l) => l.trim());
-          llmText = lines[lines.length - 1]?.trim() ?? textToProcess;
+          llmText = lines[lines.length - 1]?.trim() ?? rawText;
         }
       }
 
@@ -188,7 +168,7 @@ IMPORTANT: Your entire response must be the cleaned text and nothing else. No qu
       if (
         llmText.startsWith('"') &&
         llmText.endsWith('"') &&
-        !textToProcess.startsWith('"')
+        !rawText.startsWith('"')
       ) {
         llmText = llmText.slice(1, -1);
       }

--- a/apps/server/src/routes/post-process-route.ts
+++ b/apps/server/src/routes/post-process-route.ts
@@ -1,0 +1,23 @@
+import { Hono } from "hono";
+import { postProcess } from "../lib/post-process.js";
+
+const postProcessRoute = new Hono().post("/", async (c) => {
+  const body = await c.req.json().catch(() => null);
+
+  if (!body || typeof body.text !== "string" || !body.text.trim()) {
+    return c.json({ error: "text field is required" }, 400);
+  }
+
+  const appContext: string | null = body.appContext ?? null;
+
+  const pp = await postProcess(body.text, appContext);
+
+  return c.json({
+    cleaned: pp.cleaned,
+    inputTokens: pp.inputTokens,
+    outputTokens: pp.outputTokens,
+    costUsd: pp.costUsd,
+  });
+});
+
+export default postProcessRoute;

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -124,7 +124,7 @@ const stream = new Hono().get(
             postProcess(rawText, appContext, prevForPP ?? undefined)
               .then((pp) => {
                 const finalText = pp.cleaned;
-                if (finalText !== rawText && !closed) {
+                if (finalText !== combinedRaw && !closed) {
                   ws.send(JSON.stringify({ type: "cleaned", text: finalText }));
                 }
                 try {
@@ -134,8 +134,8 @@ const stream = new Hono().get(
                        (raw_text, cleaned_text, voice_provider, voice_model, llm_provider, llm_model, duration_ms, audio_duration_ms, input_tokens, output_tokens, cost_usd)
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
                   ).run(
-                    rawText,
-                    finalText !== rawText ? finalText : null,
+                    combinedRaw,
+                    finalText !== combinedRaw ? finalText : null,
                     voiceDefaults!.provider,
                     voiceDefaults!.model_id,
                     pp.llmProvider,
@@ -159,7 +159,7 @@ const stream = new Hono().get(
                        (raw_text, voice_provider, voice_model, duration_ms, audio_duration_ms)
                        VALUES (?, ?, ?, ?, ?)`,
                   ).run(
-                    rawText,
+                    combinedRaw,
                     voiceDefaults!.provider,
                     voiceDefaults!.model_id,
                     durationMs,

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -19,6 +19,7 @@ const stream = new Hono().get(
     let voiceDefaults: { provider: string; model_id: string } | null = null;
     let appContext: string | null = null;
     let audioDurationMs = 0;
+    let previousText: string | null = null;
 
     function connectUpstream(ws: {
       send: (data: string) => void;
@@ -108,11 +109,19 @@ const stream = new Hono().get(
               return;
             }
 
-            // Send raw text immediately so the client can paste without waiting
-            ws.send(JSON.stringify({ type: "final", text: rawText }));
+            // Send raw text immediately so the client can paste without waiting.
+            // When appending to a previous transcription, combine them for the
+            // client so it can paste the full text right away.
+            const combinedRaw = previousText
+              ? `${previousText.trim()} ${rawText.trim()}`
+              : rawText;
+            ws.send(JSON.stringify({ type: "final", text: combinedRaw }));
 
-            // Run post-processing in the background for history
-            postProcess(rawText, appContext)
+            // Run post-processing in the background for history.
+            // Pass previousText so the LLM can produce a cohesive result.
+            const prevForPP = previousText;
+            previousText = null;
+            postProcess(rawText, appContext, prevForPP ?? undefined)
               .then((pp) => {
                 const finalText = pp.cleaned;
                 if (finalText !== rawText && !closed) {
@@ -194,7 +203,12 @@ const stream = new Hono().get(
         }
 
         // Text data = JSON command
-        let msg: { type: string; context?: string; audioDurationMs?: number };
+        let msg: {
+          type: string;
+          context?: string;
+          audioDurationMs?: number;
+          previousText?: string;
+        };
         try {
           msg = JSON.parse(
             typeof event.data === "string"
@@ -222,6 +236,9 @@ const stream = new Hono().get(
           case "commit":
             if (msg.audioDurationMs && msg.audioDurationMs > 0) {
               audioDurationMs = msg.audioDurationMs;
+            }
+            if (msg.previousText) {
+              previousText = msg.previousText;
             }
             upstream?.commit();
             break;

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -19,7 +19,6 @@ const stream = new Hono().get(
     let voiceDefaults: { provider: string; model_id: string } | null = null;
     let appContext: string | null = null;
     let audioDurationMs = 0;
-    let previousText: string | null = null;
 
     function connectUpstream(ws: {
       send: (data: string) => void;
@@ -109,22 +108,12 @@ const stream = new Hono().get(
               return;
             }
 
-            // Send raw text immediately so the client can paste without waiting.
-            // When appending to a previous transcription, combine them for the
-            // client so it can paste the full text right away.
-            const combinedRaw = previousText
-              ? `${previousText.trim()} ${rawText.trim()}`
-              : rawText;
-            ws.send(JSON.stringify({ type: "final", text: combinedRaw }));
+            ws.send(JSON.stringify({ type: "final", text: rawText }));
 
-            // Run post-processing in the background for history.
-            // Pass previousText so the LLM can produce a cohesive result.
-            const prevForPP = previousText;
-            previousText = null;
-            postProcess(rawText, appContext, prevForPP ?? undefined)
+            postProcess(rawText, appContext)
               .then((pp) => {
                 const finalText = pp.cleaned;
-                if (finalText !== combinedRaw && !closed) {
+                if (finalText !== rawText && !closed) {
                   ws.send(JSON.stringify({ type: "cleaned", text: finalText }));
                 }
                 try {
@@ -134,8 +123,8 @@ const stream = new Hono().get(
                        (raw_text, cleaned_text, voice_provider, voice_model, llm_provider, llm_model, duration_ms, audio_duration_ms, input_tokens, output_tokens, cost_usd)
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
                   ).run(
-                    combinedRaw,
-                    finalText !== combinedRaw ? finalText : null,
+                    rawText,
+                    finalText !== rawText ? finalText : null,
                     voiceDefaults!.provider,
                     voiceDefaults!.model_id,
                     pp.llmProvider,
@@ -159,7 +148,7 @@ const stream = new Hono().get(
                        (raw_text, voice_provider, voice_model, duration_ms, audio_duration_ms)
                        VALUES (?, ?, ?, ?, ?)`,
                   ).run(
-                    combinedRaw,
+                    rawText,
                     voiceDefaults!.provider,
                     voiceDefaults!.model_id,
                     durationMs,
@@ -207,7 +196,6 @@ const stream = new Hono().get(
           type: string;
           context?: string;
           audioDurationMs?: number;
-          previousText?: string;
         };
         try {
           msg = JSON.parse(
@@ -236,9 +224,6 @@ const stream = new Hono().get(
           case "commit":
             if (msg.audioDurationMs && msg.audioDurationMs > 0) {
               audioDurationMs = msg.audioDurationMs;
-            }
-            if (msg.previousText) {
-              previousText = msg.previousText;
             }
             upstream?.commit();
             break;

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -103,7 +103,9 @@ const transcribeRoute = new Hono().post("/", async (c) => {
 
   // Post-process (LLM cleanup + dictionary), then return immediately.
   // DB save runs in the background after the response is sent.
-  const pp = await postProcess(rawText, appContext);
+  // When x-previous-text is provided, combine with new transcription.
+  const previousText = c.req.header("x-previous-text") ?? undefined;
+  const pp = await postProcess(rawText, appContext, previousText);
   const voiceProvider = defaults.voice.provider;
   const voiceModel = defaults.voice.model_id;
 

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -101,13 +101,43 @@ const transcribeRoute = new Hono().post("/", async (c) => {
     });
   }
 
-  // Post-process (LLM cleanup + dictionary), then return immediately.
-  // DB save runs in the background after the response is sent.
-  // When x-previous-text is provided, combine with new transcription.
-  const previousText = c.req.header("x-previous-text") ?? undefined;
-  const pp = await postProcess(rawText, appContext, previousText);
   const voiceProvider = defaults.voice.provider;
   const voiceModel = defaults.voice.model_id;
+  const skipPostProcess = c.req.header("x-skip-post-process") === "true";
+
+  if (skipPostProcess) {
+    // Caller will handle post-processing (e.g. stitching multiple
+    // recordings and running /api/post-process on the combined text).
+    // Still save raw text to history.
+    Promise.resolve()
+      .then(() => {
+        db.prepare(
+          `INSERT INTO transcription_history
+             (raw_text, voice_provider, voice_model, duration_ms, audio_duration_ms)
+             VALUES (?, ?, ?, ?, ?)`,
+        ).run(
+          rawText,
+          voiceProvider,
+          voiceModel,
+          Date.now() - start,
+          audioDurationMs,
+        );
+      })
+      .catch((err) => {
+        console.error("Failed to save history:", err);
+      });
+
+    return c.json({
+      raw: rawText,
+      cleaned: rawText,
+      model: voiceModel,
+      durationMs,
+    });
+  }
+
+  // Post-process (LLM cleanup + dictionary), then return immediately.
+  const previousText = c.req.header("x-previous-text") ?? undefined;
+  const pp = await postProcess(rawText, appContext, previousText);
 
   // Fire-and-forget: save to history without blocking the response
   Promise.resolve()

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -136,8 +136,7 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   // Post-process (LLM cleanup + dictionary), then return immediately.
-  const previousText = c.req.header("x-previous-text") ?? undefined;
-  const pp = await postProcess(rawText, appContext, previousText);
+  const pp = await postProcess(rawText, appContext);
 
   // Fire-and-forget: save to history without blocking the response
   Promise.resolve()


### PR DESCRIPTION
Enhances post-processing to go beyond filler removal — now smooths awkward phrasing, converts spoken artifacts (dot/at/slash), breaks run-on sentences, and formats numbers. Adds re-record support so pressing the hotkey while transcribing starts a new recording with a stacked pill animation; the combined text gets post-processed as a whole before pasting.

## Changes

- **Post-processing prompt**: Expanded from 4 basic rules to 8 comprehensive edits including spoken artifact conversion, run-on sentence splitting, and natural written communication formatting
- **Re-record flow**: Pressing the hotkey during transcription starts a new recording session. The recording pill slides on top of the transcribing pill with a staggered offset animation. When done, the previous post-processed text is combined with the new transcription for a final cohesive post-processing pass
- **Server support**: Both streaming (WebSocket) and REST transcription paths accept `previousText` to combine with new transcriptions
- **Edge cases**: Short re-records (<1s) paste the original text; empty re-records preserve previous text; errors during re-record don't hide the pill

## Testing

Build passes with no type errors (`pnpm run build`). Manual testing needed for the re-record animation and combined transcription flow.

<!--
## Plan

### 1. Improve post-processing (post-process.ts)
- Enhanced system prompt with 8 edit categories instead of 4
- Added spoken artifact conversion (dot → ., at → @, slash → /, etc.)
- Added run-on sentence breaking and natural communication formatting
- Changed rules from "keep exact words" to "preserve meaning and tone"

### 2. Re-record during transcription (app.tsx)
- Added `isReRecording` state and `previousTextRef` to track re-record flow
- Modified `startRecording()` to accept `forReRecord` parameter
- Modified `commitRecording()` to pass `previousText` to server
- Updated hotkey handler: transcribing state now triggers `startRecording(true)`
- onFinal/onCleaned callbacks store text in `previousTextRef` when re-recording
- Stacked pill UI: background blue transcribing pill + foreground green recording pill with slide-up animation

### 3. Server changes (stream.ts, transcribe.ts)
- stream.ts: accepts `previousText` in commit message, combines with raw text for immediate paste, passes to postProcess()
- transcribe.ts: accepts `x-previous-text` header, passes to postProcess()

### 4. Post-process combine mode (post-process.ts)
- New `previousText` parameter on postProcess()
- Combines previousText + rawText before LLM processing
- Special LLM prompt note for continuation mode
- Returns previousText when new chunk is only filler

### 5. Streamer client (streamer.ts)
- commit() now accepts optional `previousText` parameter
- Sends it as part of the commit WebSocket message
-->