### PR TITLE
fix: update & restart button and download state tracking

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -877,6 +877,7 @@ app.whenReady().then(async () => {
   // Track the version we already notified about so periodic checks don't
   // spam the user with repeat notifications every 5 minutes.
   let notifiedVersion: string | null = null;
+  let updateDownloadState: "idle" | "downloading" | "downloaded" = "idle";
 
   if (!is.dev) {
     const autoUpdateEnabled = readSettings().autoUpdate !== false;
@@ -887,6 +888,10 @@ app.whenReady().then(async () => {
       settingsWindow?.webContents.send("updater:available", {
         version: info.version,
       });
+      if (autoUpdater.autoDownload) {
+        updateDownloadState = "downloading";
+        settingsWindow?.webContents.send("updater:downloading");
+      }
       // Only show a native notification once per discovered version
       if (Notification.isSupported() && notifiedVersion !== info.version) {
         notifiedVersion = info.version;
@@ -902,6 +907,7 @@ app.whenReady().then(async () => {
     });
 
     autoUpdater.on("update-downloaded", (info) => {
+      updateDownloadState = "downloaded";
       settingsWindow?.webContents.send("updater:downloaded", {
         version: info.version,
       });
@@ -915,6 +921,15 @@ app.whenReady().then(async () => {
       }
     });
 
+    autoUpdater.on("error", (err) => {
+      if (updateDownloadState === "downloading") {
+        updateDownloadState = "idle";
+      }
+      settingsWindow?.webContents.send("updater:error", {
+        message: err?.message ?? "Update failed",
+      });
+    });
+
     autoUpdater.checkForUpdatesAndNotify();
 
     // Always start periodic background checking regardless of auto-update setting
@@ -922,10 +937,12 @@ app.whenReady().then(async () => {
   }
 
   ipcMain.on("updater:download", () => {
+    updateDownloadState = "downloading";
     autoUpdater.downloadUpdate();
   });
 
   ipcMain.on("updater:install", () => {
+    isUpdaterQuitting = true;
     autoUpdater.quitAndInstall();
   });
 
@@ -937,7 +954,7 @@ app.whenReady().then(async () => {
       if (!latest) return null;
       // Only report an update when the remote version is actually newer
       if (latest === app.getVersion()) return null;
-      return latest;
+      return { version: latest, downloadState: updateDownloadState };
     } catch {
       return null;
     }
@@ -1193,11 +1210,10 @@ app.on("window-all-closed", () => {
 });
 
 // Gracefully shut down the HTTP server and flush Sentry before quitting
+let isUpdaterQuitting = false;
 let isQuitting = false;
-app.on("before-quit", (event) => {
-  if (isQuitting) return;
-  isQuitting = true;
-  event.preventDefault();
+
+function cleanupBeforeQuit(): void {
   fetch(`http://127.0.0.1:${serverPort}/api/whisper/server/stop`, {
     method: "POST",
   }).catch(() => {});
@@ -1205,5 +1221,16 @@ app.on("before-quit", (event) => {
     httpServer.close();
     httpServer = null;
   }
+}
+
+app.on("before-quit", (event) => {
+  if (isUpdaterQuitting) {
+    cleanupBeforeQuit();
+    return;
+  }
+  if (isQuitting) return;
+  isQuitting = true;
+  event.preventDefault();
+  cleanupBeforeQuit();
   Sentry.close(2000).finally(() => app.exit(0));
 });

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -31,7 +31,10 @@ declare global {
       ) => () => void;
       onHotkeyRecordCancel: (callback: () => void) => () => void;
       // Auto-updater
-      checkForUpdate: () => Promise<string | null>;
+      checkForUpdate: () => Promise<{
+        version: string;
+        downloadState: string;
+      } | null>;
       downloadUpdate: () => void;
       installUpdate: () => void;
       onUpdateAvailable: (
@@ -39,6 +42,10 @@ declare global {
       ) => () => void;
       onUpdateDownloaded: (
         callback: (info: { version: string }) => void,
+      ) => () => void;
+      onUpdateDownloading: (callback: () => void) => () => void;
+      onUpdateError: (
+        callback: (info: { message: string }) => void,
       ) => () => void;
       // Auto-update setting
       getAutoUpdate: () => Promise<boolean>;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -70,8 +70,10 @@ const api = {
     return () => ipcRenderer.removeListener("hotkey-record:cancel", handler);
   },
   // Auto-updater
-  checkForUpdate: (): Promise<string | null> =>
-    ipcRenderer.invoke("updater:check"),
+  checkForUpdate: (): Promise<{
+    version: string;
+    downloadState: string;
+  } | null> => ipcRenderer.invoke("updater:check"),
   downloadUpdate: (): void => ipcRenderer.send("updater:download"),
   installUpdate: (): void => ipcRenderer.send("updater:install"),
   onUpdateAvailable: (
@@ -89,6 +91,19 @@ const api = {
       callback(info);
     ipcRenderer.on("updater:downloaded", handler);
     return () => ipcRenderer.removeListener("updater:downloaded", handler);
+  },
+  onUpdateDownloading: (callback: () => void): (() => void) => {
+    const handler = (): void => callback();
+    ipcRenderer.on("updater:downloading", handler);
+    return () => ipcRenderer.removeListener("updater:downloading", handler);
+  },
+  onUpdateError: (
+    callback: (info: { message: string }) => void,
+  ): (() => void) => {
+    const handler = (_: unknown, info: { message: string }): void =>
+      callback(info);
+    ipcRenderer.on("updater:error", handler);
+    return () => ipcRenderer.removeListener("updater:error", handler);
   },
   // Auto-update setting
   getAutoUpdate: (): Promise<boolean> =>

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -107,6 +107,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null);
   const [updateDownloaded, setUpdateDownloaded] = useState(false);
   const [downloading, setDownloading] = useState(false);
+  const [updateError, setUpdateError] = useState<string | null>(null);
   const [autoUpdate, setAutoUpdate] = useState(true);
 
   // Permissions
@@ -293,14 +294,29 @@ export default function GeneralSettingsPage(): React.JSX.Element {
     const removeAvail = window.api?.onUpdateAvailable((info) => {
       setUpdateAvailable(info.version);
     });
+    const removeDownloading = window.api?.onUpdateDownloading(() => {
+      setDownloading(true);
+      setUpdateError(null);
+    });
     const removeDownloaded = window.api?.onUpdateDownloaded(() => {
       setUpdateDownloaded(true);
       setDownloading(false);
     });
+    const removeError = window.api?.onUpdateError((info) => {
+      setDownloading(false);
+      setUpdateError(info.message);
+    });
     window.api
       ?.checkForUpdate()
-      .then((v) => {
-        if (v) setUpdateAvailable(v);
+      .then((result) => {
+        if (result) {
+          setUpdateAvailable(result.version);
+          if (result.downloadState === "downloading") {
+            setDownloading(true);
+          } else if (result.downloadState === "downloaded") {
+            setUpdateDownloaded(true);
+          }
+        }
       })
       .catch(() => {});
 
@@ -308,7 +324,9 @@ export default function GeneralSettingsPage(): React.JSX.Element {
 
     return () => {
       removeAvail?.();
+      removeDownloading?.();
       removeDownloaded?.();
+      removeError?.();
       if (micPollRef.current) clearInterval(micPollRef.current);
       if (accessibilityPollRef.current)
         clearInterval(accessibilityPollRef.current);
@@ -423,6 +441,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
                 type="button"
                 onClick={() => {
                   setDownloading(true);
+                  setUpdateError(null);
                   window.api?.downloadUpdate();
                 }}
                 disabled={downloading}
@@ -430,6 +449,11 @@ export default function GeneralSettingsPage(): React.JSX.Element {
               >
                 {downloading ? "Downloading..." : "Download"}
               </button>
+            )}
+            {updateError && (
+              <span className="text-destructive w-full text-xs">
+                {updateError}
+              </span>
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary

- **Fix "Restart & Update" doing nothing**: The `before-quit` handler was calling `event.preventDefault()` + `app.exit(0)`, which short-circuited `autoUpdater.quitAndInstall()` — the electron-updater never got to launch the installer. Added an `isUpdaterQuitting` flag so the quit proceeds normally when triggered by the updater.
- **Fix settings page not reflecting background downloads**: When auto-download was enabled, the download would start in the background but the settings page still showed a "Download" button instead of "Downloading...". The main process now tracks download state (`idle`/`downloading`/`downloaded`) and returns it from `updater:check`, plus sends a `updater:downloading` IPC event so the UI stays in sync.
- **Add error handling for update failures**: Added `autoUpdater.on("error", ...)` handler that forwards errors to the renderer via `updater:error` IPC, so the UI can recover from failed downloads (clears the "Downloading..." state, shows the error message) instead of getting stuck indefinitely.
- **DRY refactor**: Extracted duplicated whisper-stop + httpServer cleanup into `cleanupBeforeQuit()` helper.

## Changed files

| File | Changes |
|---|---|
| `apps/electron/src/main/index.ts` | Track `updateDownloadState`, add `isUpdaterQuitting` flag, add error handler, update `updater:check` return shape, extract `cleanupBeforeQuit()` helper |
| `apps/electron/src/preload/index.ts` | Update `checkForUpdate` return type, add `onUpdateDownloading` and `onUpdateError` bridges |
| `apps/electron/src/preload/index.d.ts` | Update type declarations to match |
| `apps/electron/src/renderer/src/pages/settings/general.tsx` | Handle new `checkForUpdate` return shape, subscribe to downloading/error events, show error in UI |