### PR TITLE
fix: address review findings from vocabulary and streaming PRs

### DIFF
--- a/apps/electron/src/renderer/src/pages/settings/vocabulary.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/vocabulary.tsx
@@ -133,12 +133,20 @@ export default function VocabularyPage(): React.JSX.Element {
 
   const deleteEntry = useCallback(
     async (id: number) => {
-      await getClient().api.vocabulary[":id"].$delete({
-        param: { id: String(id) },
-      });
-      loadData();
+      try {
+        await getClient().api.vocabulary[":id"].$delete({
+          param: { id: String(id) },
+        });
+        if (entries.length === 1 && page > 0) {
+          setPage(page - 1);
+        } else {
+          loadData();
+        }
+      } catch (err) {
+        console.error("Failed to delete vocabulary entry:", err);
+      }
     },
-    [loadData],
+    [loadData, entries.length, page],
   );
 
   const importRef = useRef<HTMLInputElement>(null);
@@ -180,17 +188,27 @@ export default function VocabularyPage(): React.JSX.Element {
     }
   }, []);
 
+  const [importError, setImportError] = useState<string | null>(null);
+
   const handleImport = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
       if (!file) return;
+      setImportError(null);
       try {
         const text = await file.text();
         const data = JSON.parse(text);
-        await getClient().api.vocabulary.import.$post({ json: data });
-        loadData();
+        const res = await getClient().api.vocabulary.import.$post({
+          json: data,
+        });
+        if (!res.ok) {
+          const detail = await res.text().catch(() => "");
+          setImportError(detail || `Import failed (HTTP ${res.status})`);
+        } else {
+          loadData();
+        }
       } catch {
-        // ignore
+        setImportError("Import failed — file must be valid JSON.");
       }
       if (importRef.current) importRef.current.value = "";
     },
