### PR TITLE
fix: MLX onboarding selection bugs and local provider UI

### DIFF
--- a/apps/electron/src/renderer/src/lib/models.ts
+++ b/apps/electron/src/renderer/src/lib/models.ts
@@ -227,6 +227,7 @@ export function buildVoiceItems(
     selectedModelId?: string;
     selectedProvider?: string;
     selectedWhisperModelId?: string;
+    selectedMlxModelId?: string;
     keyProviders: Set<string>;
   },
 ): VoiceItem[] {
@@ -300,8 +301,9 @@ export function buildVoiceItems(
             status: resolvedState?.status ?? "not_downloaded",
             state: resolvedState,
             selected:
-              ctx.selectedProvider === "local-mlx" &&
-              ctx.selectedModelId === modelId,
+              ctx.selectedMlxModelId === def.id ||
+              (ctx.selectedProvider === "local-mlx" &&
+                ctx.selectedModelId === modelId),
           };
         });
 

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -358,7 +358,7 @@ export default function OnboardingPage(): React.JSX.Element {
             json: {
               provider: "local-whisper",
               model_id: `local-whisper/${def.id}`,
-              model_name: `${def.displayName} (Local)`,
+              model_name: def.displayName,
               type: "voice",
               is_default: true,
             },
@@ -445,6 +445,7 @@ export default function OnboardingPage(): React.JSX.Element {
           ? "local-mlx"
           : undefined),
     selectedWhisperModelId: selectedWhisperDefId ?? undefined,
+    selectedMlxModelId: selectedMlxDefId ?? undefined,
     keyProviders: apiKeys,
   });
 
@@ -686,7 +687,7 @@ export default function OnboardingPage(): React.JSX.Element {
                 <h2 className="text-lg font-semibold">Choose a Voice Model</h2>
                 <p className="text-muted-foreground mt-1 text-sm">
                   Use a cloud provider with an API key, or run speech-to-text
-                  locally with whisper.cpp.
+                  locally.
                 </p>
               </div>
 
@@ -698,6 +699,7 @@ export default function OnboardingPage(): React.JSX.Element {
                     onClick={() => {
                       setModelSource("cloud");
                       setSelectedWhisperDefId(null);
+                      setSelectedMlxDefId(null);
                     }}
                     className={cn(
                       "flex items-center gap-1.5 rounded-[5px] px-3 py-1.5 text-[12px] transition-colors",

--- a/apps/electron/src/renderer/src/pages/settings/models.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/models.tsx
@@ -1896,7 +1896,10 @@ function ProvidersSection({
           <LocalProviderRow
             first={apiKeys.length === 0}
             modelCount={
-              configured.filter((m) => m.provider === "local-whisper").length
+              configured.filter(
+                (m) =>
+                  m.provider === "local-whisper" || m.provider === "local-mlx",
+              ).length
             }
           />
         )}
@@ -1979,7 +1982,7 @@ function LocalProviderRow({
       <Laptop className="text-primary h-[15px] w-[15px] shrink-0" />
       <div className="min-w-0 flex-1">
         <div className="text-foreground text-[13.5px] font-semibold">
-          On-device · whisper.cpp
+          On-device
         </div>
         <div className="mono text-muted-foreground mt-0.5 text-[11px]">
           No key needed · runs locally


### PR DESCRIPTION
Fixes UI integration issues between MLX and Whisper local models found during review of #112.

**Bugs fixed:**
- Switching to "Cloud API" tab in onboarding didn't clear the MLX selection — could silently save an MLX model instead of a cloud model when the user clicks Continue
- MLX models never showed the "SELECTED" checkmark in onboarding (missing `selectedMlxModelId` in `buildVoiceItems` context, analogous to the existing `selectedWhisperModelId`)
- `LocalProviderRow` in settings only counted `local-whisper` models — showed "0 models" when only MLX was configured

**Copy fixes:**
- Provider row label generalized from "On-device · whisper.cpp" to "On-device" (correct for both engines)
- Onboarding subtitle no longer mentions only whisper.cpp
- Whisper model name no longer appends "(Local)" on save during onboarding, matching MLX and the settings page behavior

## Testing
TypeScript and Biome lint pass. Changes are limited to 3 frontend files with no server-side impact.