### PR TITLE
feat: add voice-triggered shortcuts with dedicated hotkey and workflow builder

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -899,6 +899,9 @@ app.whenReady().then(async () => {
   registerActionHandler("open_app", async (params) => {
     const name = String(params.name ?? "");
     if (!name) return { ok: false, message: "Missing app name" };
+    if (/[&|<>^;`$]/.test(name)) {
+      return { ok: false, message: "Invalid characters in app name" };
+    }
     return new Promise((resolve) => {
       if (process.platform === "darwin") {
         execFile("open", ["-a", name], (err) => {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -22,6 +22,7 @@ import { electronApp, is, optimizer } from "@electron-toolkit/utils";
 import server, {
   autoStartWhisperServer,
   reconcileUnsupportedMlxVoiceDefault,
+  registerActionHandler,
 } from "@freestyle/server";
 import { serve } from "@hono/node-server";
 import {
@@ -106,6 +107,11 @@ let currentHotkeyAccel: string | null = null;
 let hotkeyActivationMode: "hold" | "toggle" = "hold";
 let micListener: MicListener | null = null;
 let hotkeyRecorder: HotkeyRecorder | null = null;
+
+let shortcutsKeyListener: NativeKeyListener | null = null;
+let shortcutsHotkeyPressed = false;
+let shortcutsHotkeyAccel: string | null = null;
+let shortcutsHotkeyMode: "hold" | "toggle" = "hold";
 
 function stopHotkeyRecorderProcess(): void {
   hotkeyRecorder?.stop();
@@ -889,6 +895,44 @@ app.whenReady().then(async () => {
 
   createTray();
 
+  // Register action handlers for shortcuts
+  registerActionHandler("open_app", async (params) => {
+    const name = String(params.name ?? "");
+    if (!name) return { ok: false, message: "Missing app name" };
+    return new Promise((resolve) => {
+      if (process.platform === "darwin") {
+        execFile("open", ["-a", name], (err) => {
+          if (err) resolve({ ok: false, message: err.message });
+          else resolve({ ok: true });
+        });
+      } else if (process.platform === "win32") {
+        execFile("cmd", ["/c", "start", "", name], (err) => {
+          if (err) resolve({ ok: false, message: err.message });
+          else resolve({ ok: true });
+        });
+      } else {
+        execFile("xdg-open", [name], (err) => {
+          if (err) resolve({ ok: false, message: err.message });
+          else resolve({ ok: true });
+        });
+      }
+    });
+  });
+
+  registerActionHandler("open_url", async (params) => {
+    const url = String(params.url ?? "");
+    if (!url) return { ok: false, message: "Missing URL" };
+    await shell.openExternal(url);
+    return { ok: true };
+  });
+
+  registerActionHandler("paste_clipboard", async (params) => {
+    const text = String(params.text ?? clipboard.readText());
+    if (!text) return { ok: false, message: "Nothing to paste" };
+    await pasteIntoFocusedApp(text);
+    return { ok: true };
+  });
+
   createAppWindow();
 
   if (readSettings().showDashboardOnLaunch !== false) {
@@ -1063,6 +1107,10 @@ app.whenReady().then(async () => {
   hotkeyActivationMode = loadHotkeyModeFromDB();
   registerHotkey();
 
+  // Register shortcuts hotkey via native platform binary
+  shortcutsHotkeyMode = loadShortcutsHotkeyModeFromDB();
+  registerShortcutsHotkey();
+
   // Start microphone activity monitoring
   micListener = new MicListener({
     excludePid: process.pid,
@@ -1087,6 +1135,19 @@ app.whenReady().then(async () => {
     hotkeyActivationMode = mode === "toggle" ? "toggle" : "hold";
     hotkeyPressed = false;
     registerHotkey(currentHotkeyAccel ?? undefined);
+  });
+
+  ipcMain.on("shortcuts-hotkey:update", (_event, newHotkey: string) => {
+    registerShortcutsHotkey(newHotkey);
+  });
+  ipcMain.on("shortcuts-hotkey:reload", () => {
+    shortcutsHotkeyMode = loadShortcutsHotkeyModeFromDB();
+    registerShortcutsHotkey(shortcutsHotkeyAccel ?? undefined);
+  });
+  ipcMain.on("shortcuts-hotkey:set-mode", (_event, mode: string) => {
+    shortcutsHotkeyMode = mode === "toggle" ? "toggle" : "hold";
+    shortcutsHotkeyPressed = false;
+    registerShortcutsHotkey(shortcutsHotkeyAccel ?? undefined);
   });
 });
 
@@ -1277,11 +1338,136 @@ function registerHotkey(hotkey?: string): void {
   }
 }
 
+function loadShortcutsHotkeyFromDB(): string | undefined {
+  try {
+    const dbPath = process.env.FREESTYLE_DB_PATH;
+    if (dbPath) {
+      const { DatabaseSync } = require("node:sqlite");
+      const db = new DatabaseSync(dbPath);
+      const row = db
+        .prepare("SELECT value FROM settings WHERE key = 'shortcuts_hotkey'")
+        .get() as { value: string } | undefined;
+      db.close();
+      if (row?.value && isValidAccelerator(row.value)) {
+        return row.value;
+      }
+    }
+  } catch {
+    // Ignore errors
+  }
+  return undefined;
+}
+
+function loadShortcutsHotkeyModeFromDB(): "hold" | "toggle" {
+  try {
+    const dbPath = process.env.FREESTYLE_DB_PATH;
+    if (dbPath) {
+      const { DatabaseSync } = require("node:sqlite");
+      const db = new DatabaseSync(dbPath);
+      const row = db
+        .prepare(
+          "SELECT value FROM settings WHERE key = 'shortcuts_hotkey_mode'",
+        )
+        .get() as { value: string } | undefined;
+      db.close();
+      if (row?.value === "toggle") return "toggle";
+    }
+  } catch {
+    // Ignore errors
+  }
+  return "hold";
+}
+
+function sendShortcutsHotkeyDown(): void {
+  showPill();
+  mainWindow?.webContents.send("shortcuts-hotkey:down");
+  settingsWindow?.webContents.send("shortcuts-hotkey:down");
+}
+
+function sendShortcutsHotkeyUp(): void {
+  mainWindow?.webContents.send("shortcuts-hotkey:up");
+  settingsWindow?.webContents.send("shortcuts-hotkey:up");
+}
+
+function handleNativeShortcutsHotkeyDown(): void {
+  if (shortcutsHotkeyMode === "toggle") {
+    if (!shortcutsHotkeyPressed) {
+      shortcutsHotkeyPressed = true;
+      sendShortcutsHotkeyDown();
+    } else {
+      shortcutsHotkeyPressed = false;
+      sendShortcutsHotkeyUp();
+    }
+    return;
+  }
+
+  if (!shortcutsHotkeyPressed) {
+    shortcutsHotkeyPressed = true;
+    sendShortcutsHotkeyDown();
+  }
+}
+
+function handleNativeShortcutsHotkeyUp(): void {
+  if (shortcutsHotkeyMode === "toggle") return;
+
+  if (shortcutsHotkeyPressed) {
+    shortcutsHotkeyPressed = false;
+    sendShortcutsHotkeyUp();
+  }
+}
+
+function registerShortcutsHotkey(hotkey?: string): void {
+  if (shortcutsKeyListener) {
+    shortcutsKeyListener.stop();
+    shortcutsKeyListener = null;
+  }
+  shortcutsHotkeyPressed = false;
+
+  if (!hotkey) {
+    hotkey = loadShortcutsHotkeyFromDB();
+  }
+
+  if (!hotkey || !isValidAccelerator(hotkey)) {
+    shortcutsHotkeyAccel = null;
+    return;
+  }
+
+  const normalized = normalizeAccelerator(hotkey);
+  shortcutsHotkeyAccel = normalized;
+
+  shortcutsKeyListener = new NativeKeyListener({
+    hotkey: normalized,
+    onKeyDown: handleNativeShortcutsHotkeyDown,
+    onKeyUp: handleNativeShortcutsHotkeyUp,
+    onError: (error) => {
+      console.error("[shortcuts-hotkey] Native key listener error:", error);
+    },
+    onReady: () => {
+      if (process.env.NODE_ENV !== "production") {
+        console.log(
+          `[shortcuts-hotkey] Native key listener ready for "${normalized}"`,
+        );
+      }
+    },
+  });
+
+  if (!shortcutsKeyListener.start()) {
+    console.warn(
+      "[shortcuts-hotkey] Native key listener unavailable for shortcuts hotkey.",
+    );
+    shortcutsKeyListener = null;
+  }
+}
+
 // Clean up key listener and mic listener on quit
 app.on("will-quit", () => {
   if (keyListener) {
     keyListener.stop();
     keyListener = null;
+  }
+  if (shortcutsKeyListener) {
+    shortcutsKeyListener.stop();
+    shortcutsKeyListener = null;
   }
   if (micListener) {
     micListener.stop();

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -13,6 +13,12 @@ declare global {
       getServerPort: () => Promise<number>;
       onHotkeyDown: (callback: () => void) => () => void;
       onHotkeyUp: (callback: () => void) => () => void;
+      // Shortcuts hotkey
+      onShortcutsHotkeyDown: (callback: () => void) => () => void;
+      onShortcutsHotkeyUp: (callback: () => void) => () => void;
+      updateShortcutsHotkey: (hotkey: string) => void;
+      reloadShortcutsHotkey: () => void;
+      setShortcutsHotkeyMode: (mode: "hold" | "toggle") => void;
       onPillCancel: (callback: () => void) => () => void;
       checkMicPermission: () => Promise<string>;
       requestMicPermission: () => Promise<string>;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -24,6 +24,23 @@ const api = {
     ipcRenderer.on("hotkey:up", handler);
     return () => ipcRenderer.removeListener("hotkey:up", handler);
   },
+  // Shortcuts hotkey
+  onShortcutsHotkeyDown: (callback: () => void): (() => void) => {
+    const handler = (): void => callback();
+    ipcRenderer.on("shortcuts-hotkey:down", handler);
+    return () => ipcRenderer.removeListener("shortcuts-hotkey:down", handler);
+  },
+  onShortcutsHotkeyUp: (callback: () => void): (() => void) => {
+    const handler = (): void => callback();
+    ipcRenderer.on("shortcuts-hotkey:up", handler);
+    return () => ipcRenderer.removeListener("shortcuts-hotkey:up", handler);
+  },
+  updateShortcutsHotkey: (hotkey: string): void =>
+    ipcRenderer.send("shortcuts-hotkey:update", hotkey),
+  reloadShortcutsHotkey: (): void =>
+    ipcRenderer.send("shortcuts-hotkey:reload"),
+  setShortcutsHotkeyMode: (mode: "hold" | "toggle"): void =>
+    ipcRenderer.send("shortcuts-hotkey:set-mode", mode),
   onPillCancel: (callback: () => void): (() => void) => {
     const handler = (): void => callback();
     ipcRenderer.on("pill:cancel", handler);

--- a/apps/electron/src/renderer/src/dashboard.tsx
+++ b/apps/electron/src/renderer/src/dashboard.tsx
@@ -10,6 +10,7 @@ import FormatsPage from "@renderer/pages/settings/formats";
 import GeneralSettingsPage from "@renderer/pages/settings/general";
 import HistoryPage from "@renderer/pages/settings/history";
 import ModelsPage from "@renderer/pages/settings/models";
+import ShortcutsPage from "@renderer/pages/settings/shortcuts";
 import VocabularyPage from "@renderer/pages/settings/vocabulary";
 import AppShell from "@renderer/pages/shell";
 import TodayPage from "@renderer/pages/today";
@@ -71,6 +72,7 @@ createRoot(document.getElementById("root")!).render(
                   path="/settings/dictionary"
                   element={<DictionaryPage />}
                 />
+                <Route path="/settings/shortcuts" element={<ShortcutsPage />} />
                 <Route
                   path="/settings/vocabulary"
                   element={<VocabularyPage />}

--- a/apps/electron/src/renderer/src/globals.css
+++ b/apps/electron/src/renderer/src/globals.css
@@ -197,6 +197,10 @@
     grid-template-columns: minmax(120px, 180px) minmax(0, 1fr) 90px 70px;
   }
 
+  .shortcut-entry-row {
+    grid-template-columns: minmax(140px, 200px) minmax(0, 1fr) 80px 70px;
+  }
+
   .vocabulary-entry-row {
     grid-template-columns: minmax(120px, 220px) minmax(0, 1fr) 70px;
   }
@@ -214,6 +218,7 @@
 
   @media (max-width: 900px) {
     .dictionary-entry-row,
+    .shortcut-entry-row,
     .vocabulary-entry-row {
       grid-template-columns: minmax(0, 1fr) auto;
     }

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -30,6 +30,7 @@ export class Streamer {
   private readonly callbacks: StreamerCallbacks;
   private readonly wsUrl: string;
   private currentContext: string | null = null;
+  private mode: "dictation" | "shortcuts" = "dictation";
 
   // Capture pipeline — reused across sessions when possible
   private ctx: AudioContext | null = null;
@@ -52,7 +53,11 @@ export class Streamer {
 
   setContext(context: string | null): void {
     this.currentContext = context;
-    this.sendJSON({ type: "context", context });
+    this.sendJSON({ type: "context", context, mode: this.mode });
+  }
+
+  setMode(mode: "dictation" | "shortcuts"): void {
+    this.mode = mode;
   }
 
   async startCapture(stream: MediaStream): Promise<void> {
@@ -63,7 +68,11 @@ export class Streamer {
     this.pendingChunks = [];
     this.pcmChunks = [];
     this.pcmSampleCount = 0;
-    this.sendJSON({ type: "start", context: this.currentContext });
+    this.sendJSON({
+      type: "start",
+      context: this.currentContext,
+      mode: this.mode,
+    });
 
     if (!this.ctx || this.ctx.state === "closed") {
       this.ctx = new AudioContext();
@@ -110,6 +119,7 @@ export class Streamer {
       type: "commit",
       audioDurationMs,
       context: this.currentContext,
+      mode: this.mode,
     });
   }
 

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -136,6 +136,7 @@ export default function AppPage(): React.JSX.Element {
   /** True only while state is "recording" — used by the queue drain wait loop. */
   const recordingActiveRef = useRef(false);
   const appContextRef = useRef<string | null>(null);
+  const modeRef = useRef<"dictation" | "shortcuts">("dictation");
   const pendingCommitRef = useRef(false);
   const pillActiveRef = useRef(false);
   const barModeRef = useRef<BarMode | null>(null);
@@ -569,6 +570,7 @@ export default function AppPage(): React.JSX.Element {
 
         startListening(stream);
         try {
+          getStreamer().setMode(modeRef.current);
           await streamer.startCapture(stream);
         } catch {}
       } catch (err) {
@@ -810,12 +812,28 @@ export default function AppPage(): React.JSX.Element {
     const removeDown = window.api.onHotkeyDown(() => {
       const s = stateRef.current;
       if (s === "idle" || s === "error") {
+        modeRef.current = "dictation";
         startRecording(false);
       } else if (s === "transcribing" && !recordingActiveRef.current) {
+        modeRef.current = "dictation";
         startRecording(true);
       }
     });
     const removeUp = window.api.onHotkeyUp(() => {
+      if (stateRef.current === "recording") {
+        commitRecording();
+      } else if (stateRef.current === "initializing") {
+        pendingCommitRef.current = true;
+      }
+    });
+    const removeShortcutsDown = window.api.onShortcutsHotkeyDown(() => {
+      const s = stateRef.current;
+      if (s === "idle" || s === "error") {
+        modeRef.current = "shortcuts";
+        startRecording(false);
+      }
+    });
+    const removeShortcutsUp = window.api.onShortcutsHotkeyUp(() => {
       if (stateRef.current === "recording") {
         commitRecording();
       } else if (stateRef.current === "initializing") {
@@ -828,6 +846,8 @@ export default function AppPage(): React.JSX.Element {
     return () => {
       removeDown();
       removeUp();
+      removeShortcutsDown();
+      removeShortcutsUp();
       removeCancel();
     };
   }, [startRecording, commitRecording, cancelRecording]);

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -831,6 +831,9 @@ export default function AppPage(): React.JSX.Element {
       if (s === "idle" || s === "error") {
         modeRef.current = "shortcuts";
         startRecording(false);
+      } else if (s === "transcribing" && !recordingActiveRef.current) {
+        modeRef.current = "shortcuts";
+        startRecording(true);
       }
     });
     const removeShortcutsUp = window.api.onShortcutsHotkeyUp(() => {

--- a/apps/electron/src/renderer/src/pages/settings/shortcuts.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/shortcuts.tsx
@@ -196,12 +196,90 @@ export default function ShortcutsPage(): React.JSX.Element {
     setShowForm(true);
   }, []);
 
+  // YAML toggle
+  const stepsToYaml = useCallback(
+    (s: { action: string; value: string }[]): string =>
+      s
+        .map(
+          (st) =>
+            `- action: ${st.action}\n  value: ${JSON.stringify(st.value)}`,
+        )
+        .join("\n"),
+    [],
+  );
+
+  const yamlToSteps = useCallback(
+    (yaml: string): { action: StepAction; value: string }[] | null => {
+      try {
+        const lines = yaml.split("\n");
+        const parsed: { action: StepAction; value: string }[] = [];
+        let current: { action: string; value: string } | null = null;
+        for (const line of lines) {
+          const actionMatch = line.match(/^-\s*action:\s*(.+)/);
+          if (actionMatch) {
+            if (current)
+              parsed.push(current as { action: StepAction; value: string });
+            current = { action: actionMatch[1].trim(), value: "" };
+            continue;
+          }
+          const valueMatch = line.match(/^\s+value:\s*(.*)/);
+          if (valueMatch && current) {
+            let val = valueMatch[1].trim();
+            if (
+              (val.startsWith('"') && val.endsWith('"')) ||
+              (val.startsWith("'") && val.endsWith("'"))
+            ) {
+              try {
+                val = JSON.parse(val);
+              } catch {
+                val = val.slice(1, -1);
+              }
+            }
+            current.value = val;
+          }
+        }
+        if (current)
+          parsed.push(current as { action: StepAction; value: string });
+        if (
+          parsed.length === 0 ||
+          parsed.some(
+            (st) => !(stepActions as readonly string[]).includes(st.action),
+          )
+        )
+          return null;
+        return parsed;
+      } catch {
+        return null;
+      }
+    },
+    [],
+  );
+
+  const [yamlText, setYamlText] = useState("");
+  useEffect(() => {
+    if (showYamlEditor) setYamlText(stepsToYaml(steps));
+  }, [showYamlEditor, steps, stepsToYaml]);
+
+  const applyYaml = useCallback(() => {
+    const parsed = yamlToSteps(yamlText);
+    if (parsed) {
+      setSteps(parsed);
+      setShowYamlEditor(false);
+    }
+  }, [yamlText, yamlToSteps]);
+
   const saveEntry = useCallback(async () => {
     if (!triggerPhrase.trim()) {
       setFormError("Trigger phrase is required");
       return;
     }
-    if (steps.length === 0) {
+
+    // If YAML editor is open, parse it first to capture any edits
+    const stepsToSave = showYamlEditor
+      ? (yamlToSteps(yamlText) ?? steps)
+      : steps;
+
+    if (stepsToSave.length === 0) {
       setFormError("At least one step is required");
       return;
     }
@@ -212,7 +290,7 @@ export default function ShortcutsPage(): React.JSX.Element {
       const payload = {
         key: triggerPhrase,
         description: description || undefined,
-        steps: steps.map((s) => ({ action: s.action, value: s.value })),
+        steps: stepsToSave.map((s) => ({ action: s.action, value: s.value })),
       };
       const res = editingId
         ? await client.api.shortcuts[":id"].$put({
@@ -232,7 +310,17 @@ export default function ShortcutsPage(): React.JSX.Element {
     } catch {
       setFormError("Failed to save shortcut.");
     }
-  }, [triggerPhrase, description, steps, editingId, resetForm, loadData]);
+  }, [
+    triggerPhrase,
+    description,
+    steps,
+    showYamlEditor,
+    yamlText,
+    yamlToSteps,
+    editingId,
+    resetForm,
+    loadData,
+  ]);
 
   const deleteEntry = useCallback(
     async (id: number) => {
@@ -344,76 +432,7 @@ export default function ShortcutsPage(): React.JSX.Element {
     [],
   );
 
-  // YAML toggle
-  const stepsToYaml = useCallback(
-    (steps: { action: string; value: string }[]): string =>
-      steps
-        .map(
-          (s) => `- action: ${s.action}\n  value: ${JSON.stringify(s.value)}`,
-        )
-        .join("\n"),
-    [],
-  );
-
-  const yamlToSteps = useCallback(
-    (yaml: string): { action: StepAction; value: string }[] | null => {
-      try {
-        const lines = yaml.split("\n");
-        const steps: { action: StepAction; value: string }[] = [];
-        let current: { action: string; value: string } | null = null;
-        for (const line of lines) {
-          const actionMatch = line.match(/^-\s*action:\s*(.+)/);
-          if (actionMatch) {
-            if (current)
-              steps.push(current as { action: StepAction; value: string });
-            current = { action: actionMatch[1].trim(), value: "" };
-            continue;
-          }
-          const valueMatch = line.match(/^\s+value:\s*(.*)/);
-          if (valueMatch && current) {
-            let val = valueMatch[1].trim();
-            if (
-              (val.startsWith('"') && val.endsWith('"')) ||
-              (val.startsWith("'") && val.endsWith("'"))
-            ) {
-              try {
-                val = JSON.parse(val);
-              } catch {
-                val = val.slice(1, -1);
-              }
-            }
-            current.value = val;
-          }
-        }
-        if (current)
-          steps.push(current as { action: StepAction; value: string });
-        if (
-          steps.length === 0 ||
-          steps.some(
-            (s) => !(stepActions as readonly string[]).includes(s.action),
-          )
-        )
-          return null;
-        return steps;
-      } catch {
-        return null;
-      }
-    },
-    [],
-  );
-
-  const [yamlText, setYamlText] = useState("");
-  useEffect(() => {
-    if (showYamlEditor) setYamlText(stepsToYaml(steps));
-  }, [showYamlEditor, steps, stepsToYaml]);
-
-  const applyYaml = useCallback(() => {
-    const parsed = yamlToSteps(yamlText);
-    if (parsed) {
-      setSteps(parsed);
-      setShowYamlEditor(false);
-    }
-  }, [yamlText, yamlToSteps]);
+  // (YAML functions moved above saveEntry)
 
   // Variable pills from trigger phrase
   const variables =

--- a/apps/electron/src/renderer/src/pages/settings/shortcuts.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/shortcuts.tsx
@@ -1,0 +1,1216 @@
+import { type StepAction, stepActions } from "@freestyle/validations";
+import {
+  comboDisplayKeys,
+  formatAcceleratorKeys,
+  keyDisplayLabel,
+  useHotkeyRecorder,
+} from "@renderer/hooks/use-hotkey-recorder";
+import { getClient } from "@renderer/lib/api";
+import { cn } from "@renderer/lib/utils";
+import {
+  AppWindow,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  Clipboard,
+  Download,
+  GitBranch,
+  Globe,
+  Keyboard,
+  Pencil,
+  Plus,
+  Replace,
+  Search,
+  Trash2,
+  Upload,
+  Wand2,
+  X,
+  Zap,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface StepRow {
+  id: number;
+  shortcut_id: number;
+  position: number;
+  action: string;
+  value: string;
+}
+
+interface ShortcutEntry {
+  id: number;
+  key: string;
+  description: string | null;
+  usage_count: number;
+  steps: StepRow[];
+  created_at: string;
+  updated_at: string;
+}
+
+interface StepData {
+  action: StepAction;
+  value: string;
+}
+
+// ---------------------------------------------------------------------------
+// Step action metadata
+// ---------------------------------------------------------------------------
+
+const ACTION_META: Record<
+  StepAction,
+  { label: string; icon: typeof Replace; placeholder: string }
+> = {
+  replace: {
+    label: "Replace",
+    icon: Replace,
+    placeholder: "Replacement text...",
+  },
+  open_app: {
+    label: "Open App",
+    icon: AppWindow,
+    placeholder: "Application name...",
+  },
+  open_url: { label: "Open URL", icon: Globe, placeholder: "https://..." },
+  paste_clipboard: {
+    label: "Paste Clipboard",
+    icon: Clipboard,
+    placeholder: "Text to paste (blank = current clipboard)",
+  },
+  if: {
+    label: "If",
+    icon: GitBranch,
+    placeholder: "Condition expression...",
+  },
+  transform: {
+    label: "Transform",
+    icon: Wand2,
+    placeholder: "Transformation instruction...",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE = 20;
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function ShortcutsPage(): React.JSX.Element {
+  const [entries, setEntries] = useState<ShortcutEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  // Add/edit form
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [showYamlEditor, setShowYamlEditor] = useState(false);
+
+  // Hotkey
+  const [shortcutsHotkey, setShortcutsHotkey] = useState<string>("");
+  const [shortcutsMode, setShortcutsMode] = useState<"hold" | "toggle">("hold");
+
+  const [triggerPhrase, setTriggerPhrase] = useState("");
+  const [description, setDescription] = useState("");
+  const [steps, setSteps] = useState<StepData[]>([
+    { action: "replace", value: "" },
+  ]);
+
+  // Load data
+  const loadData = useCallback(async () => {
+    try {
+      const query: Record<string, string> = {
+        limit: String(PAGE_SIZE),
+        offset: String(page * PAGE_SIZE),
+        orderBy: "-created_at",
+      };
+      if (search) query.search = search;
+
+      const res = await getClient().api.shortcuts.$get({ query });
+      if (res.ok) {
+        const data = await res.json();
+        setEntries(data.items as unknown as ShortcutEntry[]);
+        setTotal(data.total);
+      }
+    } catch (err) {
+      console.error("Failed to load shortcuts:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, search]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  // Load hotkey settings
+  useEffect(() => {
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "shortcuts_hotkey" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value) setShortcutsHotkey(data.value);
+      })
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "shortcuts_hotkey_mode" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value === "toggle") setShortcutsMode("toggle");
+      })
+      .catch(() => {});
+  }, []);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const resetForm = useCallback(() => {
+    setShowForm(false);
+    setEditingId(null);
+    setFormError(null);
+    setTriggerPhrase("");
+    setDescription("");
+    setSteps([{ action: "replace", value: "" }]);
+    setShowYamlEditor(false);
+  }, []);
+
+  const startEdit = useCallback((entry: ShortcutEntry) => {
+    setEditingId(entry.id);
+    setFormError(null);
+    const s = entry.steps.map((st) => ({
+      action: st.action as StepAction,
+      value: st.value,
+    }));
+    setSteps(s.length > 0 ? s : [{ action: "replace" as const, value: "" }]);
+    setTriggerPhrase(entry.key);
+    setDescription(entry.description ?? "");
+    setShowForm(true);
+  }, []);
+
+  const saveEntry = useCallback(async () => {
+    if (!triggerPhrase.trim()) {
+      setFormError("Trigger phrase is required");
+      return;
+    }
+    if (steps.length === 0) {
+      setFormError("At least one step is required");
+      return;
+    }
+    setFormError(null);
+
+    try {
+      const client = getClient();
+      const payload = {
+        key: triggerPhrase,
+        description: description || undefined,
+        steps: steps.map((s) => ({ action: s.action, value: s.value })),
+      };
+      const res = editingId
+        ? await client.api.shortcuts[":id"].$put({
+            param: { id: String(editingId) },
+            json: payload,
+          })
+        : await client.api.shortcuts.$post({ json: payload });
+
+      if (!res.ok) {
+        const err = await res.text().catch(() => "");
+        setFormError(err || `HTTP ${res.status}`);
+        return;
+      }
+
+      resetForm();
+      loadData();
+    } catch {
+      setFormError("Failed to save shortcut.");
+    }
+  }, [triggerPhrase, description, steps, editingId, resetForm, loadData]);
+
+  const deleteEntry = useCallback(
+    async (id: number) => {
+      await getClient().api.shortcuts[":id"].$delete({
+        param: { id: String(id) },
+      });
+      loadData();
+    },
+    [loadData],
+  );
+
+  const importRef = useRef<HTMLInputElement>(null);
+
+  const exportJson = useCallback(async () => {
+    try {
+      const res = await getClient().api.shortcuts["export"].json.$get();
+      if (!res.ok) return;
+      const data = await res.json();
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "shortcuts.json";
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const handleImport = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      try {
+        const text = await file.text();
+        const data = JSON.parse(text);
+        await getClient().api.shortcuts.import.$post({ json: data });
+        loadData();
+      } catch {
+        // ignore
+      }
+      if (importRef.current) importRef.current.value = "";
+    },
+    [loadData],
+  );
+
+  // Hotkey recording
+  const handleHotkeyRecorded = useCallback((accelerator: string) => {
+    setShortcutsHotkey(accelerator);
+    window.api?.updateShortcutsHotkey(accelerator);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "shortcuts_hotkey" },
+        json: { value: accelerator },
+      })
+      .catch(() => {});
+  }, []);
+
+  const {
+    state: recorderState,
+    liveModifiers,
+    capturedCombo,
+    canSaveRecording,
+    needsModifierOrMouseButton: needsModOrMouse,
+    invalidReleaseNotice,
+    startRecording: startHotkeyRecording,
+    cancelRecording: cancelHotkeyRecording,
+  } = useHotkeyRecorder(handleHotkeyRecorded);
+
+  const handleModeChange = useCallback((mode: "hold" | "toggle") => {
+    setShortcutsMode(mode);
+    window.api?.setShortcutsHotkeyMode(mode);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "shortcuts_hotkey_mode" },
+        json: { value: mode },
+      })
+      .catch(() => {});
+  }, []);
+
+  // Step management
+  const addStep = useCallback(() => {
+    setSteps((s) => [...s, { action: "replace", value: "" }]);
+  }, []);
+
+  const removeStep = useCallback((idx: number) => {
+    setSteps((s) => s.filter((_, i) => i !== idx));
+  }, []);
+
+  const moveStep = useCallback((idx: number, dir: -1 | 1) => {
+    setSteps((s) => {
+      const arr = [...s];
+      const target = idx + dir;
+      if (target < 0 || target >= arr.length) return s;
+      [arr[idx], arr[target]] = [arr[target], arr[idx]];
+      return arr;
+    });
+  }, []);
+
+  const updateStep = useCallback(
+    (idx: number, patch: Partial<{ action: StepAction; value: string }>) => {
+      setSteps((s) =>
+        s.map((step, i) => (i === idx ? { ...step, ...patch } : step)),
+      );
+    },
+    [],
+  );
+
+  // YAML toggle
+  const stepsToYaml = useCallback(
+    (steps: { action: string; value: string }[]): string =>
+      steps
+        .map(
+          (s) => `- action: ${s.action}\n  value: ${JSON.stringify(s.value)}`,
+        )
+        .join("\n"),
+    [],
+  );
+
+  const yamlToSteps = useCallback(
+    (yaml: string): { action: StepAction; value: string }[] | null => {
+      try {
+        const lines = yaml.split("\n");
+        const steps: { action: StepAction; value: string }[] = [];
+        let current: { action: string; value: string } | null = null;
+        for (const line of lines) {
+          const actionMatch = line.match(/^-\s*action:\s*(.+)/);
+          if (actionMatch) {
+            if (current)
+              steps.push(current as { action: StepAction; value: string });
+            current = { action: actionMatch[1].trim(), value: "" };
+            continue;
+          }
+          const valueMatch = line.match(/^\s+value:\s*(.*)/);
+          if (valueMatch && current) {
+            let val = valueMatch[1].trim();
+            if (
+              (val.startsWith('"') && val.endsWith('"')) ||
+              (val.startsWith("'") && val.endsWith("'"))
+            ) {
+              try {
+                val = JSON.parse(val);
+              } catch {
+                val = val.slice(1, -1);
+              }
+            }
+            current.value = val;
+          }
+        }
+        if (current)
+          steps.push(current as { action: StepAction; value: string });
+        if (
+          steps.length === 0 ||
+          steps.some(
+            (s) => !(stepActions as readonly string[]).includes(s.action),
+          )
+        )
+          return null;
+        return steps;
+      } catch {
+        return null;
+      }
+    },
+    [],
+  );
+
+  const [yamlText, setYamlText] = useState("");
+  useEffect(() => {
+    if (showYamlEditor) setYamlText(stepsToYaml(steps));
+  }, [showYamlEditor, steps, stepsToYaml]);
+
+  const applyYaml = useCallback(() => {
+    const parsed = yamlToSteps(yamlText);
+    if (parsed) {
+      setSteps(parsed);
+      setShowYamlEditor(false);
+    }
+  }, [yamlText, yamlToSteps]);
+
+  // Variable pills from trigger phrase
+  const variables =
+    triggerPhrase.match(/\{(\w+)\}/g)?.map((v) => v.slice(1, -1)) ?? [];
+
+  // Recorder display
+  const liveKeys = liveModifiers.map(keyDisplayLabel);
+  const draftKeys = capturedCombo ? comboDisplayKeys(capturedCombo) : liveKeys;
+  const captureHint = needsModOrMouse
+    ? "Add a modifier or side mouse button"
+    : canSaveRecording
+      ? "Release to save"
+      : "Press a modifier or side mouse button...";
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground text-sm">Loading shortcuts...</p>
+      </div>
+    );
+  }
+
+  const isEmpty = total === 0 && !search;
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col"
+      style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+    >
+      <div className="h-9 shrink-0" />
+      <div
+        className="responsive-page-scroll flex-1 overflow-auto"
+        style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+      >
+        <PageHeader
+          title="Shortcuts"
+          subtitle="Voice-triggered workflows. Say a phrase to run one or more actions."
+        />
+
+        {/* Hotkey configuration */}
+        <Section label="Hotkey">
+          <Row
+            label="Shortcuts hotkey"
+            desc={
+              shortcutsMode === "toggle"
+                ? "Press once to start, again to stop."
+                : "Hold to record, release to transcribe."
+            }
+          >
+            {recorderState === "idle" ? (
+              <div className="relative inline-flex">
+                <button
+                  type="button"
+                  onClick={startHotkeyRecording}
+                  className="border-border hover:bg-secondary inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2 transition-colors"
+                >
+                  <Keyboard className="text-muted-foreground h-4 w-4 shrink-0" />
+                  {shortcutsHotkey ? (
+                    <KeyComboDisplay
+                      keys={formatAcceleratorKeys(shortcutsHotkey)}
+                    />
+                  ) : (
+                    <span className="text-muted-foreground text-sm">
+                      Not set
+                    </span>
+                  )}
+                  <span className="text-muted-foreground ml-1 text-xs">
+                    Change
+                  </span>
+                </button>
+                {invalidReleaseNotice && (
+                  <div className="bg-popover text-popover-foreground border-border shadow-soft absolute top-[calc(100%+6px)] right-0 z-20 whitespace-nowrap rounded-md border px-2.5 py-1.5 text-xs">
+                    Hotkeys need a modifier or side mouse button
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="border-primary/60 bg-primary/5 relative inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2">
+                <Keyboard className="text-primary h-4 w-4 shrink-0" />
+                {draftKeys.length > 0 ? (
+                  <>
+                    <KeyComboDisplay keys={draftKeys} variant="dim" />
+                    <span className="text-muted-foreground text-xs">
+                      {captureHint}
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-muted-foreground animate-pulse text-sm">
+                    {captureHint}
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={cancelHotkeyRecording}
+                  className="border-border hover:bg-secondary ml-1 rounded-md border px-2.5 py-1 text-xs"
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
+          </Row>
+          <Row
+            label="Activation"
+            desc={
+              shortcutsMode === "toggle"
+                ? "Press once to start, again to stop."
+                : "Push-to-talk while held."
+            }
+            last
+          >
+            <div className="border-border bg-card inline-flex w-fit shrink-0 rounded-lg border p-0.5 text-sm">
+              <button
+                type="button"
+                onClick={() => handleModeChange("hold")}
+                className={cn(
+                  "rounded-md px-3 py-1.5 transition-colors",
+                  shortcutsMode === "hold"
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                Hold
+              </button>
+              <button
+                type="button"
+                onClick={() => handleModeChange("toggle")}
+                className={cn(
+                  "rounded-md px-3 py-1.5 transition-colors",
+                  shortcutsMode === "toggle"
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                Toggle
+              </button>
+            </div>
+          </Row>
+        </Section>
+
+        {/* Built-in actions */}
+        <Section label="Built-in Actions">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <ActionCard
+              icon={AppWindow}
+              label="Open App"
+              desc="Launch a desktop application by name."
+            />
+            <ActionCard
+              icon={Globe}
+              label="Open URL"
+              desc="Open a link in the default browser."
+            />
+            <ActionCard
+              icon={Clipboard}
+              label="Paste Clipboard"
+              desc="Type clipboard contents into the focused app."
+            />
+          </div>
+        </Section>
+
+        {/* Custom shortcuts */}
+        <div className="mt-8">
+          <h2 className="mono text-muted-foreground mb-1 text-[10px] font-semibold uppercase tracking-[0.18em]">
+            Custom Shortcuts
+          </h2>
+
+          {isEmpty && !showForm ? (
+            <EmptyState
+              onAdd={() => {
+                resetForm();
+                setShowForm(true);
+              }}
+            />
+          ) : (
+            <>
+              {/* Search + Actions */}
+              <div className="mb-5 mt-3 flex flex-col items-start gap-2.5 min-[1080px]:flex-row min-[1080px]:items-center">
+                <div className="border-border bg-card flex min-w-0 flex-1 items-center gap-2 self-stretch rounded-lg border px-3 py-2">
+                  <Search className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+                  <input
+                    type="text"
+                    value={search}
+                    onChange={(e) => {
+                      setSearch(e.target.value);
+                      setPage(0);
+                    }}
+                    placeholder="Search shortcuts..."
+                    className="placeholder:text-muted-foreground/80 text-foreground flex-1 bg-transparent text-[13px] outline-none"
+                  />
+                </div>
+                <div className="flex shrink-0 flex-wrap items-center gap-2.5">
+                  <ToolbarButton onClick={exportJson} title="Export as JSON">
+                    <Download size={13} />
+                    Export
+                  </ToolbarButton>
+                  <ToolbarButton
+                    onClick={() => importRef.current?.click()}
+                    title="Import from JSON"
+                  >
+                    <Upload size={13} />
+                    Import
+                  </ToolbarButton>
+                  <input
+                    ref={importRef}
+                    type="file"
+                    accept=".json"
+                    className="hidden"
+                    onChange={handleImport}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      resetForm();
+                      setShowForm(true);
+                    }}
+                    className="bg-primary text-primary-foreground hover:bg-primary/90 flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-3 py-2 text-[12.5px] font-medium"
+                  >
+                    <Plus size={13} />
+                    Add shortcut
+                  </button>
+                </div>
+              </div>
+
+              {/* Add/Edit form */}
+              {showForm && (
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    saveEntry();
+                  }}
+                  className="border-border bg-card mb-6 rounded-[12px] border px-[18px] py-4"
+                >
+                  <div className="mb-3 flex items-center justify-between">
+                    <span className="mono text-muted-foreground text-[10px] uppercase tracking-[0.16em]">
+                      {editingId ? "Edit shortcut" : "New shortcut"}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={resetForm}
+                      className="text-muted-foreground hover:text-foreground cursor-pointer"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+
+                  <div className="grid grid-cols-1 gap-3.5 md:grid-cols-2">
+                    <FormField label="Trigger phrase">
+                      <input
+                        type="text"
+                        value={triggerPhrase}
+                        onChange={(e) => setTriggerPhrase(e.target.value)}
+                        placeholder='e.g. "open slack" or "paste {item}"'
+                        className="border-border bg-background w-full rounded-[7px] border px-[11px] py-2 text-[13px] outline-none"
+                      />
+                      {variables.length > 0 && (
+                        <div className="mt-1.5 flex flex-wrap gap-1">
+                          {variables.map((v) => (
+                            <span
+                              key={v}
+                              className="bg-accent text-accent-foreground rounded-full px-2 py-0.5 text-[10px] font-medium"
+                            >
+                              {`{${v}}`}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </FormField>
+                    <FormField label="Description (optional)">
+                      <input
+                        type="text"
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        placeholder="What does this shortcut do?"
+                        className="border-border bg-background w-full rounded-[7px] border px-[11px] py-2 text-[13px] outline-none"
+                      />
+                    </FormField>
+                  </div>
+
+                  {/* Steps */}
+                  <div className="mt-4">
+                    <div className="mb-2 flex items-center justify-between">
+                      <span className="mono text-muted-foreground text-[10px] uppercase tracking-[0.16em]">
+                        Steps
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setShowYamlEditor(!showYamlEditor)}
+                          className="text-muted-foreground hover:text-foreground text-[10px] uppercase tracking-wider"
+                        >
+                          {showYamlEditor ? "Visual" : "YAML"}
+                        </button>
+                      </div>
+                    </div>
+
+                    {showYamlEditor ? (
+                      <div>
+                        <textarea
+                          value={yamlText}
+                          onChange={(e) => setYamlText(e.target.value)}
+                          rows={Math.max(4, steps.length * 3)}
+                          className="border-border bg-background mono w-full resize-y rounded-[7px] border px-[11px] py-2 text-[12px] outline-none"
+                        />
+                        <button
+                          type="button"
+                          onClick={applyYaml}
+                          className="border-border text-secondary-foreground/80 hover:text-foreground mt-2 cursor-pointer rounded-md border px-3 py-1.5 text-[12.5px] font-medium"
+                        >
+                          Apply YAML
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="flex flex-col gap-2">
+                        {steps.map((step, idx) => {
+                          const meta = ACTION_META[step.action];
+                          return (
+                            <div
+                              key={idx}
+                              className="border-border bg-background flex items-start gap-2 rounded-lg border px-3 py-2.5"
+                            >
+                              <div className="flex flex-col gap-1">
+                                <button
+                                  type="button"
+                                  onClick={() => moveStep(idx, -1)}
+                                  disabled={idx === 0}
+                                  className={cn(
+                                    "rounded p-0.5",
+                                    idx === 0
+                                      ? "text-muted-foreground/30 cursor-not-allowed"
+                                      : "text-muted-foreground hover:text-foreground cursor-pointer",
+                                  )}
+                                >
+                                  <ChevronUp size={12} />
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => moveStep(idx, 1)}
+                                  disabled={idx === steps.length - 1}
+                                  className={cn(
+                                    "rounded p-0.5",
+                                    idx === steps.length - 1
+                                      ? "text-muted-foreground/30 cursor-not-allowed"
+                                      : "text-muted-foreground hover:text-foreground cursor-pointer",
+                                  )}
+                                >
+                                  <ChevronDown size={12} />
+                                </button>
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-center gap-2">
+                                  <span className="mono text-muted-foreground text-[10px]">
+                                    {idx + 1}
+                                  </span>
+                                  <select
+                                    value={step.action}
+                                    onChange={(e) =>
+                                      updateStep(idx, {
+                                        action: e.target.value as StepAction,
+                                      })
+                                    }
+                                    className="border-border bg-card rounded-md border px-2 py-1 text-[12px] outline-none"
+                                  >
+                                    {stepActions.map((a) => (
+                                      <option key={a} value={a}>
+                                        {ACTION_META[a].label}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </div>
+                                <input
+                                  type="text"
+                                  value={step.value}
+                                  onChange={(e) =>
+                                    updateStep(idx, { value: e.target.value })
+                                  }
+                                  placeholder={meta.placeholder}
+                                  className="mt-1.5 w-full bg-transparent text-[13px] outline-none"
+                                />
+                                {variables.length > 0 && (
+                                  <div className="mt-1 flex flex-wrap gap-1">
+                                    {variables.map((v) => (
+                                      <button
+                                        key={v}
+                                        type="button"
+                                        onClick={() =>
+                                          updateStep(idx, {
+                                            value: step.value + `{${v}}`,
+                                          })
+                                        }
+                                        className="bg-accent/60 text-accent-foreground hover:bg-accent cursor-pointer rounded-full px-1.5 py-0.5 text-[9px]"
+                                      >
+                                        +{`{${v}}`}
+                                      </button>
+                                    ))}
+                                  </div>
+                                )}
+                              </div>
+                              {steps.length > 1 && (
+                                <button
+                                  type="button"
+                                  onClick={() => removeStep(idx)}
+                                  className="text-muted-foreground hover:text-destructive cursor-pointer rounded p-1"
+                                >
+                                  <Trash2 size={12} />
+                                </button>
+                              )}
+                            </div>
+                          );
+                        })}
+                        <button
+                          type="button"
+                          onClick={addStep}
+                          className="border-border text-muted-foreground hover:text-foreground flex cursor-pointer items-center gap-1.5 self-start rounded-md border border-dashed px-2.5 py-1.5 text-[12px]"
+                        >
+                          <Plus size={12} />
+                          Add step
+                        </button>
+                      </div>
+                    )}
+                  </div>
+
+                  {formError && (
+                    <p className="text-destructive mt-3 text-xs">{formError}</p>
+                  )}
+                  <div className="mt-4 flex flex-wrap justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={resetForm}
+                      className="border-border text-secondary-foreground/80 hover:text-foreground cursor-pointer rounded-md border px-3 py-1.5 text-[12.5px] font-medium"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      className="bg-primary text-primary-foreground hover:bg-primary/90 cursor-pointer rounded-md px-3 py-1.5 text-[12.5px] font-medium"
+                    >
+                      {editingId ? "Update" : "Add shortcut"}
+                    </button>
+                  </div>
+                </form>
+              )}
+
+              {/* Entries list */}
+              {entries.length === 0 ? (
+                <NoSearchResults search={search} />
+              ) : (
+                <div className="border-border bg-card overflow-hidden rounded-[12px] border">
+                  {entries.map((entry, i) => (
+                    <EntryRow
+                      key={entry.id}
+                      entry={entry}
+                      isLast={i === entries.length - 1}
+                      onEdit={startEdit}
+                      onDelete={deleteEntry}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {/* Footer */}
+              {total > 0 && (
+                <div className="mt-3.5 flex flex-wrap items-center justify-between gap-2">
+                  <span className="mono text-muted-foreground text-[11px] tracking-[0.04em]">
+                    {total} {total === 1 ? "shortcut" : "shortcuts"}
+                  </span>
+                  {totalPages > 1 && (
+                    <div className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => setPage((p) => Math.max(0, p - 1))}
+                        disabled={page === 0}
+                        className={cn(
+                          "rounded p-1",
+                          page === 0
+                            ? "text-muted-foreground/40 cursor-not-allowed"
+                            : "text-muted-foreground hover:text-foreground cursor-pointer",
+                        )}
+                      >
+                        <ChevronLeft size={16} />
+                      </button>
+                      <span className="mono text-muted-foreground px-2 text-[11px]">
+                        {page + 1} / {totalPages}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setPage((p) => Math.min(totalPages - 1, p + 1))
+                        }
+                        disabled={page >= totalPages - 1}
+                        className={cn(
+                          "rounded p-1",
+                          page >= totalPages - 1
+                            ? "text-muted-foreground/40 cursor-not-allowed"
+                            : "text-muted-foreground hover:text-foreground cursor-pointer",
+                        )}
+                      >
+                        <ChevronRight size={16} />
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subcomponents
+// ---------------------------------------------------------------------------
+
+function PageHeader({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle?: string;
+}): React.JSX.Element {
+  return (
+    <div className="mb-7">
+      <h1 className="serif text-foreground m-0 text-[48px] font-normal leading-[0.95] tracking-[-0.025em]">
+        <span className="serif-italic text-primary">{title}</span>
+        <span>. </span>
+      </h1>
+      {subtitle && (
+        <p className="text-muted-foreground mt-2.5 max-w-[580px] text-[14px] leading-[1.5]">
+          {subtitle}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function Section({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <section className="mt-8">
+      <h2 className="mono text-muted-foreground mb-1 text-[10px] font-semibold uppercase tracking-[0.18em]">
+        {label}
+      </h2>
+      <div className="flex flex-col">{children}</div>
+    </section>
+  );
+}
+
+function Row({
+  label,
+  desc,
+  children,
+  last,
+}: {
+  label: string;
+  desc: string;
+  children: React.ReactNode;
+  last?: boolean;
+}): React.JSX.Element {
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-1 items-start gap-3 py-[22px] min-[1080px]:grid-cols-[220px_minmax(0,1fr)] min-[1080px]:gap-8 min-[1280px]:grid-cols-[280px_minmax(0,1fr)] min-[1280px]:gap-9",
+        !last && "border-border border-b",
+      )}
+    >
+      <div>
+        <div className="text-foreground text-[15px] font-medium">{label}</div>
+        <p className="text-muted-foreground mt-0.5 text-[12.5px] leading-[1.5]">
+          {desc}
+        </p>
+      </div>
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}
+
+function ActionCard({
+  icon: Icon,
+  label,
+  desc,
+}: {
+  icon: typeof Replace;
+  label: string;
+  desc: string;
+}): React.JSX.Element {
+  return (
+    <div className="border-border bg-card rounded-[10px] border px-4 py-3.5">
+      <div className="flex items-center gap-2.5">
+        <div className="bg-accent inline-flex h-8 w-8 items-center justify-center rounded-lg">
+          <Icon className="text-primary h-4 w-4" />
+        </div>
+        <div>
+          <div className="text-foreground text-[13px] font-medium">{label}</div>
+          <p className="text-muted-foreground text-[11px] leading-[1.4]">
+            {desc}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ToolbarButton({
+  onClick,
+  title,
+  children,
+}: {
+  onClick: () => void;
+  title: string;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className="border-border text-secondary-foreground/80 hover:text-foreground flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border px-3 py-2 text-[12.5px] font-medium"
+    >
+      {children}
+    </button>
+  );
+}
+
+function FormField({
+  label,
+  error,
+  children,
+}: {
+  label: string;
+  error?: string;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <div>
+      <div className="mono text-muted-foreground mb-1.5 text-[10px] uppercase tracking-[0.16em]">
+        {label}
+      </div>
+      {children}
+      {error && <p className="text-destructive mt-1 text-xs">{error}</p>}
+    </div>
+  );
+}
+
+function KeyBadge({
+  label,
+  variant = "default",
+}: {
+  label: string;
+  variant?: "default" | "recording" | "dim";
+}): React.JSX.Element {
+  return (
+    <kbd
+      className={cn(
+        "inline-flex select-none items-center justify-center",
+        "min-w-[26px] rounded-md px-1.5 py-1",
+        "font-mono text-xs font-medium leading-none",
+        "border shadow-[0_1px_0_0_hsl(var(--border))]",
+        variant === "default" && "border-border bg-muted text-foreground",
+        variant === "recording" &&
+          "border-primary/40 bg-primary/10 text-primary",
+        variant === "dim" &&
+          "border-border/50 bg-muted/50 text-muted-foreground",
+      )}
+    >
+      {label}
+    </kbd>
+  );
+}
+
+function KeyComboDisplay({
+  keys,
+  variant = "default",
+}: {
+  keys: string[];
+  variant?: "default" | "recording" | "dim";
+}): React.JSX.Element {
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-1">
+      {keys.map((k, i) => (
+        <span key={i} className="flex items-center gap-1">
+          {i > 0 && (
+            <span className="text-muted-foreground text-[10px]">+</span>
+          )}
+          <KeyBadge label={k} variant={variant} />
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function EntryRow({
+  entry,
+  isLast,
+  onEdit,
+  onDelete,
+}: {
+  entry: ShortcutEntry;
+  isLast: boolean;
+  onEdit: (entry: ShortcutEntry) => void;
+  onDelete: (id: number) => void;
+}): React.JSX.Element {
+  const stepSummary =
+    entry.steps.length > 0
+      ? entry.steps
+          .map(
+            (s) =>
+              `${ACTION_META[s.action as StepAction]?.label ?? s.action}${s.value ? `: ${s.value.slice(0, 30)}` : ""}`,
+          )
+          .join(" -> ")
+      : "No steps";
+
+  return (
+    <div
+      className={cn(
+        "shortcut-entry-row group grid items-center gap-3.5 px-5 py-3.5",
+        !isLast && "border-border/60 border-b",
+      )}
+    >
+      <span
+        className="mono text-foreground border-border bg-background justify-self-start truncate rounded-md border px-2 py-[3px] text-[12.5px] font-medium"
+        title={entry.key}
+      >
+        {entry.key}
+      </span>
+      <span
+        className="text-secondary-foreground line-clamp-2 text-[13px] leading-[1.4]"
+        title={stepSummary}
+      >
+        {stepSummary}
+      </span>
+      <span className="mono text-muted-foreground text-right text-[11px] max-[900px]:text-left">
+        {entry.usage_count > 0 ? `${entry.usage_count}x used` : "\u2014"}
+      </span>
+      <div className="flex justify-end gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 max-[900px]:row-span-2 max-[900px]:opacity-100">
+        <button
+          type="button"
+          onClick={() => onEdit(entry)}
+          className="text-muted-foreground hover:text-foreground cursor-pointer rounded p-1"
+          title="Edit"
+        >
+          <Pencil size={13} />
+        </button>
+        <button
+          type="button"
+          onClick={() => onDelete(entry.id)}
+          className="text-muted-foreground hover:text-destructive cursor-pointer rounded p-1"
+          title="Delete"
+        >
+          <Trash2 size={13} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ onAdd }: { onAdd: () => void }): React.JSX.Element {
+  return (
+    <div className="border-border bg-card mt-4 rounded-[14px] border border-dashed px-9 py-[52px] text-center">
+      <div className="bg-accent mx-auto mb-[18px] inline-flex h-16 w-16 items-center justify-center rounded-2xl">
+        <Zap className="text-primary h-7 w-7" />
+      </div>
+      <h2 className="serif text-foreground m-0 text-[32px] font-medium leading-none">
+        No shortcuts yet.
+      </h2>
+      <p className="text-muted-foreground mx-auto mt-2.5 max-w-[440px] text-[14px] leading-[1.55]">
+        Create a trigger phrase like{" "}
+        <span className="mono border-border bg-background text-foreground rounded-[5px] border px-[7px] py-[2px] text-[12px]">
+          open slack
+        </span>{" "}
+        and assign one or more actions to run when you say it.
+      </p>
+      <button
+        type="button"
+        onClick={onAdd}
+        className="bg-primary text-primary-foreground hover:bg-primary/90 mt-[22px] inline-flex cursor-pointer items-center gap-1.5 rounded-md px-3.5 py-2 text-[12.5px] font-medium"
+      >
+        <Plus size={13} />
+        Add your first shortcut
+      </button>
+    </div>
+  );
+}
+
+function NoSearchResults({ search }: { search: string }): React.JSX.Element {
+  return (
+    <div className="text-muted-foreground py-10 text-center">
+      <span className="serif-italic text-[20px]">
+        {search
+          ? `nothing matches "${search}".`
+          : "no shortcuts \u2014 add one to start."}
+      </span>
+    </div>
+  );
+}

--- a/apps/electron/src/renderer/src/pages/shell.tsx
+++ b/apps/electron/src/renderer/src/pages/shell.tsx
@@ -10,6 +10,7 @@ import {
   FileText,
   Languages,
   Sliders,
+  Zap,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useNavigate } from "react-router";
@@ -31,19 +32,25 @@ const navItems: NavItem[] = [
     shortcut: "3",
   },
   {
+    to: "/settings/shortcuts",
+    label: "Shortcuts",
+    icon: Zap,
+    shortcut: "4",
+  },
+  {
     to: "/settings/vocabulary",
     label: "Vocabulary",
     icon: Languages,
-    shortcut: "4",
+    shortcut: "5",
   },
   {
     to: "/settings/formats",
     label: "Formats",
     icon: FileText,
-    shortcut: "5",
+    shortcut: "6",
   },
-  { to: "/settings/models", label: "Models", icon: Cpu, shortcut: "6" },
-  { to: "/settings", label: "Settings", icon: Sliders, shortcut: "7" },
+  { to: "/settings/models", label: "Models", icon: Cpu, shortcut: "7" },
+  { to: "/settings", label: "Settings", icon: Sliders, shortcut: "8" },
 ];
 
 export default function AppShell(): React.JSX.Element {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -15,6 +15,7 @@ import mlxAsr, { autoStartMlxAsrServer } from "./routes/mlx-asr.js";
 import models from "./routes/models.js";
 import postProcessRoute from "./routes/post-process-route.js";
 import settings from "./routes/settings.js";
+import shortcuts from "./routes/shortcuts.js";
 import stream from "./routes/stream.js";
 import transcribe from "./routes/transcribe.js";
 import vocabulary from "./routes/vocabulary.js";
@@ -50,6 +51,7 @@ const app = new Hono()
   .route("/api/transcribe", transcribe)
   .route("/api/history", history)
   .route("/api/dictionary", dictionary)
+  .route("/api/shortcuts", shortcuts)
   .route("/api/vocabulary", vocabulary)
   .route("/api/formats", formats)
   .route("/api/post-process", postProcessRoute)
@@ -58,6 +60,7 @@ const app = new Hono()
   .route("/mcp", mcp)
   .route("/stream", stream);
 
+export { registerActionHandler } from "./lib/actions.js";
 export {
   autoStartMlxAsrServer,
   autoStartWhisperServer,

--- a/apps/server/src/lib/actions.ts
+++ b/apps/server/src/lib/actions.ts
@@ -1,0 +1,38 @@
+export interface ActionResult {
+  ok: boolean;
+  message?: string;
+}
+
+export type ActionHandler = (
+  params: Record<string, unknown>,
+) => Promise<ActionResult>;
+
+const handlers = new Map<string, ActionHandler>();
+
+export function registerActionHandler(
+  action: string,
+  handler: ActionHandler,
+): void {
+  handlers.set(action, handler);
+}
+
+export async function executeAction(
+  action: string,
+  params: Record<string, unknown>,
+): Promise<ActionResult> {
+  const handler = handlers.get(action);
+  if (!handler) {
+    return {
+      ok: false,
+      message: `No handler registered for action: ${action}`,
+    };
+  }
+  try {
+    return await handler(params);
+  } catch (err) {
+    return {
+      ok: false,
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/server/src/lib/post-process.ts
+++ b/apps/server/src/lib/post-process.ts
@@ -3,6 +3,11 @@ import { getModelCost, isCleanupModelSupported } from "../routes/models.js";
 import { getDb } from "./db.js";
 import { capture, captureException } from "./posthog.js";
 import { createChatModel, getDefaultModels } from "./providers.js";
+import {
+  applyShortcutsFallback,
+  loadShortcuts,
+  runShortcutsAgent,
+} from "./shortcuts-agent.js";
 
 /** Build a context string from the raw x-app-context header for matching */
 function buildMatchContext(rawContext: string | null): string {
@@ -80,6 +85,7 @@ export interface PostProcessResult {
   inputTokens: number;
   outputTokens: number;
   costUsd: number;
+  actionsExecuted: string[];
 }
 
 /**
@@ -110,6 +116,7 @@ export async function postProcess(
       inputTokens: 0,
       outputTokens: 0,
       costUsd: 0,
+      actionsExecuted: [],
     };
   }
 
@@ -248,5 +255,108 @@ IMPORTANT: Your entire response must be the cleaned text and nothing else. No qu
     inputTokens,
     outputTokens,
     costUsd,
+    actionsExecuted: [],
+  };
+}
+
+/**
+ * Post-process for shortcuts mode: run the shortcuts agent or fallback.
+ */
+export async function postProcessShortcuts(
+  rawText: string,
+  appContext: string | null,
+): Promise<PostProcessResult> {
+  const ppStart = Date.now();
+  const db = getDb();
+  const defaults = getDefaultModels();
+
+  const stripped = rawText
+    .replace(/\b(um+|uh+|ah+|er+|hm+|hmm+|mm+|mhm+|you know|i mean)\b/gi, "")
+    .replace(/[.…,!?\-–—\s]+/g, "");
+  if (!stripped) {
+    return {
+      cleaned: "",
+      llmProvider: null,
+      llmModel: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      actionsExecuted: [],
+    };
+  }
+
+  const llmSetting = db
+    .prepare("SELECT value FROM settings WHERE key = 'llm_cleanup'")
+    .get() as { value: string } | undefined;
+  const llmEnabled = llmSetting?.value === "true";
+
+  let cleanedText = rawText;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let llmProvider: string | null = null;
+  let llmModel: string | null = null;
+  let costUsd = 0;
+  let actionsExecuted: string[] = [];
+
+  const contextHint = appContext ? buildMatchContext(appContext) : "";
+
+  if (llmEnabled && defaults.llm) {
+    try {
+      const chatModel = createChatModel(
+        defaults.llm.provider,
+        defaults.llm.model_id,
+      );
+      const result = await runShortcutsAgent(
+        rawText,
+        contextHint,
+        chatModel,
+        defaults.llm.model_id,
+      );
+      cleanedText = result.cleaned;
+      actionsExecuted = result.actionsExecuted;
+      inputTokens = result.inputTokens;
+      outputTokens = result.outputTokens;
+      llmProvider = defaults.llm.provider;
+      llmModel = defaults.llm.model_id;
+    } catch (err) {
+      captureException(err);
+      console.error("Shortcuts agent failed:", err);
+      const fallback = applyShortcutsFallback(rawText, loadShortcuts());
+      cleanedText = fallback.cleaned;
+      actionsExecuted = fallback.actionsExecuted;
+    }
+  } else {
+    const fallback = applyShortcutsFallback(rawText, loadShortcuts());
+    cleanedText = fallback.cleaned;
+    actionsExecuted = fallback.actionsExecuted;
+  }
+
+  if (inputTokens > 0 || outputTokens > 0) {
+    try {
+      if (llmProvider && llmModel) {
+        const pricing = await getModelCost(llmProvider, llmModel);
+        if (pricing) {
+          costUsd = inputTokens * pricing.input + outputTokens * pricing.output;
+        }
+      }
+    } catch {
+      // ignore pricing errors
+    }
+  }
+
+  capture("post process shortcuts completed", {
+    duration_ms: Date.now() - ppStart,
+    ...(llmModel ? { model: llmModel } : {}),
+    actions_count: actionsExecuted.length,
+  });
+
+  return {
+    cleaned: cleanedText,
+    llmProvider,
+    llmModel,
+    inputTokens,
+    outputTokens,
+    costUsd,
+    actionsExecuted,
   };
 }

--- a/apps/server/src/lib/post-process.ts
+++ b/apps/server/src/lib/post-process.ts
@@ -298,7 +298,7 @@ export async function postProcessShortcuts(
   let costUsd = 0;
   let actionsExecuted: string[] = [];
 
-  const contextHint = appContext ? buildMatchContext(appContext) : "";
+  const contextHint = getContextHint(appContext, db);
 
   if (llmEnabled && defaults.llm) {
     try {

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 
-const SCHEMA_VERSION = 6;
+const SCHEMA_VERSION = 7;
 
 export function initSchema(db: DatabaseSync): void {
   db.exec(`
@@ -181,6 +181,30 @@ export function initSchema(db: DatabaseSync): void {
         notes TEXT,
         created_at TEXT NOT NULL DEFAULT (datetime('now')),
         updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+  }
+
+  if (currentVersion < 7) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS shortcuts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        key TEXT NOT NULL UNIQUE,
+        description TEXT,
+        usage_count INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS shortcut_steps (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        shortcut_id INTEGER NOT NULL REFERENCES shortcuts(id) ON DELETE CASCADE,
+        position INTEGER NOT NULL,
+        action TEXT NOT NULL,
+        value TEXT NOT NULL DEFAULT '',
+        UNIQUE(shortcut_id, position)
       )
     `);
   }

--- a/apps/server/src/lib/shortcut-executor.ts
+++ b/apps/server/src/lib/shortcut-executor.ts
@@ -1,0 +1,192 @@
+import { executeAction } from "./actions.js";
+import { getDb } from "./db.js";
+
+interface StepRow {
+  id: number;
+  shortcut_id: number;
+  position: number;
+  action: string;
+  value: string;
+}
+
+export function extractVariableNames(trigger: string): string[] {
+  const matches = trigger.match(/\{(\w+)\}/g);
+  if (!matches) return [];
+  return matches.map((m) => m.slice(1, -1));
+}
+
+export function triggerToRegex(trigger: string): RegExp {
+  const escaped = trigger.replace(/[.*+?^${}()|[\]\\]/g, (ch) => {
+    if (ch === "{" || ch === "}") return ch;
+    return `\\${ch}`;
+  });
+  const pattern = escaped.replace(/\{(\w+)\}/g, "(?<$1>.+?)");
+  return new RegExp(`^${pattern}$`, "i");
+}
+
+export function interpolate(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  return template.replace(/\{(\w+)\}/g, (_, name) => vars[name] ?? "");
+}
+
+export function evaluateCondition(
+  vars: Record<string, string>,
+  config: { variable: string; operator: string; operand?: string },
+): boolean {
+  const val = vars[config.variable] ?? "";
+  const operand = config.operand ?? "";
+
+  switch (config.operator) {
+    case "equals":
+      return val.toLowerCase() === operand.toLowerCase();
+    case "contains":
+      return val.toLowerCase().includes(operand.toLowerCase());
+    case "starts_with":
+      return val.toLowerCase().startsWith(operand.toLowerCase());
+    case "ends_with":
+      return val.toLowerCase().endsWith(operand.toLowerCase());
+    case "is_empty":
+      return val.trim() === "";
+    case "not_empty":
+      return val.trim() !== "";
+    default:
+      return false;
+  }
+}
+
+export function applyTransform(value: string, operations: string[]): string {
+  let result = value;
+  for (const op of operations) {
+    if (op === "trim") {
+      result = result.trim();
+    } else if (op === "lowercase") {
+      result = result.toLowerCase();
+    } else if (op === "uppercase") {
+      result = result.toUpperCase();
+    } else if (op === "url_encode") {
+      result = encodeURIComponent(result);
+    } else if (op.startsWith("default:")) {
+      if (!result.trim()) {
+        result = op.slice("default:".length);
+      }
+    } else if (op.startsWith("replace:")) {
+      const parts = op.slice("replace:".length).split(":");
+      if (parts.length >= 2) {
+        const [from, ...rest] = parts;
+        const to = rest.join(":");
+        result = result.split(from).join(to);
+      }
+    }
+  }
+  return result;
+}
+
+export async function executeSteps(
+  steps: StepRow[],
+  vars: Record<string, string>,
+  actionsExecuted: string[],
+  textParts: string[],
+): Promise<void> {
+  for (const step of steps) {
+    const interpolatedValue = interpolate(step.value, vars);
+
+    switch (step.action) {
+      case "replace": {
+        textParts.push(interpolatedValue);
+        break;
+      }
+      case "open_app": {
+        const result = await executeAction("open_app", {
+          name: interpolatedValue,
+        });
+        actionsExecuted.push(`open_app:${interpolatedValue}`);
+        if (!result.ok && result.message) {
+          console.warn(`[shortcut] open_app failed: ${result.message}`);
+        }
+        break;
+      }
+      case "open_url": {
+        const result = await executeAction("open_url", {
+          url: interpolatedValue,
+        });
+        actionsExecuted.push(`open_url:${interpolatedValue}`);
+        if (!result.ok && result.message) {
+          console.warn(`[shortcut] open_url failed: ${result.message}`);
+        }
+        break;
+      }
+      case "paste_clipboard": {
+        const result = await executeAction("paste_clipboard", {});
+        actionsExecuted.push("paste_clipboard");
+        if (!result.ok && result.message) {
+          console.warn(`[shortcut] paste_clipboard failed: ${result.message}`);
+        }
+        break;
+      }
+      case "if": {
+        try {
+          const config = JSON.parse(interpolatedValue) as {
+            variable: string;
+            operator: string;
+            operand?: string;
+            then?: StepRow[];
+            else?: StepRow[];
+          };
+          const conditionMet = evaluateCondition(vars, config);
+          const branch = conditionMet ? config.then : config.else;
+          if (branch && branch.length > 0) {
+            await executeSteps(branch, vars, actionsExecuted, textParts);
+          }
+        } catch {
+          console.warn("[shortcut] Failed to parse if-step value");
+        }
+        break;
+      }
+      case "transform": {
+        try {
+          const config = JSON.parse(interpolatedValue) as {
+            variable: string;
+            operations: string[];
+          };
+          const currentVal = vars[config.variable] ?? "";
+          vars[config.variable] = applyTransform(currentVal, config.operations);
+        } catch {
+          console.warn("[shortcut] Failed to parse transform-step value");
+        }
+        break;
+      }
+    }
+  }
+}
+
+export async function executeShortcut(
+  shortcutId: number,
+  variables: Record<string, string>,
+): Promise<{ text: string; actionsExecuted: string[] }> {
+  const db = getDb();
+  const steps = db
+    .prepare(
+      "SELECT * FROM shortcut_steps WHERE shortcut_id = ? ORDER BY position ASC",
+    )
+    .all(shortcutId) as unknown as StepRow[];
+
+  const now = new Date();
+  const builtInVars: Record<string, string> = {
+    date: now.toISOString().slice(0, 10),
+    time: now.toTimeString().slice(0, 5),
+  };
+  const vars = { ...builtInVars, ...variables };
+
+  const actionsExecuted: string[] = [];
+  const textParts: string[] = [];
+
+  await executeSteps(steps, vars, actionsExecuted, textParts);
+
+  db.prepare(
+    "UPDATE shortcuts SET usage_count = usage_count + 1, updated_at = datetime('now') WHERE id = ?",
+  ).run(shortcutId);
+
+  return { text: textParts.join(""), actionsExecuted };
+}

--- a/apps/server/src/lib/shortcut-executor.ts
+++ b/apps/server/src/lib/shortcut-executor.ts
@@ -90,7 +90,12 @@ export async function executeSteps(
   textParts: string[],
 ): Promise<void> {
   for (const step of steps) {
-    const interpolatedValue = interpolate(step.value, vars);
+    // Skip interpolation for if/transform — their values are JSON with
+    // field names like "variable" that would collide with {variable} placeholders.
+    const interpolatedValue =
+      step.action === "if" || step.action === "transform"
+        ? step.value
+        : interpolate(step.value, vars);
 
     switch (step.action) {
       case "replace": {
@@ -118,7 +123,10 @@ export async function executeSteps(
         break;
       }
       case "paste_clipboard": {
-        const result = await executeAction("paste_clipboard", {});
+        const result = await executeAction(
+          "paste_clipboard",
+          interpolatedValue ? { text: interpolatedValue } : {},
+        );
         actionsExecuted.push("paste_clipboard");
         if (!result.ok && result.message) {
           console.warn(`[shortcut] paste_clipboard failed: ${result.message}`);

--- a/apps/server/src/lib/shortcuts-agent.ts
+++ b/apps/server/src/lib/shortcuts-agent.ts
@@ -1,0 +1,231 @@
+import type { LanguageModel, Tool } from "ai";
+import { generateText, jsonSchema, stepCountIs } from "ai";
+import { executeAction } from "./actions.js";
+import { getDb } from "./db.js";
+import {
+  executeShortcut,
+  extractVariableNames,
+  interpolate,
+  triggerToRegex,
+} from "./shortcut-executor.js";
+
+interface StepRow {
+  action: string;
+  value: string;
+  position: number;
+}
+
+interface ShortcutEntry {
+  id: number;
+  key: string;
+  description: string | null;
+  steps: StepRow[];
+}
+
+export function loadShortcuts(): ShortcutEntry[] {
+  const db = getDb();
+  const rows = db
+    .prepare(
+      "SELECT id, key, description FROM shortcuts ORDER BY length(key) DESC",
+    )
+    .all() as unknown as {
+    id: number;
+    key: string;
+    description: string | null;
+  }[];
+
+  return rows.map((row) => {
+    const steps = db
+      .prepare(
+        "SELECT action, value, position FROM shortcut_steps WHERE shortcut_id = ? ORDER BY position ASC",
+      )
+      .all(row.id) as unknown as StepRow[];
+    return { ...row, steps };
+  });
+}
+
+export function buildUserShortcutsContext(entries: ShortcutEntry[]): string {
+  if (entries.length === 0) return "No shortcuts are configured.";
+
+  const lines = entries.map((e) => {
+    const vars = extractVariableNames(e.key);
+    const varInfo = vars.length > 0 ? ` (variables: ${vars.join(", ")})` : "";
+    const desc = e.description ? ` — ${e.description}` : "";
+    const stepsInfo = e.steps.map((s) => `${s.action}: ${s.value}`).join("; ");
+    return `- ID ${e.id}: "${e.key}"${varInfo}${desc} [${stepsInfo}]`;
+  });
+  return `Available shortcuts:\n${lines.join("\n")}`;
+}
+
+export function buildSystemPrompt(
+  contextHint: string,
+  userShortcuts: string,
+): string {
+  return `You are a voice-command assistant. The user speaks commands, dictation, or a mix of both.
+
+Your job:
+1. Identify if the spoken text matches or is close to a shortcut trigger phrase.
+2. If a shortcut matches, call execute_shortcut with the shortcut ID and any extracted variables.
+3. If the user asks to open an app, call open_app.
+4. If the user asks to open a URL, call open_url.
+5. If the user asks to paste clipboard, call paste_clipboard.
+6. For pure dictation (no command intent), return the cleaned text as-is.
+7. For mixed input (command + dictation), execute the command and return remaining dictation.
+
+${contextHint ? `Context: ${contextHint}\n` : ""}
+${userShortcuts}
+
+Rules:
+- Match triggers case-insensitively and flexibly (the user is speaking, not typing).
+- Extract variables from the spoken text when the trigger has {variable} placeholders.
+- Only call tools when you detect command intent. Do not call tools for pure dictation.
+- Return the final text the user intended to type. If only commands were spoken, return an empty string.
+- Do NOT add explanations or commentary. Your entire response must be the cleaned text output.`;
+}
+
+export async function runShortcutsAgent(
+  rawText: string,
+  contextHint: string,
+  chatModel: LanguageModel,
+  modelId: string,
+): Promise<{
+  cleaned: string;
+  actionsExecuted: string[];
+  inputTokens: number;
+  outputTokens: number;
+}> {
+  const entries = loadShortcuts();
+  const userShortcuts = buildUserShortcutsContext(entries);
+  const systemPrompt = buildSystemPrompt(contextHint, userShortcuts);
+  const actionsExecuted: string[] = [];
+
+  const tools: Record<string, Tool> = {
+    execute_shortcut: {
+      description: "Execute a shortcut by ID with optional variables",
+      inputSchema: jsonSchema({
+        type: "object" as const,
+        properties: {
+          id: { type: "number", description: "Shortcut ID" },
+          variables: {
+            type: "object",
+            description:
+              "Variable name-value pairs extracted from the spoken text",
+            additionalProperties: { type: "string" },
+          },
+        },
+        required: ["id"],
+      }),
+      execute: async (args: Record<string, unknown>) => {
+        const id = args.id as number;
+        const variables = (args.variables as Record<string, string>) ?? {};
+        const result = await executeShortcut(id, variables);
+        actionsExecuted.push(...result.actionsExecuted);
+        return { text: result.text, actionsExecuted: result.actionsExecuted };
+      },
+    },
+    open_app: {
+      description: "Open an application by name",
+      inputSchema: jsonSchema({
+        type: "object" as const,
+        properties: {
+          name: { type: "string", description: "Application name" },
+        },
+        required: ["name"],
+      }),
+      execute: async (args: Record<string, unknown>) => {
+        const name = args.name as string;
+        const result = await executeAction("open_app", { name });
+        actionsExecuted.push(`open_app:${name}`);
+        return result;
+      },
+    },
+    open_url: {
+      description: "Open a URL in the browser",
+      inputSchema: jsonSchema({
+        type: "object" as const,
+        properties: {
+          url: { type: "string", description: "URL to open" },
+        },
+        required: ["url"],
+      }),
+      execute: async (args: Record<string, unknown>) => {
+        const url = args.url as string;
+        const result = await executeAction("open_url", { url });
+        actionsExecuted.push(`open_url:${url}`);
+        return result;
+      },
+    },
+    paste_clipboard: {
+      description: "Paste the current clipboard contents",
+      inputSchema: jsonSchema({
+        type: "object" as const,
+        properties: {},
+      }),
+      execute: async () => {
+        const result = await executeAction("paste_clipboard", {});
+        actionsExecuted.push("paste_clipboard");
+        return result;
+      },
+    },
+  };
+
+  const result = await generateText({
+    model: chatModel,
+    system: systemPrompt,
+    prompt: rawText,
+    tools,
+    stopWhen: stepCountIs(5),
+    temperature: 0,
+  });
+
+  return {
+    cleaned: result.text,
+    actionsExecuted,
+    inputTokens: result.usage?.inputTokens ?? 0,
+    outputTokens: result.usage?.outputTokens ?? 0,
+  };
+}
+
+export function applyShortcutsFallback(
+  text: string,
+  entries: ShortcutEntry[],
+): { cleaned: string; actionsExecuted: string[] } {
+  let remaining = text;
+  const actionsExecuted: string[] = [];
+
+  for (const entry of entries) {
+    const vars = extractVariableNames(entry.key);
+    if (vars.length > 0) {
+      const regex = triggerToRegex(entry.key);
+      const match = remaining.match(regex);
+      if (match?.groups) {
+        const variables: Record<string, string> = {};
+        for (const v of vars) {
+          variables[v] = match.groups[v] ?? "";
+        }
+        const replaceSteps = entry.steps.filter((s) => s.action === "replace");
+        if (replaceSteps.length > 0) {
+          const replacement = replaceSteps
+            .map((s) => interpolate(s.value, variables))
+            .join("");
+          remaining = remaining.replace(match[0], replacement);
+        }
+      }
+    } else {
+      const escaped = entry.key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const regex = new RegExp(`\\b${escaped}\\b`, "gi");
+      if (regex.test(remaining)) {
+        const replaceSteps = entry.steps.filter((s) => s.action === "replace");
+        if (replaceSteps.length > 0) {
+          const replacement = replaceSteps.map((s) => s.value).join("");
+          remaining = remaining.replace(
+            new RegExp(`\\b${escaped}\\b`, "gi"),
+            replacement,
+          );
+        }
+      }
+    }
+  }
+
+  return { cleaned: remaining, actionsExecuted };
+}

--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -1,8 +1,10 @@
 import {
   createDictionarySchema,
   createFormatSchema,
+  createShortcutSchema,
   updateDictionarySchema,
   updateFormatSchema,
+  updateShortcutSchema,
 } from "@freestyle/validations";
 import { StreamableHTTPTransport } from "@hono/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -11,6 +13,7 @@ import { z } from "zod/v3";
 import dictionary from "./dictionary.js";
 import formats from "./formats.js";
 import history from "./history.js";
+import shortcuts from "./shortcuts.js";
 
 async function call(
   app: Hono,
@@ -170,6 +173,66 @@ mcpServer.tool(
   idParam,
   async ({ id }) => {
     await call(dictionary, "DELETE", `/${id}`);
+    return text({ ok: true, id });
+  },
+);
+
+// --- Shortcut tools ---
+
+mcpServer.tool(
+  "shortcut_list",
+  "List shortcuts with optional search and pagination",
+  listParams,
+  async ({ limit, offset, search }) => {
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
+    if (search) params.set("search", search);
+    const { data } = await call(shortcuts, "GET", `/?${params}`);
+    return text(data);
+  },
+);
+
+mcpServer.tool(
+  "shortcut_view",
+  "View a single shortcut by ID",
+  idParam,
+  async ({ id }) => {
+    const { data, ok } = await call(shortcuts, "GET", `/${id}`);
+    if (!ok) return error(`Shortcut #${id} not found`);
+    return text(data);
+  },
+);
+
+mcpServer.tool(
+  "shortcut_create",
+  "Create a new shortcut with trigger phrase and steps",
+  createShortcutSchema.shape,
+  async (args) => {
+    const { data, ok } = await call(shortcuts, "POST", "/", args);
+    if (!ok) return error(data.error ?? "Failed to create shortcut");
+    return text(data);
+  },
+);
+
+mcpServer.tool(
+  "shortcut_update",
+  "Update an existing shortcut",
+  { ...idParam, ...updateShortcutSchema.shape },
+  async ({ id, ...body }) => {
+    const { data, ok } = await call(shortcuts, "PUT", `/${id}`, body);
+    if (!ok) return error(data.error ?? `Shortcut #${id} not found`);
+    return text({ ok: true, id });
+  },
+);
+
+mcpServer.tool(
+  "shortcut_delete",
+  "Delete a shortcut",
+  idParam,
+  async ({ id }) => {
+    await call(shortcuts, "DELETE", `/${id}`);
     return text({ ok: true, id });
   },
 );

--- a/apps/server/src/routes/post-process-route.ts
+++ b/apps/server/src/routes/post-process-route.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { postProcess } from "../lib/post-process.js";
+import { postProcess, postProcessShortcuts } from "../lib/post-process.js";
 
 const postProcessRoute = new Hono().post("/", async (c) => {
   const body = await c.req.json().catch(() => null);
@@ -9,14 +9,17 @@ const postProcessRoute = new Hono().post("/", async (c) => {
   }
 
   const appContext: string | null = body.appContext ?? null;
+  const reqMode: string = body.mode ?? "dictation";
 
-  const pp = await postProcess(body.text, appContext);
+  const ppFn = reqMode === "shortcuts" ? postProcessShortcuts : postProcess;
+  const pp = await ppFn(body.text, appContext);
 
   return c.json({
     cleaned: pp.cleaned,
     inputTokens: pp.inputTokens,
     outputTokens: pp.outputTokens,
     costUsd: pp.costUsd,
+    ...(reqMode === "shortcuts" ? { actionsExecuted: pp.actionsExecuted } : {}),
   });
 });
 

--- a/apps/server/src/routes/shortcuts.ts
+++ b/apps/server/src/routes/shortcuts.ts
@@ -1,0 +1,289 @@
+import {
+  createShortcutSchema,
+  updateShortcutSchema,
+} from "@freestyle/validations";
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { getDb } from "../lib/db.js";
+
+interface ShortcutRow {
+  id: number;
+  key: string;
+  description: string | null;
+  usage_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface StepRow {
+  id: number;
+  shortcut_id: number;
+  position: number;
+  action: string;
+  value: string;
+}
+
+function getStepsForShortcut(
+  db: ReturnType<typeof getDb>,
+  shortcutId: number,
+): StepRow[] {
+  return db
+    .prepare(
+      "SELECT * FROM shortcut_steps WHERE shortcut_id = ? ORDER BY position ASC",
+    )
+    .all(shortcutId) as unknown as StepRow[];
+}
+
+function insertSteps(
+  db: ReturnType<typeof getDb>,
+  shortcutId: number,
+  steps: { action: string; value?: string }[],
+): void {
+  const stmt = db.prepare(
+    "INSERT INTO shortcut_steps (shortcut_id, position, action, value) VALUES (?, ?, ?, ?)",
+  );
+  for (let i = 0; i < steps.length; i++) {
+    stmt.run(shortcutId, i, steps[i].action, steps[i].value ?? "");
+  }
+}
+
+const shortcuts = new Hono()
+  .get("/", (c) => {
+    const db = getDb();
+    const limit = Math.min(Number(c.req.query("limit") || 50), 200);
+    const offset = Number(c.req.query("offset") || 0);
+    const search = c.req.query("search")?.trim() || "";
+    const orderByParam = c.req.query("orderBy") || "-created_at";
+
+    const desc = orderByParam.startsWith("-");
+    const column = desc ? orderByParam.slice(1) : orderByParam;
+    const allowedColumns = new Set(["created_at", "updated_at", "key"]);
+    const orderColumn = allowedColumns.has(column) ? column : "created_at";
+    const orderDir = desc ? "DESC" : "ASC";
+
+    let rows: ShortcutRow[];
+    let countRow: { count: number };
+
+    if (search) {
+      const pattern = `%${search}%`;
+      rows = db
+        .prepare(
+          `SELECT * FROM shortcuts WHERE key LIKE ? ORDER BY ${orderColumn} ${orderDir} LIMIT ? OFFSET ?`,
+        )
+        .all(pattern, limit, offset) as unknown as ShortcutRow[];
+
+      countRow = db
+        .prepare("SELECT COUNT(*) as count FROM shortcuts WHERE key LIKE ?")
+        .get(pattern) as unknown as { count: number };
+    } else {
+      rows = db
+        .prepare(
+          `SELECT * FROM shortcuts ORDER BY ${orderColumn} ${orderDir} LIMIT ? OFFSET ?`,
+        )
+        .all(limit, offset) as unknown as ShortcutRow[];
+
+      countRow = db
+        .prepare("SELECT COUNT(*) as count FROM shortcuts")
+        .get() as unknown as { count: number };
+    }
+
+    const items = rows.map((row) => ({
+      ...row,
+      steps: getStepsForShortcut(db, row.id),
+    }));
+
+    return c.json({
+      items,
+      total: countRow.count,
+      limit,
+      offset,
+    });
+  })
+  .get("/all", (c) => {
+    const db = getDb();
+    const rows = db
+      .prepare("SELECT * FROM shortcuts ORDER BY length(key) DESC")
+      .all() as unknown as ShortcutRow[];
+
+    const items = rows.map((row) => ({
+      ...row,
+      steps: getStepsForShortcut(db, row.id),
+    }));
+
+    return c.json(items);
+  })
+  .get("/export/json", (c) => {
+    const db = getDb();
+    const rows = db
+      .prepare("SELECT * FROM shortcuts ORDER BY key ASC")
+      .all() as unknown as ShortcutRow[];
+
+    const items = rows.map((row) => ({
+      key: row.key,
+      description: row.description,
+      steps: getStepsForShortcut(db, row.id).map((s) => ({
+        action: s.action,
+        value: s.value,
+      })),
+    }));
+
+    return c.json(items);
+  })
+  .get("/:id", (c) => {
+    const db = getDb();
+    const id = Number(c.req.param("id"));
+    const row = db.prepare("SELECT * FROM shortcuts WHERE id = ?").get(id) as
+      | ShortcutRow
+      | undefined;
+
+    if (!row) return c.json({ error: "Not found" }, 404);
+
+    return c.json({
+      ...row,
+      steps: getStepsForShortcut(db, row.id),
+    });
+  })
+  .post("/", zValidator("json", createShortcutSchema), async (c) => {
+    const db = getDb();
+    const body = c.req.valid("json");
+    const key = body.key.trim().toLowerCase();
+
+    try {
+      const result = db
+        .prepare("INSERT INTO shortcuts (key, description) VALUES (?, ?)")
+        .run(key, body.description ?? null);
+
+      const shortcutId = result.lastInsertRowid as number;
+      insertSteps(db, shortcutId, body.steps);
+
+      return c.json(
+        {
+          id: shortcutId,
+          key,
+          description: body.description ?? null,
+          steps: getStepsForShortcut(db, shortcutId),
+        },
+        201,
+      );
+    } catch {
+      return c.json(
+        { error: "A shortcut with this trigger phrase already exists" },
+        409,
+      );
+    }
+  })
+  .put("/:id", zValidator("json", updateShortcutSchema), async (c) => {
+    const db = getDb();
+    const id = Number(c.req.param("id"));
+    const body = c.req.valid("json");
+
+    const existing = db
+      .prepare("SELECT * FROM shortcuts WHERE id = ?")
+      .get(id) as ShortcutRow | undefined;
+    if (!existing) return c.json({ error: "Not found" }, 404);
+
+    const newKey = body.key?.trim().toLowerCase() ?? existing.key;
+    const newDescription =
+      body.description !== undefined ? body.description : existing.description;
+
+    try {
+      db.prepare(
+        "UPDATE shortcuts SET key = ?, description = ?, updated_at = datetime('now') WHERE id = ?",
+      ).run(newKey, newDescription ?? null, id);
+
+      if (body.steps) {
+        db.prepare("DELETE FROM shortcut_steps WHERE shortcut_id = ?").run(id);
+        insertSteps(db, id, body.steps);
+      }
+
+      return c.json({
+        id,
+        key: newKey,
+        description: newDescription,
+        steps: getStepsForShortcut(db, id),
+      });
+    } catch {
+      return c.json(
+        { error: "A shortcut with this trigger phrase already exists" },
+        409,
+      );
+    }
+  })
+  .delete("/:id", (c) => {
+    const db = getDb();
+    const id = Number(c.req.param("id"));
+    db.prepare("DELETE FROM shortcuts WHERE id = ?").run(id);
+    return c.json({ ok: true });
+  })
+  .post("/import", async (c) => {
+    const db = getDb();
+    const body =
+      await c.req.json<
+        {
+          key: string;
+          value?: string;
+          action?: string;
+          description?: string;
+          steps?: { action: string; value?: string }[];
+        }[]
+      >();
+
+    if (!Array.isArray(body)) {
+      return c.json(
+        { error: "Expected a JSON array of shortcut objects" },
+        400,
+      );
+    }
+
+    let imported = 0;
+    let skipped = 0;
+
+    const insertShortcut = db.prepare(
+      "INSERT OR IGNORE INTO shortcuts (key, description) VALUES (?, ?)",
+    );
+    const insertStep = db.prepare(
+      "INSERT INTO shortcut_steps (shortcut_id, position, action, value) VALUES (?, ?, ?, ?)",
+    );
+
+    for (const entry of body) {
+      if (!entry.key?.trim()) {
+        skipped++;
+        continue;
+      }
+
+      const key = entry.key.trim().toLowerCase();
+      const description = entry.description ?? null;
+
+      const result = insertShortcut.run(key, description);
+      if (result.changes === 0) {
+        skipped++;
+        continue;
+      }
+
+      const shortcutId = result.lastInsertRowid as number;
+
+      if (entry.steps && Array.isArray(entry.steps) && entry.steps.length > 0) {
+        for (let i = 0; i < entry.steps.length; i++) {
+          insertStep.run(
+            shortcutId,
+            i,
+            entry.steps[i].action,
+            entry.steps[i].value ?? "",
+          );
+        }
+      } else if (entry.value) {
+        const action = entry.action ?? "replace";
+        insertStep.run(shortcutId, 0, action, entry.value);
+      } else {
+        skipped++;
+        db.prepare("DELETE FROM shortcuts WHERE id = ?").run(shortcutId);
+        continue;
+      }
+
+      imported++;
+    }
+
+    return c.json({ imported, skipped });
+  });
+
+export default shortcuts;

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -1,7 +1,7 @@
 import { upgradeWebSocket } from "@hono/node-server";
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
-import { postProcess } from "../lib/post-process.js";
+import { postProcess, postProcessShortcuts } from "../lib/post-process.js";
 import { capture, captureException } from "../lib/posthog.js";
 import { getDefaultModels } from "../lib/providers.js";
 import { stripProviderPrefix } from "../lib/streaming/types.js";
@@ -24,6 +24,7 @@ const stream = new Hono().get(
     let sessionStartTime = Date.now();
     let voiceDefaults: { provider: string; model_id: string } | null = null;
     let appContext: string | null = null;
+    let mode: string = "dictation";
     let audioDurationMs = 0;
     /** Audio received while the upstream socket is still connecting. */
     let pendingAudioChunks: ArrayBuffer[] = [];
@@ -167,7 +168,9 @@ const stream = new Hono().get(
               return;
             }
 
-            postProcess(rawText, appContext)
+            const ppFn =
+              mode === "shortcuts" ? postProcessShortcuts : postProcess;
+            ppFn(rawText, appContext)
               .then((pp) => {
                 capture("streaming transcription completed", {
                   provider: voiceDefaults!.provider,
@@ -181,7 +184,14 @@ const stream = new Hono().get(
                   cost_usd: pp.costUsd,
                 });
                 if (!closed) {
-                  ws.send(JSON.stringify({ type: "final", text: pp.cleaned }));
+                  const finalMsg: Record<string, unknown> = {
+                    type: "final",
+                    text: pp.cleaned,
+                  };
+                  if (mode === "shortcuts" && pp.actionsExecuted.length > 0) {
+                    finalMsg.actions = pp.actionsExecuted;
+                  }
+                  ws.send(JSON.stringify(finalMsg));
                 }
                 try {
                   const db = getDb();
@@ -309,6 +319,7 @@ const stream = new Hono().get(
         let msg: {
           type: string;
           context?: string | null;
+          mode?: string;
           audioDurationMs?: number;
         };
         try {
@@ -324,11 +335,13 @@ const stream = new Hono().get(
         switch (msg.type) {
           case "context":
             appContext = msg.context ?? null;
+            if (msg.mode) mode = msg.mode;
             break;
           case "start":
             sessionStartTime = Date.now();
             audioDurationMs = 0;
             appContext = msg.context ?? null;
+            if (msg.mode) mode = msg.mode;
             pendingAudioChunks = [];
             pendingCommit = false;
             reconnectAttempts = 0;
@@ -369,6 +382,7 @@ const stream = new Hono().get(
             if (msg.context !== undefined) {
               appContext = msg.context;
             }
+            if (msg.mode) mode = msg.mode;
             if (
               upstream &&
               (upstream.waitUntilReady || notifiedReadyToken === readyToken)

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
-import { postProcess } from "../lib/post-process.js";
+import { postProcess, postProcessShortcuts } from "../lib/post-process.js";
 import { capture, captureException } from "../lib/posthog.js";
 import { getDefaultModels } from "../lib/providers.js";
 import { getProvider } from "../lib/streaming/registry.js";
@@ -29,6 +29,7 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   const appContext = c.req.header("x-app-context") ?? null;
+  const reqMode = c.req.header("x-mode") ?? "dictation";
 
   let audioDurationMs = 0;
   if (audioData.length > 44) {
@@ -168,7 +169,8 @@ const transcribeRoute = new Hono().post("/", async (c) => {
   }
 
   const ppStart = Date.now();
-  const pp = await postProcess(rawText, appContext);
+  const ppFn = reqMode === "shortcuts" ? postProcessShortcuts : postProcess;
+  const pp = await ppFn(rawText, appContext);
   if (isDev) {
     console.log(
       `[transcribe] post-process took ${Date.now() - ppStart}ms | cleaned=${JSON.stringify(pp.cleaned).slice(0, 120)}`,

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -399,3 +399,190 @@ describe("History", () => {
     expect(res.status).toBe(404);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Shortcuts CRUD
+// ---------------------------------------------------------------------------
+
+describe("Shortcuts", () => {
+  it("GET /api/shortcuts returns empty list initially", async () => {
+    const res = await req("/api/shortcuts");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty("items");
+    expect(data).toHaveProperty("total");
+    expect(Array.isArray(data.items)).toBe(true);
+  });
+
+  it("POST creates a single-step replace shortcut", async () => {
+    const res = await json("/api/shortcuts", {
+      key: "my email",
+      description: "Insert my email address",
+      steps: [{ action: "replace", value: "test@example.com" }],
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.key).toBe("my email");
+    expect(data.id).toBeDefined();
+    expect(data.steps).toHaveLength(1);
+    expect(data.steps[0].action).toBe("replace");
+    expect(data.steps[0].value).toBe("test@example.com");
+  });
+
+  it("POST creates a multi-step shortcut", async () => {
+    const res = await json("/api/shortcuts", {
+      key: "send report",
+      steps: [
+        { action: "replace", value: "Here is the report" },
+        { action: "open_url", value: "https://example.com/report" },
+      ],
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.steps).toHaveLength(2);
+    expect(data.steps[0].action).toBe("replace");
+    expect(data.steps[1].action).toBe("open_url");
+  });
+
+  it("POST creates a shortcut with variables", async () => {
+    const res = await json("/api/shortcuts", {
+      key: "search {query}",
+      description: "Search the web",
+      steps: [
+        { action: "open_url", value: "https://google.com/search?q={query}" },
+      ],
+    });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.key).toBe("search {query}");
+  });
+
+  it("GET /:id returns shortcut with steps", async () => {
+    const create = await json("/api/shortcuts", {
+      key: "get by id test",
+      steps: [{ action: "replace", value: "found it" }],
+    });
+    const { id } = await create.json();
+
+    const get = await req(`/api/shortcuts/${id}`);
+    expect(get.status).toBe(200);
+    const data = await get.json();
+    expect(data.key).toBe("get by id test");
+    expect(data.steps).toHaveLength(1);
+    expect(data.steps[0].value).toBe("found it");
+  });
+
+  it("PUT updates steps", async () => {
+    const create = await json("/api/shortcuts", {
+      key: "update steps test",
+      steps: [{ action: "replace", value: "original" }],
+    });
+    const { id } = await create.json();
+
+    const put = await json(
+      `/api/shortcuts/${id}`,
+      {
+        steps: [
+          { action: "replace", value: "updated" },
+          { action: "open_app", value: "Notes" },
+        ],
+      },
+      "PUT",
+    );
+    expect(put.status).toBe(200);
+    const data = await put.json();
+    expect(data.steps).toHaveLength(2);
+    expect(data.steps[0].value).toBe("updated");
+    expect(data.steps[1].action).toBe("open_app");
+  });
+
+  it("DELETE removes a shortcut", async () => {
+    const create = await json("/api/shortcuts", {
+      key: "to delete shortcut",
+      steps: [{ action: "replace", value: "gone" }],
+    });
+    const { id } = await create.json();
+
+    const del = await req(`/api/shortcuts/${id}`, { method: "DELETE" });
+    expect(del.status).toBe(200);
+
+    const get = await req(`/api/shortcuts/${id}`);
+    expect(get.status).toBe(404);
+  });
+
+  it("POST rejects duplicate keys", async () => {
+    await json("/api/shortcuts", {
+      key: "dupe shortcut",
+      steps: [{ action: "replace", value: "first" }],
+    });
+    const res = await json("/api/shortcuts", {
+      key: "dupe shortcut",
+      steps: [{ action: "replace", value: "second" }],
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("GET /api/shortcuts supports search", async () => {
+    await json("/api/shortcuts", {
+      key: "searchable shortcut",
+      steps: [{ action: "replace", value: "findme" }],
+    });
+
+    const res = await req("/api/shortcuts?search=searchable");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.items.length).toBeGreaterThanOrEqual(1);
+    expect(
+      data.items.some((i: { key: string }) => i.key === "searchable shortcut"),
+    ).toBe(true);
+  });
+
+  it("GET /api/shortcuts/all returns all with steps", async () => {
+    const res = await req("/api/shortcuts/all");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+    if (data.length > 0) {
+      expect(data[0]).toHaveProperty("steps");
+    }
+  });
+
+  it("POST /api/shortcuts/import imports legacy format", async () => {
+    const entries = [
+      { key: "legacy import one", value: "LegacyValue1", action: "replace" },
+      { key: "legacy import two", value: "LegacyValue2" },
+    ];
+    const res = await json("/api/shortcuts/import", entries);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.imported).toBe(2);
+    expect(data.skipped).toBe(0);
+  });
+
+  it("POST /api/shortcuts/import imports steps format", async () => {
+    const entries = [
+      {
+        key: "steps import one",
+        steps: [
+          { action: "replace", value: "StepsValue1" },
+          { action: "open_app", value: "Notes" },
+        ],
+      },
+    ];
+    const res = await json("/api/shortcuts/import", entries);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.imported).toBe(1);
+  });
+
+  it("GET /api/shortcuts/export/json returns JSON export with steps", async () => {
+    const res = await req("/api/shortcuts/export/json");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+    if (data.length > 0) {
+      expect(data[0]).toHaveProperty("key");
+      expect(data[0]).toHaveProperty("steps");
+    }
+  });
+});

--- a/packages/validations/src/index.ts
+++ b/packages/validations/src/index.ts
@@ -5,4 +5,5 @@ export * from "./local-llm.js";
 export * from "./models.js";
 export * from "./query.js";
 export * from "./settings.js";
+export * from "./shortcuts.js";
 export * from "./vocabulary.js";

--- a/packages/validations/src/shortcuts.ts
+++ b/packages/validations/src/shortcuts.ts
@@ -1,0 +1,33 @@
+import { z } from "zod/v3";
+
+export const stepActions = [
+  "replace",
+  "open_app",
+  "open_url",
+  "paste_clipboard",
+  "if",
+  "transform",
+] as const;
+export type StepAction = (typeof stepActions)[number];
+
+export const shortcutStepSchema = z.object({
+  action: z.enum(stepActions),
+  value: z.string().default(""),
+});
+
+export type ShortcutStep = z.infer<typeof shortcutStepSchema>;
+
+export const createShortcutSchema = z.object({
+  key: z.string().min(1, "Trigger phrase is required"),
+  description: z.string().optional(),
+  steps: z.array(shortcutStepSchema).min(1, "At least one step is required"),
+});
+
+export const updateShortcutSchema = z.object({
+  key: z.string().min(1, "Trigger phrase is required").optional(),
+  description: z.string().optional(),
+  steps: z.array(shortcutStepSchema).min(1).optional(),
+});
+
+export type CreateShortcutInput = z.infer<typeof createShortcutSchema>;
+export type UpdateShortcutInput = z.infer<typeof updateShortcutSchema>;


### PR DESCRIPTION
## Summary

Adds a **Shortcuts** system alongside the existing **Dictionary**, each with its own hotkey.

- **Dictation hotkey** (existing): Record → Transcribe → LLM text cleanup → Dictionary regex replacements → Paste. No commands, no tool-calling. Pure dictation.
- **Shortcuts hotkey** (new): Record → Transcribe → LLM agent with tool-calling → Execute workflow steps. Opens apps, navigates to URLs, runs multi-step automations triggered by voice.

## Shortcuts

A shortcut is a **trigger phrase** with an ordered list of **steps**. Trigger phrases support `{variable}` placeholders that are extracted from speech and interpolated into step values at runtime.

**Step types:** Replace text, Open app, Open URL, Paste clipboard, If (conditional branching), Transform (variable manipulation).

**Example:**
```
Trigger: "email {person} about {topic}"
Steps:
  1. open_url → https://mail.google.com/mail/?view=cm&to={person}
  2. replace  → Subject: {topic}
```

## Changes

### Server (12 files)
- **Schema v7**: `shortcuts` + `shortcut_steps` tables
- **Action executor registry** (`actions.ts`): server↔Electron callback bridge for side effects
- **Shortcut executor** (`shortcut-executor.ts`): variable interpolation, conditionals, transforms, recursive step execution, built-in `{date}`/`{time}` variables
- **Shortcuts agent** (`shortcuts-agent.ts`): AI SDK `generateText` with `execute_shortcut`, `open_app`, `open_url`, `paste_clipboard` tools; regex fallback for no-LLM mode
- **Split post-processing**: `postProcess()` for dictation, `postProcessShortcuts()` for shortcuts, selected by `mode` parameter on `/stream`, `/api/transcribe`, `/api/post-process`
- **Shortcuts CRUD** (`/api/shortcuts`): paginated list, search, create/update/delete with nested steps, export/import
- **MCP tools**: `shortcut_list/view/create/update/delete`

### Electron (8 files)
- **Second hotkey**: `shortcuts_hotkey` + `shortcuts_hotkey_mode` settings, full `NativeKeyListener` registration with hold/toggle, IPC events
- **Action handlers**: `open_app` (cross-platform `execFile`), `open_url` (`shell.openExternal`), `paste_clipboard`
- **Pill dual-mode**: `modeRef` tracks dictation vs shortcuts; streamer sends `mode` in WebSocket messages
- **Preload bridge**: 5 new IPC methods for shortcuts hotkey

### UI (3 files)
- **Shortcuts page** (`/settings/shortcuts`): hotkey recorder, built-in action cards, workflow builder with stacked step cards, variable pill insertion, YAML editor toggle
- **Sidebar**: Dictionary at Cmd+3, Shortcuts at Cmd+4

## Testing
`pnpm --filter @freestyle/server test` — **49 tests pass** (37 dictionary + 12 shortcuts). All TypeScript configs compile clean.