### PR TITLE
docs: replace 'open source' with 'source-available' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 Freestyle is the dictation app that converts your voice into text. Hold down a hotkey, talk, and clean text will appear wherever your cursor is. Speak 4X faster than you type. 
 
-Freestyle is free, open source, and local first, ensuring your dictations are private and never leaves your device. 
+Freestyle is free and local first, ensuring your dictations are private and never leaves your device. 
 
 ### Features
 


### PR DESCRIPTION
## Summary

- Replaces "open source" with "source-available" in the README description to accurately reflect the FSL-1.1-ALv2 license.

The project is licensed under the Functional Source License (FSL-1.1-ALv2), which restricts competing use. This does not meet the [Open Source Definition](https://opensource.org/osd) (criterion 6: no discrimination against fields of endeavor) nor the [FSF's definition of free software](https://www.gnu.org/philosophy/free-sw.html) (freedom 0: run the program for any purpose). "Source-available" is the accurate term.

Fixes #58