### PR TITLE
Freestyle desktop app UI opens by default all the time

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -869,7 +869,9 @@ app.whenReady().then(async () => {
 
   createAppWindow();
 
-  showSettingsWindow();
+  if (readSettings().showDashboardOnLaunch !== false) {
+    showSettingsWindow();
+  }
 
   // -- Auto-update helpers --
   const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -989,6 +991,18 @@ app.whenReady().then(async () => {
   ipcMain.on("settings:set-launch-at-startup", (_event, enabled: boolean) => {
     app.setLoginItemSettings({ openAtLogin: enabled });
   });
+
+  // -- Show dashboard on launch setting IPC --
+  ipcMain.handle("settings:show-dashboard-on-launch", () => {
+    return readSettings().showDashboardOnLaunch !== false;
+  });
+
+  ipcMain.on(
+    "settings:set-show-dashboard-on-launch",
+    (_event, enabled: boolean) => {
+      writeSettings({ showDashboardOnLaunch: enabled });
+    },
+  );
 
   // -- Context-aware dictation: get frontmost app + browser context --
   ipcMain.handle("system:frontmost-app", async () => {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -869,10 +869,7 @@ app.whenReady().then(async () => {
 
   createAppWindow();
 
-  // Show the onboarding window automatically on first launch
-  if (readSettings().onboardingComplete !== true) {
-    showSettingsWindow();
-  }
+  showSettingsWindow();
 
   // -- Auto-update helpers --
   const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -1232,6 +1229,12 @@ app.on("window-all-closed", () => {
     // On non-macOS, keep the app alive for the tray
     // Only quit explicitly via tray menu
   }
+});
+
+// Re-open the dashboard when the app is activated (e.g. clicking the dock
+// icon or relaunching) and no dashboard window is currently open.
+app.on("activate", () => {
+  showSettingsWindow();
 });
 
 // Gracefully shut down the HTTP server and flush Sentry before quitting

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -53,6 +53,9 @@ declare global {
       // Launch at startup setting
       getLaunchAtStartup: () => Promise<boolean>;
       setLaunchAtStartup: (enabled: boolean) => void;
+      // Show dashboard on launch setting
+      getShowDashboardOnLaunch: () => Promise<boolean>;
+      setShowDashboardOnLaunch: (enabled: boolean) => void;
       // Context-aware dictation
       getFrontmostApp: () => Promise<string | null>;
       // Pill position

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -115,6 +115,11 @@ const api = {
     ipcRenderer.invoke("settings:launch-at-startup"),
   setLaunchAtStartup: (enabled: boolean): void =>
     ipcRenderer.send("settings:set-launch-at-startup", enabled),
+  // Show dashboard on launch setting
+  getShowDashboardOnLaunch: (): Promise<boolean> =>
+    ipcRenderer.invoke("settings:show-dashboard-on-launch"),
+  setShowDashboardOnLaunch: (enabled: boolean): void =>
+    ipcRenderer.send("settings:set-show-dashboard-on-launch", enabled),
   // Context-aware dictation
   getFrontmostApp: (): Promise<string | null> =>
     ipcRenderer.invoke("system:frontmost-app"),

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -110,6 +110,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
   const [updateError, setUpdateError] = useState<string | null>(null);
   const [autoUpdate, setAutoUpdate] = useState(true);
   const [launchAtStartup, setLaunchAtStartup] = useState(false);
+  const [showOnLaunch, setShowOnLaunch] = useState(true);
 
   // Permissions
   type MicStatus =
@@ -297,6 +298,12 @@ export default function GeneralSettingsPage(): React.JSX.Element {
       .then((v) => setLaunchAtStartup(v))
       .catch(() => {});
 
+    // Show dashboard on launch setting
+    window.api
+      ?.getShowDashboardOnLaunch()
+      .then((v) => setShowOnLaunch(v))
+      .catch(() => {});
+
     // Auto-updater events
     const removeAvail = window.api?.onUpdateAvailable((info) => {
       setUpdateAvailable(info.version);
@@ -383,6 +390,11 @@ export default function GeneralSettingsPage(): React.JSX.Element {
   const handleLaunchAtStartupToggle = useCallback((enabled: boolean) => {
     setLaunchAtStartup(enabled);
     window.api?.setLaunchAtStartup(enabled);
+  }, []);
+
+  const handleShowOnLaunchToggle = useCallback((enabled: boolean) => {
+    setShowOnLaunch(enabled);
+    window.api?.setShowDashboardOnLaunch(enabled);
   }, []);
 
   const clearHistory = useCallback(async () => {
@@ -480,12 +492,18 @@ export default function GeneralSettingsPage(): React.JSX.Element {
           <Row
             label="Launch at startup"
             desc="Automatically start Freestyle when you log in to your computer."
-            last
           >
             <Toggle
               on={launchAtStartup}
               onChange={handleLaunchAtStartupToggle}
             />
+          </Row>
+          <Row
+            label="Show dashboard on launch"
+            desc="Open the dashboard window when Freestyle starts."
+            last
+          >
+            <Toggle on={showOnLaunch} onChange={handleShowOnLaunchToggle} />
           </Row>
         </Section>
 


### PR DESCRIPTION
# Overview

Currently, the only way to open up Freestyle is with the topbar icon. The app is hidden by default. This is not a good experience as we currently don't educate the user about the topbar. 

Users might get the false sense that the app is not opening and broken 

# Fix
We change the app to always open when the app is opened

# Testing
Tested that this works locally. 