### PR TITLE
fix: increase default app window size on open

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -42,8 +42,8 @@ import { MicListener } from "./mic-listener";
 import { pasteIntoFocusedApp } from "./paste";
 
 const DEFAULT_PORT = 4649;
-const APP_WIDTH = 260;
-const APP_HEIGHT = 90;
+const APP_WIDTH = 480;
+const APP_HEIGHT = 360;
 const APP_BOTTOM_MARGIN = 0;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Increased the default window size of the Electron app from 260×90 to 480×360.

## Why

When opened, the app window was very small (260×90), causing most of the content to be hidden. Users had to manually resize the window to see the full interface. This change ensures the entire app content is visible on launch.

## Testing

- Changed `APP_WIDTH` and `APP_HEIGHT` constants in `apps/electron/src/main/index.ts`
- All existing window positioning logic (`getAppWindowPosition()`) still works correctly with the new dimensions
- Window remains centered/repositioned according to user's pill position preference