### PR TITLE
fix: add Apple Events entitlement to fix paste on macOS

### DIFF
--- a/apps/electron/build/entitlements.mac.plist
+++ b/apps/electron/build/entitlements.mac.plist
@@ -10,5 +10,7 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
## Summary

Paste fails 100% of the time on notarized macOS builds. The `macos-fast-paste` native binary exits with code 2 (no accessibility for the child process), so the paste always falls back to `osascript` which uses `tell application "System Events" to keystroke "v"`. However, the hardened runtime (enabled by `notarize: true`) blocks this Apple Event without the `com.apple.security.automation.apple-events` entitlement — the osascript command completes without error but produces no keystroke.

## Fix

Add `com.apple.security.automation.apple-events` to `entitlements.mac.plist`. One line.

## Testing

Requires a new notarized build to verify. The entitlement allows the app to send Apple Events to System Events, which is what the osascript paste fallback needs.