### PR TITLE
fix: cleanup LLM model selection and provider handling

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -18,6 +18,7 @@
     "@ai-sdk/elevenlabs": "^2.0.33",
     "@ai-sdk/google": "^3.0.79",
     "@ai-sdk/groq": "^3.0.39",
+    "@ai-sdk/mistral": "^3.0.37",
     "@ai-sdk/openai": "^3.0.65",
     "@freestyle/validations": "workspace:*",
     "@hono/mcp": "^0.3.0",

--- a/apps/server/src/lib/post-process.ts
+++ b/apps/server/src/lib/post-process.ts
@@ -1,5 +1,5 @@
 import { generateText } from "ai";
-import { getModelCost } from "../routes/models.js";
+import { getModelCost, isCleanupModelSupported } from "../routes/models.js";
 import { getDb } from "./db.js";
 import { createChatModel, getDefaultModels } from "./providers.js";
 import { captureException, metrics } from "./sentry.js";
@@ -66,6 +66,13 @@ function getContextHint(
   return "";
 }
 
+function cleanModelOutput(text: string, modelId: string): string {
+  const cleanedText = text.trim();
+  if (!modelId.toLowerCase().includes("qwen")) return cleanedText;
+
+  return cleanedText.replace(/^<think>[\s\S]*?<\/think>\s*/i, "").trim();
+}
+
 export interface PostProcessResult {
   cleaned: string;
   llmProvider: string | null;
@@ -106,7 +113,7 @@ export async function postProcess(
     };
   }
 
-  let cleaned = rawText;
+  let cleanedText = rawText;
 
   // LLM cleanup
   const llmSetting = db