@@ -246,7 +264,7 @@ export default function VocabularyPage(): React.JSX.Element {
                   className="placeholder:text-muted-foreground/80 text-foreground min-w-0 flex-1 bg-transparent text-[13px] outline-none"
                 />
                 <span className="mono text-muted-foreground shrink-0 text-[10px]">
-                  ⌘ K
+                  {navigator.platform.includes("Mac") ? "⌘" : "Ctrl+"} K
                 </span>
               </div>
               <div className="flex shrink-0 flex-wrap items-center gap-2.5">
@@ -281,6 +299,10 @@ export default function VocabularyPage(): React.JSX.Element {
                 </button>
               </div>
             </div>
+
+            {importError && (
+              <p className="text-destructive mb-4 text-xs">{importError}</p>
+            )}
 
             {showForm && (
               <form

--- a/apps/electron/src/renderer/src/pages/settings/vocabulary.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/vocabulary.tsx
@@ -264,7 +264,7 @@ export default function VocabularyPage(): React.JSX.Element {
                   className="placeholder:text-muted-foreground/80 text-foreground min-w-0 flex-1 bg-transparent text-[13px] outline-none"
                 />
                 <span className="mono text-muted-foreground shrink-0 text-[10px]">
-                  {navigator.platform.includes("Mac") ? "⌘" : "Ctrl+"} K
+                  {navigator.userAgent.includes("Mac") ? "⌘" : "Ctrl+"} K
                 </span>
               </div>
               <div className="flex shrink-0 flex-wrap items-center gap-2.5">

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -89,18 +89,6 @@ export function initSchema(db: DatabaseSync): void {
     }
   }
 
-  if (currentVersion < 6) {
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS vocabulary (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        term TEXT NOT NULL UNIQUE,
-        notes TEXT,
-        created_at TEXT NOT NULL DEFAULT (datetime('now')),
-        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-      )
-    `);
-  }
-
   if (currentVersion < 5) {
     db.exec(`
       CREATE TABLE IF NOT EXISTS format_rules (
@@ -183,6 +171,18 @@ export function initSchema(db: DatabaseSync): void {
         stmt.run(pattern, label, instructions, isDefault);
       }
     }
+  }
+
+  if (currentVersion < 6) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS vocabulary (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        term TEXT NOT NULL UNIQUE,
+        notes TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
   }
 
   // Upsert schema version

--- a/apps/server/src/lib/streaming/providers/deepgram.ts
+++ b/apps/server/src/lib/streaming/providers/deepgram.ts
@@ -15,6 +15,7 @@ import { stripProviderPrefix } from "../types.js";
 import { transcribeWithAiSdk } from "../utils.js";
 
 const DEEPGRAM_LISTEN_URL = "wss://api.deepgram.com/v1/listen";
+const COMMIT_TIMEOUT_MS = 12_000;
 
 /**
  * Merge a new finalized segment. Nova models often send cumulative transcripts
@@ -79,6 +80,14 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
     let partialText = "";
     let commitRequested = false;
     let finalDelivered = false;
+    let commitTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    function clearCommitTimeout(): void {
+      if (commitTimeout) {
+        clearTimeout(commitTimeout);
+        commitTimeout = null;
+      }
+    }
 
     const short = stripProviderPrefix(model);
 
@@ -102,6 +111,7 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
       if (finalDelivered) return;
       finalDelivered = true;
       commitRequested = false;
+      clearCommitTimeout();
       const text = (accumulatedText || partialText).trim();
       accumulatedText = "";
       partialText = "";
@@ -163,6 +173,7 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
         ws.send(chunk);
       },
       reset(): void {
+        clearCommitTimeout();
         accumulatedText = "";
         partialText = "";
         commitRequested = false;
@@ -170,13 +181,18 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
       },
       commit(): void {
         commitRequested = true;
+        clearCommitTimeout();
         if (ws.readyState !== WebSocket.OPEN) {
           deliverFinal();
           return;
         }
         ws.send(JSON.stringify({ type: "Finalize" }));
+        commitTimeout = setTimeout(() => {
+          deliverFinal();
+        }, COMMIT_TIMEOUT_MS);
       },
       cancel(): void {
+        clearCommitTimeout();
         accumulatedText = "";
         partialText = "";
         commitRequested = false;
@@ -188,6 +204,7 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
         }
       },
       close(): void {
+        clearCommitTimeout();
         if (ws.readyState <= WebSocket.OPEN) ws.close();
       },
     };

--- a/apps/server/src/lib/streaming/providers/elevenlabs.ts
+++ b/apps/server/src/lib/streaming/providers/elevenlabs.ts
@@ -90,12 +90,12 @@ export class ElevenLabsTranscriptionProvider implements TranscriptionProvider {
   readonly providerId = "elevenlabs";
 
   async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
-    if (opts.bias?.kind === "elevenlabs-keyterms") {
-      return transcribeElevenLabsWithBias(opts, opts.bias);
-    }
     const model = stripProviderPrefix(opts.model).endsWith("_realtime")
       ? opts.model.replace(/_realtime$/, "")
       : opts.model;
+    if (opts.bias?.kind === "elevenlabs-keyterms") {
+      return transcribeElevenLabsWithBias({ ...opts, model }, opts.bias);
+    }
     return transcribeWithAiSdk(
       { ...opts, model },
       createElevenLabs,

--- a/apps/server/src/lib/streaming/providers/openai.ts
+++ b/apps/server/src/lib/streaming/providers/openai.ts
@@ -114,7 +114,12 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
         );
       },
       commit(): void {
-        if (ws.readyState !== WebSocket.OPEN) return;
+        if (ws.readyState !== WebSocket.OPEN) {
+          const text = partialText.trim();
+          partialText = "";
+          callbacks.onFinal(text);
+          return;
+        }
         ws.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
       },
       reset(): void {

--- a/apps/server/src/lib/vocabulary-bias.ts
+++ b/apps/server/src/lib/vocabulary-bias.ts
@@ -15,6 +15,7 @@ const PROMPT_CHAR_BUDGET = 900;
 const DEEPGRAM_KEYTERM_MAX = 100;
 /** Keep streaming URLs short — long keyterm lists break the WS handshake. */
 const DEEPGRAM_STREAMING_KEYTERM_MAX = 25;
+const ELEVENLABS_BATCH_KEYTERM_MAX = 100;
 const ELEVENLABS_REALTIME_KEYTERM_MAX = 50;
 const ELEVENLABS_TERM_MAX_CHARS = 20;
 const ELEVENLABS_BATCH_TERM_MAX_CHARS = 50;
@@ -96,7 +97,7 @@ function capElevenLabsTerms(
 }
 
 function isNova3Model(model: string): boolean {
-  return model.includes("nova-3") || model.includes("nova-3-general");
+  return model.includes("nova-3");
 }
 
 function isNova2Model(model: string): boolean {
@@ -154,7 +155,7 @@ export function buildAsrVocabularyBias(
       if (!supportsElevenLabsKeyterms(short)) return null;
       const max = streaming
         ? ELEVENLABS_REALTIME_KEYTERM_MAX
-        : DEEPGRAM_KEYTERM_MAX;
+        : ELEVENLABS_BATCH_KEYTERM_MAX;
       const maxChars = streaming
         ? ELEVENLABS_TERM_MAX_CHARS
         : ELEVENLABS_BATCH_TERM_MAX_CHARS;

--- a/apps/server/src/lib/vocabulary.ts
+++ b/apps/server/src/lib/vocabulary.ts
@@ -18,7 +18,8 @@ export function loadVocabularyTerms(): string[] {
       )
       .all() as { term: string }[];
     return rows.map((r) => r.term.trim()).filter(Boolean);
-  } catch {
+  } catch (err) {
+    console.error("[vocabulary] Failed to load vocabulary terms:", err);
     return [];
   }
 }

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -102,14 +102,17 @@ const stream = new Hono().get(
         bias,
         callbacks: {
           onReady: (model) => {
+            if (upstream !== session) return;
             reconnectAttempts = 0;
             flushPendingAudio();
             ws.send(JSON.stringify({ type: "session.ready", model }));
           },
           onPartial: (text) => {
+            if (upstream !== session) return;
             ws.send(JSON.stringify({ type: "partial", text }));
           },
           onFinal: (rawText) => {
+            if (upstream !== session) return;
             const durationMs = Date.now() - sessionStartTime;
 
             const streamTags = {

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -189,6 +189,7 @@ const stream = new Hono().get(
               });
           },
           onError: (message) => {
+            if (upstream !== session) return;
             streamingUnsupported = true;
             ws.send(
               JSON.stringify({
@@ -198,7 +199,7 @@ const stream = new Hono().get(
               }),
             );
             ws.send(JSON.stringify({ type: "error", message }));
-            if (upstream === session) upstream = null;
+            upstream = null;
           },
           onClose: () => {
             // Ignore close from a superseded socket (replaced on a later "start").

--- a/apps/server/src/routes/vocabulary.ts
+++ b/apps/server/src/routes/vocabulary.ts
@@ -4,15 +4,9 @@ import {
 } from "@freestyle/validations";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
+import { z } from "zod/v3";
 import { getDb } from "../lib/db.js";
-
-interface VocabularyRow {
-  id: number;
-  term: string;
-  notes: string | null;
-  created_at: string;
-  updated_at: string;
-}
+import type { VocabularyRow } from "../lib/vocabulary.js";
 
 const vocabulary = new Hono()
   .get("/", (c) => {
@@ -146,37 +140,51 @@ const vocabulary = new Hono()
     db.prepare("DELETE FROM vocabulary WHERE id = ?").run(id);
     return c.json({ ok: true });
   })
-  .post("/import", async (c) => {
-    const db = getDb();
-    const body = await c.req.json<{ term: string; notes?: string | null }[]>();
+  .post(
+    "/import",
+    zValidator(
+      "json",
+      z
+        .array(
+          z.object({
+            term: z.string(),
+            notes: z.string().nullable().optional(),
+          }),
+        )
+        .max(5000, "Import limited to 5 000 entries at a time"),
+    ),
+    (c) => {
+      const db = getDb();
+      const body = c.req.valid("json");
 
-    if (!Array.isArray(body)) {
-      return c.json(
-        { error: "Expected a JSON array of {term, notes?} objects" },
-        400,
+      let imported = 0;
+      let skipped = 0;
+      const insertStmt = db.prepare(
+        "INSERT OR IGNORE INTO vocabulary (term, notes) VALUES (?, ?)",
       );
-    }
 
-    let imported = 0;
-    let skipped = 0;
-    const insertStmt = db.prepare(
-      "INSERT OR IGNORE INTO vocabulary (term, notes) VALUES (?, ?)",
-    );
-
-    for (const entry of body) {
-      if (entry.term?.trim()) {
-        const result = insertStmt.run(
-          entry.term.trim(),
-          entry.notes?.trim() || null,
-        );
-        if (result.changes > 0) imported++;
-        else skipped++;
-      } else {
-        skipped++;
+      db.exec("BEGIN");
+      try {
+        for (const entry of body) {
+          if (entry.term?.trim()) {
+            const result = insertStmt.run(
+              entry.term.trim(),
+              entry.notes?.trim() || null,
+            );
+            if (result.changes > 0) imported++;
+            else skipped++;
+          } else {
+            skipped++;
+          }
+        }
+        db.exec("COMMIT");
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
       }
-    }
 
-    return c.json({ imported, skipped });
-  });
+      return c.json({ imported, skipped });
+    },
+  );
 
 export default vocabulary;


### PR DESCRIPTION
Fixes bugs and hardening issues identified during review of #82 (ASR Vocabulary biasing and Streaming fixes).

**Bugs fixed:**
- ElevenLabs bias path now strips `_realtime` before calling the batch API (was sending invalid model ID)
- Deepgram `commit()` now has a 12s timeout matching ElevenLabs, preventing indefinite hangs
- OpenAI `commit()` delivers accumulated text when WebSocket is closed instead of silently dropping
- Streaming session callbacks (`onPartial`/`onFinal`/`onReady`) guarded against superseded sessions
- Vocabulary `/import` now uses zod validation with a 5k entry limit and wraps inserts in a transaction
- Schema migrations reordered (v5 before v6)

**Frontend fixes:**
- Vocabulary import surfaces errors instead of silently swallowing
- `deleteEntry` handles errors and navigates back when deleting the last entry on a page
- Keyboard shortcut hint shows `Ctrl+K` on non-Mac platforms

**Cleanup:**
- `loadVocabularyTerms` logs errors instead of silently returning `[]`
- Separate `ELEVENLABS_BATCH_KEYTERM_MAX` constant instead of reusing Deepgram's
- Deduplicated `VocabularyRow` interface
- Removed redundant `isNova3Model` condition

## Testing
Type-checked both `@freestyle/server` and `@freestyle/electron` — no errors. Biome lint passes.

<!--
## Plan
Address all 14 review findings from PR #82 review:

1. ElevenLabs bias path: move _realtime stripping before the bias early-return
2. Deepgram commit timeout: add COMMIT_TIMEOUT_MS matching ElevenLabs pattern
3. Vocabulary /import: add zValidator with z.array().max(5000), wrap in BEGIN/COMMIT
4. Schema migration ordering: swap v6 and v5 blocks
5. loadVocabularyTerms: log caught errors
6. Streaming session guards: add upstream !== session checks on onReady/onPartial/onFinal
7. OpenAI commit(): deliver partialText as final when WS is closed
8. Frontend import: add importError state, surface in UI
9. Frontend deleteEntry: wrap in try/catch, log errors
10. Frontend page navigation: navigate back when deleting last entry on page
11. ElevenLabs batch limit: define ELEVENLABS_BATCH_KEYTERM_MAX
12. VocabularyRow: remove duplicate, import from lib
13. Keyboard shortcut: use navigator.platform to pick ⌘ vs Ctrl+
14. isNova3Model: remove redundant nova-3-general check
-->