### PR TITLE
test: add E2E tests for API server and Electron app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,56 @@ jobs:
         working-directory: apps/electron
         run: pnpm run typecheck:web
 
+  test-server:
+    name: Test (Server API)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run server tests
+        run: pnpm --filter @freestyle/server run test
+
+  test-electron:
+    name: Test (Electron E2E)
+    needs: [test-server]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y xvfb libglib2.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libgtk-3-0 libgbm1 libasound2 libx11-xcb1
+
+      - name: Build server
+        run: pnpm --filter @freestyle/server build
+
+      - name: Build electron app
+        working-directory: apps/electron
+        run: pnpm run build
+
+      - name: Run Electron E2E tests
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" pnpm --filter @freestyle/electron run test:e2e
+
   build-linux:
     name: Build (Linux)
-    needs: [lint, typecheck]
+    needs: [lint, typecheck, test-server]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +140,7 @@ jobs:
 
   build-mac:
     name: Build (macOS)
-    needs: [lint, typecheck]
+    needs: [lint, typecheck, test-server]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -133,7 +180,7 @@ jobs:
 
   build-windows:
     name: Build (Windows)
-    needs: [lint, typecheck]
+    needs: [lint, typecheck, test-server]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y xvfb libglib2.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libgtk-3-0 libgbm1 libasound2 libx11-xcb1
+        run: sudo apt-get update && sudo apt-get install -y xvfb libglib2.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libgtk-3-0 libgbm1 libasound2t64 libx11-xcb1
 
       - name: Build server
         run: pnpm --filter @freestyle/server build

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ apps/electron/resources/bin/
 
 # Downloaded whisper.cpp binaries
 apps/electron/resources/whisper/
+
+# Test artifacts
+test-results/

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -20,7 +20,8 @@
     "build:mac": "npm run compile:native && electron-vite build && electron-builder --mac --publish never",
     "build:linux": "npm run compile:native && electron-vite build && electron-builder --linux --publish never",
     "download:whisper-cpp": "node scripts/download-whisper-cpp.mjs",
-    "download:whisper-cpp:all": "node scripts/download-whisper-cpp.mjs --all"
+    "download:whisper-cpp:all": "node scripts/download-whisper-cpp.mjs --all",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",
@@ -51,6 +52,7 @@
   },
   "devDependencies": {
     "@electron-toolkit/tsconfig": "^2.0.0",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.3.0",
     "@types/node": "^22.19.1",
     "@types/react": "^19.2.7",

--- a/apps/electron/playwright.config.ts
+++ b/apps/electron/playwright.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   workers: 1, // Electron tests must run serially
   reporter: "list",
   use: {
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
   },
 });

--- a/apps/electron/playwright.config.ts
+++ b/apps/electron/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  retries: 0,
+  workers: 1, // Electron tests must run serially
+  reporter: "list",
+  use: {
+    trace: "on-first-retry",
+  },
+});

--- a/apps/electron/tests/app.test.ts
+++ b/apps/electron/tests/app.test.ts
@@ -15,12 +15,36 @@ import { _electron as electron } from "playwright";
 
 let app: ElectronApplication;
 let dashboardPage: Page;
+let serverPort: number;
+
+const DEFAULT_PORT = 4649;
 
 /**
- * Launch the Electron app with a temporary user-data directory so
- * tests never touch real data. The app is built with `electron-vite build`
- * and the main entry is `out/main/index.js`.
+ * Wait for a window whose URL does NOT contain "pill" — that's the
+ * dashboard / onboarding window. The pill window loads pill.html and
+ * may appear first.
  */
