### PR TITLE
Fix/hotkey rebinding

### DIFF
--- a/apps/electron/native/linux-key-listener.c
+++ b/apps/electron/native/linux-key-listener.c
@@ -39,6 +39,7 @@ static int g_requireAlt = 0;
 static int g_requireShift = 0;
 static int g_requireMeta = 0;
 static int g_modifiersOnly = 0;
+static int g_record_mode = 0;
 
 /* Tracked modifier state */
 static int g_ctrlDown = 0;
@@ -200,18 +201,125 @@ static void handle_signal(int sig) {
     g_running = 0;
 }
 
+static void emit_record_modifiers(void) {
+    char buf[256] = "";
+    int len = 0;
+
+    if (g_ctrlDown) {
+        len += snprintf(buf + len, sizeof(buf) - len, "%sControl", len ? "," : "");
+    }
+    if (g_altDown) {
+        len += snprintf(buf + len, sizeof(buf) - len, "%sAlt", len ? "," : "");
+    }
+    if (g_shiftDown) {
+        len += snprintf(buf + len, sizeof(buf) - len, "%sShift", len ? "," : "");
+    }
+    if (g_metaDown) {
+        len += snprintf(buf + len, sizeof(buf) - len, "%sSuper", len ? "," : "");
+    }
+
+    printf("RECORD_MODIFIERS:%s\n", buf);
+    fflush(stdout);
+}
+
+static const char *keycode_to_record_name(int code) {
+    if (code == KEY_SPACE) return "Space";
+    if (code == KEY_TAB) return "Tab";
+    if (code == KEY_ESC) return "Escape";
+    if (code == KEY_ENTER) return "Return";
+    if (code == KEY_BACKSPACE) return "Backspace";
+    if (code == KEY_DELETE) return "Delete";
+    if (code == KEY_UP) return "Up";
+    if (code == KEY_DOWN) return "Down";
+    if (code == KEY_LEFT) return "Left";
+    if (code == KEY_RIGHT) return "Right";
+    if (code == KEY_HOME) return "Home";
+    if (code == KEY_END) return "End";
+    if (code == KEY_PAGEUP) return "PageUp";
+    if (code == KEY_PAGEDOWN) return "PageDown";
+    if (code == KEY_CAPSLOCK) return "CapsLock";
+    if (code == KEY_PAUSE) return "Pause";
+    if (code == KEY_INSERT) return "Insert";
+    if (code == KEY_RIGHTALT) return "RightAlt";
+    if (code == KEY_RIGHTCTRL) return "RightControl";
+    if (code == KEY_RIGHTSHIFT) return "RightShift";
+    if (code == KEY_RIGHTMETA) return "RightSuper";
+    if (code >= KEY_F1 && code <= KEY_F12) {
+        static char fkey[8];
+        snprintf(fkey, sizeof(fkey), "F%d", code - KEY_F1 + 1);
+        return fkey;
+    }
+    if (code >= KEY_F13 && code <= KEY_F24) {
+        static char fkey[8];
+        snprintf(fkey, sizeof(fkey), "F%d", code - KEY_F13 + 13);
+        return fkey;
+    }
+    if (code >= KEY_A && code <= KEY_Z) {
+        static char letter[2];
+        letter[0] = 'A' + (code - KEY_A);
+        letter[1] = '\0';
+        return letter;
+    }
+    if (code >= KEY_0 && code <= KEY_9) {
+        static char digit[2];
+        digit[0] = '0' + (code - KEY_0);
+        digit[1] = '\0';
+        return digit;
+    }
+    return NULL;
+}
+
+static void handle_record_event(int code, int pressed) {
+    if (!pressed) return;
+
+    if (code == KEY_ESC) {
+        printf("RECORD_CANCEL\n");
+        fflush(stdout);
+        return;
+    }
+
+    int is_mod = is_ctrl(code) || is_alt(code) || is_shift(code) || is_meta(code);
+    if (is_mod) {
+        update_modifier(code, 1);
+        if (code == KEY_RIGHTALT || code == KEY_RIGHTCTRL ||
+            code == KEY_RIGHTSHIFT || code == KEY_RIGHTMETA) {
+            const char *keyName = keycode_to_record_name(code);
+            if (keyName) {
+                printf("RECORD_KEY:%s\n", keyName);
+                fflush(stdout);
+            }
+            return;
+        }
+        emit_record_modifiers();
+        return;
+    }
+
+    const char *keyName = keycode_to_record_name(code);
+    if (keyName) {
+        emit_record_modifiers();
+        printf("RECORD_KEY:%s\n", keyName);
+        fflush(stdout);
+    }
+}
+
 int main(int argc, char *argv[]) {
     if (argc < 2) {
-        fprintf(stderr, "Usage: %s <hotkey>\n", argv[0]);
-        fprintf(stderr, "Examples: %s \"Alt+Space\"  |  %s F8\n", argv[0], argv[0]);
+        fprintf(stderr, "Usage: %s <hotkey> | %s --record\n", argv[0], argv[0]);
+        fprintf(stderr, "Examples: %s \"Alt+Space\"  |  %s F8  |  %s --record\n",
+                argv[0], argv[0], argv[0]);
         return 1;
     }
 
-    parse_hotkey(argv[1]);
+    if (strcasecmp(argv[1], "--record") == 0) {
+        g_record_mode = 1;
+        fprintf(stderr, "Hotkey recording mode\n");
+    } else {
+        parse_hotkey(argv[1]);
 
-    if (g_targetKey == 0 && !g_modifiersOnly) {
-        fprintf(stderr, "Error: Invalid hotkey '%s'\n", argv[1]);
-        return 1;
+        if (g_targetKey == 0 && !g_modifiersOnly) {
+            fprintf(stderr, "Error: Invalid hotkey '%s'\n", argv[1]);
+            return 1;
+        }
     }
 
     signal(SIGTERM, handle_signal);
@@ -234,8 +342,12 @@ int main(int argc, char *argv[]) {
     pollfds[nfds].fd = STDIN_FILENO;
     pollfds[nfds].events = POLLIN | POLLHUP;
 
-    fprintf(stderr, "Listening for: %s (key=%d, Ctrl=%d, Alt=%d, Shift=%d, Meta=%d, ModOnly=%d) on %d device(s)\n",
-            argv[1], g_targetKey, g_requireCtrl, g_requireAlt, g_requireShift, g_requireMeta, g_modifiersOnly, nfds);
+    if (!g_record_mode) {
+        fprintf(stderr, "Listening for: %s (key=%d, Ctrl=%d, Alt=%d, Shift=%d, Meta=%d, ModOnly=%d) on %d device(s)\n",
+                argv[1], g_targetKey, g_requireCtrl, g_requireAlt, g_requireShift, g_requireMeta, g_modifiersOnly, nfds);
+    } else {
+        fprintf(stderr, "Recording hotkeys on %d device(s)\n", nfds);
+    }
 
     printf("READY\n");
     fflush(stdout);
@@ -265,6 +377,12 @@ int main(int argc, char *argv[]) {
                 if (!pressed && !released) continue; /* skip autorepeat */
 
                 int code = ev.code;
+
+                if (g_record_mode) {
+                    handle_record_event(code, pressed);
+                    continue;
+                }
+
                 int is_mod = is_ctrl(code) || is_alt(code) || is_shift(code) || is_meta(code);
 
                 if (is_mod) {

--- a/apps/electron/native/macos-key-listener.swift
+++ b/apps/electron/native/macos-key-listener.swift
@@ -45,6 +45,101 @@ func emit(_ message: String) {
     fflush(stdout)
 }
 
+func emitFlags(_ flags: NSEvent.ModifierFlags) {
+    var parts: [String] = []
+    let mods = flags.intersection(modifierMask)
+    if mods.contains(.control) { parts.append("control") }
+    if mods.contains(.option) { parts.append("option") }
+    if mods.contains(.shift) { parts.append("shift") }
+    if mods.contains(.command) { parts.append("command") }
+    emit("FLAGS:" + parts.joined(separator: ","))
+}
+
+/// US ANSI keyboard keycodes (kVK_ANSI_* / kVK_Space, etc.)
+func keyCodeToName(_ code: UInt16) -> String? {
+    switch code {
+    case 0: return "A"
+    case 1: return "S"
+    case 2: return "D"
+    case 3: return "F"
+    case 4: return "H"
+    case 5: return "G"
+    case 6: return "Z"
+    case 7: return "X"
+    case 8: return "C"
+    case 9: return "V"
+    case 11: return "B"
+    case 12: return "Q"
+    case 13: return "W"
+    case 14: return "E"
+    case 15: return "R"
+    case 16: return "Y"
+    case 17: return "T"
+    case 18: return "1"
+    case 19: return "2"
+    case 20: return "3"
+    case 21: return "4"
+    case 22: return "6"
+    case 23: return "5"
+    case 24: return "="
+    case 25: return "9"
+    case 26: return "7"
+    case 27: return "-"
+    case 28: return "8"
+    case 29: return "0"
+    case 30: return "]"
+    case 31: return "O"
+    case 32: return "U"
+    case 33: return "["
+    case 34: return "I"
+    case 35: return "P"
+    case 37: return "L"
+    case 38: return "J"
+    case 39: return "'"
+    case 40: return "K"
+    case 41: return ";"
+    case 42: return "\\"
+    case 43: return ","
+    case 44: return "/"
+    case 45: return "N"
+    case 46: return "M"
+    case 47: return "."
+    case 48: return "Tab"
+    case 49: return "Space"
+    case 50: return "`"
+    case 51: return "Delete"
+    case 53: return "Escape"
+    case 36: return "Return"
+    case 117: return "ForwardDelete"
+    case 123: return "Left"
+    case 124: return "Right"
+    case 125: return "Down"
+    case 126: return "Up"
+    case 122: return "F1"
+    case 120: return "F2"
+    case 99: return "F3"
+    case 118: return "F4"
+    case 96: return "F5"
+    case 97: return "F6"
+    case 98: return "F7"
+    case 100: return "F8"
+    case 101: return "F9"
+    case 109: return "F10"
+    case 103: return "F11"
+    case 111: return "F12"
+    default: return nil
+    }
+}
+
+func emitFlagsFromCGEvent(_ flags: CGEventFlags) {
+    var parts: [String] = []
+    if flags.contains(.maskControl) { parts.append("control") }
+    if flags.contains(.maskAlternate) { parts.append("option") }
+    if flags.contains(.maskShift) { parts.append("shift") }
+    if flags.contains(.maskCommand) { parts.append("command") }
+    emit("FLAGS:" + parts.joined(separator: ","))
+}
+
 func mouseButtonName(_ buttonNumber: Int) -> String? {
     switch buttonNumber {
     case 3:
@@ -132,16 +227,70 @@ guard let monitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, h
             }
         }
         lastModifierFlags = currentModifiers
+        emitFlags(flags)
     }
 }) else {
     FileHandle.standardError.write("Failed to create event monitor\n".data(using: .utf8)!)
     exit(1)
 }
 
+// CGEvent keyboard tap — reliable KEY_UP delivery (NSEvent global monitors often miss key-up)
+let keyEventMask =
+    (1 << CGEventType.keyDown.rawValue) |
+    (1 << CGEventType.keyUp.rawValue)
+
+var keyEventTapPort: CFMachPort?
+
+let keyEventTap = CGEvent.tapCreate(
+    tap: .cgSessionEventTap,
+    place: .headInsertEventTap,
+    options: .defaultTap,
+    eventsOfInterest: CGEventMask(keyEventMask),
+    callback: { _, type, event, _ in
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let keyEventTapPort {
+                CGEvent.tapEnable(tap: keyEventTapPort, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
+        emitFlagsFromCGEvent(event.flags)
+
+        let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+        guard let name = keyCodeToName(keyCode) else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        if type == .keyDown {
+            emit("KEY_DOWN:\(name)")
+        } else if type == .keyUp {
+            emit("KEY_UP:\(name)")
+        }
+
+        return Unmanaged.passUnretained(event)
+    },
+    userInfo: nil)
+
+var keyEventRunLoopSource: CFRunLoopSource?
+if let keyEventTap {
+    keyEventTapPort = keyEventTap
+    keyEventRunLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, keyEventTap, 0)
+    CFRunLoopAddSource(CFRunLoopGetMain(), keyEventRunLoopSource, .commonModes)
+    CGEvent.tapEnable(tap: keyEventTap, enable: true)
+} else {
+    FileHandle.standardError.write("Failed to create keyboard event tap\n".data(using: .utf8)!)
+}
+
 let signalSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
 signal(SIGTERM, SIG_IGN)
 signalSource.setEventHandler {
     NSEvent.removeMonitor(monitor)
+    if let keyEventTap {
+        CGEvent.tapEnable(tap: keyEventTap, enable: false)
+    }
+    if let keyEventRunLoopSource {
+        CFRunLoopRemoveSource(CFRunLoopGetMain(), keyEventRunLoopSource, .commonModes)
+    }
     if let mouseEventTap {
         CGEvent.tapEnable(tap: mouseEventTap, enable: false)
     }

--- a/apps/electron/native/windows-key-listener.c
+++ b/apps/electron/native/windows-key-listener.c
@@ -24,6 +24,7 @@ static BOOL g_requireAlt = FALSE;
 static BOOL g_requireShift = FALSE;
 static BOOL g_requireWin = FALSE;
 static BOOL g_useModifiersOnly = FALSE;
+static BOOL g_record_mode = FALSE;
 static BOOL g_ctrlDown = FALSE;
 static BOOL g_altDown = FALSE;
 static BOOL g_shiftDown = FALSE;
@@ -80,6 +81,82 @@ static BOOL AreRequiredModifiersPressed(void) {
     if (g_requireShift && !g_shiftDown) return FALSE;
     if (g_requireWin && !(g_leftWinDown || g_rightWinDown)) return FALSE;
     return TRUE;
+}
+
+static void EmitRecordModifiers(void) {
+    char buf[256] = "";
+    int len = 0;
+
+    if (g_ctrlDown) {
+        len += snprintf(buf + len, sizeof(buf) - len, "%sControl", len ? "," : "");
+    }
+    if (g_altDown) {
+        len += snprintf(buf + len, sizeof(buf) - len, "%sAlt", len ? "," : "");
+    }
+    if (g_shiftDown) {
+        len += snprintf(buf + len, sizeof(buf) - len, "%sShift", len ? "," : "");
+    }
+    if (g_leftWinDown || g_rightWinDown) {
+        len += snprintf(buf + len, sizeof(buf) - len, "%sSuper", len ? "," : "");
+    }
+
+    printf("RECORD_MODIFIERS:%s\n", buf);
+    fflush(stdout);
+}
+
+static const char* VkToRecordKeyName(DWORD vk) {
+    if (vk == VK_SPACE) return "Space";
+    if (vk == VK_RETURN) return "Return";
+    if (vk == VK_ESCAPE) return "Escape";
+    if (vk == VK_TAB) return "Tab";
+    if (vk == VK_BACK) return "Backspace";
+    if (vk == VK_DELETE) return "Delete";
+    if (vk == VK_UP) return "Up";
+    if (vk == VK_DOWN) return "Down";
+    if (vk == VK_LEFT) return "Left";
+    if (vk == VK_RIGHT) return "Right";
+    if (vk == VK_HOME) return "Home";
+    if (vk == VK_END) return "End";
+    if (vk == VK_PRIOR) return "PageUp";
+    if (vk == VK_NEXT) return "PageDown";
+    if (vk == VK_INSERT) return "Insert";
+    if (vk == VK_PAUSE) return "Pause";
+    if (vk == VK_SCROLL) return "ScrollLock";
+    if (vk == VK_CAPITAL) return "CapsLock";
+    if (vk == VK_NUMLOCK) return "NumLock";
+    if (vk == VK_RMENU) return "RightAlt";
+    if (vk == VK_RCONTROL) return "RightControl";
+    if (vk == VK_RSHIFT) return "RightShift";
+    if (vk == VK_RWIN) return "RightSuper";
+    if (vk == VK_OEM_3) return "`";
+    if (vk == VK_OEM_MINUS) return "-";
+    if (vk == VK_OEM_PLUS) return "=";
+    if (vk == VK_OEM_4) return "[";
+    if (vk == VK_OEM_6) return "]";
+    if (vk == VK_OEM_5) return "\\";
+    if (vk == VK_OEM_1) return ";";
+    if (vk == VK_OEM_7) return "'";
+    if (vk == VK_OEM_COMMA) return ",";
+    if (vk == VK_OEM_PERIOD) return ".";
+    if (vk == VK_OEM_2) return "/";
+    if (vk >= VK_F1 && vk <= VK_F24) {
+        static char fkey[8];
+        snprintf(fkey, sizeof(fkey), "F%lu", (unsigned long)(vk - VK_F1 + 1));
+        return fkey;
+    }
+    if (vk >= 'A' && vk <= 'Z') {
+        static char letter[2];
+        letter[0] = (char)vk;
+        letter[1] = '\0';
+        return letter;
+    }
+    if (vk >= '0' && vk <= '9') {
+        static char digit[2];
+        digit[0] = (char)vk;
+        digit[1] = '\0';
+        return digit;
+    }
+    return NULL;
 }
 
 DWORD ParseKeyCode(const char* keyName) {
@@ -158,6 +235,45 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
         BOOL isUp = (wParam == WM_KEYUP || wParam == WM_SYSKEYUP);
         BOOL isModifierEvent = IsCtrlVk(kbd->vkCode) || IsAltVk(kbd->vkCode) ||
                                IsShiftVk(kbd->vkCode) || IsWinVk(kbd->vkCode);
+
+        if (g_record_mode && isDown) {
+            if (kbd->vkCode == VK_ESCAPE) {
+                printf("RECORD_CANCEL\n");
+                fflush(stdout);
+                return CallNextHookEx(g_hook, nCode, wParam, lParam);
+            }
+
+            if (isModifierEvent) {
+                UpdateModifierState(kbd->vkCode, TRUE);
+                SyncModifierState(kbd->vkCode);
+
+                if (kbd->vkCode == VK_RMENU || kbd->vkCode == VK_RCONTROL ||
+                    kbd->vkCode == VK_RSHIFT || kbd->vkCode == VK_RWIN) {
+                    const char* keyName = VkToRecordKeyName(kbd->vkCode);
+                    if (keyName) {
+                        printf("RECORD_KEY:%s\n", keyName);
+                        fflush(stdout);
+                    }
+                    return CallNextHookEx(g_hook, nCode, wParam, lParam);
+                }
+
+                EmitRecordModifiers();
+                return CallNextHookEx(g_hook, nCode, wParam, lParam);
+            }
+
+            const char* keyName = VkToRecordKeyName(kbd->vkCode);
+            if (keyName) {
+                EmitRecordModifiers();
+                printf("RECORD_KEY:%s\n", keyName);
+                fflush(stdout);
+            }
+            return CallNextHookEx(g_hook, nCode, wParam, lParam);
+        }
+
+        if (g_record_mode && isUp && isModifierEvent) {
+            UpdateModifierState(kbd->vkCode, FALSE);
+            return CallNextHookEx(g_hook, nCode, wParam, lParam);
+        }
 
         if ((isDown || isUp) && isModifierEvent) {
             UpdateModifierState(kbd->vkCode, isDown);
@@ -288,27 +404,36 @@ static DWORD WINAPI StdinMonitorThread(LPVOID param) {
 
 int main(int argc, char* argv[]) {
     if (argc < 2) {
-        fprintf(stderr, "Usage: %s <key>\n", argv[0]);
+        fprintf(stderr, "Usage: %s <key> | %s --record\n", argv[0], argv[0]);
         fprintf(stderr, "Examples:\n");
         fprintf(stderr, "  %s `                        (backtick)\n", argv[0]);
         fprintf(stderr, "  %s F8                       (function key)\n", argv[0]);
         fprintf(stderr, "  %s CommandOrControl+F11     (with modifier)\n", argv[0]);
         fprintf(stderr, "  %s Ctrl+Shift+Space         (multiple modifiers)\n", argv[0]);
+        fprintf(stderr, "  %s --record                 (hotkey rebinding mode)\n", argv[0]);
         return 1;
     }
 
-    g_targetVk = ParseCompoundHotkey(argv[1]);
+    if (_stricmp(argv[1], "--record") == 0) {
+        g_record_mode = TRUE;
+        fprintf(stderr, "Hotkey recording mode\n");
+    } else {
+        g_targetVk = ParseCompoundHotkey(argv[1]);
+    }
+
+    if (!g_record_mode) {
     if (g_targetVk == 0 && (g_requireCtrl || g_requireAlt || g_requireShift || g_requireWin)) {
         g_useModifiersOnly = TRUE;
     }
 
-    if (g_targetVk == 0 && !g_useModifiersOnly) {
-        fprintf(stderr, "Error: Invalid key '%s'\n", argv[1]);
-        return 1;
-    }
+        if (g_targetVk == 0 && !g_useModifiersOnly) {
+            fprintf(stderr, "Error: Invalid key '%s'\n", argv[1]);
+            return 1;
+        }
 
-    fprintf(stderr, "Listening for: %s (VK=0x%02X, Ctrl=%d, Alt=%d, Shift=%d, Win=%d, ModOnly=%d)\n",
-            argv[1], g_targetVk, g_requireCtrl, g_requireAlt, g_requireShift, g_requireWin, g_useModifiersOnly);
+        fprintf(stderr, "Listening for: %s (VK=0x%02X, Ctrl=%d, Alt=%d, Shift=%d, Win=%d, ModOnly=%d)\n",
+                argv[1], g_targetVk, g_requireCtrl, g_requireAlt, g_requireShift, g_requireWin, g_useModifiersOnly);
+    }
 
     SetConsoleCtrlHandler(ConsoleHandler, TRUE);
 

--- a/apps/electron/native/windows-key-listener.c
+++ b/apps/electron/native/windows-key-listener.c
@@ -422,9 +422,9 @@ int main(int argc, char* argv[]) {
     }
 
     if (!g_record_mode) {
-    if (g_targetVk == 0 && (g_requireCtrl || g_requireAlt || g_requireShift || g_requireWin)) {
-        g_useModifiersOnly = TRUE;
-    }
+        if (g_targetVk == 0 && (g_requireCtrl || g_requireAlt || g_requireShift || g_requireWin)) {
+            g_useModifiersOnly = TRUE;
+        }
 
         if (g_targetVk == 0 && !g_useModifiersOnly) {
             fprintf(stderr, "Error: Invalid key '%s'\n", argv[1]);

--- a/apps/electron/src/main/hotkey-recorder.ts
+++ b/apps/electron/src/main/hotkey-recorder.ts
@@ -1,0 +1,181 @@
+/**
+ * Global hotkey rebinding — spawns a platform listener while the user picks a
+ * new shortcut in Settings. Restores the recording IPC removed in #50.
+ *
+ * macOS: native binary (Fn / right modifiers) + renderer DOM (Alt+Space, etc.)
+ * Windows / Linux: native binary in --record mode
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import type { WebContents } from "electron";
+import { getNativeBinaryPath } from "./native-binary";
+
+export interface HotkeyCombo {
+  modifiers: string[];
+  key: string | null;
+}
+
+export interface HotkeyRecorderCallbacks {
+  onModifiers: (modifiers: string[]) => void;
+  onCaptured: (combo: HotkeyCombo) => void;
+  onCancel: () => void;
+  onError?: (message: string) => void;
+}
+
+const BINARY_NAMES: Record<string, string> = {
+  darwin: "macos-key-listener",
+  win32: "windows-key-listener",
+  linux: "linux-key-listener",
+};
+
+const MAC_RIGHT_MOD_KEYS: Record<string, string> = {
+  rightoption: "RightOption",
+  rightcommand: "RightCommand",
+  rightcontrol: "RightControl",
+  rightshift: "RightShift",
+};
+
+export class HotkeyRecorder {
+  private process: ChildProcess | null = null;
+  private target: WebContents | null = null;
+  private callbacks: HotkeyRecorderCallbacks;
+  private pendingModifiers: string[] = [];
+
+  constructor(callbacks: HotkeyRecorderCallbacks) {
+    this.callbacks = callbacks;
+  }
+
+  start(target: WebContents): boolean {
+    this.stop();
+    this.target = target;
+    this.pendingModifiers = [];
+
+    const binaryName = BINARY_NAMES[process.platform];
+    if (!binaryName) {
+      this.callbacks.onError?.(`Unsupported platform: ${process.platform}`);
+      return false;
+    }
+
+    const binaryPath = getNativeBinaryPath(binaryName);
+    if (!binaryPath) {
+      this.callbacks.onError?.(
+        `Native key listener binary not found: ${binaryName}`,
+      );
+      return false;
+    }
+
+    const args: string[] = [];
+    if (process.platform !== "darwin") {
+      args.push("--record");
+    }
+
+    try {
+      this.process = spawn(binaryPath, args, {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (err) {
+      this.callbacks.onError?.(
+        `Failed to spawn hotkey recorder: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return false;
+    }
+
+    let lineBuffer = "";
+
+    this.process.stdout?.on("data", (data: Buffer) => {
+      lineBuffer += data.toString();
+      const lines = lineBuffer.split("\n");
+      lineBuffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        this.handleLine(line.trim());
+      }
+    });
+
+    this.process.stderr?.on("data", (data: Buffer) => {
+      if (process.env.NODE_ENV !== "production") {
+        console.log(`[hotkey-recorder] ${data.toString().trim()}`);
+      }
+    });
+
+    this.process.on("close", () => {
+      this.process = null;
+    });
+
+    this.process.on("error", (err) => {
+      this.callbacks.onError?.(`Hotkey recorder process error: ${err.message}`);
+      this.process = null;
+    });
+
+    return true;
+  }
+
+  stop(): void {
+    this.target = null;
+    this.pendingModifiers = [];
+
+    if (this.process) {
+      try {
+        this.process.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+      this.process = null;
+    }
+  }
+
+  private sendModifiers(modifiers: string[]): void {
+    this.pendingModifiers = modifiers;
+    this.target?.send("hotkey-record:modifiers", modifiers);
+    this.callbacks.onModifiers(modifiers);
+  }
+
+  private sendCaptured(combo: HotkeyCombo): void {
+    this.target?.send("hotkey-record:captured", combo);
+    this.callbacks.onCaptured(combo);
+    this.stop();
+  }
+
+  private sendCancel(): void {
+    this.target?.send("hotkey-record:cancel");
+    this.callbacks.onCancel();
+    this.stop();
+  }
+
+  private handleLine(line: string): void {
+    if (!line || line === "READY") return;
+
+    if (line === "RECORD_CANCEL") {
+      this.sendCancel();
+      return;
+    }
+
+    if (line.startsWith("RECORD_MODIFIERS:")) {
+      const raw = line.slice("RECORD_MODIFIERS:".length);
+      const modifiers = raw ? raw.split(",").filter(Boolean) : [];
+      this.sendModifiers(modifiers);
+      return;
+    }
+
+    if (line.startsWith("RECORD_KEY:")) {
+      const key = line.slice("RECORD_KEY:".length);
+      if (key) {
+        this.sendCaptured({ modifiers: [...this.pendingModifiers], key });
+      }
+      return;
+    }
+
+    if (process.platform !== "darwin") return;
+
+    if (line === "FN_DOWN") {
+      this.sendCaptured({ modifiers: [], key: "Fn" });
+      return;
+    }
+
+    if (line.startsWith("RIGHT_MOD_DOWN:")) {
+      const modName = line.slice("RIGHT_MOD_DOWN:".length);
+      const key = MAC_RIGHT_MOD_KEYS[modName.toLowerCase()] ?? modName;
+      this.sendCaptured({ modifiers: [], key });
+    }
+  }
+}

--- a/apps/electron/src/main/hotkey-recorder.ts
+++ b/apps/electron/src/main/hotkey-recorder.ts
@@ -99,12 +99,20 @@ export class HotkeyRecorder {
     });
 
     this.process.on("close", () => {
+      const unexpected = this.target !== null;
       this.process = null;
+      if (unexpected) {
+        this.sendCancel();
+      }
     });
 
     this.process.on("error", (err) => {
       this.callbacks.onError?.(`Hotkey recorder process error: ${err.message}`);
+      const unexpected = this.target !== null;
       this.process = null;
+      if (unexpected) {
+        this.sendCancel();
+      }
     });
 
     return true;

--- a/apps/electron/src/main/hotkey-utils.ts
+++ b/apps/electron/src/main/hotkey-utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Normalize user-recorded accelerators to the Electron-style format expected
+ * by native binaries and isValidAccelerator.
+ */
+export function normalizeAccelerator(accel: string): string {
+  return accel
+    .split("+")
+    .map((part) => {
+      const p = part.trim();
+      if (!p) return p;
+
+      const lower = p.toLowerCase();
+      if (lower === "fn" || lower === "globe") return "Fn";
+      if (lower === "control" || lower === "ctrl") return "Control";
+      if (lower === "command" || lower === "cmd" || lower === "meta")
+        return "Command";
+      if (lower === "alt" || lower === "option") return "Alt";
+      if (lower === "shift") return "Shift";
+      if (lower === "commandorcontrol" || lower === "cmdorctrl")
+        return "CommandOrControl";
+      if (lower === "space") return "Space";
+      if (lower === "return" || lower === "enter") return "Return";
+      if (lower === "escape" || lower === "esc") return "Escape";
+      if (lower === "backspace") return "Backspace";
+      if (lower === "delete" || lower === "del") return "Delete";
+      if (lower === "tab") return "Tab";
+      if (lower === "rightalt" || lower === "rightoption") return "RightAlt";
+      if (lower === "rightcontrol" || lower === "rightctrl")
+        return "RightControl";
+      if (lower === "rightshift") return "RightShift";
+      if (lower === "rightcommand" || lower === "rightcmd")
+        return "RightCommand";
+      if (
+        lower === "rightsuper" ||
+        lower === "rightwin" ||
+        lower === "rightmeta"
+      )
+        return "RightSuper";
+      if (/^f\d+$/i.test(p)) return p.toUpperCase();
+      if (p.length === 1) return p.toUpperCase();
+      if (p === "Up" || p === "Down" || p === "Left" || p === "Right") return p;
+      return p.charAt(0).toUpperCase() + p.slice(1);
+    })
+    .join("+");
+}

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -35,6 +35,8 @@ import { autoUpdater } from "electron-updater";
 import { WebSocketServer } from "ws";
 import icon from "../../resources/icon.png?asset";
 import trayIconPath from "../../resources/tray/logoTemplate.png?asset";
+import { HotkeyRecorder } from "./hotkey-recorder";
+import { normalizeAccelerator } from "./hotkey-utils";
 import { NativeKeyListener } from "./key-listener";
 import { MicListener } from "./mic-listener";
 import { pasteIntoFocusedApp } from "./paste";
@@ -90,7 +92,9 @@ let keyListener: NativeKeyListener | null = null;
 let hotkeyPressed = false;
 let winToggleActive = false;
 let currentHotkeyAccel: string | null = null;
+let hotkeyActivationMode: "hold" | "toggle" = "hold";
 let micListener: MicListener | null = null;
+let hotkeyRecorder: HotkeyRecorder | null = null;
 
 // Register a custom app:// protocol that serves the renderer files.
 // All non-file paths fall back to index.html so BrowserRouter works in production.
@@ -722,16 +726,13 @@ app.whenReady().then(async () => {
     writeSettings({ onboardingComplete: true });
   });
 
-  // IPC: hotkey recording via main process
-  // Note: Hotkey recording currently uses the renderer's keyboard events
-  // (the settings page captures keydown in the DOM). The native binary
-  // doesn't need a separate "recording" mode -- the renderer handles it.
-  // We still support the IPC protocol for pausing/resuming the primary listener.
-  let recordingActive = false;
+  // IPC: hotkey recording — global native listener + renderer DOM on macOS
+  function stopHotkeyRecorderProcess(): void {
+    hotkeyRecorder?.stop();
+    hotkeyRecorder = null;
+  }
 
   ipcMain.on("hotkey-record:start", () => {
-    recordingActive = true;
-
     // Pause the active hotkey listener so it doesn't fire during recording
     if (keyListener) {
       keyListener.stop();
@@ -741,12 +742,37 @@ app.whenReady().then(async () => {
       globalShortcut.unregisterAll();
       winToggleActive = false;
     }
+
+    stopHotkeyRecorderProcess();
+    const target =
+      settingsWindow?.webContents ?? mainWindow?.webContents ?? null;
+    if (!target) return;
+
+    hotkeyRecorder = new HotkeyRecorder({
+      onModifiers: () => {},
+      onCaptured: () => {},
+      onCancel: () => {
+        stopHotkeyRecorderProcess();
+        registerHotkey(currentHotkeyAccel ?? undefined);
+      },
+      onError: (message) => {
+        console.warn("[hotkey-recorder]", message);
+      },
+    });
+    hotkeyRecorder.start(target);
   });
 
-  ipcMain.on("hotkey-record:stop", () => {
-    recordingActive = false;
-    // Re-register the hotkey listener
-    registerHotkey(currentHotkeyAccel ?? undefined);
+  ipcMain.on("hotkey-record:pause-recorder", () => {
+    stopHotkeyRecorderProcess();
+  });
+
+  ipcMain.on("hotkey-record:stop", (_event, hotkey?: string) => {
+    stopHotkeyRecorderProcess();
+    registerHotkey(
+      typeof hotkey === "string" && hotkey.length > 0
+        ? hotkey
+        : (currentHotkeyAccel ?? undefined),
+    );
   });
 
   // Set database path for the server before any API calls
@@ -930,6 +956,7 @@ app.whenReady().then(async () => {
   });
 
   // Register hold-to-record hotkey via native platform binary
+  hotkeyActivationMode = loadHotkeyModeFromDB();
   registerHotkey();
 
   // Start microphone activity monitoring
@@ -945,6 +972,17 @@ app.whenReady().then(async () => {
   // Listen for hotkey changes from the settings UI
   ipcMain.on("hotkey:update", (_event, newHotkey: string) => {
     registerHotkey(newHotkey);
+  });
+
+  ipcMain.on("hotkey:reload", () => {
+    hotkeyActivationMode = loadHotkeyModeFromDB();
+    registerHotkey(currentHotkeyAccel ?? undefined);
+  });
+
+  ipcMain.on("hotkey:set-mode", (_event, mode: string) => {
+    hotkeyActivationMode = mode === "toggle" ? "toggle" : "hold";
+    hotkeyPressed = false;
+    registerHotkey(currentHotkeyAccel ?? undefined);
   });
 });
 
@@ -979,6 +1017,62 @@ function loadHotkeyFromDB(): string | undefined {
   return undefined;
 }
 
+function loadHotkeyModeFromDB(): "hold" | "toggle" {
+  try {
+    const dbPath = process.env.FREESTYLE_DB_PATH;
+    if (dbPath) {
+      const { DatabaseSync } = require("node:sqlite");
+      const db = new DatabaseSync(dbPath);
+      const row = db
+        .prepare("SELECT value FROM settings WHERE key = 'hotkey_mode'")
+        .get() as { value: string } | undefined;
+      db.close();
+      if (row?.value === "toggle") return "toggle";
+    }
+  } catch {
+    // Ignore errors
+  }
+  return "hold";
+}
+
+function sendHotkeyDown(): void {
+  showPill();
+  mainWindow?.webContents.send("hotkey:down");
+  settingsWindow?.webContents.send("hotkey:down");
+}
+
+function sendHotkeyUp(): void {
+  mainWindow?.webContents.send("hotkey:up");
+  settingsWindow?.webContents.send("hotkey:up");
+}
+
+function handleNativeHotkeyDown(): void {
+  if (hotkeyActivationMode === "toggle") {
+    if (!hotkeyPressed) {
+      hotkeyPressed = true;
+      sendHotkeyDown();
+    } else {
+      hotkeyPressed = false;
+      sendHotkeyUp();
+    }
+    return;
+  }
+
+  if (!hotkeyPressed) {
+    hotkeyPressed = true;
+    sendHotkeyDown();
+  }
+}
+
+function handleNativeHotkeyUp(): void {
+  if (hotkeyActivationMode === "toggle") return;
+
+  if (hotkeyPressed) {
+    hotkeyPressed = false;
+    sendHotkeyUp();
+  }
+}
+
 function registerHotkey(hotkey?: string): void {
   // Tear down previous listener
   if (keyListener) {
@@ -995,27 +1089,16 @@ function registerHotkey(hotkey?: string): void {
     hotkey = loadHotkeyFromDB();
   }
 
-  const accel = hotkey && isValidAccelerator(hotkey) ? hotkey : DEFAULT_HOTKEY;
+  const normalized =
+    hotkey && isValidAccelerator(hotkey) ? normalizeAccelerator(hotkey) : null;
+  const accel = normalized ?? DEFAULT_HOTKEY;
   currentHotkeyAccel = accel;
 
   // Try native key listener binary first (all platforms)
   keyListener = new NativeKeyListener({
     hotkey: accel,
-    onKeyDown: () => {
-      if (!hotkeyPressed) {
-        hotkeyPressed = true;
-        showPill();
-        mainWindow?.webContents.send("hotkey:down");
-        settingsWindow?.webContents.send("hotkey:down");
-      }
-    },
-    onKeyUp: () => {
-      if (hotkeyPressed) {
-        hotkeyPressed = false;
-        mainWindow?.webContents.send("hotkey:up");
-        settingsWindow?.webContents.send("hotkey:up");
-      }
-    },
+    onKeyDown: handleNativeHotkeyDown,
+    onKeyUp: handleNativeHotkeyUp,
     onError: (error) => {
       console.error("[hotkey] Native key listener error:", error);
     },
@@ -1034,18 +1117,9 @@ function registerHotkey(hotkey?: string): void {
     );
     keyListener = null;
 
-    // Fallback: Electron's globalShortcut in toggle mode (all platforms)
+    // Fallback: Electron globalShortcut (uses same hold/toggle handlers above)
     const registered = globalShortcut.register(accel, () => {
-      if (!winToggleActive) {
-        winToggleActive = true;
-        showPill();
-        mainWindow?.webContents.send("hotkey:down");
-        settingsWindow?.webContents.send("hotkey:down");
-      } else {
-        winToggleActive = false;
-        mainWindow?.webContents.send("hotkey:up");
-        settingsWindow?.webContents.send("hotkey:up");
-      }
+      handleNativeHotkeyDown();
     });
     if (!registered) {
       const errorPayload = {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -96,6 +96,11 @@ let hotkeyActivationMode: "hold" | "toggle" = "hold";
 let micListener: MicListener | null = null;
 let hotkeyRecorder: HotkeyRecorder | null = null;
 
+function stopHotkeyRecorderProcess(): void {
+  hotkeyRecorder?.stop();
+  hotkeyRecorder = null;
+}
+
 // Register a custom app:// protocol that serves the renderer files.
 // All non-file paths fall back to index.html so BrowserRouter works in production.
 protocol.registerSchemesAsPrivileged([
@@ -245,6 +250,10 @@ function createSettingsWindow(): void {
   });
 
   settingsWindow.on("closed", () => {
+    if (hotkeyRecorder) {
+      stopHotkeyRecorderProcess();
+      registerHotkey(currentHotkeyAccel ?? undefined);
+    }
     settingsWindow = null;
   });
 
@@ -727,11 +736,6 @@ app.whenReady().then(async () => {
   });
 
   // IPC: hotkey recording — global native listener + renderer DOM on macOS
-  function stopHotkeyRecorderProcess(): void {
-    hotkeyRecorder?.stop();
-    hotkeyRecorder = null;
-  }
-
   ipcMain.on("hotkey-record:start", () => {
     // Pause the active hotkey listener so it doesn't fire during recording
     if (keyListener) {
@@ -1117,9 +1121,15 @@ function registerHotkey(hotkey?: string): void {
     );
     keyListener = null;
 
-    // Fallback: Electron globalShortcut (uses same hold/toggle handlers above)
+    // Fallback: globalShortcut has no key-up — always use toggle semantics
     const registered = globalShortcut.register(accel, () => {
-      handleNativeHotkeyDown();
+      if (!hotkeyPressed) {
+        hotkeyPressed = true;
+        sendHotkeyDown();
+      } else {
+        hotkeyPressed = false;
+        sendHotkeyUp();
+      }
     });
     if (!registered) {
       const errorPayload = {

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -87,6 +87,7 @@ export class NativeKeyListener {
 
   // macOS modifier tracking for hotkey matching
   private macModState = new Set<string>();
+  private macFlagState = new Set<string>();
   private macHotkeyActive = false;
 
   constructor(options: KeyListenerOptions) {
@@ -219,17 +220,75 @@ export class NativeKeyListener {
     // General modifier release (e.g., MODIFIER_UP:option)
     if (line.startsWith("MODIFIER_UP:")) {
       const modName = line.slice(12).toLowerCase();
+      this.macFlagState.delete(modName);
       // Remove any right-side modifier that matches this category
       for (const key of [...this.macModState]) {
         if (key.includes(modName)) {
           this.macModState.delete(key);
         }
       }
-      if (this.macHotkeyActive) {
-        this.macHotkeyActive = false;
-        this.options.onKeyUp();
-      }
+      this.checkMacCompoundRelease();
       return;
+    }
+
+    // Left/right modifier flags (e.g., Alt+Space)
+    if (line.startsWith("FLAGS:")) {
+      const raw = line.slice(6);
+      this.macFlagState = new Set(
+        raw
+          ? raw
+              .split(",")
+              .map((s) => s.trim().toLowerCase())
+              .filter(Boolean)
+          : [],
+      );
+      this.checkMacCompoundRelease();
+      return;
+    }
+
+    if (line.startsWith("KEY_DOWN:")) {
+      this.handleMacKeyEvent(line.slice(9), true);
+      return;
+    }
+
+    if (line.startsWith("KEY_UP:")) {
+      this.handleMacKeyEvent(line.slice(9), false);
+      return;
+    }
+  }
+
+  /** End compound hotkey when a required modifier is released (e.g. Option on Alt+Space). */
+  private checkMacCompoundRelease(): void {
+    if (!this.macHotkeyActive) return;
+
+    const { modifiers, key: hotkeyKey } = parseHotkeyParts(this.options.hotkey);
+    if (!hotkeyKey) return;
+    const keyLower = hotkeyKey.toLowerCase();
+    if (keyLower === "fn" || keyLower === "globe") return;
+
+    const allModsMatch = [...modifiers].every((m) => this.macFlagState.has(m));
+    if (!allModsMatch) {
+      this.macHotkeyActive = false;
+      this.options.onKeyUp();
+    }
+  }
+
+  /** Match compound hotkeys like Alt+Space using modifier flags + key events. */
+  private handleMacKeyEvent(key: string, down: boolean): void {
+    const { modifiers, key: hotkeyKey } = parseHotkeyParts(this.options.hotkey);
+    if (!hotkeyKey || hotkeyKey.toLowerCase() !== key.toLowerCase()) return;
+
+    const allModsMatch = [...modifiers].every((m) => this.macFlagState.has(m));
+    if (!allModsMatch) return;
+
+    if (down) {
+      if (!this.macHotkeyActive) {
+        this.macHotkeyActive = true;
+        this.options.onKeyDown();
+      }
+    } else if (this.macHotkeyActive) {
+      this.macHotkeyActive = false;
+      this.options.onKeyUp();
     }
   }
 
@@ -243,6 +302,7 @@ export class NativeKeyListener {
     if (this.macHotkeyActive) return;
 
     const hotkey = this.options.hotkey.toLowerCase();
+    const { modifiers, key: hotkeyKey } = parseHotkeyParts(this.options.hotkey);
 
     // Direct right-modifier hotkey (e.g., hotkey is literally "RightOption")
     if (this.macModState.has(hotkey)) {
@@ -251,8 +311,12 @@ export class NativeKeyListener {
       return;
     }
 
-    // Parse compound hotkey and check if modifiers match
-    const { modifiers } = parseHotkeyParts(this.options.hotkey);
+    // Compound hotkeys (Alt+Space, etc.) use FLAGS + KEY_DOWN — not modifier-only match
+    if (hotkeyKey) {
+      const keyLower = hotkeyKey.toLowerCase();
+      if (keyLower !== "fn" && keyLower !== "globe") return;
+    }
+
     if (modifiers.size === 0) return;
 
     // Map macOS modifier names to categories
@@ -337,6 +401,7 @@ export class NativeKeyListener {
       this.process = null;
     }
     this.macModState.clear();
+    this.macFlagState.clear();
     this.macHotkeyActive = false;
     this.restartAttempts = 0;
     this.start();

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -393,8 +393,10 @@ export class NativeKeyListener {
       this.restartTimer = null;
     }
     if (this.process) {
+      const proc = this.process;
+      proc.removeAllListeners();
       try {
-        this.process.kill("SIGTERM");
+        proc.kill("SIGTERM");
       } catch {
         // Process may already be dead
       }

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -6,6 +6,8 @@ declare global {
     api: {
       pasteText: (text: string) => Promise<void>;
       updateHotkey: (hotkey: string) => void;
+      reloadHotkey: () => void;
+      setHotkeyMode: (mode: "hold" | "toggle") => void;
       hidePill: () => void;
       getServerPort: () => Promise<number>;
       onHotkeyDown: (callback: () => void) => () => void;
@@ -19,7 +21,8 @@ declare global {
       getOnboardingComplete: () => Promise<boolean>;
       setOnboardingComplete: () => void;
       startHotkeyRecording: () => void;
-      stopHotkeyRecording: () => void;
+      pauseHotkeyRecording: () => void;
+      stopHotkeyRecording: (hotkey?: string) => void;
       onHotkeyRecordModifiers: (
         callback: (modifiers: string[]) => void,
       ) => () => void;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -7,6 +7,9 @@ const api = {
     ipcRenderer.invoke("paste:text", text),
   updateHotkey: (hotkey: string): void =>
     ipcRenderer.send("hotkey:update", hotkey),
+  reloadHotkey: (): void => ipcRenderer.send("hotkey:reload"),
+  setHotkeyMode: (mode: "hold" | "toggle"): void =>
+    ipcRenderer.send("hotkey:set-mode", mode),
   hidePill: (): void => ipcRenderer.send("pill:hide"),
   getServerPort: (): Promise<number> => ipcRenderer.invoke("server:port"),
   onHotkeyDown: (callback: () => void): (() => void) => {
@@ -39,7 +42,10 @@ const api = {
   setOnboardingComplete: (): void =>
     ipcRenderer.send("onboarding:set-complete"),
   startHotkeyRecording: (): void => ipcRenderer.send("hotkey-record:start"),
-  stopHotkeyRecording: (): void => ipcRenderer.send("hotkey-record:stop"),
+  pauseHotkeyRecording: (): void =>
+    ipcRenderer.send("hotkey-record:pause-recorder"),
+  stopHotkeyRecording: (hotkey?: string): void =>
+    ipcRenderer.send("hotkey-record:stop", hotkey),
   onHotkeyRecordModifiers: (
     callback: (modifiers: string[]) => void,
   ): (() => void) => {

--- a/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
+++ b/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
@@ -54,6 +54,48 @@ export interface HotkeyCombo {
 
 const MODIFIER_ORDER = ["Control", "Command", "Alt", "Shift"];
 
+/** macOS: compound keys (Alt+Space) via DOM; Fn/right-mod via native IPC */
+const USE_DOM_CAPTURE = IS_MAC;
+
+const DOM_MODIFIER_KEYS = new Set([
+  "Control",
+  "Meta",
+  "Alt",
+  "Shift",
+  "Command",
+  "Option",
+]);
+
+function modifiersFromEvent(e: KeyboardEvent): string[] {
+  const mods: string[] = [];
+  if (e.ctrlKey) mods.push("Control");
+  if (e.metaKey) mods.push(IS_MAC ? "Command" : "Control");
+  if (e.altKey) mods.push("Alt");
+  if (e.shiftKey) mods.push("Shift");
+  return MODIFIER_ORDER.filter((m) => mods.includes(m));
+}
+
+function domKeyFromEvent(e: KeyboardEvent): string | null {
+  const code = e.code;
+  if (code.startsWith("Key")) return code.slice(3);
+  if (code.startsWith("Digit")) return code.slice(5);
+  if (code === "Space") return "Space";
+  if (code === "Backspace") return "Backspace";
+  if (code === "Delete") return "Delete";
+  if (code === "Escape") return "Escape";
+  if (code === "Tab") return "Tab";
+  if (code === "Enter") return "Return";
+  if (code.startsWith("Arrow")) return code.slice(5);
+  if (code.startsWith("F") && /^F\d+$/.test(code)) return code;
+  if (e.key.length === 1 && e.key !== " ") return e.key.toUpperCase();
+  if (e.key === " ") return "Space";
+  return e.key.length === 1 ? e.key : null;
+}
+
+function isDomModifierKey(e: KeyboardEvent): boolean {
+  return DOM_MODIFIER_KEYS.has(e.key) || e.key === "Option";
+}
+
 export function comboToAccelerator(combo: HotkeyCombo): string | null {
   if (!combo.key) return null;
   return [...combo.modifiers, combo.key].join("+");
@@ -139,18 +181,18 @@ export function useHotkeyRecorder(
   }, []);
 
   const saveRecording = useCallback(() => {
-    if (capturedCombo?.key) {
-      const accel = comboToAccelerator(capturedCombo);
-      if (accel) onRecordRef.current(accel);
+    const accel = capturedCombo?.key ? comboToAccelerator(capturedCombo) : null;
+    if (accel) {
+      onRecordRef.current(accel);
     }
-    // Signal main process to re-register the hotkey listener
-    window.api?.stopHotkeyRecording();
+    // Re-register the global listener with the new accelerator (single IPC)
+    window.api?.stopHotkeyRecording(accel ?? undefined);
     setState("idle");
     setLiveModifiers([]);
     setCapturedCombo(null);
   }, [capturedCombo]);
 
-  // Listen for IPC events from main process
+  // Global capture: native listener (all platforms) + DOM on macOS for Alt+Space etc.
   useEffect(() => {
     if (state !== "recording" || !window.api) return;
 
@@ -176,6 +218,38 @@ export function useHotkeyRecorder(
       removeCancel();
     };
   }, [state]);
+
+  useEffect(() => {
+    if (state !== "recording" || !USE_DOM_CAPTURE) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.key === "Escape") {
+        cancelRecording();
+        return;
+      }
+
+      const modifiers = modifiersFromEvent(e);
+
+      if (isDomModifierKey(e)) {
+        setLiveModifiers(modifiers);
+        return;
+      }
+
+      const key = domKeyFromEvent(e);
+      if (!key) return;
+
+      setCapturedCombo({ modifiers, key });
+      setLiveModifiers([]);
+      setState("captured");
+      window.api?.pauseHotkeyRecording();
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [state, cancelRecording]);
 
   // Stop main process recording when component unmounts during recording
   useEffect(() => {

--- a/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
+++ b/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
@@ -165,8 +165,10 @@ export function useHotkeyRecorder(
   const [capturedCombo, setCapturedCombo] = useState<HotkeyCombo | null>(null);
   const onRecordRef = useRef(onRecord);
   onRecordRef.current = onRecord;
+  const recordingActiveRef = useRef(false);
 
   const startRecording = useCallback(() => {
+    recordingActiveRef.current = true;
     setState("recording");
     setLiveModifiers([]);
     setCapturedCombo(null);
@@ -174,6 +176,7 @@ export function useHotkeyRecorder(
   }, []);
 
   const cancelRecording = useCallback(() => {
+    recordingActiveRef.current = false;
     setState("idle");
     setLiveModifiers([]);
     setCapturedCombo(null);
@@ -187,6 +190,7 @@ export function useHotkeyRecorder(
     }
     // Re-register the global listener with the new accelerator (single IPC)
     window.api?.stopHotkeyRecording(accel ?? undefined);
+    recordingActiveRef.current = false;
     setState("idle");
     setLiveModifiers([]);
     setCapturedCombo(null);
@@ -207,6 +211,7 @@ export function useHotkeyRecorder(
     });
 
     const removeCancel = window.api.onHotkeyRecordCancel(() => {
+      recordingActiveRef.current = false;
       setState("idle");
       setLiveModifiers([]);
       setCapturedCombo(null);
@@ -251,10 +256,13 @@ export function useHotkeyRecorder(
     return () => window.removeEventListener("keydown", handleKeyDown, true);
   }, [state, cancelRecording]);
 
-  // Stop main process recording when component unmounts during recording
+  // Stop main process recording only if we started it (avoids re-registering hotkey on every settings navigation)
   useEffect(() => {
     return () => {
-      window.api?.stopHotkeyRecording();
+      if (recordingActiveRef.current) {
+        recordingActiveRef.current = false;
+        window.api?.stopHotkeyRecording();
+      }
     };
   }, []);
 

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -99,6 +99,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
   const [devices, setDevices] = useState<AudioDevice[]>([]);
   const [selectedDevice, setSelectedDevice] = useState<string>("");
   const [hotkey, setHotkey] = useState("Alt+Space");
+  const [hotkeyMode, setHotkeyMode] = useState<"hold" | "toggle">("hold");
   const [language, setLanguage] = useState("auto");
   const [pillPosition, setPillPosition] = useState("bottom-center");
   const [soundEnabled, setSoundEnabled] = useState(true);
@@ -181,6 +182,17 @@ export default function GeneralSettingsPage(): React.JSX.Element {
     }, 30000);
   }, []);
 
+  const handleHotkeyModeChange = useCallback((mode: "hold" | "toggle") => {
+    setHotkeyMode(mode);
+    window.api?.setHotkeyMode(mode);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "hotkey_mode" },
+        json: { value: mode },
+      })
+      .catch(() => {});
+  }, []);
+
   const handleHotkeyRecorded = useCallback((accelerator: string) => {
     setHotkey(accelerator);
     getClient()
@@ -189,7 +201,6 @@ export default function GeneralSettingsPage(): React.JSX.Element {
         json: { value: accelerator },
       })
       .catch(() => {});
-    window.api.updateHotkey(accelerator);
   }, []);
 
   const {
@@ -237,6 +248,13 @@ export default function GeneralSettingsPage(): React.JSX.Element {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data?.value) setHotkey(data.value);
+      })
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "hotkey_mode" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value === "toggle") setHotkeyMode("toggle");
       })
       .catch(() => {});
     getClient()
@@ -427,7 +445,14 @@ export default function GeneralSettingsPage(): React.JSX.Element {
         </Section>
 
         <Section label="Recording">
-          <Row label="Hotkey" desc="Hold to record, release to transcribe.">
+          <Row
+            label="Hotkey"
+            desc={
+              hotkeyMode === "toggle"
+                ? "Press the shortcut once to start, press again to stop."
+                : "Hold the shortcut to record, release to transcribe."
+            }
+          >
             {recorderState === "idle" ? (
               <button
                 type="button"
@@ -485,6 +510,42 @@ export default function GeneralSettingsPage(): React.JSX.Element {
                 </div>
               </div>
             )}
+          </Row>
+
+          <Row
+            label="Activation"
+            desc={
+              hotkeyMode === "toggle"
+                ? "Press the shortcut once to start, again to stop."
+                : "Push-to-talk while the shortcut is held."
+            }
+          >
+            <div className="border-border bg-card inline-flex w-fit shrink-0 rounded-lg border p-0.5 text-sm">
+              <button
+                type="button"
+                onClick={() => handleHotkeyModeChange("hold")}
+                className={cn(
+                  "rounded-md px-3 py-1.5 transition-colors",
+                  hotkeyMode === "hold"
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                Hold
+              </button>
+              <button
+                type="button"
+                onClick={() => handleHotkeyModeChange("toggle")}
+                className={cn(
+                  "rounded-md px-3 py-1.5 transition-colors",
+                  hotkeyMode === "toggle"
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                Toggle
+              </button>
+            </div>
           </Row>
 
           <Row label="Microphone" desc="Select your audio input device.">


### PR DESCRIPTION
Hotkey rebinding is now fixed. Issue was introduced with #50
#50 replaced node-global-key-listener with native binaries for push to talk, but removed recording listeners which were used in key rebinding. 

This PR restores rebinding by spawning a temporary listener while rebinding, made for all platforms.
Additionally, it adds a feature to be able to switch between holding and toggling for recording mode. Hold mode makes you hold down the key until you're done talking, toggle allows you to turn it on and keep it on until you press the hotkey again to turn it off.

Addresses #84 