### PR TITLE
feat: add local whisper.cpp voice model support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ apps/electron/tsconfig.node.tsbuildinfo
 
 # Compiled native binaries (built locally and in CI)
 apps/electron/resources/bin/
+
+# Downloaded whisper.cpp binaries
+apps/electron/resources/whisper/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+public-hoist-pattern[]=react
+public-hoist-pattern[]=react-dom

--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -18,6 +18,11 @@ extraResources:
       - "**/*"
 win:
   executableName: Freestyle
+  extraResources:
+    - from: "resources/whisper/win32-x64"
+      to: "whisper/win32-x64"
+      filter:
+        - "**/*"
 nsis:
   artifactName: ${productName}-${version}-setup.${ext}
   shortcutName: ${productName}
@@ -33,6 +38,11 @@ mac:
     NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
   notarize: false
+  extraResources:
+    - from: "resources/whisper/darwin-${arch}"
+      to: "whisper/darwin-${arch}"
+      filter:
+        - "**/*"
 dmg:
   artifactName: ${productName}-${version}.${ext}
 linux:
@@ -42,6 +52,11 @@ linux:
     - deb
   maintainer: freestyle
   category: Utility
+  extraResources:
+    - from: "resources/whisper/linux-x64"
+      to: "whisper/linux-x64"
+      filter:
+        - "**/*"
 appImage:
   artifactName: ${productName}-${version}.${ext}
 deb:

--- a/apps/electron/electron.vite.config.ts
+++ b/apps/electron/electron.vite.config.ts
@@ -22,9 +22,6 @@ export default defineConfig({
         "@renderer": resolve("src/renderer/src"),
       },
     },
-    optimizeDeps: {
-      include: ["react", "react-dom"],
-    },
     plugins: [react(), tailwindcss()],
     build: {
       rollupOptions: {

--- a/apps/electron/electron.vite.config.ts
+++ b/apps/electron/electron.vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
         "@renderer": resolve("src/renderer/src"),
       },
     },
