### PR TITLE
Changed settings window size

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -224,8 +224,8 @@ function createAppWindow(): void {
 
 function createSettingsWindow(): void {
   settingsWindow = new BrowserWindow({
-    width: 800,
-    height: 560,
+    width: 1152,
+    height: 648,
     minWidth: 720,
     minHeight: 480,
     show: false,


### PR DESCRIPTION
Changed the app size from 800x560 to 1152x648 in the `apps/electron/src/main/index.ts` file, `createSettingsWindow()` function.
After further inspection I realized that, the window that the issue was referring to is not created in the `createAppWindow()` function but instead in the `createSettingsWindow()` function, unlike what I described in the issue comment. So I didn't change `APP_WIDTH` or `APP_HEIGHT` variables.

The current page looks like this:
<img width="1919" height="1132" alt="ss" src="https://github.com/user-attachments/assets/d9309d6b-36f6-4539-9188-3881e048f205" />

Note: While changing the mentioned file, I noticed that there was a variable declaration `const APP_BOTTOM_MARGIN = 0;` that wasn't used anywhere in the code so it can be removed unless its planned for future use.

Closes #88 