### PR TITLE
feat: add launch at startup setting and fix accessibility permission check

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -618,6 +618,9 @@ app.whenReady().then(async () => {
   // Set app user model id for windows
   electronApp.setAppUserModelId("com.freestyle.app");
 
+  // Override app.name so macOS menu shows "Freestyle" instead of the package name
+  app.setName("Freestyle");
+
   // Register the custom app:// protocol for production SPA support
   registerAppProtocol();
 

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -87,6 +87,10 @@ let mainWindow: BrowserWindow | null = null;
 let settingsWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let keyListener: NativeKeyListener | null = null;
+// Latching flag: once the native key listener (or globalShortcut fallback)
+// has started successfully, accessibility is confirmed. The flag persists
+// even when keyListener is temporarily torn down for hotkey recording.
+let accessibilityConfirmed = false;
 let hotkeyPressed = false;
 let currentHotkeyAccel: string | null = null;
 let hotkeyActivationMode: "hold" | "toggle" = "hold";
@@ -734,7 +738,12 @@ app.whenReady().then(async () => {
   ipcMain.handle("permissions:check-accessibility", async () => {
     if (process.platform === "darwin") {
       const { systemPreferences } = await import("electron");
-      return systemPreferences.isTrustedAccessibilityClient(false);
+      const trusted = systemPreferences.isTrustedAccessibilityClient(false);
+      // The Electron API can return a stale result when the code signature
+      // changes between builds. Cross-check with accessibilityConfirmed —
+      // a latching flag set when the native key listener (or globalShortcut
+      // fallback) starts successfully, proving accessibility is working.
+      return trusted || accessibilityConfirmed;
     }
     return true;
   });
@@ -958,6 +967,15 @@ app.whenReady().then(async () => {
     }
   });
 
+  // -- Launch at startup setting IPC --
+  ipcMain.handle("settings:launch-at-startup", () => {
+    return app.getLoginItemSettings().openAtLogin;
+  });
+
+  ipcMain.on("settings:set-launch-at-startup", (_event, enabled: boolean) => {
+    app.setLoginItemSettings({ openAtLogin: enabled });
+  });
+
   // -- Context-aware dictation: get frontmost app + browser context --
   ipcMain.handle("system:frontmost-app", async () => {
     try {
@@ -1146,6 +1164,10 @@ function registerHotkey(hotkey?: string): void {
 
   const started = keyListener.start();
 
+  if (started) {
+    accessibilityConfirmed = true;
+  }
+
   if (!started) {
     console.warn(
       "[hotkey] Native key listener unavailable, falling back to Electron globalShortcut (toggle mode).",
@@ -1162,6 +1184,9 @@ function registerHotkey(hotkey?: string): void {
         sendHotkeyUp();
       }
     });
+    if (registered) {
+      accessibilityConfirmed = true;
+    }
     if (!registered) {
       const errorPayload = {
         message: `Could not register hotkey "${accel}". Try a different key combination in Settings.`,

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1166,9 +1166,7 @@ function registerHotkey(hotkey?: string): void {
 
   if (started) {
     accessibilityConfirmed = true;
-  }
-
-  if (!started) {
+  } else {
     console.warn(
       "[hotkey] Native key listener unavailable, falling back to Electron globalShortcut (toggle mode).",
     );
@@ -1186,8 +1184,7 @@ function registerHotkey(hotkey?: string): void {
     });
     if (registered) {
       accessibilityConfirmed = true;
-    }
-    if (!registered) {
+    } else {
       const errorPayload = {
         message: `Could not register hotkey "${accel}". Try a different key combination in Settings.`,
       };

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -43,6 +43,9 @@ declare global {
       // Auto-update setting
       getAutoUpdate: () => Promise<boolean>;
       setAutoUpdate: (enabled: boolean) => void;
+      // Launch at startup setting
+      getLaunchAtStartup: () => Promise<boolean>;
+      setLaunchAtStartup: (enabled: boolean) => void;
       // Context-aware dictation
       getFrontmostApp: () => Promise<string | null>;
       // Pill position

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -95,6 +95,11 @@ const api = {
     ipcRenderer.invoke("settings:auto-update"),
   setAutoUpdate: (enabled: boolean): void =>
     ipcRenderer.send("settings:set-auto-update", enabled),
+  // Launch at startup setting
+  getLaunchAtStartup: (): Promise<boolean> =>
+    ipcRenderer.invoke("settings:launch-at-startup"),
+  setLaunchAtStartup: (enabled: boolean): void =>
+    ipcRenderer.send("settings:set-launch-at-startup", enabled),
   // Context-aware dictation
   getFrontmostApp: (): Promise<string | null> =>
     ipcRenderer.invoke("system:frontmost-app"),

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -234,7 +234,11 @@ export default function AppPage(): React.JSX.Element {
       return;
     }
 
-    await window.api.pasteText(finalText);
+    try {
+      await window.api.pasteText(finalText);
+    } catch (err) {
+      console.error("[pill] paste failed:", err);
+    }
     window.api.sendTranscriptionDone();
 
     drainingRef.current = false;

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -533,8 +533,8 @@ export default function OnboardingPage(): React.JSX.Element {
 
               {/* Launch at startup */}
               <div className="border-border rounded-lg border p-4">
-                <div className="flex items-center gap-3">
-                  <Power className="text-muted-foreground h-5 w-5 shrink-0" />
+                <div className="flex items-start gap-3">
+                  <Power className="text-muted-foreground mt-0.5 h-5 w-5 shrink-0" />
                   <div className="flex-1">
                     <div className="text-sm font-medium">Launch at startup</div>
                     <p className="text-muted-foreground text-xs">

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -23,6 +23,7 @@ import {
   Keyboard,
   Loader2,
   Mic,
+  Power,
   Shield,
   Sparkles,
 } from "lucide-react";
@@ -44,6 +45,7 @@ export default function OnboardingPage(): React.JSX.Element {
   // Permissions state
   const [micStatus, setMicStatus] = useState<string>("unknown");
   const [accessibilityStatus, setAccessibilityStatus] = useState(false);
+  const [launchAtStartup, setLaunchAtStartup] = useState(false);
 
   // Voice model state
   const [modelSource, setModelSource] = useState<"cloud" | "local">("cloud");
@@ -88,6 +90,10 @@ export default function OnboardingPage(): React.JSX.Element {
     window.api
       ?.checkAccessibilityPermission()
       .then(setAccessibilityStatus)
+      .catch(() => {});
+    window.api
+      ?.getLaunchAtStartup()
+      .then(setLaunchAtStartup)
       .catch(() => {});
   }, []);
 
@@ -158,6 +164,11 @@ export default function OnboardingPage(): React.JSX.Element {
       }
     }, 1000);
     setTimeout(() => clearInterval(interval), 30000);
+  }, []);
+
+  const handleLaunchAtStartup = useCallback((enabled: boolean) => {
+    setLaunchAtStartup(enabled);
+    window.api?.setLaunchAtStartup(enabled);
   }, []);
 
   const openAccessibility = useCallback(() => {
@@ -517,6 +528,23 @@ export default function OnboardingPage(): React.JSX.Element {
                         : "Press once to start recording, press again to stop and transcribe. You can change this in Settings later."}
                     </p>
                   </div>
+                </div>
+              </div>
+
+              {/* Launch at startup */}
+              <div className="border-border rounded-lg border p-4">
+                <div className="flex items-center gap-3">
+                  <Power className="text-muted-foreground h-5 w-5 shrink-0" />
+                  <div className="flex-1">
+                    <div className="text-sm font-medium">Launch at startup</div>
+                    <p className="text-muted-foreground text-xs">
+                      Automatically start Freestyle when you log in.
+                    </p>
+                  </div>
+                  <Toggle
+                    on={launchAtStartup}
+                    onChange={handleLaunchAtStartup}
+                  />
                 </div>
               </div>
 

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -166,7 +166,7 @@ export default function OnboardingPage(): React.JSX.Element {
     setTimeout(() => clearInterval(interval), 30000);
   }, []);
 
-  const handleLaunchAtStartup = useCallback((enabled: boolean) => {
+  const handleLaunchAtStartupToggle = useCallback((enabled: boolean) => {
     setLaunchAtStartup(enabled);
     window.api?.setLaunchAtStartup(enabled);
   }, []);
@@ -543,7 +543,7 @@ export default function OnboardingPage(): React.JSX.Element {
                   </div>
                   <Toggle
                     on={launchAtStartup}
-                    onChange={handleLaunchAtStartup}
+                    onChange={handleLaunchAtStartupToggle}
                   />
                 </div>
               </div>

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -108,6 +108,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
   const [updateDownloaded, setUpdateDownloaded] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [autoUpdate, setAutoUpdate] = useState(true);
+  const [launchAtStartup, setLaunchAtStartup] = useState(false);
 
   // Permissions
   type MicStatus =
@@ -289,6 +290,12 @@ export default function GeneralSettingsPage(): React.JSX.Element {
       .then((v) => setAutoUpdate(v))
       .catch(() => {});
 
+    // Launch at startup setting
+    window.api
+      ?.getLaunchAtStartup()
+      .then((v) => setLaunchAtStartup(v))
+      .catch(() => {});
+
     // Auto-updater events
     const removeAvail = window.api?.onUpdateAvailable((info) => {
       setUpdateAvailable(info.version);
@@ -353,6 +360,11 @@ export default function GeneralSettingsPage(): React.JSX.Element {
   const handleAutoUpdateToggle = useCallback((enabled: boolean) => {
     setAutoUpdate(enabled);
     window.api?.setAutoUpdate(enabled);
+  }, []);
+
+  const handleLaunchAtStartupToggle = useCallback((enabled: boolean) => {
+    setLaunchAtStartup(enabled);
+    window.api?.setLaunchAtStartup(enabled);
   }, []);
 
   const clearHistory = useCallback(async () => {
@@ -438,9 +450,18 @@ export default function GeneralSettingsPage(): React.JSX.Element {
           <Row
             label="Automatic updates"
             desc="Download new versions in the background as soon as they ship."
-            last
           >
             <Toggle on={autoUpdate} onChange={handleAutoUpdateToggle} />
+          </Row>
+          <Row
+            label="Launch at startup"
+            desc="Automatically start Freestyle when you log in to your computer."
+            last
+          >
+            <Toggle
+              on={launchAtStartup}
+              onChange={handleLaunchAtStartupToggle}
+            />
           </Row>
         </Section>
 
@@ -689,6 +710,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
               onAction={
                 micStatus === "denied" && isMac ? openMicSettings : requestMic
               }
+              onManage={isMac ? openMicSettings : undefined}
             />
           </Row>
           <Row
@@ -712,6 +734,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
               }
               external={isMac}
               onAction={openAccessibility}
+              onManage={isMac ? openAccessibility : undefined}
               note={
                 !isMac && accessibilityStatus !== true
                   ? "Auto-granted"
@@ -885,6 +908,7 @@ function PermissionControl({
   actionLabel,
   external,
   onAction,
+  onManage,
   note,
 }: {
   granted: boolean;
@@ -892,13 +916,26 @@ function PermissionControl({
   actionLabel: string | null;
   external?: boolean;
   onAction?: () => void;
+  onManage?: () => void;
   note?: string;
 }) {
   return (
     <div className="flex items-center gap-3">
       <StatusDot granted={granted} checking={checking} />
       {granted ? (
-        <Check className="text-primary h-4 w-4" />
+        <>
+          <Check className="text-primary h-4 w-4" />
+          {onManage && (
+            <button
+              type="button"
+              onClick={onManage}
+              className="border-border hover:bg-secondary inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors"
+            >
+              Manage
+              <ExternalLink className="h-3 w-3" />
+            </button>
+          )}
+        </>
       ) : note ? (
         <span className="text-muted-foreground text-xs">{note}</span>
       ) : actionLabel && onAction ? (


### PR DESCRIPTION
Add "Launch at Startup" toggle and fix the accessibility permission status showing "Needed" even after granting.

## Changes

- **Launch at Startup**: Add `app.setLoginItemSettings` IPC handlers, preload bridge, a toggle in Settings > General > Application, and an opt-in card in the Onboarding permissions step. Works cross-platform via Electron's login item API.
- **Accessibility check fix**: `systemPreferences.isTrustedAccessibilityClient(false)` returns stale `false` on macOS when the code signature changes between builds (TCC cache mismatch). Added a latching `accessibilityConfirmed` flag that gets set when the native key listener or globalShortcut fallback starts successfully, proving accessibility is working.
- **Manage button**: Granted permissions now show a "Manage" button (macOS only) that opens the relevant System Settings pane so users can review or revoke permissions.

## Testing

TypeScript compiles clean across all configs (`tsconfig.node.json`, `tsconfig.web.json`). Biome lint/format passes. Manual testing required for the macOS accessibility cross-check behavior.

<!--
## Plan

### Feature 1: Launch at Startup
1. Main process (`index.ts`): Add `settings:launch-at-startup` (handle) and `settings:set-launch-at-startup` (on) IPC handlers using `app.getLoginItemSettings()` / `app.setLoginItemSettings({ openAtLogin })`.
2. Preload bridge (`preload/index.ts` + `index.d.ts`): Expose `getLaunchAtStartup()` and `setLaunchAtStartup(enabled)`.
3. Settings UI (`general.tsx`): Add `launchAtStartup` state, load on mount, toggle handler, and a new Row in the Application section below "Automatic updates".
4. Onboarding (`onboarding.tsx`): Add a "Launch at startup" toggle card in the permissions step with Power icon.

### Feature 2: Accessibility Permission Fix
Root cause: `systemPreferences.isTrustedAccessibilityClient(false)` queries the macOS TCC database which caches results by code signing hash. When the app is rebuilt or updated, the hash changes and the cached TCC entry becomes stale, returning `false` even though accessibility is granted.

Fix: Added a module-level `accessibilityConfirmed` latching boolean. It gets set to `true` when either:
- The native key listener binary starts successfully (`keyListener.start()` returns true) — this binary uses `CGEvent.tapCreate` which requires accessibility
- The Electron `globalShortcut` fallback registers successfully

The accessibility IPC check now returns `trusted || accessibilityConfirmed`. The latch persists even when `keyListener` is temporarily set to `null` during hotkey recording, avoiding false negatives.

### Feature 3: Manage Button
Added `onManage` optional prop to `PermissionControl` component. When granted and `onManage` is provided, renders a small outlined "Manage" button with ExternalLink icon next to the check mark. Passed for both Mic and Accessibility rows on macOS only.
-->