### PR TITLE
fix: make ui reponsive in all pages

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -217,6 +217,8 @@ function createSettingsWindow(): void {
   settingsWindow = new BrowserWindow({
     width: 800,
     height: 560,
+    minWidth: 720,
+    minHeight: 480,
     show: false,
     autoHideMenuBar: true,
     titleBarStyle: process.platform === "darwin" ? "hiddenInset" : "default",

--- a/apps/electron/src/renderer/src/dashboard.tsx
+++ b/apps/electron/src/renderer/src/dashboard.tsx
@@ -27,7 +27,7 @@ import { BrowserRouter, Navigate, Outlet, Route, Routes } from "react-router";
 
 function PagePad(): React.JSX.Element {
   return (
-    <div className="px-12 py-9">
+    <div className="responsive-route-pad">
       <Outlet />
     </div>
   );

--- a/apps/electron/src/renderer/src/globals.css
+++ b/apps/electron/src/renderer/src/globals.css
@@ -134,12 +134,14 @@
   * {
     @apply border-border outline-ring/50;
   }
+
   html,
   body,
   #root {
     height: 100%;
     margin: 0;
   }
+
   body {
     @apply text-foreground;
     background: transparent;
@@ -150,9 +152,11 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+
   ::selection {
     background-color: rgba(107, 143, 18, 0.25);
   }
+
   button:not(:disabled) {
     cursor: pointer;
   }
@@ -173,4 +177,55 @@
 
 .mono {
   font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
+}
+
+@layer components {
+  .responsive-route-pad {
+    padding: 2.25rem 3rem;
+  }
+
+  .responsive-page-scroll {
+    padding-inline: 3rem;
+    padding-bottom: 3rem;
+  }
+
+  .responsive-standalone-pad {
+    padding-inline: 1.5rem;
+  }
+
+  .dictionary-entry-row {
+    grid-template-columns: minmax(120px, 180px) minmax(0, 1fr) 90px 70px;
+  }
+
+  @media (max-width: 1080px) {
+    .responsive-route-pad {
+      padding: 2rem;
+    }
+
+    .responsive-page-scroll {
+      padding-inline: 2rem;
+      padding-bottom: 2rem;
+    }
+  }
+
+  @media (max-width: 900px) {
+    .dictionary-entry-row {
+      grid-template-columns: minmax(0, 1fr) auto;
+    }
+  }
+
+  @media (max-width: 820px) {
+    .responsive-route-pad {
+      padding: 1.5rem 1rem;
+    }
+
+    .responsive-page-scroll {
+      padding-inline: 1rem;
+      padding-bottom: 1.5rem;
+    }
+
+    .responsive-standalone-pad {
+      padding-inline: 1rem;
+    }
+  }
 }

--- a/apps/electron/src/renderer/src/hooks/use-mobile.ts
+++ b/apps/electron/src/renderer/src/hooks/use-mobile.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-const MOBILE_BREAKPOINT = 768;
+const MOBILE_BREAKPOINT = 820;
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -195,7 +195,7 @@ export default function OnboardingPage(): React.JSX.Element {
         />
       )}
       <div className="flex flex-1 items-center justify-center">
-        <div className="w-full max-w-md space-y-8 px-6">
+        <div className="responsive-standalone-pad w-full max-w-md space-y-8">
           {/* Logo */}
           <div className="flex flex-col items-center gap-3">
             <img

--- a/apps/electron/src/renderer/src/pages/settings/dictionary.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/dictionary.tsx
@@ -191,7 +191,7 @@ export default function DictionaryPage(): React.JSX.Element {
     >
       <div className="h-9 shrink-0" />
       <div
-        className="flex-1 overflow-auto px-12 pb-12"
+        className="responsive-page-scroll flex-1 overflow-auto"
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
         <PageHeader
@@ -209,8 +209,8 @@ export default function DictionaryPage(): React.JSX.Element {
         ) : (
           <>
             {/* Search + Actions */}
-            <div className="mb-5 flex items-center gap-2.5">
-              <div className="border-border bg-card flex flex-1 items-center gap-2 rounded-lg border px-3 py-2">
+            <div className="mb-5 flex flex-col items-start gap-2.5 min-[1080px]:flex-row min-[1080px]:items-center">
+              <div className="border-border bg-card flex min-w-0 flex-1 items-center gap-2 self-stretch rounded-lg border px-3 py-2">
                 <Search className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
                 <input
                   type="text"
@@ -226,35 +226,37 @@ export default function DictionaryPage(): React.JSX.Element {
                   ⌘ K
                 </span>
               </div>
-              <ToolbarButton onClick={exportJson} title="Export as JSON">
-                <Download size={13} />
-                Export
-              </ToolbarButton>
-              <ToolbarButton
-                onClick={() => importRef.current?.click()}
-                title="Import from JSON"
-              >
-                <Upload size={13} />
-                Import
-              </ToolbarButton>
-              <input
-                ref={importRef}
-                type="file"
-                accept=".json"
-                className="hidden"
-                onChange={handleImport}
-              />
-              <button
-                type="button"
-                onClick={() => {
-                  resetForm();
-                  setShowForm(true);
-                }}
-                className="bg-primary text-primary-foreground hover:bg-primary/90 flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-2 text-[12.5px] font-medium"
-              >
-                <Plus size={13} />
-                Add entry
-              </button>
+              <div className="flex shrink-0 flex-wrap items-center gap-2.5">
+                <ToolbarButton onClick={exportJson} title="Export as JSON">
+                  <Download size={13} />
+                  Export
+                </ToolbarButton>
+                <ToolbarButton
+                  onClick={() => importRef.current?.click()}
+                  title="Import from JSON"
+                >
+                  <Upload size={13} />
+                  Import
+                </ToolbarButton>
+                <input
+                  ref={importRef}
+                  type="file"
+                  accept=".json"
+                  className="hidden"
+                  onChange={handleImport}
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    resetForm();
+                    setShowForm(true);
+                  }}
+                  className="bg-primary text-primary-foreground hover:bg-primary/90 flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-3 py-2 text-[12.5px] font-medium"
+                >
+                  <Plus size={13} />
+                  Add entry
+                </button>
+              </div>
             </div>
 
             {/* Add/Edit form */}
@@ -308,7 +310,7 @@ export default function DictionaryPage(): React.JSX.Element {
                 {formError && (
                   <p className="text-destructive mt-3 text-xs">{formError}</p>
                 )}
-                <div className="mt-4 flex justify-end gap-2">
+                <div className="mt-4 flex flex-wrap justify-end gap-2">
                   <button
                     type="button"
                     onClick={resetForm}
@@ -345,7 +347,7 @@ export default function DictionaryPage(): React.JSX.Element {
 
             {/* Footer · count + pagination */}
             {total > 0 && (
-              <div className="mt-3.5 flex items-center justify-between">
+              <div className="mt-3.5 flex flex-wrap items-center justify-between gap-2">
                 <span className="mono text-muted-foreground text-[11px] tracking-[0.04em]">
                   {total} {total === 1 ? "entry" : "entries"}
                 </span>
@@ -433,7 +435,7 @@ function ToolbarButton({
       type="button"
       onClick={onClick}
       title={title}
-      className="border-border text-secondary-foreground/80 hover:text-foreground flex cursor-pointer items-center gap-1.5 rounded-md border px-3 py-2 text-[12.5px] font-medium"
+      className="border-border text-secondary-foreground/80 hover:text-foreground flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border px-3 py-2 text-[12.5px] font-medium"
     >
       {children}
     </button>
@@ -474,10 +476,9 @@ function EntryRow({
   return (
     <div
       className={cn(
-        "group grid items-center gap-3.5 px-5 py-3.5",
+        "dictionary-entry-row group grid items-center gap-3.5 px-5 py-3.5",
         !isLast && "border-border/60 border-b",
       )}
-      style={{ gridTemplateColumns: "minmax(120px, 180px) 1fr 90px 70px" }}
     >
       <span
         className="mono text-foreground border-border bg-background justify-self-start truncate rounded-md border px-2 py-[3px] text-[12.5px] font-medium"
@@ -488,10 +489,10 @@ function EntryRow({
       <span className="text-secondary-foreground line-clamp-2 text-[13px] leading-[1.4]">
         {entry.value}
       </span>
-      <span className="mono text-muted-foreground text-right text-[11px]">
+      <span className="mono text-muted-foreground text-right text-[11px] max-[900px]:text-left">
         {entry.usage_count > 0 ? `${entry.usage_count}× used` : "—"}
       </span>
-      <div className="flex justify-end gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+      <div className="flex justify-end gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 max-[900px]:row-span-2 max-[900px]:opacity-100">
         <button
           type="button"
           onClick={() => onEdit(entry)}

--- a/apps/electron/src/renderer/src/pages/settings/formats.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/formats.tsx
@@ -131,7 +131,7 @@ export default function FormatsPage(): React.JSX.Element {
     >
       <div className="h-9 shrink-0" />
       <div
-        className="flex-1 overflow-auto px-12 pb-12"
+        className="responsive-page-scroll flex-1 overflow-auto"
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
         <PageHeader title="Formats" />

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -62,7 +62,7 @@ function KeyComboDisplay({
   variant?: "default" | "recording" | "dim";
 }) {
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex min-w-0 flex-wrap items-center gap-1">
       {keys.map((k, i) => (
         <span key={i} className="flex items-center gap-1">
           {i > 0 && (
@@ -369,7 +369,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
     >
       <div className="h-9 shrink-0" />
       <div
-        className="flex-1 overflow-auto px-12 pb-12"
+        className="responsive-page-scroll flex-1 overflow-auto"
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
         <div className="mb-7">
@@ -383,10 +383,10 @@ export default function GeneralSettingsPage(): React.JSX.Element {
         </div>
 
         {updateAvailable && (
-          <div className="border-primary/30 bg-primary/5 mb-6 flex items-center justify-between rounded-lg border px-4 py-3">
-            <div className="flex items-center gap-2">
+          <div className="border-primary/30 bg-primary/5 mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3">
+            <div className="flex min-w-0 items-center gap-2">
               <Download className="text-primary h-4 w-4" />
-              <span className="text-sm">
+              <span className="min-w-0 text-sm">
                 {updateDownloaded
                   ? `Version ${updateAvailable} ready to install`
                   : `Version ${updateAvailable} available`}
@@ -432,7 +432,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
               <button
                 type="button"
                 onClick={startHotkeyRecording}
-                className="border-border hover:bg-secondary inline-flex items-center gap-3 rounded-lg border px-3.5 py-2 transition-colors"
+                className="border-border hover:bg-secondary inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2 transition-colors"
               >
                 <Keyboard className="text-muted-foreground h-4 w-4 shrink-0" />
                 <KeyComboDisplay keys={formatAcceleratorKeys(hotkey)} />
@@ -441,7 +441,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
                 </span>
               </button>
             ) : recorderState === "recording" ? (
-              <div className="border-primary/60 bg-primary/5 inline-flex items-center gap-3 rounded-lg border px-3.5 py-2">
+              <div className="border-primary/60 bg-primary/5 inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2">
                 <Keyboard className="text-primary h-4 w-4 shrink-0" />
                 {liveKeys.length > 0 ? (
                   <>
@@ -464,7 +464,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
                 </button>
               </div>
             ) : (
-              <div className="border-primary/60 bg-primary/5 inline-flex items-center gap-3 rounded-lg border px-3.5 py-2">
+              <div className="border-primary/60 bg-primary/5 inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2">
                 <Keyboard className="text-primary h-4 w-4 shrink-0" />
                 <KeyComboDisplay keys={capturedKeys} variant="recording" />
                 <div className="ml-2 flex items-center gap-2">
@@ -488,14 +488,13 @@ export default function GeneralSettingsPage(): React.JSX.Element {
           </Row>
 
           <Row label="Microphone" desc="Select your audio input device.">
-            <div className="border-border bg-card text-foreground inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm">
+            <div className="border-border bg-card text-foreground flex w-full max-w-md items-center gap-2 rounded-lg border px-3 py-2 text-sm">
               <Mic className="text-muted-foreground h-4 w-4 shrink-0" />
               <select
                 id="settings-microphone"
                 value={selectedDevice}
                 onChange={(e) => handleDeviceChange(e.target.value)}
-                className="bg-transparent outline-none"
-                style={{ minWidth: 240 }}
+                className="w-full min-w-0 truncate bg-transparent pr-6 outline-none"
               >
                 <option value="">System default</option>
                 {devices.map((d) => (
@@ -508,14 +507,13 @@ export default function GeneralSettingsPage(): React.JSX.Element {
           </Row>
 
           <Row label="Language" desc="Hint for the transcription model.">
-            <div className="border-border bg-card text-foreground inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm">
+            <div className="border-border bg-card text-foreground flex w-full max-w-xs items-center gap-2 rounded-lg border px-3 py-2 text-sm">
               <Languages className="text-muted-foreground h-4 w-4 shrink-0" />
               <select
                 id="settings-language"
                 value={language}
                 onChange={(e) => handleLanguageChange(e.target.value)}
-                className="bg-transparent outline-none"
-                style={{ minWidth: 200 }}
+                className="w-full min-w-0 truncate bg-transparent pr-6 outline-none"
               >
                 <option value="auto">Auto-detect</option>
                 <option value="en">English</option>
@@ -720,17 +718,17 @@ function Row({
   return (
     <div
       className={cn(
-        "grid grid-cols-[280px_1fr] items-start gap-9 py-[22px]",
+        "grid grid-cols-1 items-start gap-3 py-[22px] min-[1080px]:grid-cols-[220px_minmax(0,1fr)] min-[1080px]:gap-8 min-[1280px]:grid-cols-[280px_minmax(0,1fr)] min-[1280px]:gap-9",
         !last && "border-border border-b",
       )}
     >
       <div>
         <div className="text-foreground text-[15px] font-medium">{label}</div>
-        <p className="text-muted-foreground mt-0.5 max-w-[260px] text-[12.5px] leading-[1.5]">
+        <p className="text-muted-foreground mt-0.5 text-[12.5px] leading-[1.5]">
           {desc}
         </p>
       </div>
-      <div>{children}</div>
+      <div className="min-w-0">{children}</div>
     </div>
   );
 }
@@ -785,7 +783,7 @@ function Segment({
   compact?: boolean;
 }) {
   return (
-    <div className="border-border bg-secondary inline-flex gap-[2px] rounded-[9px] border p-[3px]">
+    <div className="border-border bg-secondary inline-flex max-w-full flex-nowrap gap-[2px] rounded-[9px] border p-[3px]">
       {options.map((o) => {
         const isOn = o.id === active;
         const Icon = o.icon;

--- a/apps/electron/src/renderer/src/pages/settings/history.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/history.tsx
@@ -175,7 +175,7 @@ export default function HistoryPage(): React.JSX.Element {
     >
       <div className="h-9 shrink-0" />
       <div
-        className="flex-1 overflow-auto px-12 pb-12"
+        className="responsive-page-scroll flex-1 overflow-auto"
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
         <PageHeader title="History" />

--- a/apps/electron/src/renderer/src/pages/settings/models.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/models.tsx
@@ -649,7 +649,7 @@ function PageShell({
     >
       <div className="h-9 shrink-0" />
       <div
-        className="flex-1 overflow-auto px-12 pb-12"
+        className="responsive-page-scroll flex-1 overflow-auto"
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
         {children}
@@ -706,7 +706,7 @@ function PairCard({
   pickerOpen: PickerType;
 }): React.JSX.Element {
   return (
-    <section className="border-border bg-card grid grid-cols-2 gap-6 rounded-[14px] border p-6">
+    <section className="border-border bg-card grid grid-cols-1 gap-6 rounded-[14px] border p-6 min-[820px]:grid-cols-2">
       <PairSide
         kicker="Voice · required"
         modelName={voice?.model_name}
@@ -716,7 +716,7 @@ function PairCard({
         active={pickerOpen === "voice"}
         onChange={onChangeVoice}
       />
-      <div className="border-border border-l pl-6">
+      <div className="border-border border-t pt-6 min-[820px]:border-l min-[820px]:border-t-0 min-[820px]:pl-6 min-[820px]:pt-0">
         <PairSide
           kicker="LLM cleanup · optional"
           modelName={llm?.model_name}
@@ -1281,7 +1281,7 @@ function ProvidersSection({
         <button
           type="button"
           onClick={onAdd}
-          className="border-border text-foreground hover:bg-secondary flex items-center gap-1.5 rounded-[7px] border px-3 py-1.5 text-[12.5px] font-medium"
+          className="shrink-0 border-border text-foreground hover:bg-secondary flex items-center gap-1.5 rounded-[7px] border px-3 py-1.5 text-[12.5px] font-medium"
         >
           <Plus size={13} />
           Add provider

--- a/apps/electron/src/renderer/src/pages/shell.tsx
+++ b/apps/electron/src/renderer/src/pages/shell.tsx
@@ -144,7 +144,7 @@ export default function AppShell(): React.JSX.Element {
         </nav>
       </aside>
 
-      <main className="flex-1 overflow-auto">
+      <main className="min-w-0 flex-1 overflow-auto">
         <Outlet />
       </main>
     </div>

--- a/apps/electron/src/renderer/src/pages/today.tsx
+++ b/apps/electron/src/renderer/src/pages/today.tsx
@@ -195,7 +195,7 @@ export default function TodayPage(): React.JSX.Element {
         {/* macOS drag region — the title bar area */}
         <div className="h-9 shrink-0" />
         <div
-          className="flex-1 overflow-auto px-9 pb-6"
+          className="responsive-page-scroll flex-1 overflow-auto"
           style={
             {
               WebkitAppRegion: "no-drag",
@@ -213,7 +213,7 @@ export default function TodayPage(): React.JSX.Element {
               {/* "Open slot" cap — represents the next, future session. With
                   reverse-chronological order it sits above the latest entry. */}
               <div className="relative mb-5">
-                <span className="border-border bg-background absolute top-1 -left-[25px] h-2.5 w-2.5 rounded-full border-[1.5px] border-dashed" />
+                <span className="border-border bg-background absolute top-1 -left-[30px] h-2.5 w-2.5 rounded-full border-[1.5px] border-dashed" />
                 <span className="serif-italic text-muted-foreground text-[18px]">
                   ready when you are…
                 </span>


### PR DESCRIPTION
This fixes #71 

- Responsive padding added to Settings pages
- Dictionary toolbar stacks search and action buttons cleanly when narrow
- Dictionary form actions and pagination wrap properly at small widths
- Model selector card switches to stacked layout on smaller widths
- Window minimum size set to 720×480