+    optimizeDeps: {
+      include: ["react", "react-dom"],
+    },
     plugins: [react(), tailwindcss()],
     build: {
       rollupOptions: {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -18,7 +18,9 @@
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run compile:native && electron-vite build && electron-builder --win --publish never",
     "build:mac": "npm run compile:native && electron-vite build && electron-builder --mac --publish never",
-    "build:linux": "npm run compile:native && electron-vite build && electron-builder --linux --publish never"
+    "build:linux": "npm run compile:native && electron-vite build && electron-builder --linux --publish never",
+    "download:whisper-cpp": "node scripts/download-whisper-cpp.mjs",
+    "download:whisper-cpp:all": "node scripts/download-whisper-cpp.mjs --all"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",

--- a/apps/electron/scripts/download-whisper-cpp.mjs
+++ b/apps/electron/scripts/download-whisper-cpp.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+/**
+ * Download pre-built whisper.cpp binaries for the current platform.
+ *
+ * Usage:
+ *   node scripts/download-whisper-cpp.mjs           # current platform only
+ *   node scripts/download-whisper-cpp.mjs --all      # all platforms
+ *
+ * Binaries are placed in resources/whisper/<platform>-<arch>/
+ */
+
+import { chmodSync, createWriteStream, existsSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+
+// whisper.cpp release tag to download
+const WHISPER_VERSION = "v1.7.5";
+const GITHUB_BASE = `https://github.com/ggerganov/whisper.cpp/releases/download/${WHISPER_VERSION}`;
+
+// Map of platform-arch to download info
+const PLATFORMS = {
+  "darwin-arm64": {
+    archive: `whisper-${WHISPER_VERSION}-bin-macos-arm64.zip`,
+    binaries: ["whisper-cli", "whisper-server"],
+  },
+  "darwin-x64": {
+    archive: `whisper-${WHISPER_VERSION}-bin-macos-x86_64.zip`,
+    binaries: ["whisper-cli", "whisper-server"],
+  },
+  "linux-x64": {
+    archive: `whisper-${WHISPER_VERSION}-bin-ubuntu-x86_64.zip`,
+    binaries: ["whisper-cli", "whisper-server"],
+  },
+  "win32-x64": {
+    archive: `whisper-${WHISPER_VERSION}-bin-win-x86_64.zip`,
+    binaries: ["whisper-cli.exe", "whisper-server.exe"],
+  },
+};
+
+async function downloadAndExtract(platformKey) {
+  const config = PLATFORMS[platformKey];
+  if (!config) {
+    console.error(`Unknown platform: ${platformKey}`);
+    return;
+  }
+
+  const destDir = join(ROOT, "resources", "whisper", platformKey);
+  if (!existsSync(destDir)) mkdirSync(destDir, { recursive: true });
+
+  const allExist = config.binaries.every((b) => existsSync(join(destDir, b)));
+  if (allExist) {
+    console.log(`[${platformKey}] Already downloaded, skipping.`);
+    return;
+  }
+
+  const url = `${GITHUB_BASE}/${config.archive}`;
+  console.log(`[${platformKey}] Downloading ${url}...`);
+
+  const tmpZip = join(destDir, "tmp-whisper.zip");
+
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    console.error(
+      `[${platformKey}] Download failed: ${res.status} ${res.statusText}`,
+    );
+    console.error(
+      `Note: You may need to download whisper.cpp binaries manually from`,
+    );
+    console.error(`  https://github.com/ggerganov/whisper.cpp/releases`);
+    console.error(`  and place them in ${destDir}`);
+    return;
+  }
+
+  const fileStream = createWriteStream(tmpZip);
+  const reader = res.body.getReader();
+  const nodeStream = new Readable({
+    async read() {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          this.push(null);
+          return;
+        }
+        this.push(Buffer.from(value));
+      } catch (err) {
+        this.destroy(err instanceof Error ? err : new Error(String(err)));
+      }
+    },
+  });
+  await pipeline(nodeStream, fileStream);
+
+  console.log(`[${platformKey}] Extracting...`);
+
+  // Use unzip command (available on macOS, Linux, and Git Bash on Windows)
+  const { execSync } = await import("node:child_process");
+  try {
+    execSync(`unzip -o -j "${tmpZip}" -d "${destDir}"`, { stdio: "pipe" });
+  } catch {
+    console.error(`[${platformKey}] Failed to extract. Please install unzip.`);
+    return;
+  }
+
+  // Clean up
+  const { unlinkSync } = await import("node:fs");
+  try {
+    unlinkSync(tmpZip);
+  } catch {}
+
+  // Make binaries executable on Unix
+  if (!platformKey.startsWith("win32")) {
+    for (const bin of config.binaries) {
+      const binPath = join(destDir, bin);
+      if (existsSync(binPath)) {
+        chmodSync(binPath, 0o755);
+      }
+    }
+  }
+
+  console.log(`[${platformKey}] Done.`);
+}
+
+async function main() {
+  const all = process.argv.includes("--all");
+  if (all) {
+    for (const key of Object.keys(PLATFORMS)) {
+      await downloadAndExtract(key);
+    }
+  } else {
+    const key = `${process.platform}-${process.arch}`;
+    await downloadAndExtract(key);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/electron/scripts/download-whisper-cpp.mjs
+++ b/apps/electron/scripts/download-whisper-cpp.mjs
@@ -21,7 +21,7 @@ const ROOT = join(__dirname, "..");
 
 // whisper.cpp release tag to download
 const WHISPER_VERSION = "v1.7.5";
-const GITHUB_BASE = `https://github.com/ggerganov/whisper.cpp/releases/download/${WHISPER_VERSION}`;
+const GITHUB_BASE = `https://github.com/ggml-org/whisper.cpp/releases/download/${WHISPER_VERSION}`;
 
 // Map of platform-arch to download info
 const PLATFORMS = {

--- a/apps/electron/scripts/download-whisper-cpp.mjs
+++ b/apps/electron/scripts/download-whisper-cpp.mjs
@@ -1,83 +1,45 @@
 #!/usr/bin/env node
 
 /**
- * Download pre-built whisper.cpp binaries for the current platform.
+ * Download or build whisper.cpp binaries for development.
  *
  * Usage:
- *   node scripts/download-whisper-cpp.mjs           # current platform only
- *   node scripts/download-whisper-cpp.mjs --all      # all platforms
+ *   node scripts/download-whisper-cpp.mjs
  *
- * Binaries are placed in resources/whisper/<platform>-<arch>/
+ * On Windows: downloads pre-built binaries from GitHub releases.
+ * On macOS/Linux: builds from source (requires cmake + C compiler).
+ *
+ * Binaries are placed in ~/.cache/freestyle/whisper-bin/ (same
+ * location the app uses at runtime, so the dev build picks them up).
  */
 
-import { chmodSync, createWriteStream, existsSync, mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  unlinkSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = join(__dirname, "..");
+const VERSION = "1.7.5";
+const WIN_VERSION = "1.8.5";
+const BIN_DIR = join(homedir(), ".cache", "freestyle", "whisper-bin");
 
-// whisper.cpp release tag to download
-const WHISPER_VERSION = "v1.7.5";
-const GITHUB_BASE = `https://github.com/ggml-org/whisper.cpp/releases/download/${WHISPER_VERSION}`;
-
-// Map of platform-arch to download info
-const PLATFORMS = {
-  "darwin-arm64": {
-    archive: `whisper-${WHISPER_VERSION}-bin-macos-arm64.zip`,
-    binaries: ["whisper-cli", "whisper-server"],
-  },
-  "darwin-x64": {
-    archive: `whisper-${WHISPER_VERSION}-bin-macos-x86_64.zip`,
-    binaries: ["whisper-cli", "whisper-server"],
-  },
-  "linux-x64": {
-    archive: `whisper-${WHISPER_VERSION}-bin-ubuntu-x86_64.zip`,
-    binaries: ["whisper-cli", "whisper-server"],
-  },
-  "win32-x64": {
-    archive: `whisper-${WHISPER_VERSION}-bin-win-x86_64.zip`,
-    binaries: ["whisper-cli.exe", "whisper-server.exe"],
-  },
-};
-
-async function downloadAndExtract(platformKey) {
-  const config = PLATFORMS[platformKey];
-  if (!config) {
-    console.error(`Unknown platform: ${platformKey}`);
-    return;
-  }
-
-  const destDir = join(ROOT, "resources", "whisper", platformKey);
-  if (!existsSync(destDir)) mkdirSync(destDir, { recursive: true });
-
-  const allExist = config.binaries.every((b) => existsSync(join(destDir, b)));
-  if (allExist) {
-    console.log(`[${platformKey}] Already downloaded, skipping.`);
-    return;
-  }
-
-  const url = `${GITHUB_BASE}/${config.archive}`;
-  console.log(`[${platformKey}] Downloading ${url}...`);
-
-  const tmpZip = join(destDir, "tmp-whisper.zip");
-
-  const res = await fetch(url, { redirect: "follow" });
-  if (!res.ok) {
-    console.error(
-      `[${platformKey}] Download failed: ${res.status} ${res.statusText}`,
-    );
-    console.error(
-      `Note: You may need to download whisper.cpp binaries manually from`,
-    );
-    console.error(`  https://github.com/ggerganov/whisper.cpp/releases`);
-    console.error(`  and place them in ${destDir}`);
-    return;
-  }
-
-  const fileStream = createWriteStream(tmpZip);
+async function fetchToFile(url, dest) {
+  const res = await fetch(url, {
+    redirect: "follow",
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!res.ok || !res.body) throw new Error(`HTTP ${res.status} for ${url}`);
+  const fileStream = createWriteStream(dest);
   const reader = res.body.getReader();
   const nodeStream = new Readable({
     async read() {
@@ -94,52 +56,121 @@ async function downloadAndExtract(platformKey) {
     },
   });
   await pipeline(nodeStream, fileStream);
+}
 
-  console.log(`[${platformKey}] Extracting...`);
+async function buildFromSource() {
+  if (!existsSync(BIN_DIR)) mkdirSync(BIN_DIR, { recursive: true });
 
-  // Use unzip command (available on macOS, Linux, and Git Bash on Windows)
-  const { execFileSync } = await import("node:child_process");
+  const srcDir = join(BIN_DIR, "whisper.cpp-src");
+  const buildDir = join(srcDir, "build");
+  const tarPath = join(BIN_DIR, `whisper-${VERSION}.tar.gz`);
+  const tarballUrl = `https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${VERSION}.tar.gz`;
+
+  console.log("Downloading whisper.cpp source...");
+  await fetchToFile(tarballUrl, tarPath);
+
+  console.log("Extracting...");
+  if (existsSync(srcDir)) rmSync(srcDir, { recursive: true, force: true });
+  mkdirSync(srcDir, { recursive: true });
+  execFileSync("tar", ["xzf", tarPath, "-C", srcDir, "--strip-components=1"], {
+    stdio: "pipe",
+  });
   try {
-    execFileSync("unzip", ["-o", "-j", tmpZip, "-d", destDir], {
-      stdio: "pipe",
-    });
-  } catch {
-    console.error(`[${platformKey}] Failed to extract. Please install unzip.`);
-    return;
-  }
-
-  // Clean up
-  const { unlinkSync } = await import("node:fs");
-  try {
-    unlinkSync(tmpZip);
+    unlinkSync(tarPath);
   } catch {}
 
-  // Make binaries executable on Unix
-  if (!platformKey.startsWith("win32")) {
-    for (const bin of config.binaries) {
-      const binPath = join(destDir, bin);
-      if (existsSync(binPath)) {
-        chmodSync(binPath, 0o755);
+  console.log("Building (this may take a minute)...");
+  mkdirSync(buildDir, { recursive: true });
+  execFileSync(
+    "cmake",
+    ["..", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_SHARED_LIBS=OFF"],
+    {
+      cwd: buildDir,
+      stdio: "inherit",
+      timeout: 60_000,
+    },
+  );
+  execFileSync("cmake", ["--build", ".", "--config", "Release", "-j"], {
+    cwd: buildDir,
+    stdio: "inherit",
+    timeout: 300_000,
+  });
+
+  for (const name of ["whisper-cli", "whisper-server"]) {
+    const built = join(buildDir, "bin", name);
+    if (existsSync(built)) {
+      copyFileSync(built, join(BIN_DIR, name));
+      chmodSync(join(BIN_DIR, name), 0o755);
+    }
+  }
+
+  const libDirs = [join(buildDir, "src"), join(buildDir, "ggml", "src")];
+  for (const libDir of libDirs) {
+    if (!existsSync(libDir)) continue;
+    for (const file of readdirSync(libDir)) {
+      if (file.endsWith(".dylib") || /\.so(\.\d+)*$/.test(file)) {
+        copyFileSync(join(libDir, file), join(BIN_DIR, file));
       }
     }
   }
 
-  console.log(`[${platformKey}] Done.`);
+  if (process.platform === "darwin") {
+    for (const name of ["whisper-cli", "whisper-server"]) {
+      const binPath = join(BIN_DIR, name);
+      if (!existsSync(binPath)) continue;
+      try {
+        execFileSync("install_name_tool", ["-add_rpath", BIN_DIR, binPath], {
+          stdio: "pipe",
+        });
+      } catch {}
+    }
+  }
+
+  try {
+    rmSync(srcDir, { recursive: true, force: true });
+  } catch {}
+  console.log("Done. Binaries at", BIN_DIR);
+}
+
+async function downloadWindows() {
+  if (!existsSync(BIN_DIR)) mkdirSync(BIN_DIR, { recursive: true });
+
+  const url = `https://github.com/ggml-org/whisper.cpp/releases/download/v${WIN_VERSION}/whisper-bin-x64.zip`;
+  const tmpZip = join(BIN_DIR, "whisper-bin.zip");
+
+  console.log("Downloading pre-built Windows binaries...");
+  await fetchToFile(url, tmpZip);
+
+  execFileSync(
+    "powershell",
+    [
+      "-Command",
+      `Expand-Archive -Force -Path '${tmpZip}' -DestinationPath '${BIN_DIR}'`,
+    ],
+    { stdio: "pipe", timeout: 30_000 },
+  );
+
+  try {
+    unlinkSync(tmpZip);
+  } catch {}
+  console.log("Done. Binaries at", BIN_DIR);
 }
 
 async function main() {
-  const all = process.argv.includes("--all");
-  if (all) {
-    for (const key of Object.keys(PLATFORMS)) {
-      await downloadAndExtract(key);
-    }
+  const cli = process.platform === "win32" ? "whisper-cli.exe" : "whisper-cli";
+  if (existsSync(join(BIN_DIR, cli))) {
+    console.log("whisper-cli already exists at", BIN_DIR);
+    return;
+  }
+
+  if (process.platform === "win32") {
+    await downloadWindows();
   } else {
-    const key = `${process.platform}-${process.arch}`;
-    await downloadAndExtract(key);
+    await buildFromSource();
   }
 }
 
 main().catch((err) => {
-  console.error(err);
+  console.error(err.message || err);
   process.exit(1);
 });

--- a/apps/electron/scripts/download-whisper-cpp.mjs
+++ b/apps/electron/scripts/download-whisper-cpp.mjs
@@ -98,9 +98,11 @@ async function downloadAndExtract(platformKey) {
   console.log(`[${platformKey}] Extracting...`);
 
   // Use unzip command (available on macOS, Linux, and Git Bash on Windows)
-  const { execSync } = await import("node:child_process");
+  const { execFileSync } = await import("node:child_process");
   try {
-    execSync(`unzip -o -j "${tmpZip}" -d "${destDir}"`, { stdio: "pipe" });
+    execFileSync("unzip", ["-o", "-j", tmpZip, "-d", destDir], {
+      stdio: "pipe",
+    });
   } catch {
     console.error(`[${platformKey}] Failed to extract. Please install unzip.`);
     return;

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1068,6 +1068,9 @@ app.on("will-quit", () => {
   if (process.platform === "win32") {
     globalShortcut.unregisterAll();
   }
+  fetch(`http://127.0.0.1:${serverPort}/api/whisper/server/stop`, {
+    method: "POST",
+  }).catch(() => {});
 });
 
 // Keep app running in background when windows are closed (tray stays active)

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -210,6 +210,13 @@ function createAppWindow(): void {
     return { action: "deny" };
   });
 
+  mainWindow.webContents.on("console-message", (_event, level, message) => {
+    if (message.startsWith("[debug]")) {
+      const prefix = level === 3 ? "[pill:error]" : "[pill]";
+      console.log(prefix, message);
+    }
+  });
+
   mainWindow.loadURL(getPillURL());
 }
 

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -210,13 +210,6 @@ function createAppWindow(): void {
     return { action: "deny" };
   });
 
-  mainWindow.webContents.on("console-message", (_event, level, message) => {
-    if (message.startsWith("[debug]")) {
-      const prefix = level === 3 ? "[pill:error]" : "[pill]";
-      console.log(prefix, message);
-    }
-  });
-
   mainWindow.loadURL(getPillURL());
 }
 

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1068,9 +1068,6 @@ app.on("will-quit", () => {
   if (process.platform === "win32") {
     globalShortcut.unregisterAll();
   }
-  fetch(`http://127.0.0.1:${serverPort}/api/whisper/server/stop`, {
-    method: "POST",
-  }).catch(() => {});
 });
 
 // Keep app running in background when windows are closed (tray stays active)
@@ -1087,6 +1084,9 @@ app.on("before-quit", (event) => {
   if (isQuitting) return;
   isQuitting = true;
   event.preventDefault();
+  fetch(`http://127.0.0.1:${serverPort}/api/whisper/server/stop`, {
+    method: "POST",
+  }).catch(() => {});
   if (httpServer) {
     httpServer.close();
     httpServer = null;

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -55,16 +55,7 @@ export class Streamer {
   }
 
   async startCapture(stream: MediaStream): Promise<void> {
-    console.log(
-      "[streamer] startCapture, ws state:",
-      this.ws?.readyState,
-      "sessionReady:",
-      this.sessionReady,
-      "streamingSupported:",
-      this.streamingSupported,
-    );
     if (!this.ws || this.ws.readyState > WebSocket.OPEN) {
-      console.log("[streamer] reconnecting WS");
       this.openWebSocket();
     }
     this.capturing = true;
@@ -122,14 +113,6 @@ export class Streamer {
   }
 
   getWavBlob(): Blob | null {
-    console.log(
-      "[streamer] getWavBlob, pcmSampleCount:",
-      this.pcmSampleCount,
-      "pcmChunks:",
-      this.pcmChunks.length,
-      "capturing:",
-      this.capturing,
-    );
     if (this.pcmSampleCount === 0) return null;
     const blob = encodeWavFromInt16(
       this.pcmChunks,

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -54,7 +54,6 @@ export class Streamer {
   }
 
   async startCapture(stream: MediaStream): Promise<void> {
-    this.stopCapture();
     this.capturing = true;
     this.pendingChunks = [];
     this.pcmChunks = [];
@@ -110,7 +109,6 @@ export class Streamer {
   }
 
   getWavBlob(): Blob | null {
-    this.stopCapture();
     if (this.pcmSampleCount === 0) return null;
     const blob = encodeWavFromInt16(
       this.pcmChunks,

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -27,6 +27,7 @@ export class Streamer {
   private sessionReady = false;
   private pendingChunks: ArrayBuffer[] = [];
   private destroyed = false;
+  private streamingSupported = false;
   private readonly callbacks: StreamerCallbacks;
   private readonly wsUrl: string;
 
@@ -54,6 +55,9 @@ export class Streamer {
   }
 
   async startCapture(stream: MediaStream): Promise<void> {
+    if (!this.ws || this.ws.readyState > WebSocket.OPEN) {
+      this.openWebSocket();
+    }
     this.capturing = true;
     this.pendingChunks = [];
     this.pcmChunks = [];
@@ -189,8 +193,9 @@ export class Streamer {
       }
       switch (msg.type) {
         case "config":
+          this.streamingSupported = msg.streaming ?? false;
           this.callbacks.onConfig({
-            streaming: msg.streaming ?? false,
+            streaming: this.streamingSupported,
             model: msg.model ?? "",
           });
           break;
@@ -219,7 +224,7 @@ export class Streamer {
     ws.addEventListener("close", () => {
       this.sessionReady = false;
       this.pendingChunks = [];
-      if (!this.destroyed) {
+      if (!this.destroyed && this.streamingSupported) {
         setTimeout(() => {
           if (!this.destroyed) this.openWebSocket();
         }, 1000);

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -54,6 +54,7 @@ export class Streamer {
   }
 
   async startCapture(stream: MediaStream): Promise<void> {
+    this.stopCapture();
     this.capturing = true;
     this.pendingChunks = [];
     this.pcmChunks = [];
@@ -109,6 +110,7 @@ export class Streamer {
   }
 
   getWavBlob(): Blob | null {
+    this.stopCapture();
     if (this.pcmSampleCount === 0) return null;
     const blob = encodeWavFromInt16(
       this.pcmChunks,

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -55,7 +55,16 @@ export class Streamer {
   }
 
   async startCapture(stream: MediaStream): Promise<void> {
+    console.log(
+      "[streamer] startCapture, ws state:",
+      this.ws?.readyState,
+      "sessionReady:",
+      this.sessionReady,
+      "streamingSupported:",
+      this.streamingSupported,
+    );
     if (!this.ws || this.ws.readyState > WebSocket.OPEN) {
+      console.log("[streamer] reconnecting WS");
       this.openWebSocket();
     }
     this.capturing = true;
@@ -113,6 +122,14 @@ export class Streamer {
   }
 
   getWavBlob(): Blob | null {
+    console.log(
+      "[streamer] getWavBlob, pcmSampleCount:",
+      this.pcmSampleCount,
+      "pcmChunks:",
+      this.pcmChunks.length,
+      "capturing:",
+      this.capturing,
+    );
     if (this.pcmSampleCount === 0) return null;
     const blob = encodeWavFromInt16(
       this.pcmChunks,

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -151,16 +151,6 @@ export default function AppPage(): React.JSX.Element {
 
   // ---- Queue drain ----
   const drainQueue = useCallback(async () => {
-    console.log(
-      "[debug] drainQueue called, draining:",
-      drainingRef.current,
-      "queueLen:",
-      queueRef.current.length,
-      "wantsMic:",
-      wantsMicRef.current,
-      "pillActive:",
-      pillActiveRef.current,
-    );
     if (drainingRef.current) return;
     drainingRef.current = true;
 
@@ -169,25 +159,14 @@ export default function AppPage(): React.JSX.Element {
     }
 
     if (!pillActiveRef.current || queueRef.current.length === 0) {
-      console.log(
-        "[debug] drainQueue early exit, pillActive:",
-        pillActiveRef.current,
-        "queueLen:",
-        queueRef.current.length,
-      );
       drainingRef.current = false;
       return;
     }
 
     const batch = [...queueRef.current];
     queueRef.current = [];
-    console.log("[debug] drainQueue processing batch of", batch.length);
 
     const results = await Promise.all(batch.map((e) => e.promise));
-    console.log(
-      "[debug] drainQueue results:",
-      results.map((r) => r.raw.slice(0, 50)),
-    );
 
     if (!pillActiveRef.current) {
       drainingRef.current = false;
@@ -274,28 +253,18 @@ export default function AppPage(): React.JSX.Element {
     if (!streamerRef.current) {
       streamerRef.current = new Streamer(getApiBase(), {
         onConfig: (config) => {
-          console.log("[debug] streamer onConfig:", config);
           useStreamingRef.current = config.streaming;
         },
-        onReady: () => {
-          console.log("[debug] streamer onReady");
-        },
-        onPartial: (text) => {
-          console.log("[debug] streamer onPartial:", text.slice(0, 60));
-        },
+        onReady: () => {},
+        onPartial: () => {},
         onFinal: (text) => {
-          console.log("[debug] streamer onFinal:", text.slice(0, 100));
           const resolver = streamResolverRef.current;
-          if (!resolver) {
-            console.warn("[debug] onFinal but no resolver!");
-            return;
-          }
+          if (!resolver) return;
           streamResolverRef.current = null;
           resolver({ raw: text, cleaned: text });
         },
         onCleaned: () => {},
         onError: (msg) => {
-          console.error("[debug] streamer onError:", msg);
           if (!pillActiveRef.current) return;
           const resolver = streamResolverRef.current;
           if (resolver) {
@@ -471,10 +440,6 @@ export default function AppPage(): React.JSX.Element {
   // ---- Start recording ----
   const startRecording = useCallback(
     async (forReRecord = false) => {
-      console.log(
-        "[app] startRecording, useStreaming:",
-        useStreamingRef.current,
-      );
       if (wantsMicRef.current) {
         return;
       }
@@ -512,12 +477,6 @@ export default function AppPage(): React.JSX.Element {
 
       try {
         sessionStreamingRef.current = useStreamingRef.current;
-        console.log(
-          "[debug] startRecording sessionStreaming:",
-          sessionStreamingRef.current,
-          "useStreaming:",
-          useStreamingRef.current,
-        );
         const stream = sessionStreamingRef.current
           ? await recorderRef.current.acquireStream()
           : await recorderRef.current.start();
@@ -608,17 +567,7 @@ export default function AppPage(): React.JSX.Element {
 
     const empty: TranscribeResult = { raw: "", cleaned: "" };
 
-    console.log(
-      "[debug] commitRecording sessionStreaming:",
-      sessionStreamingRef.current,
-      "useStreaming:",
-      useStreamingRef.current,
-      "hasStreamer:",
-      !!streamerRef.current,
-    );
-
     if (sessionStreamingRef.current && streamerRef.current) {
-      console.log("[debug] -> streaming commit path");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
 
@@ -627,7 +576,6 @@ export default function AppPage(): React.JSX.Element {
         streamResolverRef.current = resolve;
         setTimeout(() => {
           if (streamResolverRef.current === resolve) {
-            console.warn("[debug] streaming commit timed out after 30s");
             streamResolverRef.current = null;
             resolve(empty);
           }
@@ -639,32 +587,18 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
-    console.log("[debug] -> batch commit path");
     let wavBlob: Blob | null = streamerRef.current?.getWavBlob() ?? null;
-    console.log(
-      "[debug] getWavBlob:",
-      wavBlob ? `${wavBlob.size}b` : "null",
-      "isRecording:",
-      recorderRef.current.isRecording(),
-    );
     if (!wavBlob && recorderRef.current.isRecording()) {
-      console.log("[debug] falling back to MediaRecorder");
       wavBlob = await recorderRef.current.stop();
-      console.log(
-        "[debug] MediaRecorder blob:",
-        wavBlob ? `${wavBlob.size}b` : "null",
-      );
     }
     recorderRef.current.cancel();
     recorderRef.current.releaseStream();
 
     if (!pillActiveRef.current) {
-      console.log("[debug] pill inactive, aborting");
       return;
     }
 
     if (!wavBlob) {
-      console.log("[debug] no wavBlob, hiding");
       if (queueRef.current.length === 0 && !drainingRef.current) hidePill();
       return;
     }
@@ -677,14 +611,12 @@ export default function AppPage(): React.JSX.Element {
     if (appContextRef.current) headers["x-app-context"] = appContextRef.current;
     if (isSubsequent) headers["x-skip-post-process"] = "true";
 
-    console.log("[debug] POSTing /api/transcribe, size:", wavBlob.size);
     setPendingCount((c) => c + 1);
     const transcribePromise: Promise<TranscribeResult> = fetch(
       `${getApiBase()}/api/transcribe`,
       { method: "POST", body: wavBlob, headers },
     )
       .then(async (res) => {
-        console.log("[debug] transcribe response:", res.status);
         if (!res.ok) {
           const body = await res.json().catch(() => null);
           const msg =
@@ -699,19 +631,12 @@ export default function AppPage(): React.JSX.Element {
           return empty;
         }
         const data = await res.json();
-        console.log(
-          "[debug] transcribe result:",
-          JSON.stringify(data).slice(0, 200),
-        );
         return {
           raw: (data.raw || "").trim(),
           cleaned: (data.cleaned || data.raw || "").trim(),
         };
       })
-      .catch((err) => {
-        console.error("[debug] transcribe fetch error:", err);
-        return empty;
-      });
+      .catch(() => empty);
 
     queueRef.current.push({ promise: transcribePromise });
     drainQueue();

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -617,7 +617,19 @@ export default function AppPage(): React.JSX.Element {
       { method: "POST", body: wavBlob, headers },
     )
       .then(async (res) => {
-        if (!res.ok) return empty;
+        if (!res.ok) {
+          const body = await res.json().catch(() => null);
+          const msg =
+            body?.error ||
+            body?.detail ||
+            `Transcription failed (${res.status})`;
+          if (pillActiveRef.current && !wantsMicRef.current) {
+            setState("error");
+            setMessage(msg);
+            setTimeout(() => hidePill(), 3000);
+          }
+          return empty;
+        }
         const data = await res.json();
         return {
           raw: (data.raw || "").trim(),

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -252,28 +252,18 @@ export default function AppPage(): React.JSX.Element {
     if (!streamerRef.current) {
       streamerRef.current = new Streamer(getApiBase(), {
         onConfig: (config) => {
-          console.log("[app] onConfig:", config);
           useStreamingRef.current = config.streaming;
         },
-        onReady: () => {
-          console.log("[app] onReady");
-        },
-        onPartial: (text) => {
-          console.log("[app] onPartial:", text.slice(0, 80));
-        },
+        onReady: () => {},
+        onPartial: () => {},
         onFinal: (text) => {
-          console.log("[app] onFinal:", text.slice(0, 120));
           const resolver = streamResolverRef.current;
-          if (!resolver) {
-            console.warn("[app] onFinal but no resolver");
-            return;
-          }
+          if (!resolver) return;
           streamResolverRef.current = null;
           resolver({ raw: text, cleaned: text });
         },
         onCleaned: () => {},
         onError: (msg) => {
-          console.error("[app] onError:", msg);
           if (!pillActiveRef.current) return;
           const resolver = streamResolverRef.current;
           if (resolver) {
@@ -579,15 +569,7 @@ export default function AppPage(): React.JSX.Element {
 
     const empty: TranscribeResult = { raw: "", cleaned: "" };
 
-    console.log(
-      "[app] commitRecording, useStreaming:",
-      useStreamingRef.current,
-      "hasStreamer:",
-      !!streamerRef.current,
-    );
-
     if (useStreamingRef.current && streamerRef.current) {
-      console.log("[app] commit via streaming path");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
 
@@ -596,7 +578,6 @@ export default function AppPage(): React.JSX.Element {
         streamResolverRef.current = resolve;
         setTimeout(() => {
           if (streamResolverRef.current === resolve) {
-            console.warn("[app] streaming commit timed out after 30s");
             streamResolverRef.current = null;
             resolve(empty);
           }
@@ -608,30 +589,18 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
-    console.log("[app] commit via batch (REST) path");
     let wavBlob: Blob | null = streamerRef.current?.getWavBlob() ?? null;
-    console.log(
-      "[app] getWavBlob:",
-      wavBlob ? `${wavBlob.size} bytes` : "null",
-    );
     if (!wavBlob && recorderRef.current.isRecording()) {
-      console.log("[app] falling back to MediaRecorder.stop()");
       wavBlob = await recorderRef.current.stop();
-      console.log(
-        "[app] MediaRecorder blob:",
-        wavBlob ? `${wavBlob.size} bytes` : "null",
-      );
     }
     recorderRef.current.cancel();
     recorderRef.current.releaseStream();
 
     if (!pillActiveRef.current) {
-      console.log("[app] pill no longer active, aborting");
       return;
     }
 
     if (!wavBlob) {
-      console.log("[app] no wav blob, hiding pill");
       if (queueRef.current.length === 0 && !drainingRef.current) hidePill();
       return;
     }
@@ -644,17 +613,14 @@ export default function AppPage(): React.JSX.Element {
     if (appContextRef.current) headers["x-app-context"] = appContextRef.current;
     if (isSubsequent) headers["x-skip-post-process"] = "true";
 
-    console.log("[app] POSTing to /api/transcribe, blob size:", wavBlob.size);
     setPendingCount((c) => c + 1);
     const transcribePromise: Promise<TranscribeResult> = fetch(
       `${getApiBase()}/api/transcribe`,
       { method: "POST", body: wavBlob, headers },
     )
       .then(async (res) => {
-        console.log("[app] /api/transcribe response:", res.status);
         if (!res.ok) {
           const body = await res.json().catch(() => null);
-          console.error("[app] transcribe error body:", body);
           const msg =
             body?.error ||
             body?.detail ||
@@ -667,19 +633,12 @@ export default function AppPage(): React.JSX.Element {
           return empty;
         }
         const data = await res.json();
-        console.log(
-          "[app] transcribe result:",
-          JSON.stringify(data).slice(0, 200),
-        );
         return {
           raw: (data.raw || "").trim(),
           cleaned: (data.cleaned || data.raw || "").trim(),
         };
       })
-      .catch((err) => {
-        console.error("[app] transcribe fetch error:", err);
-        return empty;
-      });
+      .catch(() => empty);
 
     queueRef.current.push({ promise: transcribePromise });
     drainQueue();

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -113,6 +113,7 @@ export default function AppPage(): React.JSX.Element {
   const [pillAlign, setPillAlign] = useState<"start" | "end">("end");
   const [pillSide, setPillSide] = useState<"center" | "right">("center");
   const useStreamingRef = useRef(false);
+  const sessionStreamingRef = useRef(false);
 
   const [isReRecording, setIsReRecording] = useState(false);
   const isReRecordingRef = useRef(false);
@@ -479,7 +480,8 @@ export default function AppPage(): React.JSX.Element {
       }
 
       try {
-        const stream = useStreamingRef.current
+        sessionStreamingRef.current = useStreamingRef.current;
+        const stream = sessionStreamingRef.current
           ? await recorderRef.current.acquireStream()
           : await recorderRef.current.start();
 
@@ -569,7 +571,7 @@ export default function AppPage(): React.JSX.Element {
 
     const empty: TranscribeResult = { raw: "", cleaned: "" };
 
-    if (useStreamingRef.current && streamerRef.current) {
+    if (sessionStreamingRef.current && streamerRef.current) {
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
 

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -252,21 +252,29 @@ export default function AppPage(): React.JSX.Element {
     if (!streamerRef.current) {
       streamerRef.current = new Streamer(getApiBase(), {
         onConfig: (config) => {
+          console.log("[app] onConfig:", config);
           useStreamingRef.current = config.streaming;
         },
-        onReady: () => {},
-        onPartial: () => {},
+        onReady: () => {
+          console.log("[app] onReady");
+        },
+        onPartial: (text) => {
+          console.log("[app] onPartial:", text.slice(0, 80));
+        },
         onFinal: (text) => {
+          console.log("[app] onFinal:", text.slice(0, 120));
           const resolver = streamResolverRef.current;
-          if (!resolver) return;
+          if (!resolver) {
+            console.warn("[app] onFinal but no resolver");
+            return;
+          }
           streamResolverRef.current = null;
           resolver({ raw: text, cleaned: text });
         },
         onCleaned: () => {},
         onError: (msg) => {
+          console.error("[app] onError:", msg);
           if (!pillActiveRef.current) return;
-          // If we're waiting for a streaming result, resolve with empty
-          // so the app doesn't stay stuck in "transcribing"
           const resolver = streamResolverRef.current;
           if (resolver) {
             streamResolverRef.current = null;
@@ -441,6 +449,10 @@ export default function AppPage(): React.JSX.Element {
   // ---- Start recording ----
   const startRecording = useCallback(
     async (forReRecord = false) => {
+      console.log(
+        "[app] startRecording, useStreaming:",
+        useStreamingRef.current,
+      );
       if (wantsMicRef.current) {
         return;
       }
@@ -567,7 +579,15 @@ export default function AppPage(): React.JSX.Element {
 
     const empty: TranscribeResult = { raw: "", cleaned: "" };
 
+    console.log(
+      "[app] commitRecording, useStreaming:",
+      useStreamingRef.current,
+      "hasStreamer:",
+      !!streamerRef.current,
+    );
+
     if (useStreamingRef.current && streamerRef.current) {
+      console.log("[app] commit via streaming path");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
 
@@ -576,6 +596,7 @@ export default function AppPage(): React.JSX.Element {
         streamResolverRef.current = resolve;
         setTimeout(() => {
           if (streamResolverRef.current === resolve) {
+            console.warn("[app] streaming commit timed out after 30s");
             streamResolverRef.current = null;
             resolve(empty);
           }
@@ -587,18 +608,30 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
+    console.log("[app] commit via batch (REST) path");
     let wavBlob: Blob | null = streamerRef.current?.getWavBlob() ?? null;
+    console.log(
+      "[app] getWavBlob:",
+      wavBlob ? `${wavBlob.size} bytes` : "null",
+    );
     if (!wavBlob && recorderRef.current.isRecording()) {
+      console.log("[app] falling back to MediaRecorder.stop()");
       wavBlob = await recorderRef.current.stop();
+      console.log(
+        "[app] MediaRecorder blob:",
+        wavBlob ? `${wavBlob.size} bytes` : "null",
+      );
     }
     recorderRef.current.cancel();
     recorderRef.current.releaseStream();
 
     if (!pillActiveRef.current) {
+      console.log("[app] pill no longer active, aborting");
       return;
     }
 
     if (!wavBlob) {
+      console.log("[app] no wav blob, hiding pill");
       if (queueRef.current.length === 0 && !drainingRef.current) hidePill();
       return;
     }
@@ -611,14 +644,17 @@ export default function AppPage(): React.JSX.Element {
     if (appContextRef.current) headers["x-app-context"] = appContextRef.current;
     if (isSubsequent) headers["x-skip-post-process"] = "true";
 
+    console.log("[app] POSTing to /api/transcribe, blob size:", wavBlob.size);
     setPendingCount((c) => c + 1);
     const transcribePromise: Promise<TranscribeResult> = fetch(
       `${getApiBase()}/api/transcribe`,
       { method: "POST", body: wavBlob, headers },
     )
       .then(async (res) => {
+        console.log("[app] /api/transcribe response:", res.status);
         if (!res.ok) {
           const body = await res.json().catch(() => null);
+          console.error("[app] transcribe error body:", body);
           const msg =
             body?.error ||
             body?.detail ||
@@ -631,12 +667,19 @@ export default function AppPage(): React.JSX.Element {
           return empty;
         }
         const data = await res.json();
+        console.log(
+          "[app] transcribe result:",
+          JSON.stringify(data).slice(0, 200),
+        );
         return {
           raw: (data.raw || "").trim(),
           cleaned: (data.cleaned || data.raw || "").trim(),
         };
       })
-      .catch(() => empty);
+      .catch((err) => {
+        console.error("[app] transcribe fetch error:", err);
+        return empty;
+      });
 
     queueRef.current.push({ promise: transcribePromise });
     drainQueue();

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -151,6 +151,16 @@ export default function AppPage(): React.JSX.Element {
 
   // ---- Queue drain ----
   const drainQueue = useCallback(async () => {
+    console.log(
+      "[debug] drainQueue called, draining:",
+      drainingRef.current,
+      "queueLen:",
+      queueRef.current.length,
+      "wantsMic:",
+      wantsMicRef.current,
+      "pillActive:",
+      pillActiveRef.current,
+    );
     if (drainingRef.current) return;
     drainingRef.current = true;
 
@@ -159,14 +169,25 @@ export default function AppPage(): React.JSX.Element {
     }
 
     if (!pillActiveRef.current || queueRef.current.length === 0) {
+      console.log(
+        "[debug] drainQueue early exit, pillActive:",
+        pillActiveRef.current,
+        "queueLen:",
+        queueRef.current.length,
+      );
       drainingRef.current = false;
       return;
     }
 
     const batch = [...queueRef.current];
     queueRef.current = [];
+    console.log("[debug] drainQueue processing batch of", batch.length);
 
     const results = await Promise.all(batch.map((e) => e.promise));
+    console.log(
+      "[debug] drainQueue results:",
+      results.map((r) => r.raw.slice(0, 50)),
+    );
 
     if (!pillActiveRef.current) {
       drainingRef.current = false;
@@ -253,18 +274,28 @@ export default function AppPage(): React.JSX.Element {
     if (!streamerRef.current) {
       streamerRef.current = new Streamer(getApiBase(), {
         onConfig: (config) => {
+          console.log("[debug] streamer onConfig:", config);
           useStreamingRef.current = config.streaming;
         },
-        onReady: () => {},
-        onPartial: () => {},
+        onReady: () => {
+          console.log("[debug] streamer onReady");
+        },
+        onPartial: (text) => {
+          console.log("[debug] streamer onPartial:", text.slice(0, 60));
+        },
         onFinal: (text) => {
+          console.log("[debug] streamer onFinal:", text.slice(0, 100));
           const resolver = streamResolverRef.current;
-          if (!resolver) return;
+          if (!resolver) {
+            console.warn("[debug] onFinal but no resolver!");
+            return;
+          }
           streamResolverRef.current = null;
           resolver({ raw: text, cleaned: text });
         },
         onCleaned: () => {},
         onError: (msg) => {
+          console.error("[debug] streamer onError:", msg);
           if (!pillActiveRef.current) return;
           const resolver = streamResolverRef.current;
           if (resolver) {
@@ -481,6 +512,12 @@ export default function AppPage(): React.JSX.Element {
 
       try {
         sessionStreamingRef.current = useStreamingRef.current;
+        console.log(
+          "[debug] startRecording sessionStreaming:",
+          sessionStreamingRef.current,
+          "useStreaming:",
+          useStreamingRef.current,
+        );
         const stream = sessionStreamingRef.current
           ? await recorderRef.current.acquireStream()
           : await recorderRef.current.start();
@@ -571,7 +608,17 @@ export default function AppPage(): React.JSX.Element {
 
     const empty: TranscribeResult = { raw: "", cleaned: "" };
 
+    console.log(
+      "[debug] commitRecording sessionStreaming:",
+      sessionStreamingRef.current,
+      "useStreaming:",
+      useStreamingRef.current,
+      "hasStreamer:",
+      !!streamerRef.current,
+    );
+
     if (sessionStreamingRef.current && streamerRef.current) {
+      console.log("[debug] -> streaming commit path");
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
 
@@ -580,6 +627,7 @@ export default function AppPage(): React.JSX.Element {
         streamResolverRef.current = resolve;
         setTimeout(() => {
           if (streamResolverRef.current === resolve) {
+            console.warn("[debug] streaming commit timed out after 30s");
             streamResolverRef.current = null;
             resolve(empty);
           }
@@ -591,18 +639,32 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
+    console.log("[debug] -> batch commit path");
     let wavBlob: Blob | null = streamerRef.current?.getWavBlob() ?? null;
+    console.log(
+      "[debug] getWavBlob:",
+      wavBlob ? `${wavBlob.size}b` : "null",
+      "isRecording:",
+      recorderRef.current.isRecording(),
+    );
     if (!wavBlob && recorderRef.current.isRecording()) {
+      console.log("[debug] falling back to MediaRecorder");
       wavBlob = await recorderRef.current.stop();
+      console.log(
+        "[debug] MediaRecorder blob:",
+        wavBlob ? `${wavBlob.size}b` : "null",
+      );
     }
     recorderRef.current.cancel();
     recorderRef.current.releaseStream();
 
     if (!pillActiveRef.current) {
+      console.log("[debug] pill inactive, aborting");
       return;
     }
 
     if (!wavBlob) {
+      console.log("[debug] no wavBlob, hiding");
       if (queueRef.current.length === 0 && !drainingRef.current) hidePill();
       return;
     }
@@ -615,12 +677,14 @@ export default function AppPage(): React.JSX.Element {
     if (appContextRef.current) headers["x-app-context"] = appContextRef.current;
     if (isSubsequent) headers["x-skip-post-process"] = "true";
 
+    console.log("[debug] POSTing /api/transcribe, size:", wavBlob.size);
     setPendingCount((c) => c + 1);
     const transcribePromise: Promise<TranscribeResult> = fetch(
       `${getApiBase()}/api/transcribe`,
       { method: "POST", body: wavBlob, headers },
     )
       .then(async (res) => {
+        console.log("[debug] transcribe response:", res.status);
         if (!res.ok) {
           const body = await res.json().catch(() => null);
           const msg =
@@ -635,12 +699,19 @@ export default function AppPage(): React.JSX.Element {
           return empty;
         }
         const data = await res.json();
+        console.log(
+          "[debug] transcribe result:",
+          JSON.stringify(data).slice(0, 200),
+        );
         return {
           raw: (data.raw || "").trim(),
           cleaned: (data.cleaned || data.raw || "").trim(),
         };
       })
-      .catch(() => empty);
+      .catch((err) => {
+        console.error("[debug] transcribe fetch error:", err);
+        return empty;
+      });
 
     queueRef.current.push({ promise: transcribePromise });
     drainQueue();

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -265,6 +265,13 @@ export default function AppPage(): React.JSX.Element {
         onCleaned: () => {},
         onError: (msg) => {
           if (!pillActiveRef.current) return;
+          // If we're waiting for a streaming result, resolve with empty
+          // so the app doesn't stay stuck in "transcribing"
+          const resolver = streamResolverRef.current;
+          if (resolver) {
+            streamResolverRef.current = null;
+            resolver({ raw: "", cleaned: "" });
+          }
           if (wantsMicRef.current) return;
           setState("error");
           setMessage(msg);

--- a/apps/electron/src/renderer/src/pages/settings/models.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/models.tsx
@@ -64,6 +64,7 @@ interface WhisperModelDownloadState {
   sizeBytes: number;
   displayName: string;
   status: "not_downloaded" | "downloading" | "verifying" | "ready" | "error";
+  phase?: "building_binary" | "downloading_model";
   downloadProgress?: {
     bytesDownloaded: number;
     bytesTotal: number;
@@ -1245,29 +1246,46 @@ function LocalWhisperSection({
                   <span>{def.ramRequired}</span>
                 </div>
 
-                {/* Download progress bar */}
-                {status === "downloading" && state?.downloadProgress && (
-                  <div className="mt-2 space-y-1">
-                    <div className="bg-secondary h-1.5 w-full overflow-hidden rounded-full">
-                      <div
-                        className="bg-primary h-full rounded-full transition-all"
-                        style={{ width: `${state.downloadProgress.percent}%` }}
-                      />
+                {/* Build phase — indeterminate progress */}
+                {status === "downloading" &&
+                  state?.phase === "building_binary" && (
+                    <div className="mt-2 space-y-1">
+                      <div className="bg-secondary h-1.5 w-full overflow-hidden rounded-full">
+                        <div className="bg-primary h-full w-full animate-pulse rounded-full" />
+                      </div>
+                      <div className="text-muted-foreground text-[10px]">
+                        Building whisper.cpp — this may take a minute…
+                      </div>
                     </div>
-                    <div className="text-muted-foreground flex justify-between text-[10px]">
-                      <span>
-                        {formatBytes(state.downloadProgress.bytesDownloaded)} /{" "}
-                        {formatBytes(state.downloadProgress.bytesTotal)}
-                      </span>
-                      <span>
-                        {state.downloadProgress.speedBps > 0 &&
-                          formatSpeed(state.downloadProgress.speedBps)}
-                        {state.downloadProgress.percent > 0 &&
-                          ` · ${state.downloadProgress.percent}%`}
-                      </span>
+                  )}
+
+                {/* Download phase — byte progress bar */}
+                {status === "downloading" &&
+                  state?.phase === "downloading_model" &&
+                  state.downloadProgress && (
+                    <div className="mt-2 space-y-1">
+                      <div className="bg-secondary h-1.5 w-full overflow-hidden rounded-full">
+                        <div
+                          className="bg-primary h-full rounded-full transition-all"
+                          style={{
+                            width: `${state.downloadProgress.percent}%`,
+                          }}
+                        />
+                      </div>
+                      <div className="text-muted-foreground flex justify-between text-[10px]">
+                        <span>
+                          {formatBytes(state.downloadProgress.bytesDownloaded)}{" "}
+                          / {formatBytes(state.downloadProgress.bytesTotal)}
+                        </span>
+                        <span>
+                          {state.downloadProgress.speedBps > 0 &&
+                            formatSpeed(state.downloadProgress.speedBps)}
+                          {state.downloadProgress.percent > 0 &&
+                            ` · ${state.downloadProgress.percent}%`}
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
 
                 {/* Error message */}
                 {status === "error" && state?.error && (

--- a/apps/electron/src/renderer/src/pages/settings/models.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/models.tsx
@@ -1203,7 +1203,7 @@ function LocalWhisperSection({
         <div className="border-border bg-card flex items-center gap-2.5 rounded-[10px] border px-4 py-3">
           <Loader2 className="text-primary h-3.5 w-3.5 shrink-0 animate-spin" />
           <span className="text-muted-foreground text-[12px]">
-            Downloading whisper.cpp binary…
+            Building whisper.cpp from source — this may take a minute…
           </span>
         </div>
       )}

--- a/apps/electron/src/renderer/src/pages/settings/models.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/models.tsx
@@ -5,21 +5,24 @@ import {
   localLlmConfigSchema,
 } from "@freestyle/validations";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { getClient } from "@renderer/lib/api";
+import { getApiBase, getClient } from "@renderer/lib/api";
 import { cn } from "@renderer/lib/utils";
 import {
   AlertTriangle,
   Check,
   ChevronRight,
   Cpu,
+  Download,
   Eye,
   EyeOff,
+  HardDrive,
   Key,
   Loader2,
   Mic,
   Monitor,
   Pencil,
   Plus,
+  RefreshCw,
   Search,
   Sparkles,
   Trash2,
@@ -55,11 +58,50 @@ interface ApiKeyEntry {
   created_at: string;
 }
 
+interface WhisperModelDownloadState {
+  model: string;
+  fileName: string;
+  sizeBytes: number;
+  displayName: string;
+  status: "not_downloaded" | "downloading" | "verifying" | "ready" | "error";
+  downloadProgress?: {
+    bytesDownloaded: number;
+    bytesTotal: number;
+    percent: number;
+    speedBps: number;
+  };
+  error?: string;
+}
+
+interface WhisperModelDef {
+  id: string;
+  displayName: string;
+  sizeBytes: number;
+  ramRequired: string;
+  speed: string;
+  quality: string;
+}
+
+interface WhisperStatus {
+  binaryAvailable: boolean;
+  serverBinaryAvailable: boolean;
+  serverRunning: boolean;
+  modelsDir: string;
+  models: WhisperModelDownloadState[];
+  modelDefinitions: WhisperModelDef[];
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const VOICE_PROVIDERS = ["openai", "groq", "deepgram", "elevenlabs"];
+const VOICE_PROVIDERS = [
+  "openai",
+  "groq",
+  "deepgram",
+  "elevenlabs",
+  "local-whisper",
+];
 const LLM_PROVIDERS = [
   "openai",
   "anthropic",
@@ -79,6 +121,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   mistral: "Mistral",
   openrouter: "OpenRouter",
   "local-llm": "Local LLM",
+  "local-whisper": "Local Whisper",
 };
 
 /** Editorial empty-state suggestions — surfaced when no providers exist. */
@@ -140,6 +183,11 @@ export default function ModelsPage(): React.JSX.Element {
   // Delete confirmation
   const [deleteProvider, setDeleteProvider] = useState<string | null>(null);
   const [deleteBlockedBy, setDeleteBlockedBy] = useState<string[]>([]);
+
+  // Local Whisper
+  const [whisperStatus, setWhisperStatus] = useState<WhisperStatus | null>(
+    null,
+  );
 
   // Local LLM
   const [useLocalLlm, setUseLocalLlm] = useState(false);
@@ -219,9 +267,46 @@ export default function ModelsPage(): React.JSX.Element {
     }
   }, [localLlmForm.setValue]);
 
+  const loadWhisperStatus = useCallback(async () => {
+    try {
+      const res = await fetch(`${getApiBase()}/api/whisper/status`);
+      if (res.ok) {
+        const data: WhisperStatus = await res.json();
+        setWhisperStatus(data);
+        return data;
+      }
+    } catch (err) {
+      console.error("Failed to load whisper status:", err);
+    }
+    return null;
+  }, []);
+
   useEffect(() => {
     loadData();
-  }, [loadData]);
+    loadWhisperStatus();
+  }, [loadData, loadWhisperStatus]);
+
+  // Poll whisper status while a download is active
+  useEffect(() => {
+    const hasActiveDownload = whisperStatus?.models.some(
+      (m) => m.status === "downloading" || m.status === "verifying",
+    );
+    if (!hasActiveDownload) return;
+    const interval = setInterval(() => {
+      loadWhisperStatus().then((data) => {
+        // If download just finished, reload available models
+        if (
+          data &&
+          !data.models.some(
+            (m) => m.status === "downloading" || m.status === "verifying",
+          )
+        ) {
+          loadData();
+        }
+      });
+    }, 500);
+    return () => clearInterval(interval);
+  }, [whisperStatus, loadWhisperStatus, loadData]);
 
   // Close the inline picker when mousedown lands outside both the pair card
   // (which holds the Change triggers) and the picker itself. Wrapping refs on
@@ -267,8 +352,9 @@ export default function ModelsPage(): React.JSX.Element {
     for (const m of list) {
       if (m.type !== type) continue;
       if (!allowed.includes(m.provider_id)) continue;
-      // Local LLM has its own dedicated section, not the cloud picker
+      // Local LLM and Local Whisper have their own dedicated sections
       if (type === "llm" && m.provider_id === "local-llm") continue;
+      if (type === "voice" && m.provider_id === "local-whisper") continue;
       let entry = map.get(m.provider_id);
       if (!entry) {
         entry = {
@@ -311,6 +397,7 @@ export default function ModelsPage(): React.JSX.Element {
     async (model: AvailableModel, type: "voice" | "llm") => {
       if (
         model.provider_id !== "local-llm" &&
+        model.provider_id !== "local-whisper" &&
         !keyProviders.has(model.provider_id)
       ) {
         setPendingModel(model);
@@ -501,6 +588,7 @@ export default function ModelsPage(): React.JSX.Element {
   }
 
   const hasAnyProvider = apiKeys.length > 0;
+  const isLocalWhisperActive = defaultVoice?.provider === "local-whisper";
 
   // -------------------------------------------------------------------------
   // Render
@@ -548,6 +636,47 @@ export default function ModelsPage(): React.JSX.Element {
             />
           </div>
         )}
+
+        {/* Local Whisper section */}
+        <LocalWhisperSection
+          whisperStatus={whisperStatus}
+          isActive={isLocalWhisperActive}
+          defaultVoice={defaultVoice}
+          onDownload={async (modelId: string) => {
+            await fetch(
+              `${getApiBase()}/api/whisper/models/${modelId}/download`,
+              { method: "POST" },
+            );
+            loadWhisperStatus();
+          }}
+          onCancel={async (modelId: string) => {
+            await fetch(
+              `${getApiBase()}/api/whisper/models/${modelId}/cancel`,
+              { method: "POST" },
+            );
+            loadWhisperStatus();
+          }}
+          onDelete={async (modelId: string) => {
+            await fetch(`${getApiBase()}/api/whisper/models/${modelId}`, {
+              method: "DELETE",
+            });
+            loadWhisperStatus();
+            loadData();
+          }}
+          onSelect={async (modelId: string, modelName: string) => {
+            await getClient().api.models.configured.$post({
+              json: {
+                provider: "local-whisper",
+                model_id: `local-whisper/${modelId}`,
+                model_name: modelName,
+                type: "voice",
+                is_default: true,
+              },
+            });
+            loadData();
+          }}
+          onRefresh={loadWhisperStatus}
+        />
 
         {/* Local LLM toggle + config — only shown when cleanup is on */}
         {llmCleanup && hasAnyProvider && (
@@ -976,6 +1105,218 @@ function ModelPicker({
               </div>
             );
           },
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// LocalWhisperSection — Local voice model download and management
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1_000_000) return `${(bytes / 1_000).toFixed(0)} KB`;
+  if (bytes < 1_000_000_000) return `${(bytes / 1_000_000).toFixed(0)} MB`;
+  return `${(bytes / 1_000_000_000).toFixed(1)} GB`;
+}
+
+function formatSpeed(bps: number): string {
+  if (bps < 1_000_000) return `${(bps / 1_000).toFixed(0)} KB/s`;
+  return `${(bps / 1_000_000).toFixed(1)} MB/s`;
+}
+
+function LocalWhisperSection({
+  whisperStatus,
+  isActive,
+  defaultVoice,
+  onDownload,
+  onCancel,
+  onDelete,
+  onSelect,
+  onRefresh,
+}: {
+  whisperStatus: WhisperStatus | null;
+  isActive: boolean;
+  defaultVoice: ConfiguredModel | undefined;
+  onDownload: (modelId: string) => Promise<void>;
+  onCancel: (modelId: string) => Promise<void>;
+  onDelete: (modelId: string) => Promise<void>;
+  onSelect: (modelId: string, modelName: string) => Promise<void>;
+  onRefresh: () => void;
+}): React.JSX.Element {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <HardDrive className="text-muted-foreground h-3.5 w-3.5" />
+          <span
+            className="mono text-muted-foreground text-[10px] uppercase"
+            style={{ letterSpacing: "0.14em" }}
+          >
+            Local Voice Models
+          </span>
+          {isActive && (
+            <span
+              className="mono bg-primary text-primary-foreground rounded-full px-1.5 py-[2px] text-[9px]"
+              style={{ letterSpacing: "0.12em" }}
+            >
+              ACTIVE
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          className="text-muted-foreground hover:text-foreground p-1"
+          title="Refresh status"
+        >
+          <RefreshCw size={13} />
+        </button>
+      </div>
+
+      <p className="text-muted-foreground text-[12.5px] leading-relaxed">
+        Run speech-to-text locally with whisper.cpp. Audio never leaves your
+        device. Download a model to get started.
+      </p>
+
+      <div className="border-border bg-card overflow-hidden rounded-[12px] border">
+        {whisperStatus?.modelDefinitions.map((def) => {
+          const state = whisperStatus.models.find((m) => m.model === def.id);
+          const status = state?.status ?? "not_downloaded";
+          const isSelected =
+            defaultVoice?.provider === "local-whisper" &&
+            defaultVoice?.model_id === `local-whisper/${def.id}`;
+
+          return (
+            <div
+              key={def.id}
+              className={cn(
+                "border-border flex items-center gap-3 border-b px-4 py-3 last:border-b-0",
+                isSelected && "bg-primary/5",
+              )}
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-foreground text-[13px] font-medium">
+                    {def.displayName}
+                  </span>
+                  <span className="text-muted-foreground text-[11px]">
+                    {formatBytes(def.sizeBytes)}
+                  </span>
+                  {isSelected && (
+                    <Check size={13} className="text-primary shrink-0" />
+                  )}
+                </div>
+                <div className="text-muted-foreground mt-0.5 flex gap-2 text-[11px]">
+                  <span>{def.speed}</span>
+                  <span>·</span>
+                  <span>{def.quality}</span>
+                  <span>·</span>
+                  <span>{def.ramRequired}</span>
+                </div>
+
+                {/* Download progress bar */}
+                {status === "downloading" && state?.downloadProgress && (
+                  <div className="mt-2 space-y-1">
+                    <div className="bg-secondary h-1.5 w-full overflow-hidden rounded-full">
+                      <div
+                        className="bg-primary h-full rounded-full transition-all"
+                        style={{ width: `${state.downloadProgress.percent}%` }}
+                      />
+                    </div>
+                    <div className="text-muted-foreground flex justify-between text-[10px]">
+                      <span>
+                        {formatBytes(state.downloadProgress.bytesDownloaded)} /{" "}
+                        {formatBytes(state.downloadProgress.bytesTotal)}
+                      </span>
+                      <span>
+                        {state.downloadProgress.speedBps > 0 &&
+                          formatSpeed(state.downloadProgress.speedBps)}
+                        {state.downloadProgress.percent > 0 &&
+                          ` · ${state.downloadProgress.percent}%`}
+                      </span>
+                    </div>
+                  </div>
+                )}
+
+                {/* Error message */}
+                {status === "error" && state?.error && (
+                  <div className="text-destructive mt-1 text-[11px]">
+                    {state.error}
+                  </div>
+                )}
+              </div>
+
+              {/* Action buttons */}
+              <div className="flex shrink-0 items-center gap-1.5">
+                {status === "not_downloaded" && (
+                  <button
+                    type="button"
+                    onClick={() => onDownload(def.id)}
+                    className="border-border hover:bg-secondary flex items-center gap-1.5 rounded-[7px] border px-2.5 py-1.5 text-[11.5px] font-medium"
+                  >
+                    <Download size={12} />
+                    Download
+                  </button>
+                )}
+
+                {status === "downloading" && (
+                  <button
+                    type="button"
+                    onClick={() => onCancel(def.id)}
+                    className="border-border hover:bg-secondary flex items-center gap-1.5 rounded-[7px] border px-2.5 py-1.5 text-[11.5px] font-medium"
+                  >
+                    <X size={12} />
+                    Cancel
+                  </button>
+                )}
+
+                {status === "error" && (
+                  <button
+                    type="button"
+                    onClick={() => onDownload(def.id)}
+                    className="border-border hover:bg-secondary flex items-center gap-1.5 rounded-[7px] border px-2.5 py-1.5 text-[11.5px] font-medium"
+                  >
+                    <RefreshCw size={12} />
+                    Retry
+                  </button>
+                )}
+
+                {status === "ready" && !isSelected && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onSelect(def.id, `${def.displayName} (Local)`)
+                    }
+                    className="bg-foreground text-background hover:bg-foreground/90 rounded-[7px] px-2.5 py-1.5 text-[11.5px] font-medium"
+                  >
+                    Use
+                  </button>
+                )}
+
+                {status === "ready" && (
+                  <button
+                    type="button"
+                    onClick={() => onDelete(def.id)}
+                    className="text-muted-foreground hover:text-destructive hover:bg-secondary rounded p-1.5"
+                    title="Delete model"
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+
+        {!whisperStatus && (
+          <div className="px-4 py-6 text-center">
+            <Loader2 className="text-muted-foreground mx-auto h-5 w-5 animate-spin" />
+            <p className="text-muted-foreground mt-2 text-[12px]">
+              Loading whisper status...
+            </p>
+          </div>
         )}
       </div>
     </section>

--- a/apps/electron/src/renderer/src/pages/settings/models.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/models.tsx
@@ -1180,6 +1180,26 @@ function LocalWhisperSection({
         device. Download a model to get started.
       </p>
 
+      {whisperStatus && !whisperStatus.binaryAvailable && (
+        <div className="border-destructive/30 bg-destructive/5 flex items-start gap-2.5 rounded-[10px] border px-4 py-3">
+          <AlertTriangle className="text-destructive mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <div className="text-[12px] leading-relaxed">
+            <span className="text-foreground font-medium">
+              whisper.cpp binary not found.
+            </span>{" "}
+            <span className="text-muted-foreground">
+              Run{" "}
+              <code className="bg-secondary rounded px-1 py-0.5 text-[11px]">
+                pnpm download:whisper-cpp
+              </code>{" "}
+              in the electron app directory, or download it from the{" "}
+              <span className="text-foreground/80">whisper.cpp releases</span>{" "}
+              page.
+            </span>
+          </div>
+        </div>
+      )}
+
       <div className="border-border bg-card overflow-hidden rounded-[12px] border">
         {whisperStatus?.modelDefinitions.map((def) => {
           const state = whisperStatus.models.find((m) => m.model === def.id);

--- a/apps/electron/src/renderer/src/pages/settings/models.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/models.tsx
@@ -81,6 +81,7 @@ interface WhisperModelDef {
   ramRequired: string;
   speed: string;
   quality: string;
+  quantized: boolean;
 }
 
 interface WhisperStatus {
@@ -88,6 +89,7 @@ interface WhisperStatus {
   binaryDownloading: boolean;
   serverBinaryAvailable: boolean;
   serverRunning: boolean;
+  serverFailed: boolean;
   modelsDir: string;
   models: WhisperModelDownloadState[];
   modelDefinitions: WhisperModelDef[];
@@ -677,6 +679,11 @@ export default function ModelsPage(): React.JSX.Element {
                 is_default: true,
               },
             });
+            fetch(`${getApiBase()}/api/whisper/server/start`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ modelId }),
+            }).catch(() => {});
             loadData();
           }}
           onRefresh={loadWhisperStatus}
@@ -1234,6 +1241,14 @@ function LocalWhisperSection({
                   <span className="text-muted-foreground text-[11px]">
                     {formatBytes(def.sizeBytes)}
                   </span>
+                  {def.quantized && (
+                    <span
+                      className="mono bg-primary/10 text-primary rounded-full px-1.5 py-[1px] text-[9px]"
+                      style={{ letterSpacing: "0.08em" }}
+                    >
+                      FASTER
+                    </span>
+                  )}
                   {isSelected && (
                     <Check size={13} className="text-primary shrink-0" />
                   )}

--- a/apps/electron/src/renderer/src/pages/settings/models.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/models.tsx
@@ -84,6 +84,7 @@ interface WhisperModelDef {
 
 interface WhisperStatus {
   binaryAvailable: boolean;
+  binaryDownloading: boolean;
   serverBinaryAvailable: boolean;
   serverRunning: boolean;
   modelsDir: string;
@@ -288,15 +289,17 @@ export default function ModelsPage(): React.JSX.Element {
 
   // Poll whisper status while a download is active
   useEffect(() => {
-    const hasActiveDownload = whisperStatus?.models.some(
-      (m) => m.status === "downloading" || m.status === "verifying",
-    );
+    const hasActiveDownload =
+      whisperStatus?.binaryDownloading ||
+      whisperStatus?.models.some(
+        (m) => m.status === "downloading" || m.status === "verifying",
+      );
     if (!hasActiveDownload) return;
     const interval = setInterval(() => {
       loadWhisperStatus().then((data) => {
-        // If download just finished, reload available models
         if (
           data &&
+          !data.binaryDownloading &&
           !data.models.some(
             (m) => m.status === "downloading" || m.status === "verifying",
           )
@@ -1180,23 +1183,28 @@ function LocalWhisperSection({
         device. Download a model to get started.
       </p>
 
-      {whisperStatus && !whisperStatus.binaryAvailable && (
-        <div className="border-destructive/30 bg-destructive/5 flex items-start gap-2.5 rounded-[10px] border px-4 py-3">
-          <AlertTriangle className="text-destructive mt-0.5 h-3.5 w-3.5 shrink-0" />
-          <div className="text-[12px] leading-relaxed">
-            <span className="text-foreground font-medium">
-              whisper.cpp binary not found.
-            </span>{" "}
-            <span className="text-muted-foreground">
-              Run{" "}
-              <code className="bg-secondary rounded px-1 py-0.5 text-[11px]">
-                pnpm download:whisper-cpp
-              </code>{" "}
-              in the electron app directory, or download it from the{" "}
-              <span className="text-foreground/80">whisper.cpp releases</span>{" "}
-              page.
-            </span>
+      {whisperStatus &&
+        !whisperStatus.binaryAvailable &&
+        !whisperStatus.binaryDownloading && (
+          <div className="border-destructive/30 bg-destructive/5 flex items-start gap-2.5 rounded-[10px] border px-4 py-3">
+            <AlertTriangle className="text-destructive mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <div className="text-[12px] leading-relaxed">
+              <span className="text-foreground font-medium">
+                whisper.cpp binary not found.
+              </span>{" "}
+              <span className="text-muted-foreground">
+                It will be downloaded automatically when you download a model.
+              </span>
+            </div>
           </div>
+        )}
+
+      {whisperStatus?.binaryDownloading && (
+        <div className="border-border bg-card flex items-center gap-2.5 rounded-[10px] border px-4 py-3">
+          <Loader2 className="text-primary h-3.5 w-3.5 shrink-0 animate-spin" />
+          <span className="text-muted-foreground text-[12px]">
+            Downloading whisper.cpp binary…
+          </span>
         </div>
       )}
 
@@ -1205,6 +1213,7 @@ function LocalWhisperSection({
           const state = whisperStatus.models.find((m) => m.model === def.id);
           const status = state?.status ?? "not_downloaded";
           const isSelected =
+            status === "ready" &&
             defaultVoice?.provider === "local-whisper" &&
             defaultVoice?.model_id === `local-whisper/${def.id}`;
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -12,6 +12,7 @@ import postProcessRoute from "./routes/post-process-route.js";
 import settings from "./routes/settings.js";
 import stream from "./routes/stream.js";
 import transcribe from "./routes/transcribe.js";
+import whisper from "./routes/whisper.js";
 
 initSentry();
 
@@ -42,6 +43,7 @@ const app = new Hono()
   .route("/api/formats", formats)
   .route("/api/post-process", postProcessRoute)
   .route("/api/feedback", feedback)
+  .route("/api/whisper", whisper)
   .route("/mcp", mcp)
   .route("/stream", stream);
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -12,9 +12,11 @@ import postProcessRoute from "./routes/post-process-route.js";
 import settings from "./routes/settings.js";
 import stream from "./routes/stream.js";
 import transcribe from "./routes/transcribe.js";
-import whisper from "./routes/whisper.js";
+import whisper, { autoStartWhisperServer } from "./routes/whisper.js";
 
 initSentry();
+
+setTimeout(() => autoStartWhisperServer(), 1000);
 
 const app = new Hono()
   // CORS for renderer requests (skip WebSocket upgrades)

--- a/apps/server/src/lib/streaming-stt.ts
+++ b/apps/server/src/lib/streaming-stt.ts
@@ -1,9 +1,12 @@
 import { getDb } from "./db.js";
 import { getProvider, supportsStreaming } from "./streaming/registry.js";
 import type { StreamCallbacks, StreamSession } from "./streaming/types.js";
+import { WHISPER_PROVIDER_ID } from "./whisper/constants.js";
 
 export { supportsStreaming } from "./streaming/registry.js";
 export type { StreamCallbacks, StreamSession } from "./streaming/types.js";
+
+const LOCAL_STT_PROVIDERS = new Set([WHISPER_PROVIDER_ID]);
 
 export function openStreamingSession(opts: {
   providerId: string;
@@ -31,6 +34,8 @@ export function openStreamingSession(opts: {
 }
 
 export function getApiKeyForProvider(providerId: string): string | null {
+  if (LOCAL_STT_PROVIDERS.has(providerId)) return "local";
+
   const db = getDb();
   const row = db
     .prepare("SELECT key FROM api_keys WHERE provider = ?")

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -33,17 +33,22 @@ export class WhisperLocalTranscriptionProvider
       await ensureBinariesDownloaded();
     }
 
+    // Prefer whisper-server (model stays loaded in memory, much faster)
+    if (isServerRunning() || isServerBinaryAvailable()) {
+      try {
+        await ensureServerRunning(modelId);
+        return await transcribeViaServer(opts.audio, getServerPort());
+      } catch {
+        // Fall through to CLI
+      }
+    }
+
     if (isBinaryAvailable()) {
       return transcribeWithWhisper({
         audio: opts.audio,
         modelId,
         language: opts.language,
       });
-    }
-
-    if (isServerBinaryAvailable() || isServerRunning()) {
-      await ensureServerRunning(modelId);
-      return transcribeViaServer(opts.audio, getServerPort());
     }
 
     throw new Error(

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -1,10 +1,8 @@
-import { Buffer } from "node:buffer";
 import {
   isBinaryAvailable,
   isServerBinaryAvailable,
 } from "../../whisper/binary.js";
 import { WHISPER_PROVIDER_ID } from "../../whisper/constants.js";
-import { getDownloadedModelPath } from "../../whisper/models.js";
 import {
   ensureServerRunning,
   getServerPort,
@@ -12,8 +10,6 @@ import {
 } from "../../whisper/server.js";
 import { transcribeWithWhisper } from "../../whisper/transcribe.js";
 import type {
-  StreamingSessionOptions,
-  StreamSession,
   TranscribeOptions,
   TranscribeResult,
   TranscriptionProvider,
@@ -46,104 +42,8 @@ export class WhisperLocalTranscriptionProvider
     );
   }
 
-  supportsStreaming(modelId: string): boolean {
-    if (!isServerBinaryAvailable()) return false;
-    const id = stripProviderPrefix(modelId);
-    return getDownloadedModelPath(id) !== null;
-  }
-
-  openStreamingSession(opts: StreamingSessionOptions): StreamSession {
-    const { model, callbacks } = opts;
-    const modelId = stripProviderPrefix(model);
-    let closed = false;
-    let commitRequested = false;
-    let serverReady = false;
-    const audioChunks: Buffer[] = [];
-
-    const port = getServerPort();
-    const inferenceUrl = `http://127.0.0.1:${port}/inference`;
-
-    ensureServerRunning(modelId)
-      .then(() => {
-        if (closed) return;
-        serverReady = true;
-        callbacks.onReady(modelId);
-
-        if (commitRequested) {
-          doInference();
-        }
-      })
-      .catch((err) => {
-        if (closed) return;
-        callbacks.onError(err instanceof Error ? err.message : String(err));
-      });
-
-    async function doInference(): Promise<void> {
-      commitRequested = false;
-
-      if (audioChunks.length === 0) {
-        callbacks.onFinal("");
-        return;
-      }
-
-      const combined = Buffer.concat(audioChunks);
-      audioChunks.length = 0;
-
-      const wavHeader = buildWavHeader(combined.length, 16000, 1, 16);
-      const wavBuffer = Buffer.concat([wavHeader, combined]);
-
-      try {
-        const form = new FormData();
-        form.append(
-          "file",
-          new Blob([wavBuffer], { type: "audio/wav" }),
-          "audio.wav",
-        );
-        form.append("response_format", "json");
-
-        const res = await fetch(inferenceUrl, {
-          method: "POST",
-          body: form,
-          signal: AbortSignal.timeout(120_000),
-        });
-
-        if (!res.ok) {
-          const detail = await res.text().catch(() => "");
-          callbacks.onError(
-            `Whisper inference failed: HTTP ${res.status} ${detail}`,
-          );
-          return;
-        }
-
-        const data = (await res.json()) as { text?: string };
-        const text = data.text?.trim() ?? "";
-        callbacks.onFinal(text);
-      } catch (err) {
-        callbacks.onError(err instanceof Error ? err.message : String(err));
-      }
-    }
-
-    return {
-      sendAudio(chunk: ArrayBuffer): void {
-        if (closed) return;
-        audioChunks.push(Buffer.from(chunk));
-      },
-      commit(): void {
-        if (closed) return;
-        commitRequested = true;
-        if (serverReady) {
-          doInference();
-        }
-      },
-      cancel(): void {
-        closed = true;
-        audioChunks.length = 0;
-      },
-      close(): void {
-        closed = true;
-        audioChunks.length = 0;
-      },
-    };
+  supportsStreaming(_modelId: string): boolean {
+    return false;
   }
 }
 
@@ -178,31 +78,4 @@ async function transcribeViaServer(
 
   const data = (await res.json()) as { text?: string };
   return { text: data.text?.trim() ?? "" };
-}
-
-function buildWavHeader(
-  dataSize: number,
-  sampleRate: number,
-  channels: number,
-  bitsPerSample: number,
-): Buffer {
-  const blockAlign = (channels * bitsPerSample) / 8;
-  const byteRate = sampleRate * blockAlign;
-  const headerSize = 44;
-
-  const buf = Buffer.alloc(headerSize);
-  buf.write("RIFF", 0);
-  buf.writeUInt32LE(dataSize + headerSize - 8, 4);
-  buf.write("WAVE", 8);
-  buf.write("fmt ", 12);
-  buf.writeUInt32LE(16, 16); // PCM chunk size
-  buf.writeUInt16LE(1, 20); // PCM format
-  buf.writeUInt16LE(channels, 22);
-  buf.writeUInt32LE(sampleRate, 24);
-  buf.writeUInt32LE(byteRate, 28);
-  buf.writeUInt16LE(blockAlign, 32);
-  buf.writeUInt16LE(bitsPerSample, 34);
-  buf.write("data", 36);
-  buf.writeUInt32LE(dataSize, 40);
-  return buf;
 }

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -1,0 +1,152 @@
+import { Buffer } from "node:buffer";
+import { WHISPER_PROVIDER_ID } from "../../whisper/constants.js";
+import { getDownloadedModelPath } from "../../whisper/models.js";
+import { ensureServerRunning, getServerPort } from "../../whisper/server.js";
+import { transcribeWithWhisper } from "../../whisper/transcribe.js";
+import type {
+  StreamingSessionOptions,
+  StreamSession,
+  TranscribeOptions,
+  TranscribeResult,
+  TranscriptionProvider,
+} from "../types.js";
+import { stripProviderPrefix } from "../types.js";
+
+export class WhisperLocalTranscriptionProvider
+  implements TranscriptionProvider
+{
+  readonly providerId = WHISPER_PROVIDER_ID;
+
+  async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
+    const modelId = stripProviderPrefix(opts.model);
+    return transcribeWithWhisper({
+      audio: opts.audio,
+      modelId,
+      language: opts.language,
+    });
+  }
+
+  supportsStreaming(modelId: string): boolean {
+    const id = stripProviderPrefix(modelId);
+    return getDownloadedModelPath(id) !== null;
+  }
+
+  openStreamingSession(opts: StreamingSessionOptions): StreamSession {
+    const { model, callbacks } = opts;
+    const modelId = stripProviderPrefix(model);
+    let closed = false;
+    let commitRequested = false;
+    let serverReady = false;
+    const audioChunks: Buffer[] = [];
+
+    const port = getServerPort();
+    const inferenceUrl = `http://127.0.0.1:${port}/inference`;
+
+    ensureServerRunning(modelId)
+      .then(() => {
+        if (closed) return;
+        serverReady = true;
+        callbacks.onReady(modelId);
+
+        if (commitRequested) {
+          doInference();
+        }
+      })
+      .catch((err) => {
+        callbacks.onError(err instanceof Error ? err.message : String(err));
+        callbacks.onClose();
+      });
+
+    async function doInference(): Promise<void> {
+      if (audioChunks.length === 0) {
+        callbacks.onFinal("");
+        return;
+      }
+
+      const combined = Buffer.concat(audioChunks);
+      audioChunks.length = 0;
+
+      const wavHeader = buildWavHeader(combined.length, 16000, 1, 16);
+      const wavBuffer = Buffer.concat([wavHeader, combined]);
+
+      try {
+        const form = new FormData();
+        form.append(
+          "file",
+          new Blob([wavBuffer], { type: "audio/wav" }),
+          "audio.wav",
+        );
+        form.append("response_format", "json");
+
+        const res = await fetch(inferenceUrl, {
+          method: "POST",
+          body: form,
+          signal: AbortSignal.timeout(120_000),
+        });
+
+        if (!res.ok) {
+          const detail = await res.text().catch(() => "");
+          callbacks.onError(
+            `Whisper inference failed: HTTP ${res.status} ${detail}`,
+          );
+          return;
+        }
+
+        const data = (await res.json()) as { text?: string };
+        const text = data.text?.trim() ?? "";
+        callbacks.onFinal(text);
+      } catch (err) {
+        callbacks.onError(err instanceof Error ? err.message : String(err));
+      }
+    }
+
+    return {
+      sendAudio(chunk: ArrayBuffer): void {
+        if (closed) return;
+        audioChunks.push(Buffer.from(chunk));
+      },
+      commit(): void {
+        if (closed) return;
+        commitRequested = true;
+        if (serverReady) {
+          doInference();
+        }
+      },
+      cancel(): void {
+        closed = true;
+        audioChunks.length = 0;
+      },
+      close(): void {
+        closed = true;
+        audioChunks.length = 0;
+      },
+    };
+  }
+}
+
+function buildWavHeader(
+  dataSize: number,
+  sampleRate: number,
+  channels: number,
+  bitsPerSample: number,
+): Buffer {
+  const blockAlign = (channels * bitsPerSample) / 8;
+  const byteRate = sampleRate * blockAlign;
+  const headerSize = 44;
+
+  const buf = Buffer.alloc(headerSize);
+  buf.write("RIFF", 0);
+  buf.writeUInt32LE(dataSize + headerSize - 8, 4);
+  buf.write("WAVE", 8);
+  buf.write("fmt ", 12);
+  buf.writeUInt32LE(16, 16); // PCM chunk size
+  buf.writeUInt16LE(1, 20); // PCM format
+  buf.writeUInt16LE(channels, 22);
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(byteRate, 28);
+  buf.writeUInt16LE(blockAlign, 32);
+  buf.writeUInt16LE(bitsPerSample, 34);
+  buf.write("data", 36);
+  buf.writeUInt32LE(dataSize, 40);
+  return buf;
+}

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -27,42 +27,20 @@ export class WhisperLocalTranscriptionProvider
 
   async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
     const modelId = stripProviderPrefix(opts.model);
-    console.log(
-      "[whisper-local] transcribe modelId:",
-      modelId,
-      "audioSize:",
-      opts.audio.length,
-    );
-    console.log(
-      "[whisper-local] binaryAvailable:",
-      isBinaryAvailable(),
-      "serverBinaryAvailable:",
-      isServerBinaryAvailable(),
-      "serverRunning:",
-      isServerRunning(),
-    );
 
     if (isBinaryAvailable()) {
-      console.log("[whisper-local] using whisper-cli");
-      const result = await transcribeWithWhisper({
+      return transcribeWithWhisper({
         audio: opts.audio,
         modelId,
         language: opts.language,
       });
-      console.log(
-        "[whisper-local] whisper-cli result:",
-        JSON.stringify(result.text).slice(0, 200),
-      );
-      return result;
     }
 
     if (isServerBinaryAvailable() || isServerRunning()) {
-      console.log("[whisper-local] using whisper-server fallback");
       await ensureServerRunning(modelId);
       return transcribeViaServer(opts.audio, getServerPort());
     }
 
-    console.error("[whisper-local] no binary found");
     throw new Error(
       "whisper.cpp binary not found. Run 'pnpm download:whisper-cpp' in the electron app directory.",
     );

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -34,6 +34,12 @@ export class WhisperLocalTranscriptionProvider
       await ensureBinariesDownloaded();
     }
 
+    if (isDev) {
+      console.log(
+        `[whisper] transcribe: serverRunning=${isServerRunning()} serverBinary=${isServerBinaryAvailable()} cli=${isBinaryAvailable()}`,
+      );
+    }
+
     if (isServerRunning()) {
       try {
         const t0 = Date.now();

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -1,8 +1,15 @@
 import { Buffer } from "node:buffer";
-import { isServerBinaryAvailable } from "../../whisper/binary.js";
+import {
+  isBinaryAvailable,
+  isServerBinaryAvailable,
+} from "../../whisper/binary.js";
 import { WHISPER_PROVIDER_ID } from "../../whisper/constants.js";
 import { getDownloadedModelPath } from "../../whisper/models.js";
-import { ensureServerRunning, getServerPort } from "../../whisper/server.js";
+import {
+  ensureServerRunning,
+  getServerPort,
+  isServerRunning,
+} from "../../whisper/server.js";
 import { transcribeWithWhisper } from "../../whisper/transcribe.js";
 import type {
   StreamingSessionOptions,
@@ -20,11 +27,23 @@ export class WhisperLocalTranscriptionProvider
 
   async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
     const modelId = stripProviderPrefix(opts.model);
-    return transcribeWithWhisper({
-      audio: opts.audio,
-      modelId,
-      language: opts.language,
-    });
+
+    if (isBinaryAvailable()) {
+      return transcribeWithWhisper({
+        audio: opts.audio,
+        modelId,
+        language: opts.language,
+      });
+    }
+
+    if (isServerBinaryAvailable() || isServerRunning()) {
+      await ensureServerRunning(modelId);
+      return transcribeViaServer(opts.audio, getServerPort());
+    }
+
+    throw new Error(
+      "whisper.cpp binary not found. Run 'pnpm download:whisper-cpp' in the electron app directory.",
+    );
   }
 
   supportsStreaming(modelId: string): boolean {
@@ -126,6 +145,39 @@ export class WhisperLocalTranscriptionProvider
       },
     };
   }
+}
+
+async function transcribeViaServer(
+  audio: Uint8Array,
+  port: number,
+): Promise<TranscribeResult> {
+  const form = new FormData();
+  const audioBuffer = audio.buffer.slice(
+    audio.byteOffset,
+    audio.byteOffset + audio.byteLength,
+  ) as ArrayBuffer;
+  form.append(
+    "file",
+    new Blob([audioBuffer], { type: "audio/wav" }),
+    "audio.wav",
+  );
+  form.append("response_format", "json");
+
+  const res = await fetch(`http://127.0.0.1:${port}/inference`, {
+    method: "POST",
+    body: form,
+    signal: AbortSignal.timeout(120_000),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(
+      `Whisper server inference failed: HTTP ${res.status} ${detail}`,
+    );
+  }
+
+  const data = (await res.json()) as { text?: string };
+  return { text: data.text?.trim() ?? "" };
 }
 
 function buildWavHeader(

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -5,9 +5,9 @@ import {
 import { WHISPER_PROVIDER_ID } from "../../whisper/constants.js";
 import { ensureBinariesDownloaded } from "../../whisper/models.js";
 import {
-  ensureServerRunning,
   getServerPort,
   isServerRunning,
+  startInBackground,
 } from "../../whisper/server.js";
 import { transcribeWithWhisper } from "../../whisper/transcribe.js";
 import type {
@@ -33,22 +33,29 @@ export class WhisperLocalTranscriptionProvider
       await ensureBinariesDownloaded();
     }
 
-    // Prefer whisper-server (model stays loaded in memory, much faster)
-    if (isServerRunning() || isServerBinaryAvailable()) {
+    // Use the server if it's already running (fast path, model in memory)
+    if (isServerRunning()) {
       try {
-        await ensureServerRunning(modelId);
         return await transcribeViaServer(opts.audio, getServerPort());
       } catch {
-        // Fall through to CLI
+        // Server returned an error — fall through to CLI
       }
     }
 
+    // Use CLI as the reliable fallback
     if (isBinaryAvailable()) {
-      return transcribeWithWhisper({
+      const result = await transcribeWithWhisper({
         audio: opts.audio,
         modelId,
         language: opts.language,
       });
+
+      // Kick off server in the background so the next transcription is faster
+      if (isServerBinaryAvailable() && !isServerRunning()) {
+        startInBackground(modelId);
+      }
+
+      return result;
     }
 
     throw new Error(

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -24,6 +24,7 @@ export class WhisperLocalTranscriptionProvider
 
   async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
     const modelId = stripProviderPrefix(opts.model);
+    const isDev = process.env.NODE_ENV !== "production";
 
     if (
       !isBinaryAvailable() &&
@@ -33,24 +34,30 @@ export class WhisperLocalTranscriptionProvider
       await ensureBinariesDownloaded();
     }
 
-    // Use the server if it's already running (fast path, model in memory)
     if (isServerRunning()) {
       try {
-        return await transcribeViaServer(opts.audio, getServerPort());
+        const t0 = Date.now();
+        const result = await transcribeViaServer(opts.audio, getServerPort());
+        if (isDev) {
+          console.log(`[whisper] server inference took ${Date.now() - t0}ms`);
+        }
+        return result;
       } catch {
-        // Server returned an error — fall through to CLI
+        // fall through to CLI
       }
     }
 
-    // Use CLI as the reliable fallback
     if (isBinaryAvailable()) {
+      const t0 = Date.now();
       const result = await transcribeWithWhisper({
         audio: opts.audio,
         modelId,
         language: opts.language,
       });
+      if (isDev) {
+        console.log(`[whisper] CLI inference took ${Date.now() - t0}ms`);
+      }
 
-      // Kick off server in the background so the next transcription is faster
       if (isServerBinaryAvailable() && !isServerRunning()) {
         startInBackground(modelId);
       }

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -3,6 +3,7 @@ import {
   isServerBinaryAvailable,
 } from "../../whisper/binary.js";
 import { WHISPER_PROVIDER_ID } from "../../whisper/constants.js";
+import { ensureBinariesDownloaded } from "../../whisper/models.js";
 import {
   ensureServerRunning,
   getServerPort,
@@ -24,6 +25,14 @@ export class WhisperLocalTranscriptionProvider
   async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
     const modelId = stripProviderPrefix(opts.model);
 
+    if (
+      !isBinaryAvailable() &&
+      !isServerBinaryAvailable() &&
+      !isServerRunning()
+    ) {
+      await ensureBinariesDownloaded();
+    }
+
     if (isBinaryAvailable()) {
       return transcribeWithWhisper({
         audio: opts.audio,
@@ -38,7 +47,7 @@ export class WhisperLocalTranscriptionProvider
     }
 
     throw new Error(
-      "whisper.cpp binary not found. Run 'pnpm download:whisper-cpp' in the electron app directory.",
+      "whisper.cpp binary not found. The build may have failed — check the logs above.",
     );
   }
 

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -60,6 +60,8 @@ export class WhisperLocalTranscriptionProvider
       });
 
     async function doInference(): Promise<void> {
+      commitRequested = false;
+
       if (audioChunks.length === 0) {
         callbacks.onFinal("");
         return;

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -27,20 +27,42 @@ export class WhisperLocalTranscriptionProvider
 
   async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
     const modelId = stripProviderPrefix(opts.model);
+    console.log(
+      "[whisper-local] transcribe modelId:",
+      modelId,
+      "audioSize:",
+      opts.audio.length,
+    );
+    console.log(
+      "[whisper-local] binaryAvailable:",
+      isBinaryAvailable(),
+      "serverBinaryAvailable:",
+      isServerBinaryAvailable(),
+      "serverRunning:",
+      isServerRunning(),
+    );
 
     if (isBinaryAvailable()) {
-      return transcribeWithWhisper({
+      console.log("[whisper-local] using whisper-cli");
+      const result = await transcribeWithWhisper({
         audio: opts.audio,
         modelId,
         language: opts.language,
       });
+      console.log(
+        "[whisper-local] whisper-cli result:",
+        JSON.stringify(result.text).slice(0, 200),
+      );
+      return result;
     }
 
     if (isServerBinaryAvailable() || isServerRunning()) {
+      console.log("[whisper-local] using whisper-server fallback");
       await ensureServerRunning(modelId);
       return transcribeViaServer(opts.audio, getServerPort());
     }
 
+    console.error("[whisper-local] no binary found");
     throw new Error(
       "whisper.cpp binary not found. Run 'pnpm download:whisper-cpp' in the electron app directory.",
     );

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { isServerBinaryAvailable } from "../../whisper/binary.js";
 import { WHISPER_PROVIDER_ID } from "../../whisper/constants.js";
 import { getDownloadedModelPath } from "../../whisper/models.js";
 import { ensureServerRunning, getServerPort } from "../../whisper/server.js";
@@ -27,6 +28,7 @@ export class WhisperLocalTranscriptionProvider
   }
 
   supportsStreaming(modelId: string): boolean {
+    if (!isServerBinaryAvailable()) return false;
     const id = stripProviderPrefix(modelId);
     return getDownloadedModelPath(id) !== null;
   }
@@ -53,8 +55,8 @@ export class WhisperLocalTranscriptionProvider
         }
       })
       .catch((err) => {
+        if (closed) return;
         callbacks.onError(err instanceof Error ? err.message : String(err));
-        callbacks.onClose();
       });
 
     async function doInference(): Promise<void> {

--- a/apps/server/src/lib/streaming/registry.ts
+++ b/apps/server/src/lib/streaming/registry.ts
@@ -2,6 +2,7 @@ import { DeepgramTranscriptionProvider } from "./providers/deepgram.js";
 import { ElevenLabsTranscriptionProvider } from "./providers/elevenlabs.js";
 import { GroqTranscriptionProvider } from "./providers/groq.js";
 import { OpenAITranscriptionProvider } from "./providers/openai.js";
+import { WhisperLocalTranscriptionProvider } from "./providers/whisper-local.js";
 import type { TranscriptionProvider } from "./types.js";
 
 const providers: TranscriptionProvider[] = [
@@ -9,6 +10,7 @@ const providers: TranscriptionProvider[] = [
   new DeepgramTranscriptionProvider(),
   new ElevenLabsTranscriptionProvider(),
   new GroqTranscriptionProvider(),
+  new WhisperLocalTranscriptionProvider(),
 ];
 
 const providerMap = new Map(providers.map((p) => [p.providerId, p]));

--- a/apps/server/src/lib/whisper/binary.ts
+++ b/apps/server/src/lib/whisper/binary.ts
@@ -2,6 +2,7 @@ import { accessSync, constants } from "node:fs";
 import { join } from "node:path";
 import {
   getBinaryName,
+  getBinDir,
   getResourcesDir,
   getServerBinaryName,
 } from "./constants.js";
@@ -9,9 +10,16 @@ import {
 function findExecutable(name: string | null): string | null {
   if (!name) return null;
 
+  // Check user-local download dir first (~/.cache/freestyle/whisper-bin/)
+  const localPath = join(getBinDir(), name);
+  try {
+    accessSync(localPath, constants.X_OK);
+    return localPath;
+  } catch {}
+
+  // Then check bundled resources dir
   const resourcesDir = getResourcesDir();
   const bundledPath = join(resourcesDir, name);
-
   try {
     accessSync(bundledPath, constants.X_OK);
     return bundledPath;

--- a/apps/server/src/lib/whisper/binary.ts
+++ b/apps/server/src/lib/whisper/binary.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { accessSync, constants } from "node:fs";
 import { join } from "node:path";
 import {
@@ -7,17 +8,28 @@ import {
   getServerBinaryName,
 } from "./constants.js";
 
+function findInPath(name: string): string | null {
+  try {
+    const cmd = process.platform === "win32" ? "where" : "which";
+    const result = execFileSync(cmd, [name], {
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 3000,
+    });
+    const path = result.toString().trim().split("\n")[0];
+    if (path) return path;
+  } catch {}
+  return null;
+}
+
 function findExecutable(name: string | null): string | null {
   if (!name) return null;
 
-  // Check user-local download dir first (~/.cache/freestyle/whisper-bin/)
   const localPath = join(getBinDir(), name);
   try {
     accessSync(localPath, constants.X_OK);
     return localPath;
   } catch {}
 
-  // Then check bundled resources dir
   const resourcesDir = getResourcesDir();
   const bundledPath = join(resourcesDir, name);
   try {
@@ -25,11 +37,14 @@ function findExecutable(name: string | null): string | null {
     return bundledPath;
   } catch {}
 
-  return null;
+  return findInPath(name);
 }
 
 export function findWhisperBinary(): string | null {
-  return findExecutable(getBinaryName());
+  const primary = findExecutable(getBinaryName());
+  if (primary) return primary;
+  // Homebrew installs as "whisper-cpp" not "whisper-cli"
+  return findInPath("whisper-cpp");
 }
 
 export function findWhisperServer(): string | null {

--- a/apps/server/src/lib/whisper/binary.ts
+++ b/apps/server/src/lib/whisper/binary.ts
@@ -1,0 +1,37 @@
+import { accessSync, constants } from "node:fs";
+import { join } from "node:path";
+import {
+  getBinaryName,
+  getResourcesDir,
+  getServerBinaryName,
+} from "./constants.js";
+
+function findExecutable(name: string | null): string | null {
+  if (!name) return null;
+
+  const resourcesDir = getResourcesDir();
+  const bundledPath = join(resourcesDir, name);
+
+  try {
+    accessSync(bundledPath, constants.X_OK);
+    return bundledPath;
+  } catch {}
+
+  return null;
+}
+
+export function findWhisperBinary(): string | null {
+  return findExecutable(getBinaryName());
+}
+
+export function findWhisperServer(): string | null {
+  return findExecutable(getServerBinaryName());
+}
+
+export function isBinaryAvailable(): boolean {
+  return findWhisperBinary() !== null;
+}
+
+export function isServerBinaryAvailable(): boolean {
+  return findWhisperServer() !== null;
+}

--- a/apps/server/src/lib/whisper/constants.ts
+++ b/apps/server/src/lib/whisper/constants.ts
@@ -124,4 +124,39 @@ export function getResourcesDir(): string {
   );
 }
 
+export function getBinDir(): string {
+  return join(homedir(), ".cache", "freestyle", "whisper-bin");
+}
+
+interface BinaryReleaseDef {
+  archive: string;
+  binaries: string[];
+}
+
+const WHISPER_BIN_VERSION = "v1.7.5";
+const WHISPER_BIN_BASE = `https://github.com/ggml-org/whisper.cpp/releases/download/${WHISPER_BIN_VERSION}`;
+
+const BINARY_RELEASES: Record<string, BinaryReleaseDef> = {
+  "darwin-arm64": {
+    archive: `${WHISPER_BIN_BASE}/whisper-${WHISPER_BIN_VERSION}-bin-macos-arm64.zip`,
+    binaries: ["whisper-cli", "whisper-server"],
+  },
+  "darwin-x64": {
+    archive: `${WHISPER_BIN_BASE}/whisper-${WHISPER_BIN_VERSION}-bin-macos-x86_64.zip`,
+    binaries: ["whisper-cli", "whisper-server"],
+  },
+  "linux-x64": {
+    archive: `${WHISPER_BIN_BASE}/whisper-${WHISPER_BIN_VERSION}-bin-ubuntu-x86_64.zip`,
+    binaries: ["whisper-cli", "whisper-server"],
+  },
+  "win32-x64": {
+    archive: `${WHISPER_BIN_BASE}/whisper-${WHISPER_BIN_VERSION}-bin-win-x86_64.zip`,
+    binaries: ["whisper-cli.exe", "whisper-server.exe"],
+  },
+};
+
+export function getBinaryRelease(): BinaryReleaseDef | null {
+  return BINARY_RELEASES[`${process.platform}-${process.arch}`] ?? null;
+}
+
 export const WHISPER_SERVER_PORT = 8178;

--- a/apps/server/src/lib/whisper/constants.ts
+++ b/apps/server/src/lib/whisper/constants.ts
@@ -11,6 +11,7 @@ export interface WhisperModelDef {
   ramRequired: string;
   speed: string;
   quality: string;
+  quantized: boolean;
   url: string;
 }
 
@@ -25,7 +26,19 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     ramRequired: "~1 GB",
     speed: "Fastest",
     quality: "Basic",
+    quantized: false,
     url: `${HF_BASE}/ggml-tiny.bin`,
+  },
+  {
+    id: "tiny-q5_1",
+    fileName: "ggml-tiny-q5_1.bin",
+    displayName: "Tiny Q5",
+    sizeBytes: 31_000_000,
+    ramRequired: "~1 GB",
+    speed: "Fastest",
+    quality: "Basic",
+    quantized: true,
+    url: `${HF_BASE}/ggml-tiny-q5_1.bin`,
   },
   {
     id: "base",
@@ -35,7 +48,19 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     ramRequired: "~1 GB",
     speed: "Fast",
     quality: "Good",
+    quantized: false,
     url: `${HF_BASE}/ggml-base.bin`,
+  },
+  {
+    id: "base-q5_1",
+    fileName: "ggml-base-q5_1.bin",
+    displayName: "Base Q5",
+    sizeBytes: 57_000_000,
+    ramRequired: "~1 GB",
+    speed: "Very Fast",
+    quality: "Good",
+    quantized: true,
+    url: `${HF_BASE}/ggml-base-q5_1.bin`,
   },
   {
     id: "small",
@@ -45,7 +70,19 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     ramRequired: "~2 GB",
     speed: "Medium",
     quality: "Better",
+    quantized: false,
     url: `${HF_BASE}/ggml-small.bin`,
+  },
+  {
+    id: "small-q5_1",
+    fileName: "ggml-small-q5_1.bin",
+    displayName: "Small Q5",
+    sizeBytes: 181_000_000,
+    ramRequired: "~2 GB",
+    speed: "Fast",
+    quality: "Better",
+    quantized: true,
+    url: `${HF_BASE}/ggml-small-q5_1.bin`,
   },
   {
     id: "medium",
@@ -55,7 +92,19 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     ramRequired: "~5 GB",
     speed: "Slow",
     quality: "High",
+    quantized: false,
     url: `${HF_BASE}/ggml-medium.bin`,
+  },
+  {
+    id: "medium-q5_0",
+    fileName: "ggml-medium-q5_0.bin",
+    displayName: "Medium Q5",
+    sizeBytes: 539_000_000,
+    ramRequired: "~3 GB",
+    speed: "Medium",
+    quality: "High",
+    quantized: true,
+    url: `${HF_BASE}/ggml-medium-q5_0.bin`,
   },
   {
     id: "large",
@@ -65,6 +114,7 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     ramRequired: "~6 GB",
     speed: "Slow",
     quality: "Best",
+    quantized: false,
     url: `${HF_BASE}/ggml-large-v3-turbo.bin`,
   },
 ];

--- a/apps/server/src/lib/whisper/constants.ts
+++ b/apps/server/src/lib/whisper/constants.ts
@@ -128,35 +128,6 @@ export function getBinDir(): string {
   return join(homedir(), ".cache", "freestyle", "whisper-bin");
 }
 
-interface BinaryReleaseDef {
-  archive: string;
-  binaries: string[];
-}
-
-const WHISPER_BIN_VERSION = "v1.7.5";
-const WHISPER_BIN_BASE = `https://github.com/ggml-org/whisper.cpp/releases/download/${WHISPER_BIN_VERSION}`;
-
-const BINARY_RELEASES: Record<string, BinaryReleaseDef> = {
-  "darwin-arm64": {
-    archive: `${WHISPER_BIN_BASE}/whisper-${WHISPER_BIN_VERSION}-bin-macos-arm64.zip`,
-    binaries: ["whisper-cli", "whisper-server"],
-  },
-  "darwin-x64": {
-    archive: `${WHISPER_BIN_BASE}/whisper-${WHISPER_BIN_VERSION}-bin-macos-x86_64.zip`,
-    binaries: ["whisper-cli", "whisper-server"],
-  },
-  "linux-x64": {
-    archive: `${WHISPER_BIN_BASE}/whisper-${WHISPER_BIN_VERSION}-bin-ubuntu-x86_64.zip`,
-    binaries: ["whisper-cli", "whisper-server"],
-  },
-  "win32-x64": {
-    archive: `${WHISPER_BIN_BASE}/whisper-${WHISPER_BIN_VERSION}-bin-win-x86_64.zip`,
-    binaries: ["whisper-cli.exe", "whisper-server.exe"],
-  },
-};
-
-export function getBinaryRelease(): BinaryReleaseDef | null {
-  return BINARY_RELEASES[`${process.platform}-${process.arch}`] ?? null;
-}
+export const WHISPER_CPP_VERSION = "1.7.5";
 
 export const WHISPER_SERVER_PORT = 8178;

--- a/apps/server/src/lib/whisper/constants.ts
+++ b/apps/server/src/lib/whisper/constants.ts
@@ -1,0 +1,127 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const WHISPER_PROVIDER_ID = "local-whisper";
+
+export interface WhisperModelDef {
+  id: string;
+  fileName: string;
+  displayName: string;
+  sizeBytes: number;
+  ramRequired: string;
+  speed: string;
+  quality: string;
+  url: string;
+}
+
+const HF_BASE = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main";
+
+export const WHISPER_MODELS: WhisperModelDef[] = [
+  {
+    id: "tiny",
+    fileName: "ggml-tiny.bin",
+    displayName: "Tiny",
+    sizeBytes: 75_000_000,
+    ramRequired: "~1 GB",
+    speed: "Fastest",
+    quality: "Basic",
+    url: `${HF_BASE}/ggml-tiny.bin`,
+  },
+  {
+    id: "base",
+    fileName: "ggml-base.bin",
+    displayName: "Base",
+    sizeBytes: 142_000_000,
+    ramRequired: "~1 GB",
+    speed: "Fast",
+    quality: "Good",
+    url: `${HF_BASE}/ggml-base.bin`,
+  },
+  {
+    id: "small",
+    fileName: "ggml-small.bin",
+    displayName: "Small",
+    sizeBytes: 466_000_000,
+    ramRequired: "~2 GB",
+    speed: "Medium",
+    quality: "Better",
+    url: `${HF_BASE}/ggml-small.bin`,
+  },
+  {
+    id: "medium",
+    fileName: "ggml-medium.bin",
+    displayName: "Medium",
+    sizeBytes: 1_500_000_000,
+    ramRequired: "~5 GB",
+    speed: "Slow",
+    quality: "High",
+    url: `${HF_BASE}/ggml-medium.bin`,
+  },
+  {
+    id: "large",
+    fileName: "ggml-large-v3-turbo.bin",
+    displayName: "Large V3 Turbo",
+    sizeBytes: 1_600_000_000,
+    ramRequired: "~6 GB",
+    speed: "Slow",
+    quality: "Best",
+    url: `${HF_BASE}/ggml-large-v3-turbo.bin`,
+  },
+];
+
+export function getWhisperModel(id: string): WhisperModelDef | undefined {
+  return WHISPER_MODELS.find((m) => m.id === id);
+}
+
+export function getModelsDir(): string {
+  return join(homedir(), ".cache", "freestyle", "whisper-models");
+}
+
+export function getModelPath(model: WhisperModelDef): string {
+  return join(getModelsDir(), model.fileName);
+}
+
+const BINARY_NAMES: Record<string, Record<string, string>> = {
+  darwin: { arm64: "whisper-cli", x64: "whisper-cli" },
+  linux: { x64: "whisper-cli" },
+  win32: { x64: "whisper-cli.exe" },
+};
+
+const SERVER_NAMES: Record<string, Record<string, string>> = {
+  darwin: { arm64: "whisper-server", x64: "whisper-server" },
+  linux: { x64: "whisper-server" },
+  win32: { x64: "whisper-server.exe" },
+};
+
+export function getBinaryName(): string | null {
+  const platform = process.platform;
+  const arch = process.arch;
+  return BINARY_NAMES[platform]?.[arch] ?? null;
+}
+
+export function getServerBinaryName(): string | null {
+  const platform = process.platform;
+  const arch = process.arch;
+  return SERVER_NAMES[platform]?.[arch] ?? null;
+}
+
+export function getResourcesDir(): string {
+  const electronProcess = process as NodeJS.Process & {
+    resourcesPath?: string;
+  };
+  if (electronProcess.resourcesPath) {
+    return join(
+      electronProcess.resourcesPath,
+      "whisper",
+      `${process.platform}-${process.arch}`,
+    );
+  }
+  return join(
+    process.cwd(),
+    "resources",
+    "whisper",
+    `${process.platform}-${process.arch}`,
+  );
+}
+
+export const WHISPER_SERVER_PORT = 8178;

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -26,12 +26,15 @@ export type DownloadStatus =
   | "ready"
   | "error";
 
+export type DownloadPhase = "building_binary" | "downloading_model";
+
 export interface ModelDownloadState {
   model: string;
   fileName: string;
   sizeBytes: number;
   displayName: string;
   status: DownloadStatus;
+  phase?: DownloadPhase;
   downloadProgress?: {
     bytesDownloaded: number;
     bytesTotal: number;
@@ -43,6 +46,7 @@ export interface ModelDownloadState {
 
 interface ActiveDownload {
   controller: AbortController;
+  phase: DownloadPhase;
   bytesDownloaded: number;
   bytesTotal: number;
   speedBps: number;
@@ -92,6 +96,7 @@ export function getModelStatus(modelId: string): ModelDownloadState | null {
       sizeBytes: model.sizeBytes,
       displayName: model.displayName,
       status: "downloading",
+      phase: active.phase,
       downloadProgress: {
         bytesDownloaded: active.bytesDownloaded,
         bytesTotal: active.bytesTotal,
@@ -144,8 +149,9 @@ export async function downloadModel(modelId: string): Promise<void> {
   const controller = new AbortController();
   const active: ActiveDownload = {
     controller,
+    phase: "building_binary",
     bytesDownloaded: 0,
-    bytesTotal: model.sizeBytes,
+    bytesTotal: 0,
     speedBps: 0,
     startedAt: Date.now(),
     lastUpdate: Date.now(),
@@ -159,6 +165,13 @@ export async function downloadModel(modelId: string): Promise<void> {
     active.error = err instanceof Error ? err.message : String(err);
     throw err;
   }
+
+  active.phase = "downloading_model";
+  active.bytesTotal = model.sizeBytes;
+  active.bytesDownloaded = 0;
+  active.speedBps = 0;
+  active.lastUpdate = Date.now();
+  active.lastBytes = 0;
 
   ensureModelsDir();
 
@@ -285,7 +298,11 @@ export async function ensureBinariesDownloaded(): Promise<void> {
   if (isBinaryAvailable()) return;
 
   if (binaryDownloadPromise) return binaryDownloadPromise;
-  binaryDownloadPromise = buildFromSource().finally(() => {
+  const task =
+    process.platform === "win32"
+      ? downloadWindowsBinaries()
+      : buildFromSource();
+  binaryDownloadPromise = task.finally(() => {
     binaryDownloadPromise = null;
   });
   return binaryDownloadPromise;
@@ -416,4 +433,64 @@ async function buildFromSource(): Promise<void> {
   }
 
   console.log("[whisper] Build complete");
+}
+
+async function downloadWindowsBinaries(): Promise<void> {
+  const binDir = getBinDir();
+  if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
+
+  const version = "1.8.4";
+  const archiveUrl = `https://github.com/ggml-org/whisper.cpp/releases/download/v${version}/whisper-bin-x64.zip`;
+  const tmpZip = join(binDir, "whisper-bin.zip");
+
+  console.log("[whisper] Downloading pre-built Windows binaries...");
+
+  const res = await fetch(archiveUrl, {
+    redirect: "follow",
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!res.ok || !res.body) {
+    throw new Error(`Failed to download whisper binaries: HTTP ${res.status}`);
+  }
+
+  const fileStream = createWriteStream(tmpZip);
+  const reader = res.body.getReader();
+  const nodeStream = new Readable({
+    async read() {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          this.push(null);
+          return;
+        }
+        this.push(Buffer.from(value));
+      } catch (err) {
+        this.destroy(err instanceof Error ? err : new Error(String(err)));
+      }
+    },
+  });
+  await pipeline(nodeStream, fileStream);
+
+  const { execFileSync } = await import("node:child_process");
+  try {
+    execFileSync(
+      "powershell",
+      [
+        "-Command",
+        `Expand-Archive -Force -Path '${tmpZip}' -DestinationPath '${binDir}'`,
+      ],
+      { stdio: "pipe", timeout: 30_000 },
+    );
+  } catch {
+    try {
+      unlinkSync(tmpZip);
+    } catch {}
+    throw new Error("Failed to extract whisper binaries.");
+  }
+
+  try {
+    unlinkSync(tmpZip);
+  } catch {}
+
+  console.log("[whisper] Windows binaries downloaded");
 }

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -11,7 +11,6 @@ import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import {
-  getBinaryRelease,
   getBinDir,
   getModelPath,
   getModelsDir,
@@ -286,37 +285,38 @@ export async function ensureBinariesDownloaded(): Promise<void> {
   if (isBinaryAvailable()) return;
 
   if (binaryDownloadPromise) return binaryDownloadPromise;
-  binaryDownloadPromise = downloadBinaries().finally(() => {
+  binaryDownloadPromise = buildFromSource().finally(() => {
     binaryDownloadPromise = null;
   });
   return binaryDownloadPromise;
 }
 
-async function downloadBinaries(): Promise<void> {
-  const release = getBinaryRelease();
-  if (!release) {
-    throw new Error(
-      `No whisper.cpp binary available for ${process.platform}-${process.arch}`,
-    );
-  }
+async function buildFromSource(): Promise<void> {
+  const { execFileSync } = await import("node:child_process");
 
   const binDir = getBinDir();
   if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
 
-  const archiveUrl = release.archive;
-  const tmpZip = join(binDir, "whisper-download.zip");
+  const srcDir = join(binDir, "whisper.cpp-src");
+  const buildDir = join(srcDir, "build");
 
-  console.log("[whisper] Downloading binaries from", archiveUrl);
+  const version = "1.7.5";
+  const tarballUrl = `https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${version}.tar.gz`;
+  const tarPath = join(binDir, `whisper-${version}.tar.gz`);
 
-  const res = await fetch(archiveUrl, {
+  console.log("[whisper] Downloading whisper.cpp source...");
+
+  const res = await fetch(tarballUrl, {
     redirect: "follow",
-    signal: AbortSignal.timeout(120_000),
+    signal: AbortSignal.timeout(60_000),
   });
   if (!res.ok || !res.body) {
-    throw new Error(`Failed to download whisper binaries: HTTP ${res.status}`);
+    throw new Error(
+      `Failed to download whisper.cpp source: HTTP ${res.status}`,
+    );
   }
 
-  const fileStream = createWriteStream(tmpZip);
+  const fileStream = createWriteStream(tarPath);
   const reader = res.body.getReader();
   const nodeStream = new Readable({
     async read() {
@@ -334,35 +334,86 @@ async function downloadBinaries(): Promise<void> {
   });
   await pipeline(nodeStream, fileStream);
 
-  console.log("[whisper] Extracting binaries to", binDir);
+  console.log("[whisper] Extracting source...");
 
-  const { execFileSync } = await import("node:child_process");
+  if (existsSync(srcDir)) {
+    const { rmSync } = await import("node:fs");
+    rmSync(srcDir, { recursive: true, force: true });
+  }
+  mkdirSync(srcDir, { recursive: true });
+
   try {
-    execFileSync("unzip", ["-o", "-j", tmpZip, "-d", binDir], {
-      stdio: "pipe",
-    });
+    execFileSync(
+      "tar",
+      ["xzf", tarPath, "-C", srcDir, "--strip-components=1"],
+      {
+        stdio: "pipe",
+        timeout: 30_000,
+      },
+    );
   } catch {
-    try {
-      unlinkSync(tmpZip);
-    } catch {}
     throw new Error(
-      "Failed to extract whisper binaries. Ensure 'unzip' is installed.",
+      "Failed to extract whisper.cpp source. Ensure 'tar' is installed.",
     );
   }
 
   try {
-    unlinkSync(tmpZip);
+    unlinkSync(tarPath);
   } catch {}
 
-  if (process.platform !== "win32") {
-    const { chmodSync } = await import("node:fs");
-    for (const bin of release.binaries) {
-      const binPath = join(binDir, bin);
-      if (existsSync(binPath)) {
-        chmodSync(binPath, 0o755);
-      }
-    }
+  console.log("[whisper] Building whisper.cpp (this may take a minute)...");
+
+  try {
+    mkdirSync(buildDir, { recursive: true });
+    execFileSync("cmake", ["..", "-DCMAKE_BUILD_TYPE=Release"], {
+      cwd: buildDir,
+      stdio: "pipe",
+      timeout: 60_000,
+    });
+    execFileSync("cmake", ["--build", ".", "--config", "Release", "-j"], {
+      cwd: buildDir,
+      stdio: "pipe",
+      timeout: 300_000,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to build whisper.cpp. Ensure cmake and a C/C++ compiler are installed.\n${msg}`,
+    );
   }
 
-  console.log("[whisper] Binaries downloaded successfully");
+  const binaryName =
+    process.platform === "win32" ? "whisper-cli.exe" : "whisper-cli";
+  const serverName =
+    process.platform === "win32" ? "whisper-server.exe" : "whisper-server";
+  const { copyFileSync, chmodSync } = await import("node:fs");
+
+  const builtBin = join(buildDir, "bin", binaryName);
+  const builtServer = join(buildDir, "bin", serverName);
+
+  if (existsSync(builtBin)) {
+    copyFileSync(builtBin, join(binDir, binaryName));
+    if (process.platform !== "win32")
+      chmodSync(join(binDir, binaryName), 0o755);
+  }
+  if (existsSync(builtServer)) {
+    copyFileSync(builtServer, join(binDir, serverName));
+    if (process.platform !== "win32")
+      chmodSync(join(binDir, serverName), 0o755);
+  }
+
+  // Clean up source
+  try {
+    const { rmSync } = await import("node:fs");
+    rmSync(srcDir, { recursive: true, force: true });
+  } catch {}
+
+  const { isBinaryAvailable } = await import("./binary.js");
+  if (!isBinaryAvailable()) {
+    throw new Error(
+      "whisper.cpp build completed but binary not found. Check build output.",
+    );
+  }
+
+  console.log("[whisper] Build complete");
 }

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -382,11 +382,11 @@ async function buildFromSource(): Promise<void> {
 
   try {
     mkdirSync(buildDir, { recursive: true });
-    execFileSync("cmake", ["..", "-DCMAKE_BUILD_TYPE=Release"], {
-      cwd: buildDir,
-      stdio: "pipe",
-      timeout: 60_000,
-    });
+    execFileSync(
+      "cmake",
+      ["..", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_SHARED_LIBS=OFF"],
+      { cwd: buildDir, stdio: "pipe", timeout: 60_000 },
+    );
     execFileSync("cmake", ["--build", ".", "--config", "Release", "-j"], {
       cwd: buildDir,
       stdio: "pipe",
@@ -403,7 +403,7 @@ async function buildFromSource(): Promise<void> {
     process.platform === "win32" ? "whisper-cli.exe" : "whisper-cli";
   const serverName =
     process.platform === "win32" ? "whisper-server.exe" : "whisper-server";
-  const { copyFileSync, chmodSync } = await import("node:fs");
+  const { copyFileSync, chmodSync, readdirSync } = await import("node:fs");
 
   const builtBin = join(buildDir, "bin", binaryName);
   const builtServer = join(buildDir, "bin", serverName);
@@ -417,6 +417,34 @@ async function buildFromSource(): Promise<void> {
     copyFileSync(builtServer, join(binDir, serverName));
     if (process.platform !== "win32")
       chmodSync(join(binDir, serverName), 0o755);
+  }
+
+  // Copy shared libraries (.dylib / .so) next to the binaries
+  const libDirs = [join(buildDir, "src"), join(buildDir, "ggml", "src")];
+  for (const libDir of libDirs) {
+    if (!existsSync(libDir)) continue;
+    for (const file of readdirSync(libDir)) {
+      if (
+        file.endsWith(".dylib") ||
+        (file.endsWith(".so") && file.includes("lib"))
+      ) {
+        copyFileSync(join(libDir, file), join(binDir, file));
+      }
+    }
+  }
+
+  // Fix rpath on macOS so the binary finds libs in its own directory
+  if (process.platform === "darwin") {
+    for (const bin of [binaryName, serverName]) {
+      const binPath = join(binDir, bin);
+      if (!existsSync(binPath)) continue;
+      try {
+        execFileSync("install_name_tool", ["-add_rpath", binDir, binPath], {
+          stdio: "pipe",
+          timeout: 10_000,
+        });
+      } catch {}
+    }
   }
 
   // Clean up source

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -7,9 +7,12 @@ import {
   statSync,
   unlinkSync,
 } from "node:fs";
+import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import {
+  getBinaryRelease,
+  getBinDir,
   getModelPath,
   getModelsDir,
   getWhisperModel,
@@ -139,6 +142,8 @@ export async function downloadModel(modelId: string): Promise<void> {
 
   if (isModelDownloaded(model)) return;
 
+  await ensureBinariesDownloaded();
+
   ensureModelsDir();
 
   const controller = new AbortController();
@@ -259,4 +264,96 @@ export function getDownloadedModelPath(modelId: string): string | null {
   if (!model) return null;
   if (!isModelDownloaded(model)) return null;
   return getModelPath(model);
+}
+
+// ---------------------------------------------------------------------------
+// Binary download
+// ---------------------------------------------------------------------------
+
+let binaryDownloadPromise: Promise<void> | null = null;
+
+export async function ensureBinariesDownloaded(): Promise<void> {
+  const { isBinaryAvailable } = await import("./binary.js");
+  if (isBinaryAvailable()) return;
+
+  if (binaryDownloadPromise) return binaryDownloadPromise;
+  binaryDownloadPromise = downloadBinaries().finally(() => {
+    binaryDownloadPromise = null;
+  });
+  return binaryDownloadPromise;
+}
+
+async function downloadBinaries(): Promise<void> {
+  const release = getBinaryRelease();
+  if (!release) {
+    throw new Error(
+      `No whisper.cpp binary available for ${process.platform}-${process.arch}`,
+    );
+  }
+
+  const binDir = getBinDir();
+  if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
+
+  const archiveUrl = release.archive;
+  const tmpZip = join(binDir, "whisper-download.zip");
+
+  console.log("[whisper] Downloading binaries from", archiveUrl);
+
+  const res = await fetch(archiveUrl, {
+    redirect: "follow",
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!res.ok || !res.body) {
+    throw new Error(`Failed to download whisper binaries: HTTP ${res.status}`);
+  }
+
+  const fileStream = createWriteStream(tmpZip);
+  const reader = res.body.getReader();
+  const nodeStream = new Readable({
+    async read() {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          this.push(null);
+          return;
+        }
+        this.push(Buffer.from(value));
+      } catch (err) {
+        this.destroy(err instanceof Error ? err : new Error(String(err)));
+      }
+    },
+  });
+  await pipeline(nodeStream, fileStream);
+
+  console.log("[whisper] Extracting binaries to", binDir);
+
+  const { execFileSync } = await import("node:child_process");
+  try {
+    execFileSync("unzip", ["-o", "-j", tmpZip, "-d", binDir], {
+      stdio: "pipe",
+    });
+  } catch {
+    try {
+      unlinkSync(tmpZip);
+    } catch {}
+    throw new Error(
+      "Failed to extract whisper binaries. Ensure 'unzip' is installed.",
+    );
+  }
+
+  try {
+    unlinkSync(tmpZip);
+  } catch {}
+
+  if (process.platform !== "win32") {
+    const { chmodSync } = await import("node:fs");
+    for (const bin of release.binaries) {
+      const binPath = join(binDir, bin);
+      if (existsSync(binPath)) {
+        chmodSync(binPath, 0o755);
+      }
+    }
+  }
+
+  console.log("[whisper] Binaries downloaded successfully");
 }

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -1,9 +1,14 @@
 import { Buffer } from "node:buffer";
+import { execFileSync } from "node:child_process";
 import {
+  chmodSync,
+  copyFileSync,
   createWriteStream,
   existsSync,
   mkdirSync,
+  readdirSync,
   renameSync,
+  rmSync,
   statSync,
   unlinkSync,
 } from "node:fs";
@@ -15,6 +20,7 @@ import {
   getModelPath,
   getModelsDir,
   getWhisperModel,
+  WHISPER_CPP_VERSION,
   WHISPER_MODELS,
   type WhisperModelDef,
 } from "./constants.js";
@@ -72,6 +78,21 @@ function isModelDownloaded(model: WhisperModelDef): boolean {
   return stat.size >= model.sizeBytes * 0.95;
 }
 
+function baseModelState(
+  modelId: string,
+  model: WhisperModelDef,
+): Pick<
+  ModelDownloadState,
+  "model" | "fileName" | "sizeBytes" | "displayName"
+> {
+  return {
+    model: modelId,
+    fileName: model.fileName,
+    sizeBytes: model.sizeBytes,
+    displayName: model.displayName,
+  };
+}
+
 export function getModelStatus(modelId: string): ModelDownloadState | null {
   const model = getWhisperModel(modelId);
   if (!model) return null;
@@ -80,10 +101,7 @@ export function getModelStatus(modelId: string): ModelDownloadState | null {
 
   if (active?.error) {
     return {
-      model: modelId,
-      fileName: model.fileName,
-      sizeBytes: model.sizeBytes,
-      displayName: model.displayName,
+      ...baseModelState(modelId, model),
       status: "error",
       error: active.error,
     };
@@ -91,10 +109,7 @@ export function getModelStatus(modelId: string): ModelDownloadState | null {
 
   if (active) {
     return {
-      model: modelId,
-      fileName: model.fileName,
-      sizeBytes: model.sizeBytes,
-      displayName: model.displayName,
+      ...baseModelState(modelId, model),
       status: "downloading",
       phase: active.phase,
       downloadProgress: {
@@ -110,22 +125,10 @@ export function getModelStatus(modelId: string): ModelDownloadState | null {
   }
 
   if (isModelDownloaded(model)) {
-    return {
-      model: modelId,
-      fileName: model.fileName,
-      sizeBytes: model.sizeBytes,
-      displayName: model.displayName,
-      status: "ready",
-    };
+    return { ...baseModelState(modelId, model), status: "ready" };
   }
 
-  return {
-    model: modelId,
-    fileName: model.fileName,
-    sizeBytes: model.sizeBytes,
-    displayName: model.displayName,
-    status: "not_downloaded",
-  };
+  return { ...baseModelState(modelId, model), status: "not_downloaded" };
 }
 
 export function getAllModelStatuses(): ModelDownloadState[] {
@@ -146,12 +149,15 @@ export async function downloadModel(modelId: string): Promise<void> {
 
   if (isModelDownloaded(model)) return;
 
+  const { isBinaryAvailable } = await import("./binary.js");
+  const needsBinary = !isBinaryAvailable();
+
   const controller = new AbortController();
   const active: ActiveDownload = {
     controller,
-    phase: "building_binary",
+    phase: needsBinary ? "building_binary" : "downloading_model",
     bytesDownloaded: 0,
-    bytesTotal: 0,
+    bytesTotal: needsBinary ? 0 : model.sizeBytes,
     speedBps: 0,
     startedAt: Date.now(),
     lastUpdate: Date.now(),
@@ -159,19 +165,21 @@ export async function downloadModel(modelId: string): Promise<void> {
   };
   activeDownloads.set(modelId, active);
 
-  try {
-    await ensureBinariesDownloaded();
-  } catch (err) {
-    active.error = err instanceof Error ? err.message : String(err);
-    throw err;
-  }
+  if (needsBinary) {
+    try {
+      await ensureBinariesDownloaded();
+    } catch (err) {
+      active.error = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
 
-  active.phase = "downloading_model";
-  active.bytesTotal = model.sizeBytes;
-  active.bytesDownloaded = 0;
-  active.speedBps = 0;
-  active.lastUpdate = Date.now();
-  active.lastBytes = 0;
+    active.phase = "downloading_model";
+    active.bytesTotal = model.sizeBytes;
+    active.bytesDownloaded = 0;
+    active.speedBps = 0;
+    active.lastUpdate = Date.now();
+    active.lastBytes = 0;
+  }
 
   ensureModelsDir();
 
@@ -198,35 +206,7 @@ export async function downloadModel(modelId: string): Promise<void> {
     }
 
     const fileStream = createWriteStream(tempPath);
-    const reader = res.body.getReader();
-
-    const nodeStream = new Readable({
-      async read() {
-        try {
-          const { done, value } = await reader.read();
-          if (done) {
-            this.push(null);
-            return;
-          }
-          active.bytesDownloaded += value.byteLength;
-
-          const now = Date.now();
-          const elapsed = now - active.lastUpdate;
-          if (elapsed >= 500) {
-            const bytesDelta = active.bytesDownloaded - active.lastBytes;
-            active.speedBps = Math.round((bytesDelta / elapsed) * 1000);
-            active.lastUpdate = now;
-            active.lastBytes = active.bytesDownloaded;
-          }
-
-          this.push(Buffer.from(value));
-        } catch (err) {
-          this.destroy(err instanceof Error ? err : new Error(String(err)));
-        }
-      },
-    });
-
-    await pipeline(nodeStream, fileStream);
+    await pipeline(webBodyToReadable(res.body, active), fileStream);
 
     renameSync(tempPath, destPath);
     activeDownloads.delete(modelId);
@@ -284,7 +264,7 @@ export function getDownloadedModelPath(modelId: string): string | null {
 }
 
 // ---------------------------------------------------------------------------
-// Binary download
+// Binary acquisition
 // ---------------------------------------------------------------------------
 
 let binaryDownloadPromise: Promise<void> | null = null;
@@ -309,17 +289,14 @@ export async function ensureBinariesDownloaded(): Promise<void> {
 }
 
 async function buildFromSource(): Promise<void> {
-  const { execFileSync } = await import("node:child_process");
-
   const binDir = getBinDir();
   if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
 
   const srcDir = join(binDir, "whisper.cpp-src");
   const buildDir = join(srcDir, "build");
 
-  const version = "1.7.5";
-  const tarballUrl = `https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${version}.tar.gz`;
-  const tarPath = join(binDir, `whisper-${version}.tar.gz`);
+  const tarballUrl = `https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${WHISPER_CPP_VERSION}.tar.gz`;
+  const tarPath = join(binDir, `whisper-${WHISPER_CPP_VERSION}.tar.gz`);
 
   console.log("[whisper] Downloading whisper.cpp source...");
 
@@ -334,27 +311,11 @@ async function buildFromSource(): Promise<void> {
   }
 
   const fileStream = createWriteStream(tarPath);
-  const reader = res.body.getReader();
-  const nodeStream = new Readable({
-    async read() {
-      try {
-        const { done, value } = await reader.read();
-        if (done) {
-          this.push(null);
-          return;
-        }
-        this.push(Buffer.from(value));
-      } catch (err) {
-        this.destroy(err instanceof Error ? err : new Error(String(err)));
-      }
-    },
-  });
-  await pipeline(nodeStream, fileStream);
+  await pipeline(webBodyToReadable(res.body), fileStream);
 
   console.log("[whisper] Extracting source...");
 
   if (existsSync(srcDir)) {
-    const { rmSync } = await import("node:fs");
     rmSync(srcDir, { recursive: true, force: true });
   }
   mkdirSync(srcDir, { recursive: true });
@@ -363,10 +324,7 @@ async function buildFromSource(): Promise<void> {
     execFileSync(
       "tar",
       ["xzf", tarPath, "-C", srcDir, "--strip-components=1"],
-      {
-        stdio: "pipe",
-        timeout: 30_000,
-      },
+      { stdio: "pipe", timeout: 30_000 },
     );
   } catch {
     throw new Error(
@@ -399,44 +357,30 @@ async function buildFromSource(): Promise<void> {
     );
   }
 
-  const binaryName =
-    process.platform === "win32" ? "whisper-cli.exe" : "whisper-cli";
-  const serverName =
-    process.platform === "win32" ? "whisper-server.exe" : "whisper-server";
-  const { copyFileSync, chmodSync, readdirSync } = await import("node:fs");
+  const binaryName = "whisper-cli";
+  const serverName = "whisper-server";
 
-  const builtBin = join(buildDir, "bin", binaryName);
-  const builtServer = join(buildDir, "bin", serverName);
-
-  if (existsSync(builtBin)) {
-    copyFileSync(builtBin, join(binDir, binaryName));
-    if (process.platform !== "win32")
-      chmodSync(join(binDir, binaryName), 0o755);
-  }
-  if (existsSync(builtServer)) {
-    copyFileSync(builtServer, join(binDir, serverName));
-    if (process.platform !== "win32")
-      chmodSync(join(binDir, serverName), 0o755);
+  for (const name of [binaryName, serverName]) {
+    const builtPath = join(buildDir, "bin", name);
+    if (existsSync(builtPath)) {
+      copyFileSync(builtPath, join(binDir, name));
+      chmodSync(join(binDir, name), 0o755);
+    }
   }
 
-  // Copy shared libraries (.dylib / .so) next to the binaries
   const libDirs = [join(buildDir, "src"), join(buildDir, "ggml", "src")];
   for (const libDir of libDirs) {
     if (!existsSync(libDir)) continue;
     for (const file of readdirSync(libDir)) {
-      if (
-        file.endsWith(".dylib") ||
-        (file.endsWith(".so") && file.includes("lib"))
-      ) {
+      if (file.endsWith(".dylib") || /\.so(\.\d+)*$/.test(file)) {
         copyFileSync(join(libDir, file), join(binDir, file));
       }
     }
   }
 
-  // Fix rpath on macOS so the binary finds libs in its own directory
   if (process.platform === "darwin") {
-    for (const bin of [binaryName, serverName]) {
-      const binPath = join(binDir, bin);
+    for (const name of [binaryName, serverName]) {
+      const binPath = join(binDir, name);
       if (!existsSync(binPath)) continue;
       try {
         execFileSync("install_name_tool", ["-add_rpath", binDir, binPath], {
@@ -447,9 +391,7 @@ async function buildFromSource(): Promise<void> {
     }
   }
 
-  // Clean up source
   try {
-    const { rmSync } = await import("node:fs");
     rmSync(srcDir, { recursive: true, force: true });
   } catch {}
 
@@ -467,8 +409,7 @@ async function downloadWindowsBinaries(): Promise<void> {
   const binDir = getBinDir();
   if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
 
-  const version = "1.8.4";
-  const archiveUrl = `https://github.com/ggml-org/whisper.cpp/releases/download/v${version}/whisper-bin-x64.zip`;
+  const archiveUrl = `https://github.com/ggml-org/whisper.cpp/releases/download/v${WHISPER_CPP_VERSION}/whisper-bin-x64.zip`;
   const tmpZip = join(binDir, "whisper-bin.zip");
 
   console.log("[whisper] Downloading pre-built Windows binaries...");
@@ -482,24 +423,8 @@ async function downloadWindowsBinaries(): Promise<void> {
   }
 
   const fileStream = createWriteStream(tmpZip);
-  const reader = res.body.getReader();
-  const nodeStream = new Readable({
-    async read() {
-      try {
-        const { done, value } = await reader.read();
-        if (done) {
-          this.push(null);
-          return;
-        }
-        this.push(Buffer.from(value));
-      } catch (err) {
-        this.destroy(err instanceof Error ? err : new Error(String(err)));
-      }
-    },
-  });
-  await pipeline(nodeStream, fileStream);
+  await pipeline(webBodyToReadable(res.body), fileStream);
 
-  const { execFileSync } = await import("node:child_process");
   try {
     execFileSync(
       "powershell",
@@ -521,4 +446,45 @@ async function downloadWindowsBinaries(): Promise<void> {
   } catch {}
 
   console.log("[whisper] Windows binaries downloaded");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function webBodyToReadable(
+  body: ReadableStream<Uint8Array>,
+  progress?: {
+    bytesDownloaded: number;
+    lastUpdate: number;
+    lastBytes: number;
+    speedBps: number;
+  },
+): Readable {
+  const reader = body.getReader();
+  return new Readable({
+    async read() {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          this.push(null);
+          return;
+        }
+        if (progress) {
+          progress.bytesDownloaded += value.byteLength;
+          const now = Date.now();
+          const elapsed = now - progress.lastUpdate;
+          if (elapsed >= 500) {
+            const bytesDelta = progress.bytesDownloaded - progress.lastBytes;
+            progress.speedBps = Math.round((bytesDelta / elapsed) * 1000);
+            progress.lastUpdate = now;
+            progress.lastBytes = progress.bytesDownloaded;
+          }
+        }
+        this.push(Buffer.from(value));
+      } catch (err) {
+        this.destroy(err instanceof Error ? err : new Error(String(err)));
+      }
+    },
+  });
 }

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -1,0 +1,262 @@
+import { Buffer } from "node:buffer";
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import {
+  getModelPath,
+  getModelsDir,
+  getWhisperModel,
+  WHISPER_MODELS,
+  type WhisperModelDef,
+} from "./constants.js";
+
+export type DownloadStatus =
+  | "not_downloaded"
+  | "downloading"
+  | "verifying"
+  | "ready"
+  | "error";
+
+export interface ModelDownloadState {
+  model: string;
+  fileName: string;
+  sizeBytes: number;
+  displayName: string;
+  status: DownloadStatus;
+  downloadProgress?: {
+    bytesDownloaded: number;
+    bytesTotal: number;
+    percent: number;
+    speedBps: number;
+  };
+  error?: string;
+}
+
+interface ActiveDownload {
+  controller: AbortController;
+  bytesDownloaded: number;
+  bytesTotal: number;
+  speedBps: number;
+  startedAt: number;
+  lastUpdate: number;
+  lastBytes: number;
+  error?: string;
+}
+
+const activeDownloads = new Map<string, ActiveDownload>();
+
+function ensureModelsDir(): void {
+  const dir = getModelsDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+function isModelDownloaded(model: WhisperModelDef): boolean {
+  const path = getModelPath(model);
+  if (!existsSync(path)) return false;
+  const stat = statSync(path);
+  return stat.size >= model.sizeBytes * 0.95;
+}
+
+export function getModelStatus(modelId: string): ModelDownloadState | null {
+  const model = getWhisperModel(modelId);
+  if (!model) return null;
+
+  const active = activeDownloads.get(modelId);
+
+  if (active?.error) {
+    return {
+      model: modelId,
+      fileName: model.fileName,
+      sizeBytes: model.sizeBytes,
+      displayName: model.displayName,
+      status: "error",
+      error: active.error,
+    };
+  }
+
+  if (active) {
+    return {
+      model: modelId,
+      fileName: model.fileName,
+      sizeBytes: model.sizeBytes,
+      displayName: model.displayName,
+      status: "downloading",
+      downloadProgress: {
+        bytesDownloaded: active.bytesDownloaded,
+        bytesTotal: active.bytesTotal,
+        percent:
+          active.bytesTotal > 0
+            ? Math.round((active.bytesDownloaded / active.bytesTotal) * 100)
+            : 0,
+        speedBps: active.speedBps,
+      },
+    };
+  }
+
+  if (isModelDownloaded(model)) {
+    return {
+      model: modelId,
+      fileName: model.fileName,
+      sizeBytes: model.sizeBytes,
+      displayName: model.displayName,
+      status: "ready",
+    };
+  }
+
+  return {
+    model: modelId,
+    fileName: model.fileName,
+    sizeBytes: model.sizeBytes,
+    displayName: model.displayName,
+    status: "not_downloaded",
+  };
+}
+
+export function getAllModelStatuses(): ModelDownloadState[] {
+  return WHISPER_MODELS.map((m) => getModelStatus(m.id)!);
+}
+
+export async function downloadModel(modelId: string): Promise<void> {
+  const model = getWhisperModel(modelId);
+  if (!model) throw new Error(`Unknown whisper model: ${modelId}`);
+
+  const existing = activeDownloads.get(modelId);
+  if (existing && !existing.error) {
+    throw new Error(`Model ${modelId} is already downloading`);
+  }
+  if (existing?.error) {
+    activeDownloads.delete(modelId);
+  }
+
+  if (isModelDownloaded(model)) return;
+
+  ensureModelsDir();
+
+  const controller = new AbortController();
+  const active: ActiveDownload = {
+    controller,
+    bytesDownloaded: 0,
+    bytesTotal: model.sizeBytes,
+    speedBps: 0,
+    startedAt: Date.now(),
+    lastUpdate: Date.now(),
+    lastBytes: 0,
+  };
+  activeDownloads.set(modelId, active);
+
+  const destPath = getModelPath(model);
+  const tempPath = `${destPath}.downloading`;
+
+  try {
+    const res = await fetch(model.url, {
+      signal: controller.signal,
+      redirect: "follow",
+    });
+
+    if (!res.ok) {
+      throw new Error(`Download failed: HTTP ${res.status} ${res.statusText}`);
+    }
+
+    const contentLength = res.headers.get("content-length");
+    if (contentLength) {
+      active.bytesTotal = Number.parseInt(contentLength, 10);
+    }
+
+    if (!res.body) {
+      throw new Error("No response body received");
+    }
+
+    const fileStream = createWriteStream(tempPath);
+    const reader = res.body.getReader();
+
+    const nodeStream = new Readable({
+      async read() {
+        try {
+          const { done, value } = await reader.read();
+          if (done) {
+            this.push(null);
+            return;
+          }
+          active.bytesDownloaded += value.byteLength;
+
+          const now = Date.now();
+          const elapsed = now - active.lastUpdate;
+          if (elapsed >= 500) {
+            const bytesDelta = active.bytesDownloaded - active.lastBytes;
+            active.speedBps = Math.round((bytesDelta / elapsed) * 1000);
+            active.lastUpdate = now;
+            active.lastBytes = active.bytesDownloaded;
+          }
+
+          this.push(Buffer.from(value));
+        } catch (err) {
+          this.destroy(err instanceof Error ? err : new Error(String(err)));
+        }
+      },
+    });
+
+    await pipeline(nodeStream, fileStream);
+
+    renameSync(tempPath, destPath);
+    activeDownloads.delete(modelId);
+  } catch (err) {
+    try {
+      if (existsSync(tempPath)) unlinkSync(tempPath);
+    } catch {}
+
+    if (controller.signal.aborted) {
+      activeDownloads.delete(modelId);
+      return;
+    }
+
+    active.error = err instanceof Error ? err.message : String(err);
+    throw err;
+  }
+}
+
+export function cancelDownload(modelId: string): boolean {
+  const active = activeDownloads.get(modelId);
+  if (!active) return false;
+  active.controller.abort();
+  activeDownloads.delete(modelId);
+  return true;
+}
+
+export function deleteModel(modelId: string): boolean {
+  const model = getWhisperModel(modelId);
+  if (!model) return false;
+
+  cancelDownload(modelId);
+
+  const path = getModelPath(model);
+  try {
+    if (existsSync(path)) {
+      unlinkSync(path);
+      return true;
+    }
+  } catch {}
+  return false;
+}
+
+export function clearDownloadError(modelId: string): void {
+  const active = activeDownloads.get(modelId);
+  if (active?.error) {
+    activeDownloads.delete(modelId);
+  }
+}
+
+export function getDownloadedModelPath(modelId: string): string | null {
+  const model = getWhisperModel(modelId);
+  if (!model) return null;
+  if (!isModelDownloaded(model)) return null;
+  return getModelPath(model);
+}

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -409,7 +409,8 @@ async function downloadWindowsBinaries(): Promise<void> {
   const binDir = getBinDir();
   if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
 
-  const archiveUrl = `https://github.com/ggml-org/whisper.cpp/releases/download/v${WHISPER_CPP_VERSION}/whisper-bin-x64.zip`;
+  const winVersion = "1.8.5";
+  const archiveUrl = `https://github.com/ggml-org/whisper.cpp/releases/download/v${winVersion}/whisper-bin-x64.zip`;
   const tmpZip = join(binDir, "whisper-bin.zip");
 
   console.log("[whisper] Downloading pre-built Windows binaries...");

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -142,10 +142,6 @@ export async function downloadModel(modelId: string): Promise<void> {
 
   if (isModelDownloaded(model)) return;
 
-  await ensureBinariesDownloaded();
-
-  ensureModelsDir();
-
   const controller = new AbortController();
   const active: ActiveDownload = {
     controller,
@@ -157,6 +153,15 @@ export async function downloadModel(modelId: string): Promise<void> {
     lastBytes: 0,
   };
   activeDownloads.set(modelId, active);
+
+  try {
+    await ensureBinariesDownloaded();
+  } catch (err) {
+    active.error = err instanceof Error ? err.message : String(err);
+    throw err;
+  }
+
+  ensureModelsDir();
 
   const destPath = getModelPath(model);
   const tempPath = `${destPath}.downloading`;
@@ -271,6 +276,10 @@ export function getDownloadedModelPath(modelId: string): string | null {
 // ---------------------------------------------------------------------------
 
 let binaryDownloadPromise: Promise<void> | null = null;
+
+export function isBinaryDownloading(): boolean {
+  return binaryDownloadPromise !== null;
+}
 
 export async function ensureBinariesDownloaded(): Promise<void> {
   const { isBinaryAvailable } = await import("./binary.js");

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -36,9 +36,13 @@ export function startInBackground(modelId: string): void {
   restartCount = 0;
   autoRestart = true;
 
-  ensureServerRunning(modelId).catch((err) => {
-    console.error("[whisper] Background server start failed:", err.message);
-  });
+  ensureServerRunning(modelId)
+    .then(() => {
+      console.log("[whisper] Server ready on port", WHISPER_SERVER_PORT);
+    })
+    .catch((err) => {
+      console.error("[whisper] Background server start failed:", err.message);
+    });
 }
 
 export async function ensureServerRunning(modelId: string): Promise<void> {

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -3,17 +3,42 @@ import { findWhisperServer } from "./binary.js";
 import { WHISPER_SERVER_PORT } from "./constants.js";
 import { getDownloadedModelPath } from "./models.js";
 
+const MAX_RESTARTS = 3;
+const RESTART_COOLDOWN_MS = 3_000;
+const STABILITY_THRESHOLD_MS = 30_000;
+
 let serverProcess: ChildProcess | null = null;
 let currentModelId: string | null = null;
 let serverReady = false;
 let startPromise: Promise<void> | null = null;
+let autoRestart = false;
+let restartCount = 0;
+let stabilityTimer: ReturnType<typeof setTimeout> | null = null;
+let serverFailed = false;
 
 export function isServerRunning(): boolean {
   return serverProcess !== null && serverReady;
 }
 
+export function isServerFailed(): boolean {
+  return serverFailed;
+}
+
 export function getServerPort(): number {
   return WHISPER_SERVER_PORT;
+}
+
+export function startInBackground(modelId: string): void {
+  if (serverProcess && currentModelId === modelId && serverReady) return;
+  if (startPromise && currentModelId === modelId) return;
+
+  serverFailed = false;
+  restartCount = 0;
+  autoRestart = true;
+
+  ensureServerRunning(modelId).catch((err) => {
+    console.error("[whisper] Background server start failed:", err.message);
+  });
 }
 
 export async function ensureServerRunning(modelId: string): Promise<void> {
@@ -26,6 +51,8 @@ export async function ensureServerRunning(modelId: string): Promise<void> {
   }
 
   await stopServer();
+  autoRestart = true;
+  serverFailed = false;
 
   const promise = doStart(modelId);
   startPromise = promise;
@@ -112,26 +139,73 @@ async function doStart(modelId: string): Promise<void> {
 
     proc.on("close", (code) => {
       clearTimeout(timeout);
+      clearStabilityTimer();
       const wasReady = serverReady;
+      const modelForRestart = currentModelId;
       serverProcess = null;
       serverReady = false;
-      currentModelId = null;
 
       if (!settled) {
         settled = true;
+        currentModelId = null;
         const detail = stderr.trim() || `exit code ${code}`;
         reject(new Error(`whisper-server exited unexpectedly: ${detail}`));
-      } else if (wasReady) {
-        console.error(`whisper-server exited unexpectedly (code ${code})`);
+        return;
+      }
+
+      if (wasReady && autoRestart && modelForRestart) {
+        scheduleRestart(modelForRestart);
       }
     });
   });
 
-  await new Promise((r) => setTimeout(r, 200));
+  startStabilityTimer();
+}
+
+function scheduleRestart(modelId: string): void {
+  restartCount++;
+  if (restartCount > MAX_RESTARTS) {
+    console.error(
+      `[whisper] Server crashed ${MAX_RESTARTS} times, not restarting`,
+    );
+    serverFailed = true;
+    autoRestart = false;
+    currentModelId = null;
+    return;
+  }
+
+  console.log(
+    `[whisper] Server crashed, restarting in ${RESTART_COOLDOWN_MS / 1000}s (attempt ${restartCount}/${MAX_RESTARTS})`,
+  );
+
+  setTimeout(() => {
+    if (!autoRestart) return;
+    ensureServerRunning(modelId).catch((err) => {
+      console.error("[whisper] Restart failed:", err.message);
+    });
+  }, RESTART_COOLDOWN_MS);
+}
+
+function startStabilityTimer(): void {
+  clearStabilityTimer();
+  stabilityTimer = setTimeout(() => {
+    if (serverReady) {
+      restartCount = 0;
+    }
+  }, STABILITY_THRESHOLD_MS);
+}
+
+function clearStabilityTimer(): void {
+  if (stabilityTimer) {
+    clearTimeout(stabilityTimer);
+    stabilityTimer = null;
+  }
 }
 
 export async function stopServer(): Promise<void> {
+  autoRestart = false;
   startPromise = null;
+  clearStabilityTimer();
   if (!serverProcess) return;
 
   const proc = serverProcess;

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -86,7 +86,6 @@ async function doStart(modelId: string): Promise<void> {
     String(WHISPER_SERVER_PORT),
     "--host",
     "127.0.0.1",
-    "--convert",
   ];
 
   const proc = spawn(serverBinary, args, {

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -1,0 +1,162 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { findWhisperServer } from "./binary.js";
+import { WHISPER_SERVER_PORT } from "./constants.js";
+import { getDownloadedModelPath } from "./models.js";
+
+let serverProcess: ChildProcess | null = null;
+let currentModelId: string | null = null;
+let serverReady = false;
+let startPromise: Promise<void> | null = null;
+
+export function isServerRunning(): boolean {
+  return serverProcess !== null && serverReady;
+}
+
+export function getServerPort(): number {
+  return WHISPER_SERVER_PORT;
+}
+
+export async function ensureServerRunning(modelId: string): Promise<void> {
+  if (serverProcess && currentModelId === modelId && serverReady) {
+    return;
+  }
+
+  if (startPromise && currentModelId === modelId) {
+    return startPromise;
+  }
+
+  await stopServer();
+
+  const promise = doStart(modelId);
+  startPromise = promise;
+  try {
+    await promise;
+  } finally {
+    if (startPromise === promise) {
+      startPromise = null;
+    }
+  }
+}
+
+async function doStart(modelId: string): Promise<void> {
+  const serverBinary = findWhisperServer();
+  if (!serverBinary) {
+    throw new Error("whisper-server binary not found");
+  }
+
+  const modelPath = getDownloadedModelPath(modelId);
+  if (!modelPath) {
+    throw new Error(`Whisper model "${modelId}" not downloaded`);
+  }
+
+  currentModelId = modelId;
+  serverReady = false;
+
+  const args = [
+    "--model",
+    modelPath,
+    "--port",
+    String(WHISPER_SERVER_PORT),
+    "--host",
+    "127.0.0.1",
+    "--convert",
+  ];
+
+  const proc = spawn(serverBinary, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  serverProcess = proc;
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let stderr = "";
+
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error("whisper-server failed to start within 30 seconds"));
+    }, 30_000);
+
+    function onReady() {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      serverReady = true;
+      resolve();
+    }
+
+    proc.stdout?.on("data", (data: Buffer) => {
+      const text = data.toString();
+      if (text.includes("listening") || text.includes("model loaded")) {
+        onReady();
+      }
+    });
+
+    proc.stderr?.on("data", (data: Buffer) => {
+      const text = data.toString();
+      stderr += text;
+      if (text.includes("listening") || text.includes("model loaded")) {
+        onReady();
+      }
+    });
+
+    proc.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      serverProcess = null;
+      currentModelId = null;
+      reject(new Error(`Failed to start whisper-server: ${err.message}`));
+    });
+
+    proc.on("close", (code) => {
+      clearTimeout(timeout);
+      const wasReady = serverReady;
+      serverProcess = null;
+      serverReady = false;
+      currentModelId = null;
+
+      if (!settled) {
+        settled = true;
+        const detail = stderr.trim() || `exit code ${code}`;
+        reject(new Error(`whisper-server exited unexpectedly: ${detail}`));
+      } else if (wasReady) {
+        console.error(`whisper-server exited unexpectedly (code ${code})`);
+      }
+    });
+  });
+
+  await new Promise((r) => setTimeout(r, 200));
+}
+
+export async function stopServer(): Promise<void> {
+  startPromise = null;
+  if (!serverProcess) return;
+
+  const proc = serverProcess;
+  serverProcess = null;
+  currentModelId = null;
+  serverReady = false;
+
+  return new Promise((resolve) => {
+    let done = false;
+    const killTimeout = setTimeout(() => {
+      if (done) return;
+      try {
+        proc.kill("SIGKILL");
+      } catch {}
+      done = true;
+      resolve();
+    }, 5_000);
+
+    proc.once("close", () => {
+      if (done) return;
+      done = true;
+      clearTimeout(killTimeout);
+      resolve();
+    });
+
+    proc.kill("SIGTERM");
+  });
+}

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -218,7 +218,7 @@ export async function stopServer(): Promise<void> {
     const killTimeout = setTimeout(() => {
       if (done) return;
       try {
-        proc.kill("SIGKILL");
+        proc.kill();
       } catch {}
       done = true;
       resolve();
@@ -231,6 +231,12 @@ export async function stopServer(): Promise<void> {
       resolve();
     });
 
-    proc.kill("SIGTERM");
+    try {
+      proc.kill(process.platform === "win32" ? undefined : "SIGTERM");
+    } catch {
+      done = true;
+      clearTimeout(killTimeout);
+      resolve();
+    }
   });
 }

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -101,8 +101,8 @@ async function doStart(modelId: string): Promise<void> {
     const timeout = setTimeout(() => {
       if (settled) return;
       settled = true;
-      reject(new Error("whisper-server failed to start within 30 seconds"));
-    }, 30_000);
+      reject(new Error("whisper-server failed to start within 90 seconds"));
+    }, 90_000);
 
     function onReady() {
       if (settled) return;

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -101,40 +101,75 @@ async function doStart(modelId: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let settled = false;
     let stderr = "";
+    const isDev = process.env.NODE_ENV !== "production";
 
     const timeout = setTimeout(() => {
       if (settled) return;
       settled = true;
-      reject(new Error("whisper-server failed to start within 90 seconds"));
+      const lastOutput = stderr.trim().slice(-500);
+      reject(
+        new Error(
+          `whisper-server failed to start within 90 seconds. Last output:\n${lastOutput}`,
+        ),
+      );
     }, 90_000);
+
+    let healthCheckInterval: ReturnType<typeof setInterval> | null = null;
 
     function onReady() {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
+      if (healthCheckInterval) clearInterval(healthCheckInterval);
       serverReady = true;
       resolve();
     }
 
-    proc.stdout?.on("data", (data: Buffer) => {
-      const text = data.toString();
-      if (text.includes("listening") || text.includes("model loaded")) {
+    function checkReady(text: string): void {
+      if (
+        text.includes("listening") ||
+        text.includes("model loaded") ||
+        text.includes("http://") ||
+        text.includes("running on")
+      ) {
         onReady();
       }
+    }
+
+    proc.stdout?.on("data", (data: Buffer) => {
+      const text = data.toString();
+      if (isDev) console.log("[whisper-server:stdout]", text.trimEnd());
+      checkReady(text);
     });
 
     proc.stderr?.on("data", (data: Buffer) => {
       const text = data.toString();
       stderr += text;
-      if (text.includes("listening") || text.includes("model loaded")) {
-        onReady();
-      }
+      if (isDev) console.log("[whisper-server:stderr]", text.trimEnd());
+      checkReady(text);
     });
+
+    // Poll the HTTP endpoint as a fallback readiness check
+    healthCheckInterval = setInterval(async () => {
+      if (settled) {
+        if (healthCheckInterval) clearInterval(healthCheckInterval);
+        return;
+      }
+      try {
+        const res = await fetch(`http://127.0.0.1:${WHISPER_SERVER_PORT}/`, {
+          signal: AbortSignal.timeout(1000),
+        });
+        if (res.ok || res.status === 404 || res.status === 405) {
+          onReady();
+        }
+      } catch {}
+    }, 2000);
 
     proc.on("error", (err) => {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
+      if (healthCheckInterval) clearInterval(healthCheckInterval);
       serverProcess = null;
       currentModelId = null;
       reject(new Error(`Failed to start whisper-server: ${err.message}`));
@@ -142,6 +177,7 @@ async function doStart(modelId: string): Promise<void> {
 
     proc.on("close", (code) => {
       clearTimeout(timeout);
+      if (healthCheckInterval) clearInterval(healthCheckInterval);
       clearStabilityTimer();
       const wasReady = serverReady;
       const modelForRestart = currentModelId;

--- a/apps/server/src/lib/whisper/transcribe.ts
+++ b/apps/server/src/lib/whisper/transcribe.ts
@@ -1,0 +1,162 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TranscribeResult } from "../streaming/types.js";
+import { findWhisperBinary } from "./binary.js";
+import { getDownloadedModelPath } from "./models.js";
+
+interface WhisperTranscribeOptions {
+  audio: Uint8Array;
+  modelId: string;
+  language?: string;
+}
+
+function getTempDir(): string {
+  const dir = join(tmpdir(), "freestyle-whisper");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export async function transcribeWithWhisper(
+  opts: WhisperTranscribeOptions,
+): Promise<TranscribeResult> {
+  const binaryPath = findWhisperBinary();
+  if (!binaryPath) {
+    throw new Error(
+      "whisper.cpp binary not found. It should be bundled with the app.",
+    );
+  }
+
+  const modelPath = getDownloadedModelPath(opts.modelId);
+  if (!modelPath) {
+    throw new Error(
+      `Whisper model "${opts.modelId}" is not downloaded. Download it from Settings > Models.`,
+    );
+  }
+
+  const tempDir = getTempDir();
+  const id = randomBytes(8).toString("hex");
+  const wavPath = join(tempDir, `input-${id}.wav`);
+
+  try {
+    writeFileSync(wavPath, opts.audio);
+
+    const args = [
+      "--model",
+      modelPath,
+      "--file",
+      wavPath,
+      "--output-json-full",
+      "--no-prints",
+    ];
+
+    if (opts.language && opts.language !== "auto") {
+      args.push("--language", opts.language);
+    }
+
+    const result = await runWhisperProcess(binaryPath, args);
+    return parseWhisperOutput(result);
+  } finally {
+    try {
+      if (existsSync(wavPath)) unlinkSync(wavPath);
+    } catch {}
+  }
+}
+
+function runWhisperProcess(
+  binaryPath: string,
+  args: string[],
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(binaryPath, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 120_000,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on("error", (err) => {
+      reject(new Error(`Failed to start whisper.cpp: ${err.message}`));
+    });
+
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        const detail = stderr.trim() || stdout.trim() || `exit code ${code}`;
+        reject(new Error(`whisper.cpp failed: ${detail}`));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+interface WhisperJsonOutput {
+  transcription?: Array<{
+    timestamps: { from: string; to: string };
+    offsets: { from: number; to: number };
+    text: string;
+  }>;
+}
+
+function parseTimestamp(ts: string): number {
+  const parts = ts.replace(",", ".").split(":");
+  if (parts.length === 3) {
+    const h = Number.parseFloat(parts[0]);
+    const m = Number.parseFloat(parts[1]);
+    const s = Number.parseFloat(parts[2]);
+    return h * 3600 + m * 60 + s;
+  }
+  return 0;
+}
+
+function parseWhisperOutput(raw: string): TranscribeResult {
+  const trimmed = raw.trim();
+
+  try {
+    const json = JSON.parse(trimmed) as WhisperJsonOutput;
+    if (json.transcription && Array.isArray(json.transcription)) {
+      const segments = json.transcription.map((seg) => ({
+        text: seg.text.trim(),
+        startSecond: seg.offsets
+          ? seg.offsets.from / 1000
+          : parseTimestamp(seg.timestamps.from),
+        endSecond: seg.offsets
+          ? seg.offsets.to / 1000
+          : parseTimestamp(seg.timestamps.to),
+      }));
+
+      const text = segments
+        .map((s) => s.text)
+        .join(" ")
+        .trim();
+      const durationInSeconds =
+        segments.length > 0
+          ? segments[segments.length - 1].endSecond
+          : undefined;
+
+      return { text, segments, durationInSeconds };
+    }
+  } catch {}
+
+  const text = trimmed
+    .split("\n")
+    .map((line) => {
+      return line.replace(/^\[[\d:.,\s\->]+\]\s*/, "").trim();
+    })
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return { text };
+}

--- a/apps/server/src/lib/whisper/transcribe.ts
+++ b/apps/server/src/lib/whisper/transcribe.ts
@@ -50,6 +50,12 @@ export async function transcribeWithWhisper(
       wavPath,
       "--output-json-full",
       "--no-prints",
+      "--no-fallback",
+      "--beam-size",
+      "1",
+      "--best-of",
+      "1",
+      "--no-timestamps",
     ];
 
     if (opts.language && opts.language !== "auto") {

--- a/apps/server/src/lib/whisper/transcribe.ts
+++ b/apps/server/src/lib/whisper/transcribe.ts
@@ -48,7 +48,6 @@ export async function transcribeWithWhisper(
       modelPath,
       "--file",
       wavPath,
-      "--output-json-full",
       "--no-prints",
       "--no-fallback",
       "--beam-size",
@@ -107,59 +106,11 @@ function runWhisperProcess(
   });
 }
 
-interface WhisperJsonOutput {
-  transcription?: Array<{
-    timestamps: { from: string; to: string };
-    offsets: { from: number; to: number };
-    text: string;
-  }>;
-}
-
-function parseTimestamp(ts: string): number {
-  const parts = ts.replace(",", ".").split(":");
-  if (parts.length === 3) {
-    const h = Number.parseFloat(parts[0]);
-    const m = Number.parseFloat(parts[1]);
-    const s = Number.parseFloat(parts[2]);
-    return h * 3600 + m * 60 + s;
-  }
-  return 0;
-}
-
 function parseWhisperOutput(raw: string): TranscribeResult {
-  const trimmed = raw.trim();
-
-  try {
-    const json = JSON.parse(trimmed) as WhisperJsonOutput;
-    if (json.transcription && Array.isArray(json.transcription)) {
-      const segments = json.transcription.map((seg) => ({
-        text: seg.text.trim(),
-        startSecond: seg.offsets
-          ? seg.offsets.from / 1000
-          : parseTimestamp(seg.timestamps.from),
-        endSecond: seg.offsets
-          ? seg.offsets.to / 1000
-          : parseTimestamp(seg.timestamps.to),
-      }));
-
-      const text = segments
-        .map((s) => s.text)
-        .join(" ")
-        .trim();
-      const durationInSeconds =
-        segments.length > 0
-          ? segments[segments.length - 1].endSecond
-          : undefined;
-
-      return { text, segments, durationInSeconds };
-    }
-  } catch {}
-
-  const text = trimmed
+  const text = raw
+    .trim()
     .split("\n")
-    .map((line) => {
-      return line.replace(/^\[[\d:.,\s\->]+\]\s*/, "").trim();
-    })
+    .map((line) => line.replace(/^\[[\d:.,\s\->]+\]\s*/, "").trim())
     .filter(Boolean)
     .join(" ")
     .trim();

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -1,5 +1,10 @@
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
+import {
+  WHISPER_MODELS,
+  WHISPER_PROVIDER_ID,
+} from "../lib/whisper/constants.js";
+import { getModelStatus } from "../lib/whisper/models.js";
 
 interface AvailableModel {
   provider_id: string;
@@ -52,6 +57,20 @@ async function fetchLocalLlmModels(): Promise<AvailableModel[]> {
 
 // Speech-to-text model families from models.dev
 const STT_FAMILIES = new Set(["whisper", "deepgram"]);
+
+// Local Whisper voice models (generated from constants)
+const LOCAL_WHISPER_VOICE_MODELS: AvailableModel[] = WHISPER_MODELS.map(
+  (m) => ({
+    provider_id: WHISPER_PROVIDER_ID,
+    provider_name: "Local Whisper",
+    model_id: `${WHISPER_PROVIDER_ID}/${m.id}`,
+    model_name: `${m.displayName} (Local)`,
+    family: "whisper-local",
+    type: "voice" as const,
+    cost_input: 0,
+    cost_output: 0,
+  }),
+);
 
 // Hardcoded transcription models for providers missing from models.dev registry
 const BUILTIN_VOICE_MODELS: AvailableModel[] = [
@@ -245,6 +264,15 @@ const models = new Hono()
 
       // Add builtin voice models
       available.push(...BUILTIN_VOICE_MODELS);
+
+      // Add local whisper voice models (only those that are downloaded)
+      for (const whisperModel of LOCAL_WHISPER_VOICE_MODELS) {
+        const modelId = whisperModel.model_id.split("/")[1];
+        const status = getModelStatus(modelId);
+        if (status?.status === "ready") {
+          available.push(whisperModel);
+        }
+      }
 
       try {
         const localModels = await fetchLocalLlmModels();

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -21,6 +21,8 @@ const stream = new Hono().get(
     let voiceDefaults: { provider: string; model_id: string } | null = null;
     let appContext: string | null = null;
     let audioDurationMs = 0;
+    let reconnectAttempts = 0;
+    const MAX_RECONNECT_ATTEMPTS = 3;
 
     function connectUpstream(ws: {
       send: (data: string) => void;
@@ -91,6 +93,7 @@ const stream = new Hono().get(
         prompt,
         callbacks: {
           onReady: (model) => {
+            reconnectAttempts = 0;
             ws.send(JSON.stringify({ type: "session.ready", model }));
           },
           onPartial: (text) => {
@@ -178,7 +181,8 @@ const stream = new Hono().get(
           },
           onClose: () => {
             upstream = null;
-            if (!closed) {
+            if (!closed && reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+              reconnectAttempts++;
               try {
                 connectUpstream(ws);
               } catch {}
@@ -245,6 +249,7 @@ const stream = new Hono().get(
             sessionStartTime = Date.now();
             audioDurationMs = 0;
             appContext = null;
+            reconnectAttempts = 0;
             if (!upstream) {
               try {
                 connectUpstream(ws);

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -58,13 +58,6 @@ const stream = new Hono().get(
         defaults.voice.model_id,
       );
 
-      console.log(
-        "[debug:stream] connectUpstream provider:",
-        defaults.voice.provider,
-        "canStream:",
-        canStream,
-      );
-
       ws.send(
         JSON.stringify({
           type: "config",
@@ -253,7 +246,6 @@ const stream = new Hono().get(
             appContext = msg.context ?? null;
             break;
           case "start":
-            console.log("[debug:stream] start msg, upstream:", !!upstream);
             sessionStartTime = Date.now();
             audioDurationMs = 0;
             appContext = null;
@@ -265,12 +257,6 @@ const stream = new Hono().get(
             }
             break;
           case "commit":
-            console.log(
-              "[debug:stream] commit msg, upstream:",
-              !!upstream,
-              "audioDurationMs:",
-              msg.audioDurationMs,
-            );
             if (msg.audioDurationMs && msg.audioDurationMs > 0) {
               audioDurationMs = msg.audioDurationMs;
             }

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -58,15 +58,6 @@ const stream = new Hono().get(
         defaults.voice.model_id,
       );
 
-      console.log(
-        "[stream] provider:",
-        defaults.voice.provider,
-        "model:",
-        defaults.voice.model_id,
-        "canStream:",
-        canStream,
-      );
-
       ws.send(
         JSON.stringify({
           type: "config",
@@ -76,7 +67,6 @@ const stream = new Hono().get(
       );
 
       if (!canStream) {
-        console.log("[stream] streaming not supported, closing WS");
         ws.close();
         return;
       }

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -86,7 +86,7 @@ const stream = new Hono().get(
         attributes: { provider: defaults.voice.provider },
       });
 
-      const session = openStreamingSession({
+      upstream = openStreamingSession({
         providerId: defaults.voice.provider,
         apiKey,
         model: defaults.voice.model_id,
@@ -177,10 +177,9 @@ const stream = new Hono().get(
           },
           onError: (message) => {
             ws.send(JSON.stringify({ type: "error", message }));
-            if (upstream === session) upstream = null;
+            upstream = null;
           },
           onClose: () => {
-            if (upstream !== session) return;
             upstream = null;
             if (!closed && reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
               reconnectAttempts++;
@@ -191,7 +190,6 @@ const stream = new Hono().get(
           },
         },
       });
-      upstream = session;
     }
 
     return {
@@ -247,23 +245,17 @@ const stream = new Hono().get(
           case "context":
             appContext = msg.context ?? null;
             break;
-          case "start": {
+          case "start":
             sessionStartTime = Date.now();
             audioDurationMs = 0;
             appContext = null;
             reconnectAttempts = 0;
-            const stale = upstream;
-            upstream = null;
-            if (stale) {
+            if (!upstream) {
               try {
-                stale.close();
+                connectUpstream(ws);
               } catch {}
             }
-            try {
-              connectUpstream(ws);
-            } catch {}
             break;
-          }
           case "commit":
             if (msg.audioDurationMs && msg.audioDurationMs > 0) {
               audioDurationMs = msg.audioDurationMs;

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -58,6 +58,13 @@ const stream = new Hono().get(
         defaults.voice.model_id,
       );
 
+      console.log(
+        "[debug:stream] connectUpstream provider:",
+        defaults.voice.provider,
+        "canStream:",
+        canStream,
+      );
+
       ws.send(
         JSON.stringify({
           type: "config",
@@ -246,6 +253,7 @@ const stream = new Hono().get(
             appContext = msg.context ?? null;
             break;
           case "start":
+            console.log("[debug:stream] start msg, upstream:", !!upstream);
             sessionStartTime = Date.now();
             audioDurationMs = 0;
             appContext = null;
@@ -257,6 +265,12 @@ const stream = new Hono().get(
             }
             break;
           case "commit":
+            console.log(
+              "[debug:stream] commit msg, upstream:",
+              !!upstream,
+              "audioDurationMs:",
+              msg.audioDurationMs,
+            );
             if (msg.audioDurationMs && msg.audioDurationMs > 0) {
               audioDurationMs = msg.audioDurationMs;
             }

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -86,7 +86,7 @@ const stream = new Hono().get(
         attributes: { provider: defaults.voice.provider },
       });
 
-      upstream = openStreamingSession({
+      const session = openStreamingSession({
         providerId: defaults.voice.provider,
         apiKey,
         model: defaults.voice.model_id,
@@ -177,9 +177,10 @@ const stream = new Hono().get(
           },
           onError: (message) => {
             ws.send(JSON.stringify({ type: "error", message }));
-            upstream = null;
+            if (upstream === session) upstream = null;
           },
           onClose: () => {
+            if (upstream !== session) return;
             upstream = null;
             if (!closed && reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
               reconnectAttempts++;
@@ -190,6 +191,7 @@ const stream = new Hono().get(
           },
         },
       });
+      upstream = session;
     }
 
     return {
@@ -245,17 +247,23 @@ const stream = new Hono().get(
           case "context":
             appContext = msg.context ?? null;
             break;
-          case "start":
+          case "start": {
             sessionStartTime = Date.now();
             audioDurationMs = 0;
             appContext = null;
             reconnectAttempts = 0;
-            if (!upstream) {
+            const stale = upstream;
+            upstream = null;
+            if (stale) {
               try {
-                connectUpstream(ws);
+                stale.close();
               } catch {}
             }
+            try {
+              connectUpstream(ws);
+            } catch {}
             break;
+          }
           case "commit":
             if (msg.audioDurationMs && msg.audioDurationMs > 0) {
               audioDurationMs = msg.audioDurationMs;

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -58,6 +58,15 @@ const stream = new Hono().get(
         defaults.voice.model_id,
       );
 
+      console.log(
+        "[stream] provider:",
+        defaults.voice.provider,
+        "model:",
+        defaults.voice.model_id,
+        "canStream:",
+        canStream,
+      );
+
       ws.send(
         JSON.stringify({
           type: "config",
@@ -67,6 +76,7 @@ const stream = new Hono().get(
       );
 
       if (!canStream) {
+        console.log("[stream] streaming not supported, closing WS");
         ws.close();
         return;
       }

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -39,14 +39,7 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   const defaults = getDefaultModels();
-  console.log(
-    "[transcribe] provider:",
-    defaults.voice?.provider,
-    "model:",
-    defaults.voice?.model_id,
-  );
   if (!defaults.voice) {
-    console.error("[transcribe] no voice model configured");
     return c.json(
       {
         error: "No voice model configured. Go to Settings > Models to add one.",
@@ -64,15 +57,7 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   const language = langSetting?.value || undefined;
 
   const provider = getProvider(defaults.voice.provider);
-  console.log(
-    "[transcribe] resolved provider:",
-    provider?.providerId ?? "null",
-  );
   if (!provider) {
-    console.error(
-      "[transcribe] unsupported provider:",
-      defaults.voice.provider,
-    );
     return c.json(
       {
         error: `Unsupported transcription provider: ${defaults.voice.provider}`,
@@ -82,7 +67,6 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   const apiKey = getApiKeyForProvider(defaults.voice.provider);
-  console.log("[transcribe] apiKey:", apiKey ? "(present)" : "null");
   if (!apiKey) {
     return c.json(
       {
@@ -93,10 +77,6 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   try {
-    console.log(
-      "[transcribe] calling provider.transcribe, audioData size:",
-      audioData.length,
-    );
     const result = await provider.transcribe({
       audio: audioData,
       model: defaults.voice.model_id,
@@ -104,9 +84,12 @@ const transcribeRoute = new Hono().post("/", async (c) => {
       ...(language ? { language } : {}),
     });
     rawText = result.text;
-    console.log("[transcribe] rawText:", JSON.stringify(rawText).slice(0, 200));
+    if (process.env.NODE_ENV !== "production") {
+      console.log(
+        `[transcribe] rawText=${JSON.stringify(rawText)}, audioDurationMs=${audioDurationMs}`,
+      );
+    }
   } catch (err) {
-    console.error("[transcribe] provider.transcribe threw:", err);
     captureException(err);
     metrics.count("transcription.error", 1, {
       attributes: { provider: defaults.voice.provider },

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -7,7 +7,6 @@ import { getProvider } from "../lib/streaming/registry.js";
 import { getApiKeyForProvider } from "../lib/streaming-stt.js";
 
 const transcribeRoute = new Hono().post("/", async (c) => {
-  console.log("[debug:transcribe] POST /api/transcribe received");
   const start = Date.now();
 
   const contentType = c.req.header("content-type") ?? "";
@@ -40,14 +39,6 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   const defaults = getDefaultModels();
-  console.log(
-    "[debug:transcribe] provider:",
-    defaults.voice?.provider,
-    "model:",
-    defaults.voice?.model_id,
-    "audioSize:",
-    audioData.length,
-  );
   if (!defaults.voice) {
     return c.json(
       {
@@ -86,7 +77,6 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   try {
-    console.log("[debug:transcribe] calling provider.transcribe()");
     const result = await provider.transcribe({
       audio: audioData,
       model: defaults.voice.model_id,
@@ -94,13 +84,12 @@ const transcribeRoute = new Hono().post("/", async (c) => {
       ...(language ? { language } : {}),
     });
     rawText = result.text;
-    console.log(
-      "[debug:transcribe] success, text:",
-      JSON.stringify(rawText).slice(0, 150),
-    );
+    if (process.env.NODE_ENV !== "production") {
+      console.log(
+        `[transcribe] rawText=${JSON.stringify(rawText)}, audioDurationMs=${audioDurationMs}`,
+      );
+    }
   } catch (err) {
-    console.error("[debug:transcribe] error:", err);
-
     captureException(err);
     metrics.count("transcription.error", 1, {
       attributes: { provider: defaults.voice.provider },

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -7,6 +7,7 @@ import { getProvider } from "../lib/streaming/registry.js";
 import { getApiKeyForProvider } from "../lib/streaming-stt.js";
 
 const transcribeRoute = new Hono().post("/", async (c) => {
+  console.log("[debug:transcribe] POST /api/transcribe received");
   const start = Date.now();
 
   const contentType = c.req.header("content-type") ?? "";
@@ -39,6 +40,14 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   const defaults = getDefaultModels();
+  console.log(
+    "[debug:transcribe] provider:",
+    defaults.voice?.provider,
+    "model:",
+    defaults.voice?.model_id,
+    "audioSize:",
+    audioData.length,
+  );
   if (!defaults.voice) {
     return c.json(
       {
@@ -77,6 +86,7 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   try {
+    console.log("[debug:transcribe] calling provider.transcribe()");
     const result = await provider.transcribe({
       audio: audioData,
       model: defaults.voice.model_id,
@@ -84,12 +94,13 @@ const transcribeRoute = new Hono().post("/", async (c) => {
       ...(language ? { language } : {}),
     });
     rawText = result.text;
-    if (process.env.NODE_ENV !== "production") {
-      console.log(
-        `[transcribe] rawText=${JSON.stringify(rawText)}, audioDurationMs=${audioDurationMs}`,
-      );
-    }
+    console.log(
+      "[debug:transcribe] success, text:",
+      JSON.stringify(rawText).slice(0, 150),
+    );
   } catch (err) {
+    console.error("[debug:transcribe] error:", err);
+
     captureException(err);
     metrics.count("transcription.error", 1, {
       attributes: { provider: defaults.voice.provider },

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -76,7 +76,10 @@ const transcribeRoute = new Hono().post("/", async (c) => {
     );
   }
 
+  const isDev = process.env.NODE_ENV !== "production";
+
   try {
+    const t0 = Date.now();
     const result = await provider.transcribe({
       audio: audioData,
       model: defaults.voice.model_id,
@@ -84,9 +87,9 @@ const transcribeRoute = new Hono().post("/", async (c) => {
       ...(language ? { language } : {}),
     });
     rawText = result.text;
-    if (process.env.NODE_ENV !== "production") {
+    if (isDev) {
       console.log(
-        `[transcribe] rawText=${JSON.stringify(rawText)}, audioDurationMs=${audioDurationMs}`,
+        `[transcribe] STT took ${Date.now() - t0}ms | rawText=${JSON.stringify(rawText).slice(0, 120)}`,
       );
     }
   } catch (err) {
@@ -161,7 +164,13 @@ const transcribeRoute = new Hono().post("/", async (c) => {
     });
   }
 
+  const ppStart = Date.now();
   const pp = await postProcess(rawText, appContext);
+  if (isDev) {
+    console.log(
+      `[transcribe] post-process took ${Date.now() - ppStart}ms | cleaned=${JSON.stringify(pp.cleaned).slice(0, 120)}`,
+    );
+  }
 
   Promise.resolve()
     .then(() => {
@@ -186,6 +195,10 @@ const transcribeRoute = new Hono().post("/", async (c) => {
     .catch((err) => {
       console.error("Failed to save history:", err);
     });
+
+  if (isDev) {
+    console.log(`[transcribe] total ${Date.now() - start}ms`);
+  }
 
   return c.json({
     raw: rawText,

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -39,7 +39,14 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   const defaults = getDefaultModels();
+  console.log(
+    "[transcribe] provider:",
+    defaults.voice?.provider,
+    "model:",
+    defaults.voice?.model_id,
+  );
   if (!defaults.voice) {
+    console.error("[transcribe] no voice model configured");
     return c.json(
       {
         error: "No voice model configured. Go to Settings > Models to add one.",
@@ -57,7 +64,15 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   const language = langSetting?.value || undefined;
 
   const provider = getProvider(defaults.voice.provider);
+  console.log(
+    "[transcribe] resolved provider:",
+    provider?.providerId ?? "null",
+  );
   if (!provider) {
+    console.error(
+      "[transcribe] unsupported provider:",
+      defaults.voice.provider,
+    );
     return c.json(
       {
         error: `Unsupported transcription provider: ${defaults.voice.provider}`,
@@ -67,6 +82,7 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   const apiKey = getApiKeyForProvider(defaults.voice.provider);
+  console.log("[transcribe] apiKey:", apiKey ? "(present)" : "null");
   if (!apiKey) {
     return c.json(
       {
@@ -77,6 +93,10 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   try {
+    console.log(
+      "[transcribe] calling provider.transcribe, audioData size:",
+      audioData.length,
+    );
     const result = await provider.transcribe({
       audio: audioData,
       model: defaults.voice.model_id,
@@ -84,12 +104,9 @@ const transcribeRoute = new Hono().post("/", async (c) => {
       ...(language ? { language } : {}),
     });
     rawText = result.text;
-    if (process.env.NODE_ENV !== "production") {
-      console.log(
-        `[transcribe] rawText=${JSON.stringify(rawText)}, audioDurationMs=${audioDurationMs}`,
-      );
-    }
+    console.log("[transcribe] rawText:", JSON.stringify(rawText).slice(0, 200));
   } catch (err) {
+    console.error("[transcribe] provider.transcribe threw:", err);
     captureException(err);
     metrics.count("transcription.error", 1, {
       attributes: { provider: defaults.voice.provider },

--- a/apps/server/src/routes/whisper.ts
+++ b/apps/server/src/routes/whisper.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono";
+import {
+  isBinaryAvailable,
+  isServerBinaryAvailable,
+} from "../lib/whisper/binary.js";
+import { getModelsDir, WHISPER_MODELS } from "../lib/whisper/constants.js";
+import {
+  cancelDownload,
+  clearDownloadError,
+  deleteModel,
+  downloadModel,
+  getAllModelStatuses,
+  getModelStatus,
+} from "../lib/whisper/models.js";
+import { isServerRunning, stopServer } from "../lib/whisper/server.js";
+
+const whisper = new Hono()
+  .get("/status", (c) => {
+    return c.json({
+      binaryAvailable: isBinaryAvailable(),
+      serverBinaryAvailable: isServerBinaryAvailable(),
+      serverRunning: isServerRunning(),
+      modelsDir: getModelsDir(),
+      models: getAllModelStatuses(),
+      modelDefinitions: WHISPER_MODELS.map((m) => ({
+        id: m.id,
+        displayName: m.displayName,
+        sizeBytes: m.sizeBytes,
+        ramRequired: m.ramRequired,
+        speed: m.speed,
+        quality: m.quality,
+      })),
+    });
+  })
+  .post("/models/:model/download", async (c) => {
+    const modelId = c.req.param("model");
+
+    const status = getModelStatus(modelId);
+    if (!status) {
+      return c.json({ error: `Unknown model: ${modelId}` }, 400);
+    }
+
+    if (status.status === "ready") {
+      return c.json({ ok: true, message: "Model already downloaded" });
+    }
+
+    if (status.status === "downloading") {
+      return c.json({ ok: true, message: "Download already in progress" });
+    }
+
+    clearDownloadError(modelId);
+
+    downloadModel(modelId).catch(() => {});
+
+    return c.json({ ok: true, message: "Download started" });
+  })
+  .post("/models/:model/cancel", (c) => {
+    const modelId = c.req.param("model");
+    const cancelled = cancelDownload(modelId);
+    return c.json({ ok: cancelled });
+  })
+  .delete("/models/:model", (c) => {
+    const modelId = c.req.param("model");
+    const deleted = deleteModel(modelId);
+    return c.json({ ok: deleted });
+  })
+  .post("/server/stop", async (c) => {
+    await stopServer();
+    return c.json({ ok: true });
+  });
+
+export default whisper;

--- a/apps/server/src/routes/whisper.ts
+++ b/apps/server/src/routes/whisper.ts
@@ -1,9 +1,15 @@
 import { Hono } from "hono";
+import { getDefaultModels } from "../lib/providers.js";
+import { stripProviderPrefix } from "../lib/streaming/types.js";
 import {
   isBinaryAvailable,
   isServerBinaryAvailable,
 } from "../lib/whisper/binary.js";
-import { getModelsDir, WHISPER_MODELS } from "../lib/whisper/constants.js";
+import {
+  getModelsDir,
+  WHISPER_MODELS,
+  WHISPER_PROVIDER_ID,
+} from "../lib/whisper/constants.js";
 import {
   cancelDownload,
   clearDownloadError,
@@ -13,7 +19,12 @@ import {
   getModelStatus,
   isBinaryDownloading,
 } from "../lib/whisper/models.js";
-import { isServerRunning, stopServer } from "../lib/whisper/server.js";
+import {
+  isServerFailed,
+  isServerRunning,
+  startInBackground,
+  stopServer,
+} from "../lib/whisper/server.js";
 
 const whisper = new Hono()
   .get("/status", (c) => {
@@ -22,6 +33,7 @@ const whisper = new Hono()
       binaryDownloading: isBinaryDownloading(),
       serverBinaryAvailable: isServerBinaryAvailable(),
       serverRunning: isServerRunning(),
+      serverFailed: isServerFailed(),
       modelsDir: getModelsDir(),
       models: getAllModelStatuses(),
       modelDefinitions: WHISPER_MODELS.map((m) => ({
@@ -31,6 +43,7 @@ const whisper = new Hono()
         ramRequired: m.ramRequired,
         speed: m.speed,
         quality: m.quality,
+        quantized: m.quantized,
       })),
     });
   })
@@ -66,9 +79,39 @@ const whisper = new Hono()
     const deleted = deleteModel(modelId);
     return c.json({ ok: deleted });
   })
+  .post("/server/start", async (c) => {
+    const body = await c.req
+      .json<{ modelId?: string }>()
+      .catch(() => ({ modelId: undefined }));
+    let modelId = body.modelId;
+
+    if (!modelId) {
+      const defaults = getDefaultModels();
+      if (defaults.voice?.provider === WHISPER_PROVIDER_ID) {
+        modelId = stripProviderPrefix(defaults.voice.model_id);
+      }
+    }
+
+    if (!modelId) {
+      return c.json({ error: "No model specified" }, 400);
+    }
+
+    startInBackground(modelId);
+    return c.json({ ok: true });
+  })
   .post("/server/stop", async (c) => {
     await stopServer();
     return c.json({ ok: true });
   });
 
 export default whisper;
+
+export function autoStartWhisperServer(): void {
+  const defaults = getDefaultModels();
+  if (defaults.voice?.provider !== WHISPER_PROVIDER_ID) return;
+  if (!isBinaryAvailable() && !isServerBinaryAvailable()) return;
+
+  const modelId = stripProviderPrefix(defaults.voice.model_id);
+  console.log("[whisper] Auto-starting server for model:", modelId);
+  startInBackground(modelId);
+}

--- a/apps/server/src/routes/whisper.ts
+++ b/apps/server/src/routes/whisper.ts
@@ -107,11 +107,30 @@ const whisper = new Hono()
 export default whisper;
 
 export function autoStartWhisperServer(): void {
-  const defaults = getDefaultModels();
-  if (defaults.voice?.provider !== WHISPER_PROVIDER_ID) return;
-  if (!isBinaryAvailable() && !isServerBinaryAvailable()) return;
+  try {
+    const defaults = getDefaultModels();
+    if (defaults.voice?.provider !== WHISPER_PROVIDER_ID) return;
 
-  const modelId = stripProviderPrefix(defaults.voice.model_id);
-  console.log("[whisper] Auto-starting server for model:", modelId);
-  startInBackground(modelId);
+    const hasCli = isBinaryAvailable();
+    const hasServer = isServerBinaryAvailable();
+    if (!hasCli && !hasServer) return;
+
+    const modelId = stripProviderPrefix(defaults.voice.model_id);
+
+    if (!hasServer) {
+      if (process.env.NODE_ENV !== "production") {
+        console.log(
+          "[whisper] whisper-server binary not found, skipping auto-start (CLI will be used)",
+        );
+      }
+      return;
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+      console.log("[whisper] Auto-starting server for model:", modelId);
+    }
+    startInBackground(modelId);
+  } catch {
+    // DB not ready or other init issue — silently skip
+  }
 }

--- a/apps/server/src/routes/whisper.ts
+++ b/apps/server/src/routes/whisper.ts
@@ -11,6 +11,7 @@ import {
   downloadModel,
   getAllModelStatuses,
   getModelStatus,
+  isBinaryDownloading,
 } from "../lib/whisper/models.js";
 import { isServerRunning, stopServer } from "../lib/whisper/server.js";
 
@@ -18,6 +19,7 @@ const whisper = new Hono()
   .get("/status", (c) => {
     return c.json({
       binaryAvailable: isBinaryAvailable(),
+      binaryDownloading: isBinaryDownloading(),
       serverBinaryAvailable: isServerBinaryAvailable(),
       serverRunning: isServerRunning(),
       modelsDir: getModelsDir(),


### PR DESCRIPTION
## Summary
- Adds privacy-first local speech-to-text via bundled whisper.cpp binaries (macOS, Windows, Linux)
- Server-owned model download lifecycle with progress tracking, cancel, and retry — UI just polls `/api/whisper/status`
- New `local-whisper` transcription provider implementing the existing `TranscriptionProvider` interface with both batch (CLI) and streaming (whisper-server HTTP) paths

## Testing
- Server package type-checks cleanly (`tsc --noEmit`)
- Biome lint/format passes
- Pre-commit hooks pass
- No new type errors introduced in renderer (all errors are pre-existing Hono RPC client resolution)

<!--
## Plan

### Architecture
- whisper.cpp binary bundled in `resources/whisper/<platform>-<arch>/` via electron-builder extraResources
- GGML models downloaded from Hugging Face to `~/.cache/freestyle/whisper-models/`
- New `WhisperLocalTranscriptionProvider` implements `TranscriptionProvider` interface
- `getApiKeyForProvider()` returns `"local"` sentinel for local providers
- Server manages download state in memory; UI polls for status

### New files (server)
- `lib/whisper/constants.ts` — model definitions, binary names, paths
- `lib/whisper/binary.ts` — locate bundled whisper-cli and whisper-server
- `lib/whisper/models.ts` — download manager with progress, cancel, retry, delete
- `lib/whisper/transcribe.ts` — spawn whisper-cli for batch transcription
- `lib/whisper/server.ts` — whisper-server process lifecycle
- `lib/streaming/providers/whisper-local.ts` — TranscriptionProvider implementation
- `routes/whisper.ts` — GET /status, POST /download, POST /cancel, DELETE /model, POST /server/stop

### Modified files
- `streaming/registry.ts` — register WhisperLocalTranscriptionProvider
- `streaming-stt.ts` — return "local" API key for local STT providers
- `routes/models.ts` — include downloaded local whisper models in available list
- `index.ts` — register /api/whisper route
- `models.tsx` — LocalWhisperSection UI with download progress, model selection
- `electron-builder.yml` — per-platform whisper binary extraResources
- `package.json` — download:whisper-cpp scripts
- `.gitignore` — ignore downloaded whisper binaries

### Review fixes applied
- Fixed server.ts close handler that always rejected (checked serverReady after resetting it)
- Fixed server.ts stopServer kill timeout leak (clearTimeout on close)
- Fixed whisper-local.ts using non-existent WebSocket endpoint (switched to HTTP POST /inference)
- Fixed whisper-local.ts commit() silently dropping when server not ready (deferred commit with flag)
- Fixed models.ts download guard blocking retries after error (check error state)
- Fixed transcribe.ts --output-json (changed to --output-json-full for stdout)
- Fixed models.tsx hardcoded port 4649 (use getApiBase())
- Fixed electron-builder.yml platform variable mismatch (per-platform extraResources)
- Fixed linux-arm64 in constants but missing from download script (removed)
- Added missing Buffer import in models.ts
- Added error handling in download script's stream reader
- Removed unused isLocalSttProvider export
- Removed 15+ sloppy comments that narrated obvious code
-->