### PR TITLE
fix: streaming pipeline — process before sending, resolve immediately

### DIFF
--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -144,7 +144,6 @@ export default function AppPage(): React.JSX.Element {
   const streamResolverRef = useRef<((r: TranscribeResult) => void) | null>(
     null,
   );
-  const streamFinalTextRef = useRef("");
 
   const getInputVolume = useCallback(() => volumeRef.current, []);
 
@@ -259,23 +258,10 @@ export default function AppPage(): React.JSX.Element {
         onFinal: (text) => {
           const resolver = streamResolverRef.current;
           if (!resolver) return;
-          streamFinalTextRef.current = text;
-          setTimeout(() => {
-            if (streamResolverRef.current === resolver) {
-              streamResolverRef.current = null;
-              resolver({ raw: text, cleaned: text });
-            }
-          }, 3000);
-        },
-        onCleaned: (text) => {
-          const resolver = streamResolverRef.current;
-          if (!resolver) return;
           streamResolverRef.current = null;
-          resolver({
-            raw: streamFinalTextRef.current || text,
-            cleaned: text,
-          });
+          resolver({ raw: text, cleaned: text });
         },
+        onCleaned: () => {},
         onError: (msg) => {
           if (!pillActiveRef.current) return;
           if (wantsMicRef.current) return;

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -99,12 +99,6 @@ const stream = new Hono().get(
           onFinal: (rawText) => {
             const durationMs = Date.now() - sessionStartTime;
 
-            if (process.env.NODE_ENV !== "production") {
-              console.log(
-                `[stream] onFinal: rawText=${JSON.stringify(rawText)}, audioDurationMs=${audioDurationMs}, durationMs=${durationMs}`,
-              );
-            }
-
             const streamTags = {
               provider: voiceDefaults!.provider,
               model: voiceDefaults!.model_id,
@@ -129,13 +123,10 @@ const stream = new Hono().get(
               return;
             }
 
-            ws.send(JSON.stringify({ type: "final", text: rawText }));
-
             postProcess(rawText, appContext)
               .then((pp) => {
-                const finalText = pp.cleaned;
-                if (finalText !== rawText && !closed) {
-                  ws.send(JSON.stringify({ type: "cleaned", text: finalText }));
+                if (!closed) {
+                  ws.send(JSON.stringify({ type: "final", text: pp.cleaned }));
                 }
                 try {
                   const db = getDb();
@@ -145,7 +136,7 @@ const stream = new Hono().get(
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
                   ).run(
                     rawText,
-                    finalText !== rawText ? finalText : null,
+                    pp.cleaned !== rawText ? pp.cleaned : null,
                     voiceDefaults!.provider,
                     voiceDefaults!.model_id,
                     pp.llmProvider,
@@ -162,7 +153,9 @@ const stream = new Hono().get(
               })
               .catch((err) => {
                 captureException(err);
-                console.error("Post-processing failed:", err);
+                if (!closed) {
+                  ws.send(JSON.stringify({ type: "final", text: rawText }));
+                }
                 try {
                   const db = getDb();
                   db.prepare(


### PR DESCRIPTION
The streaming flow had a 3-second timeout race between `onFinal` and `onCleaned`. Now it's a simple pipeline.

**Before:** Server sent raw text via `final` immediately, then ran `postProcess()` async and sent `cleaned` later. Client waited up to 3s.

**After:** Server runs the full pipeline (dict replacements + optional LLM) before sending `final`. One message, fully processed. Client resolves immediately.

- LLM disabled → dict only → milliseconds → instant paste
- LLM enabled → waits for LLM → sends processed text → client resolves immediately on receipt
- Pipeline fails → falls back to raw text

Net deletion: 29 lines removed, 8 added.