### PR TITLE
fix: set app name to Freestyle in macOS menu bar

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -618,6 +618,9 @@ app.whenReady().then(async () => {
   // Set app user model id for windows
   electronApp.setAppUserModelId("com.freestyle.app");
 
+  // Override app.name so macOS menu shows "Freestyle" instead of the package name
+  app.setName("Freestyle");
+
   // Register the custom app:// protocol for production SPA support
   registerAppProtocol();
 


### PR DESCRIPTION
## Summary

- During development, `app.name` defaults to the `package.json` `name` field (`@freestyle/electron`), causing the macOS application menu to display "About @freestyle/electron", "Hide @freestyle/electron", "Quit @freestyle/electron"
- Adds `app.setName("Freestyle")` in the main process so the menu correctly shows "About Freestyle", "Hide Freestyle", "Quit Freestyle" in both dev and production