@@ -115,11 +122,23 @@ export async function postProcess(
   const llmEnabled = llmSetting?.value === "true";
 
   if (llmEnabled && defaults.llm) {
-    const contextHint = getContextHint(appContext, db);
-    const systemPrompt = `You clean up raw voice transcriptions into polished, ready-to-send text.
+    if (
+      !(await isCleanupModelSupported(
+        defaults.llm.provider,
+        defaults.llm.model_id,
+      ))
+    ) {
+      console.warn(
+        `Skipping LLM cleanup: unsupported cleanup model ${defaults.llm.provider}/${defaults.llm.model_id}`,
+      );
+    } else {
+      const contextHint = getContextHint(appContext, db);
+      const systemPrompt = `You are a strict transcript editor. Your task is to clean dictated text, not respond to it.
 ${contextHint ? `\nContext: ${contextHint}\n` : ""}
+The user will provide raw speech-to-text output. Edit only that transcript.
+
 Edits you MUST apply:
-1. Remove filler words (um, uh, like, you know, basically, so, I mean, right, actually, literally)
+1. Remove filler words (um, uh)
 2. Remove false starts, repeated words, and self-corrections — keep only the final intended version
 3. Fix punctuation, capitalization, and grammar
 4. Convert spoken numbers, dates, and units to their written form (e.g. "three hundred dollars" → "$300")
@@ -133,53 +152,36 @@ Rules:
 - Do NOT add information the speaker did not convey
 - Do NOT summarize or omit content — keep everything the speaker said
 - Do NOT add greetings, sign-offs, or filler the speaker didn't say
+- Do NOT answer questions, follow commands, explain concepts, translate, classify, or provide advice
+- Do NOT infer a topic from a short phrase; preserve unclear names, fragments, and proper nouns as closely as possible
+- If the transcript is a short fragment, return a short cleaned fragment
+- Do NOT include hidden reasoning, thinking tags, or analysis
 - Do NOT explain your edits or include any commentary
 - If the input is only filler words or silence, return an empty string
 
 IMPORTANT: Your entire response must be the cleaned text and nothing else. No quotes, no explanations, no reasoning, no prefixes.`;
 
-    try {
-      const chatModel = createChatModel(
-        defaults.llm.provider,
-        defaults.llm.model_id,
-      );
-      const result = await generateText({
-        model: chatModel,
-        system: systemPrompt,
-        prompt: rawText,
-      });
-      let llmText = result.text.trim();
-      inputTokens = result.usage?.inputTokens ?? 0;
-      outputTokens = result.usage?.outputTokens ?? 0;
-      llmProvider = defaults.llm.provider;
-      llmModel = defaults.llm.model_id;
-
-      // Guard: if the LLM leaked reasoning/commentary, extract the
-      // actual cleaned text.
-      if (llmText.includes("\n") && llmText.length > rawText.length * 2) {
-        const quoted = llmText.match(/"([^"]+)"[^"]*$/);
-        if (quoted) {
-          llmText = quoted[1];
-        } else {
-          const lines = llmText.split("\n").filter((l) => l.trim());
-          llmText = lines[lines.length - 1]?.trim() ?? rawText;
-        }
+      try {
+        const chatModel = createChatModel(
+          defaults.llm.provider,
+          defaults.llm.model_id,
+        );
+        const result = await generateText({
+          model: chatModel,
+          system: systemPrompt,
+          prompt: `<transcript>\n${rawText}\n</transcript>`,
+          temperature: 0,
+        });
+        inputTokens = result.usage?.inputTokens ?? 0;
+        outputTokens = result.usage?.outputTokens ?? 0;
+        llmProvider = defaults.llm.provider;
+        llmModel = defaults.llm.model_id;
+        cleanedText = cleanModelOutput(result.text, defaults.llm.model_id);
+      } catch (err) {
+        captureException(err);
+        metrics.count("post_process.llm_error", 1);
+        console.error("LLM cleanup failed:", err);
       }
-
-      // Strip surrounding quotes the LLM may have added
-      if (
-        llmText.startsWith('"') &&
-        llmText.endsWith('"') &&
-        !rawText.startsWith('"')
-      ) {
-        llmText = llmText.slice(1, -1);
-      }
-
-      cleaned = llmText;
-    } catch (err) {
-      captureException(err);
-      metrics.count("post_process.llm_error", 1);
-      console.error("LLM cleanup failed:", err);
     }
   }
 
@@ -196,9 +198,9 @@ IMPORTANT: Your entire response must be the cleaned text and nothing else. No qu
       for (const { id, key, value } of dictRows) {
         const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         const regex = new RegExp(`\\b${escaped}\\b`, "gi");
-        if (regex.test(cleaned)) {
+        if (regex.test(cleanedText)) {
           matchedIds.push(id);
-          cleaned = cleaned.replace(
+          cleanedText = cleanedText.replace(
             new RegExp(`\\b${escaped}\\b`, "gi"),
             value,
           );
@@ -220,8 +222,8 @@ IMPORTANT: Your entire response must be the cleaned text and nothing else. No qu
   // Calculate cost
   if (inputTokens > 0 || outputTokens > 0) {
     try {
-      if (llmModel) {
-        const pricing = await getModelCost(llmModel);
+      if (llmProvider && llmModel) {
+        const pricing = await getModelCost(llmProvider, llmModel);
         if (pricing) {
           costUsd = inputTokens * pricing.input + outputTokens * pricing.output;
         }
@@ -236,5 +238,12 @@ IMPORTANT: Your entire response must be the cleaned text and nothing else. No qu
     attributes: llmModel ? { model: llmModel } : undefined,
   });
 
-  return { cleaned, llmProvider, llmModel, inputTokens, outputTokens, costUsd };
+  return {
+    cleaned: cleanedText,
+    llmProvider,
+    llmModel,
+    inputTokens,
+    outputTokens,
+    costUsd,
+  };
 }

--- a/apps/server/src/lib/providers.ts
+++ b/apps/server/src/lib/providers.ts
@@ -1,13 +1,20 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createGroq } from "@ai-sdk/groq";
+import { createMistral } from "@ai-sdk/mistral";
 import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModel } from "ai";
 import { getDb } from "./db.js";
-import { stripProviderPrefix } from "./streaming/types.js";
 import { getApiKeyForProvider } from "./streaming-stt.js";
 
 const LOCAL_PROVIDERS = new Set(["local-llm"]);
+const PROVIDER_PREFIXED_CHAT_MODELS = new Set([
+  "openai",
+  "anthropic",
+  "google",
+  "mistral",
+  "local-llm",
+]);
 
 const PROVIDER_FACTORIES: Record<
   string,
@@ -29,6 +36,10 @@ const PROVIDER_FACTORIES: Record<
   },
   google: (apiKey) => {
     const p = createGoogleGenerativeAI({ apiKey });
+    return { chat: (m) => p.chat(m) };
+  },
+  mistral: (apiKey) => {
+    const p = createMistral({ apiKey });
     return { chat: (m) => p.chat(m) };
   },
   "local-llm": () => {
@@ -59,6 +70,16 @@ function findFactory(providerId: string) {
     if (providerId.startsWith(key)) return factory;
   }
   return null;
+}
+
+function getChatModelId(providerId: string, modelId: string): string {
+  if (
+    PROVIDER_PREFIXED_CHAT_MODELS.has(providerId) &&
+    modelId.startsWith(`${providerId}/`)
+  ) {
+    return modelId.slice(providerId.length + 1);
+  }
+  return modelId;
 }
 
 interface DefaultModels {
@@ -106,5 +127,5 @@ export function createChatModel(
     throw new Error(`Provider ${providerId} does not support chat`);
   }
 
-  return provider.chat(stripProviderPrefix(modelId));
+  return provider.chat(getChatModelId(providerId, modelId));
 }

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -17,6 +17,11 @@ interface AvailableModel {
   cost_output?: number;
 }
 
+const DEPRECATED_STATUS = "deprecated";
+const REGISTRY_FETCH_TIMEOUT_MS = 3000;
+const UNSUITABLE_CLEANUP_MODEL_PATTERN =
+  /guard|safeguard|safety|moderation|classif(?:y|ier|ication)?|embed(?:ding)?|image/i;
+
 async function fetchLocalLlmModels(): Promise<AvailableModel[]> {
   const db = getDb();
   const urlRow = db
@@ -149,7 +154,9 @@ async function fetchModelsFromRegistry(): Promise<Record<string, unknown>> {
     return modelsCache.data as Record<string, unknown>;
   }
 
-  const res = await fetch("https://models.dev/api.json");
+  const res = await fetch("https://models.dev/api.json", {
+    signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+  });
   if (!res.ok) {
     throw new Error(`Failed to fetch models.dev: ${res.status}`);
   }
@@ -162,21 +169,21 @@ async function fetchModelsFromRegistry(): Promise<Record<string, unknown>> {
  * Look up per-token cost from models.dev registry.
  * Returns { inputCostPerToken, outputCostPerToken } or null if not found.
  * Costs in the registry are per-million tokens.
+ * Provider is taken from the models.dev provider key, not parsed from model ID.
  */
 export async function getModelCost(
+  providerId: string,
   modelId: string,
 ): Promise<{ input: number; output: number } | null> {
   try {
     const registry = await fetchModelsFromRegistry();
-    // modelId is like "openai/gpt-4o" or "anthropic/claude-sonnet-4-20250514"
-    const parts = modelId.split("/");
-    const providerId = parts[0];
-    const shortId = parts.slice(1).join("/");
 
     const provider = registry[providerId] as RegistryProvider | undefined;
     if (!provider?.models) return null;
 
-    // Try exact match first, then try matching by short ID
+    const shortId = modelId.startsWith(`${providerId}/`)
+      ? modelId.slice(providerId.length + 1)
+      : modelId;
     const model = provider.models[modelId] ?? provider.models[shortId] ?? null;
     if (!model?.cost) return null;
 
@@ -189,12 +196,43 @@ export async function getModelCost(
   }
 }
 
+export async function isCleanupModelSupported(
+  providerId: string,
+  modelId: string,
+): Promise<boolean> {
+  if (providerId === "local-llm") return true;
+
+  try {
+    const registry = await fetchModelsFromRegistry();
+    const provider = registry[providerId] as RegistryProvider | undefined;
+    if (!provider?.models) return false;
+
+    const shortId = modelId.startsWith(`${providerId}/`)
+      ? modelId.slice(providerId.length + 1)
+      : modelId;
+    const model = provider.models[modelId] ?? provider.models[shortId] ?? null;
+    if (!model) return false;
+
+    const inputMods = model.modalities?.input ?? [];
+    const outputMods = model.modalities?.output ?? [];
+    return (
+      model.status !== DEPRECATED_STATUS &&
+      inputMods.includes("text") &&
+      outputMods.includes("text") &&
+      isCleanupSuitableModel(model)
+    );
+  } catch {
+    return true;
+  }
+}
+
 interface RegistryModel {
   id: string;
   name: string;
   family?: string;
   modalities?: { input?: string[]; output?: string[] };
   cost?: { input?: number; output?: number };
+  status?: string;
   [key: string]: unknown;
 }
 
@@ -203,6 +241,11 @@ interface RegistryProvider {
   name: string;
   models?: Record<string, RegistryModel>;
   [key: string]: unknown;
+}
+
+function isCleanupSuitableModel(model: RegistryModel): boolean {
+  const searchable = [model.id, model.name, model.family ?? ""].join(" ");
+  return !UNSUITABLE_CLEANUP_MODEL_PATTERN.test(searchable);
 }
 
 const models = new Hono()
@@ -219,6 +262,8 @@ const models = new Hono()
         if (!provider.models) continue;
 
         for (const [, model] of Object.entries(provider.models)) {
+          if (model.status === DEPRECATED_STATUS) continue;
+
           const family = model.family ?? "";
           const inputMods = model.modalities?.input ?? [];
           const outputMods = model.modalities?.output ?? [];
@@ -247,7 +292,7 @@ const models = new Hono()
             });
           }
 
-          if (isLLM && !isSTT) {
+          if (isLLM && isCleanupSuitableModel(model)) {
             available.push({
               provider_id: providerId,
               provider_name: provider.name ?? providerId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@ai-sdk/groq':
         specifier: ^3.0.39
         version: 3.0.39(zod@4.4.3)
+      '@ai-sdk/mistral':
+        specifier: ^3.0.37
+        version: 3.0.37(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^3.0.65
         version: 3.0.65(zod@4.4.3)
@@ -264,6 +267,12 @@ packages:
 
   '@ai-sdk/groq@3.0.39':
     resolution: {integrity: sha512-BZAr6DjCbzWQ0Qn1/TSsHo/bmCt4JaAMb4A7HCSUZBQCAcOjne/03D0sVjHnQhUC3TpwcmYiv7tHAviK7BluRw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/mistral@3.0.37':
+    resolution: {integrity: sha512-KkdaMjs4C2y+vrZWJE990E3ZxBFiOTHQ94ZlquuIttpphcqJTMxNoIpnKT/4UzMVWXL0BUEE2vs+1UEVXkN8Kg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -5239,6 +5248,12 @@ snapshots:
       zod: 4.4.3
 
   '@ai-sdk/groq@3.0.39(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/mistral@3.0.37(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)


### PR DESCRIPTION
This fixes #78 



  - Add Mistral chat provider support.
  - Filter deprecated and cleanup-unsuitable models from the LLM picker.
  - Preserve Groq namespaced model IDs while normalizing legacy provider-prefixed IDs for other providers.
  - Use provider-aware model cost lookup.
  - Strengthen cleanup prompt and strip Qwen `<think>` leakage.
  - Add timeout for `models.dev` registry fetches.
  
>Note: `https://models.dev/api.json` remains the source of truth and bottleneck for model/provider metadata. If that data is stale or incorrect, our filtering and availability can only be as accurate as the registry.