+async function waitForDashboardWindow(
+  electronApp: ElectronApplication,
+  timeoutMs = 10_000,
+): Promise<Page> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    for (const win of electronApp.windows()) {
+      const url = win.url();
+      if (!url.includes("pill") && url.length > 0) {
+        await win.waitForLoadState("domcontentloaded");
+        return win;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  // Fallback: return whatever window we have
+  return electronApp.windows()[0];
+}
+
 test.beforeAll(async () => {
   const userDataDir = mkdtempSync(join(tmpdir(), "freestyle-e2e-"));
   const dbPath = join(userDataDir, "freestyle.db");
@@ -36,26 +60,28 @@ test.beforeAll(async () => {
     timeout: 20_000,
   });
 
-  // The app creates a pill window (small, always-on-top) immediately,
-  // and a settings/dashboard window on first launch (onboarding).
-  // Wait for the first window, then try to find the dashboard.
-  dashboardPage = await app.firstWindow();
-  await dashboardPage.waitForLoadState("domcontentloaded");
+  // Wait for the first window so Playwright's internal state is ready.
+  await app.firstWindow();
 
-  // If we got the pill, look for the dashboard window
-  const windows = app.windows();
-  for (const win of windows) {
-    const url = win.url();
-    if (
-      url.includes("index.html") ||
-      url.includes("/today") ||
-      url.includes("/onboarding") ||
-      url.includes("app://renderer")
-    ) {
-      dashboardPage = win;
-      break;
+  // Find the dashboard (non-pill) window.
+  dashboardPage = await waitForDashboardWindow(app);
+
+  // Resolve the actual server port by probing the default port from the
+  // main process. The server starts on DEFAULT_PORT and only falls back
+  // to a random port when DEFAULT_PORT is already in use.
+  // Note: app.evaluate passes (electronModule, arg) so the user arg is
+  // the second parameter.
+  const portResult = await app.evaluate(async (_electron, port) => {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/health`);
+      if (res.ok) return port;
+    } catch {
+      // port not available
     }
-  }
+    return 0;
+  }, DEFAULT_PORT);
+
+  serverPort = portResult || DEFAULT_PORT;
 });
 
 test.afterAll(async () => {
@@ -94,8 +120,7 @@ test("dashboard window loads a valid route", async () => {
   const isValidRoute =
     url.includes("/today") ||
     url.includes("/onboarding") ||
-    url.includes("index.html") ||
-    url.includes("app://renderer");
+    url.includes("index.html");
   expect(isValidRoute).toBe(true);
 });
 
@@ -108,37 +133,32 @@ test("dashboard window has a reasonable viewport", async () => {
 });
 
 test("embedded server is running", async () => {
-  // Query the health endpoint from the main process to avoid
-  // CORS issues in the renderer.
-  const health = await app.evaluate(async () => {
-    const res = await fetch("http://127.0.0.1:4649/api/health");
+  const health = await app.evaluate(async (_electron, port) => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/health`);
     return res.json() as Promise<{ status: string; name: string }>;
-  });
+  }, serverPort);
   expect(health).toEqual({ status: "ok", name: "freestyle" });
 });
 
 test("settings API works via embedded server", async () => {
-  // Write a setting and read it back via the embedded server
-  await app.evaluate(async () => {
-    await fetch("http://127.0.0.1:4649/api/settings/e2e_test", {
+  await app.evaluate(async (_electron, port) => {
+    await fetch(`http://127.0.0.1:${port}/api/settings/e2e_test`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ value: "hello" }),
     });
-  });
+  }, serverPort);
 
-  const result = await app.evaluate(async () => {
-    const res = await fetch("http://127.0.0.1:4649/api/settings/e2e_test");
+  const result = await app.evaluate(async (_electron, port) => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/settings/e2e_test`);
     return res.json() as Promise<{ key: string; value: string }>;
-  });
+  }, serverPort);
   expect(result).toEqual({ key: "e2e_test", value: "hello" });
 });
 
 test("dashboard renders content", async () => {
-  // Wait for at least some content to render
   await dashboardPage.waitForTimeout(1000);
 
-  // The page should have some text content
   const bodyText = await dashboardPage.locator("body").innerText();
   expect(bodyText.length).toBeGreaterThan(0);
 });
@@ -146,7 +166,7 @@ test("dashboard renders content", async () => {
 test("sidebar navigation is rendered", async () => {
   const url = dashboardPage.url();
   if (url.includes("/onboarding")) {
-    // On onboarding page, there's no sidebar
+    // On onboarding page, there's no sidebar but there is content
     const body = await dashboardPage.locator("body").innerText();
     expect(body.length).toBeGreaterThan(0);
     return;

--- a/apps/electron/tests/app.test.ts
+++ b/apps/electron/tests/app.test.ts
@@ -1,0 +1,158 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  type ElectronApplication,
+  expect,
+  type Page,
+  test,
+} from "@playwright/test";
+import { _electron as electron } from "playwright";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let app: ElectronApplication;
+let dashboardPage: Page;
+
+/**
+ * Launch the Electron app with a temporary user-data directory so
+ * tests never touch real data. The app is built with `electron-vite build`
+ * and the main entry is `out/main/index.js`.
+ */
+test.beforeAll(async () => {
+  const userDataDir = mkdtempSync(join(tmpdir(), "freestyle-e2e-"));
+  const dbPath = join(userDataDir, "freestyle.db");
+
+  app = await electron.launch({
+    args: [resolve(__dirname, "../out/main/index.js")],
+    env: {
+      ...process.env,
+      NODE_ENV: "development",
+      FREESTYLE_DB_PATH: dbPath,
+      ELECTRON_DISABLE_SECURITY_WARNINGS: "true",
+    },
+    timeout: 20_000,
+  });
+
+  // The app creates a pill window (small, always-on-top) immediately,
+  // and a settings/dashboard window on first launch (onboarding).
+  // Wait for the first window, then try to find the dashboard.
+  dashboardPage = await app.firstWindow();
+  await dashboardPage.waitForLoadState("domcontentloaded");
+
+  // If we got the pill, look for the dashboard window
+  const windows = app.windows();
+  for (const win of windows) {
+    const url = win.url();
+    if (
+      url.includes("index.html") ||
+      url.includes("/today") ||
+      url.includes("/onboarding") ||
+      url.includes("app://renderer")
+    ) {
+      dashboardPage = win;
+      break;
+    }
+  }
+});
+
+test.afterAll(async () => {
+  if (app) {
+    await app.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("app launches and creates windows", async () => {
+  const windows = app.windows();
+  expect(windows.length).toBeGreaterThanOrEqual(1);
+});
+
+test("main process is responsive", async () => {
+  const isPackaged = await app.evaluate(({ app }) => app.isPackaged);
+  expect(isPackaged).toBe(false);
+});
+
+test("app name is Freestyle", async () => {
+  const appName = await app.evaluate(({ app }) => app.getName());
+  expect(appName).toBe("Freestyle");
+});
+
+test("app version is defined", async () => {
+  const version = await app.evaluate(({ app }) => app.getVersion());
+  expect(version).toBeTruthy();
+  expect(version).toMatch(/^\d+\.\d+/);
+});
+
+test("dashboard window loads a valid route", async () => {
+  const url = dashboardPage.url();
+  const isValidRoute =
+    url.includes("/today") ||
+    url.includes("/onboarding") ||
+    url.includes("index.html") ||
+    url.includes("app://renderer");
+  expect(isValidRoute).toBe(true);
+});
+
+test("dashboard window has a reasonable viewport", async () => {
+  const size = dashboardPage.viewportSize();
+  if (size) {
+    expect(size.width).toBeGreaterThanOrEqual(700);
+    expect(size.height).toBeGreaterThanOrEqual(400);
+  }
+});
+
+test("embedded server is running", async () => {
+  // Query the health endpoint from the main process to avoid
+  // CORS issues in the renderer.
+  const health = await app.evaluate(async () => {
+    const res = await fetch("http://127.0.0.1:4649/api/health");
+    return res.json() as Promise<{ status: string; name: string }>;
+  });
+  expect(health).toEqual({ status: "ok", name: "freestyle" });
+});
+
+test("settings API works via embedded server", async () => {
+  // Write a setting and read it back via the embedded server
+  await app.evaluate(async () => {
+    await fetch("http://127.0.0.1:4649/api/settings/e2e_test", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value: "hello" }),
+    });
+  });
+
+  const result = await app.evaluate(async () => {
+    const res = await fetch("http://127.0.0.1:4649/api/settings/e2e_test");
+    return res.json() as Promise<{ key: string; value: string }>;
+  });
+  expect(result).toEqual({ key: "e2e_test", value: "hello" });
+});
+
+test("dashboard renders content", async () => {
+  // Wait for at least some content to render
+  await dashboardPage.waitForTimeout(1000);
+
+  // The page should have some text content
+  const bodyText = await dashboardPage.locator("body").innerText();
+  expect(bodyText.length).toBeGreaterThan(0);
+});
+
+test("sidebar navigation is rendered", async () => {
+  const url = dashboardPage.url();
+  if (url.includes("/onboarding")) {
+    // On onboarding page, there's no sidebar
+    const body = await dashboardPage.locator("body").innerText();
+    expect(body.length).toBeGreaterThan(0);
+    return;
+  }
+
+  await dashboardPage.waitForSelector("nav", { timeout: 5000 });
+  const navLinks = await dashboardPage.locator("nav a").all();
+  expect(navLinks.length).toBe(6);
+});

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,7 +2,9 @@
   "name": "@freestyle/server",
   "type": "module",
   "scripts": {
-    "build": "tsc --emitDeclarationOnly && pkgroll --minify src/index.ts"
+    "build": "tsc --emitDeclarationOnly && pkgroll --minify src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "exports": {
     ".": {
@@ -37,6 +39,7 @@
     "@types/node": "latest",
     "@types/ws": "^8.18.1",
     "pkgroll": "^2.27.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.7"
   }
 }

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, it } from "vitest";
+import app from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Helper – shorthand for making requests against the Hono app
+// ---------------------------------------------------------------------------
+
+function req(path: string, init?: RequestInit) {
+  return app.request(path, init);
+}
+
+function json(path: string, body: unknown, method = "POST") {
+  return req(path, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Root & Health
+// ---------------------------------------------------------------------------
+
+describe("Root & Health", () => {
+  it("GET / returns Freestyle API text", async () => {
+    const res = await req("/");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("Freestyle API");
+  });
+
+  it("GET /api/health returns ok", async () => {
+    const res = await req("/api/health");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ status: "ok", name: "freestyle" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Settings CRUD
+// ---------------------------------------------------------------------------
+
+describe("Settings", () => {
+  it("GET /api/settings returns empty object initially", async () => {
+    const res = await req("/api/settings");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({});
+  });
+
+  it("PUT then GET a setting", async () => {
+    const put = await json("/api/settings/theme", { value: "dark" }, "PUT");
+    expect(put.status).toBe(200);
+    expect(await put.json()).toEqual({ key: "theme", value: "dark" });
+
+    const get = await req("/api/settings/theme");
+    expect(get.status).toBe(200);
+    expect(await get.json()).toEqual({ key: "theme", value: "dark" });
+  });
+
+  it("PUT overwrites an existing setting", async () => {
+    await json("/api/settings/theme", { value: "dark" }, "PUT");
+    await json("/api/settings/theme", { value: "light" }, "PUT");
+
+    const get = await req("/api/settings/theme");
+    const data = await get.json();
+    expect(data.value).toBe("light");
+  });
+
+  it("GET returns 404 for unknown key", async () => {
+    const res = await req("/api/settings/nonexistent");
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE removes a setting", async () => {
+    await json("/api/settings/to-delete", { value: "bye" }, "PUT");
+    const del = await req("/api/settings/to-delete", { method: "DELETE" });
+    expect(del.status).toBe(200);
+
+    const get = await req("/api/settings/to-delete");
+    expect(get.status).toBe(404);
+  });
+
+  it("GET /api/settings lists all settings", async () => {
+    await json("/api/settings/a", { value: "1" }, "PUT");
+    await json("/api/settings/b", { value: "2" }, "PUT");
+
+    const res = await req("/api/settings");
+    const data = await res.json();
+    expect(data.a).toBe("1");
+    expect(data.b).toBe("2");
+  });
+
+  it("PUT rejects missing value", async () => {
+    const res = await json("/api/settings/bad", {}, "PUT");
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dictionary CRUD
+// ---------------------------------------------------------------------------
+
+describe("Dictionary", () => {
+  it("GET /api/dictionary returns empty list initially (ignoring seed data)", async () => {
+    const res = await req("/api/dictionary");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty("items");
+    expect(data).toHaveProperty("total");
+    expect(Array.isArray(data.items)).toBe(true);
+  });
+
+  it("POST creates a new entry", async () => {
+    const res = await json("/api/dictionary", {
+      key: "type script",
+      value: "TypeScript",
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.key).toBe("type script");
+    expect(data.value).toBe("TypeScript");
+    expect(data.id).toBeDefined();
+  });
+
+  it("GET /:id returns the created entry", async () => {
+    const create = await json("/api/dictionary", {
+      key: "react js",
+      value: "React.js",
+    });
+    const { id } = await create.json();
+
+    const get = await req(`/api/dictionary/${id}`);
+    expect(get.status).toBe(200);
+    const data = await get.json();
+    expect(data.key).toBe("react js");
+    expect(data.value).toBe("React.js");
+  });
+
+  it("PUT updates an entry", async () => {
+    const create = await json("/api/dictionary", {
+      key: "node js",
+      value: "Node.js",
+    });
+    const { id } = await create.json();
+
+    const put = await json(`/api/dictionary/${id}`, { value: "NodeJS" }, "PUT");
+    expect(put.status).toBe(200);
+    const data = await put.json();
+    expect(data.value).toBe("NodeJS");
+  });
+
+  it("DELETE removes an entry", async () => {
+    const create = await json("/api/dictionary", {
+      key: "to delete",
+      value: "gone",
+    });
+    const { id } = await create.json();
+
+    const del = await req(`/api/dictionary/${id}`, { method: "DELETE" });
+    expect(del.status).toBe(200);
+
+    const get = await req(`/api/dictionary/${id}`);
+    expect(get.status).toBe(404);
+  });
+
+  it("POST rejects duplicate keys", async () => {
+    await json("/api/dictionary", { key: "dupe", value: "first" });
+    const res = await json("/api/dictionary", { key: "dupe", value: "second" });
+    expect(res.status).toBe(409);
+  });
+
+  it("GET /api/dictionary supports search", async () => {
+    await json("/api/dictionary", { key: "searchable", value: "findme" });
+
+    const res = await req("/api/dictionary?search=searchable");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.items.length).toBeGreaterThanOrEqual(1);
+    expect(
+      data.items.some((i: { key: string }) => i.key === "searchable"),
+    ).toBe(true);
+  });
+
+  it("GET /api/dictionary/all returns all entries", async () => {
+    const res = await req("/api/dictionary/all");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  it("POST /api/dictionary/import bulk imports", async () => {
+    const entries = [
+      { key: "import one", value: "Import1" },
+      { key: "import two", value: "Import2" },
+    ];
+    const res = await json("/api/dictionary/import", entries);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.imported).toBe(2);
+    expect(data.skipped).toBe(0);
+  });
+
+  it("GET /api/dictionary/export/json returns JSON export", async () => {
+    const res = await req("/api/dictionary/export/json");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Format Rules CRUD
+// ---------------------------------------------------------------------------
+
+describe("Formats", () => {
+  it("GET /api/formats returns seeded defaults", async () => {
+    const res = await req("/api/formats");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.total).toBeGreaterThan(0);
+    // The schema seeds 10 default format rules
+    expect(data.items.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("POST creates a custom format", async () => {
+    const res = await json("/api/formats", {
+      app_pattern: "figma.com|Figma",
+      label: "Figma",
+      instructions: "Design-focused, concise annotations.",
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.label).toBe("Figma");
+  });
+
+  it("GET /:id returns a format", async () => {
+    const create = await json("/api/formats", {
+      app_pattern: "test-app",
+      label: "Test",
+      instructions: "Test instructions.",
+    });
+    const { id } = await create.json();
+
+    const get = await req(`/api/formats/${id}`);
+    expect(get.status).toBe(200);
+    const data = await get.json();
+    expect(data.label).toBe("Test");
+  });
+
+  it("PUT updates a format", async () => {
+    const create = await json("/api/formats", {
+      app_pattern: "update-me",
+      label: "Before",
+      instructions: "Old instructions.",
+    });
+    const { id } = await create.json();
+
+    const put = await json(
+      `/api/formats/${id}`,
+      { label: "After", instructions: "New instructions." },
+      "PUT",
+    );
+    expect(put.status).toBe(200);
+
+    const get = await req(`/api/formats/${id}`);
+    const data = await get.json();
+    expect(data.label).toBe("After");
+    expect(data.instructions).toBe("New instructions.");
+  });
+
+  it("DELETE removes a format", async () => {
+    const create = await json("/api/formats", {
+      app_pattern: "delete-me",
+      label: "ToDelete",
+      instructions: "Will be deleted.",
+    });
+    const { id } = await create.json();
+
+    const del = await req(`/api/formats/${id}`, { method: "DELETE" });
+    expect(del.status).toBe(200);
+
+    const get = await req(`/api/formats/${id}`);
+    expect(get.status).toBe(404);
+  });
+
+  it("GET /api/formats/match matches by context", async () => {
+    // The seed data includes a Slack rule with pattern "slack.com|Slack"
+    const res = await req("/api/formats/match?context=slack.com");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).not.toBeNull();
+    expect(data.label).toBe("Slack");
+  });
+
+  it("GET /api/formats/match returns null for unknown context", async () => {
+    const res = await req("/api/formats/match?context=unknownapp");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toBeNull();
+  });
+
+  it("GET /api/formats supports search", async () => {
+    const res = await req("/api/formats?search=Email");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.items.some((i: { label: string }) => i.label === "Email")).toBe(
+      true,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// API Keys CRUD
+// ---------------------------------------------------------------------------
+
+describe("API Keys", () => {
+  it("GET /api/keys returns empty list initially", async () => {
+    const res = await req("/api/keys");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual([]);
+  });
+
+  it("POST stores an API key", async () => {
+    const res = await json("/api/keys", {
+      provider: "openai",
+      key: "sk-test-123",
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.provider).toBe("openai");
+    expect(data.configured).toBe(true);
+  });
+
+  it("GET /:provider confirms key is configured (key not exposed)", async () => {
+    await json("/api/keys", { provider: "groq", key: "gsk-test" });
+
+    const get = await req("/api/keys/groq");
+    expect(get.status).toBe(200);
+    const data = await get.json();
+    expect(data.provider).toBe("groq");
+    expect(data.configured).toBe(true);
+    // The actual key must NOT be returned
+    expect(data.key).toBeUndefined();
+  });
+
+  it("GET /:provider returns 404 for missing provider", async () => {
+    const res = await req("/api/keys/nonexistent");
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE removes an API key", async () => {
+    await json("/api/keys", { provider: "anthropic", key: "sk-ant-test" });
+
+    const del = await req("/api/keys/anthropic", { method: "DELETE" });
+    expect(del.status).toBe(200);
+
+    const get = await req("/api/keys/anthropic");
+    expect(get.status).toBe(404);
+  });
+
+  it("POST upserts on conflict", async () => {
+    await json("/api/keys", { provider: "deepgram", key: "old-key" });
+    await json("/api/keys", { provider: "deepgram", key: "new-key" });
+
+    const list = await req("/api/keys");
+    const data = await list.json();
+    const deepgram = data.filter(
+      (k: { provider: string }) => k.provider === "deepgram",
+    );
+    expect(deepgram.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// History
+// ---------------------------------------------------------------------------
+
+describe("History", () => {
+  it("GET /api/history returns empty list initially", async () => {
+    const res = await req("/api/history");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.items).toEqual([]);
+    expect(data.total).toBe(0);
+  });
+
+  it("GET /api/history/stats returns zero stats initially", async () => {
+    const res = await req("/api/history/stats");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.total_sessions).toBe(0);
+    expect(data.total_cost_usd).toBe(0);
+  });
+
+  it("GET /api/history/:id returns 404 for missing entry", async () => {
+    const res = await req("/api/history/9999");
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/server/tests/setup.ts
+++ b/apps/server/tests/setup.ts
@@ -1,0 +1,31 @@
+import { mkdtempSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, beforeEach } from "vitest";
+
+let dbPath: string;
+
+/**
+ * Initialise a throwaway SQLite database before the test suite runs.
+ * Each test file gets its own temporary DB so tests stay isolated.
+ */
+beforeAll(() => {
+  const dir = mkdtempSync(join(tmpdir(), "freestyle-test-"));
+  dbPath = join(dir, "test.db");
+  process.env.FREESTYLE_DB_PATH = dbPath;
+});
+
+/**
+ * Clean up the database file after all tests in the suite finish.
+ */
+afterAll(() => {
+  // Reset the module-level singleton so the next suite gets a fresh DB.
+  // The db module caches the connection; deleting the env var and
+  // removing the file is enough because each test file runs in its
+  // own forked process (pool: "forks").
+  try {
+    unlinkSync(dbPath);
+  } catch {
+    // Already cleaned up or never created.
+  }
+});

--- a/apps/server/tests/setup.ts
+++ b/apps/server/tests/setup.ts
@@ -1,15 +1,21 @@
 import { mkdtempSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeAll, beforeEach } from "vitest";
+import { afterAll, beforeAll, vi } from "vitest";
 
 let dbPath: string;
 
 /**
  * Initialise a throwaway SQLite database before the test suite runs.
  * Each test file gets its own temporary DB so tests stay isolated.
+ *
+ * We also use fake timers to prevent the module-level
+ * `setTimeout(() => autoStartWhisperServer(), 1000)` in the server
+ * entry from firing during tests.
  */
 beforeAll(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: false });
+
   const dir = mkdtempSync(join(tmpdir(), "freestyle-test-"));
   dbPath = join(dir, "test.db");
   process.env.FREESTYLE_DB_PATH = dbPath;
@@ -18,11 +24,14 @@ beforeAll(() => {
 /**
  * Clean up the database file after all tests in the suite finish.
  */
-afterAll(() => {
-  // Reset the module-level singleton so the next suite gets a fresh DB.
-  // The db module caches the connection; deleting the env var and
-  // removing the file is enough because each test file runs in its
-  // own forked process (pool: "forks").
+afterAll(async () => {
+  vi.useRealTimers();
+
+  // Close the cached DB connection so the file handle is released
+  // before we attempt to delete it.
+  const { closeDb } = await import("../src/lib/db.js");
+  closeDb();
+
   try {
     unlinkSync(dbPath);
   } catch {

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,0 +1,20 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@freestyle/validations": resolve(
+        __dirname,
+        "../../packages/validations/src/index.ts",
+      ),
+    },
+  },
+  test: {
+    globals: true,
+    include: ["tests/**/*.test.ts"],
+    setupFiles: ["tests/setup.ts"],
+    testTimeout: 10_000,
+    pool: "forks",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "format": "biome check --write .",
+    "test": "turbo test",
     "prepare": "is-ci || husky"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
         version: 2.0.0(@types/node@22.19.19)
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
@@ -223,6 +226,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
 
   packages/validations:
     dependencies:
@@ -1404,6 +1410,11 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
@@ -2613,11 +2624,17 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
@@ -2728,6 +2745,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
@@ -2819,6 +2865,10 @@ packages:
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -2950,6 +3000,10 @@ packages:
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -3310,6 +3364,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -3358,6 +3415,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -3377,6 +3437,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -3503,6 +3567,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4220,6 +4289,9 @@ packages:
     resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
     engines: {node: '>= 10'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -4294,6 +4366,9 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
@@ -4336,6 +4411,16 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -4701,6 +4786,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -4737,6 +4825,9 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
@@ -4753,6 +4844,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -4857,9 +4951,20 @@ packages:
   tiny-typed-emitter@2.1.0:
     resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.1.0:
     resolution: {integrity: sha512-Ou+YJ467tR700sk2mZBB1/uFah6LDeH/VKO0N4xfjFOXE0hJkZgiOgXj16gEi1wQ4L6334UTKjxF6gum8ftZzQ==}
@@ -5065,6 +5170,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -5093,6 +5239,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -5940,6 +6091,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.19
 
+  '@inquirer/confirm@6.0.13(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+    optional: true
+
   '@inquirer/core@11.1.10(@types/node@22.19.19)':
     dependencies:
       '@inquirer/ansi': 2.0.5
@@ -5952,11 +6111,29 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.19
 
+  '@inquirer/core@11.1.10(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+    optional: true
+
   '@inquirer/figures@2.0.5': {}
 
   '@inquirer/type@4.0.5(@types/node@22.19.19)':
     optionalDependencies:
       '@types/node': 22.19.19
+
+  '@inquirer/type@4.0.5(@types/node@25.9.1)':
+    optionalDependencies:
+      '@types/node': 25.9.1
+    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -6330,6 +6507,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -7558,6 +7739,11 @@ snapshots:
       '@types/node': 22.19.19
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 25.9.1
@@ -7565,6 +7751,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/draco3d@1.4.10': {}
 
@@ -7690,6 +7878,48 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@25.9.1)(typescript@5.9.3)
+      vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xmldom/xmldom@0.8.13': {}
 
   '@xmldom/xmldom@0.9.10':
@@ -7803,6 +8033,8 @@ snapshots:
 
   assert-plus@1.0.0:
     optional: true
+
+  assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
     dependencies:
@@ -7955,6 +8187,8 @@ snapshots:
       three: 0.184.0
 
   caniuse-lite@1.0.30001793: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -8315,6 +8549,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -8429,6 +8665,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   etag@1.8.1: {}
 
   eventsource-parser@3.0.8: {}
@@ -8463,6 +8703,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -8635,6 +8877,9 @@ snapshots:
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -9178,6 +9423,32 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.0.13(@types/node@25.9.1)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.0
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   mute-stream@3.0.0: {}
 
   nano-staged@1.0.2: {}
@@ -9248,6 +9519,8 @@ snapshots:
     optional: true
 
   object-treeify@1.1.33: {}
+
+  obug@2.1.1: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -9323,6 +9596,8 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pathe@2.0.3: {}
+
   pe-library@0.4.1: {}
 
   pend@1.2.0: {}
@@ -9365,6 +9640,14 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - vite
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:
@@ -9848,6 +10131,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -9880,6 +10165,8 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
 
   stats-gl@2.4.2(@types/three@0.184.1)(three@0.184.0):
@@ -9890,6 +10177,8 @@ snapshots:
   stats.js@0.17.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -9993,10 +10282,16 @@ snapshots:
 
   tiny-typed-emitter@2.1.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.1.0: {}
 
@@ -10176,7 +10471,34 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.32.0
       yaml: 2.9.0
-    optional: true
+
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - msw
 
   web-streams-polyfill@3.3.3: {}
 
@@ -10199,6 +10521,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,10 @@
       "dependsOn": ["^build"],
       "persistent": true,
       "cache": false
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
Adds the first automated tests to the project — two layers of E2E coverage:

- **Server API tests** (Vitest, 36 tests): health, settings, dictionary, format rules, API keys, and history endpoints, each exercised against a temporary SQLite database.
- **Electron app tests** (Playwright, 10 tests): app launch, window creation, route loading, embedded server health, settings round-trip, dashboard rendering, and sidebar navigation.

Also wires up `test` scripts in `package.json` files and adds a `test` task to the Turbo pipeline.

## Testing
```
pnpm --filter @freestyle/server run test        # 36 passed
xvfb-run pnpm --filter @freestyle/electron run test:e2e  # 10 passed (requires display server)
```

<!--
## Plan
1. Add Vitest to @freestyle/server with a setup file that provisions a temp SQLite DB per suite.
2. Write api.test.ts covering all CRUD routes: health, settings, dictionary (with search/import/export), formats (with pattern matching), api-keys, history + stats.
3. Add Playwright + Electron support to @freestyle/electron.
4. Write app.test.ts covering: app launch, main process eval, app name/version, route loading, viewport size, embedded server health, settings API round-trip, dashboard rendering, sidebar navigation.
5. Add test scripts to package.json files and a turbo test task.
6. Add test-results/ to .gitignore.
-->