### PR TITLE
fix: local Whisper model fails to start on Windows due to binary path mismatch

### DIFF
--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -446,6 +446,16 @@ async function downloadWindowsBinaries(): Promise<void> {
     unlinkSync(tmpZip);
   } catch {}
 
+  // The upstream zip nests executables inside a Release/ subdirectory.
+  // Move them up so they sit directly inside binDir where findExecutable looks.
+  const releaseDir = join(binDir, "Release");
+  if (existsSync(releaseDir)) {
+    for (const name of readdirSync(releaseDir)) {
+      renameSync(join(releaseDir, name), join(binDir, name));
+    }
+    rmSync(releaseDir, { recursive: true, force: true });
+  }
+
   console.log("[whisper] Windows binaries downloaded");
 }
 


### PR DESCRIPTION
## Summary

- Fixes local Whisper model failing to start on Windows with `whisper-server binary not found`

Closes #123

## Problem

The upstream `whisper.cpp` pre-built Windows zip (`whisper-bin-x64.zip`) nests executables inside a `Release/` subdirectory. After `Expand-Archive` extracts to `~/.cache/freestyle/whisper-bin/`, the binary ends up at:

```
~/.cache/freestyle/whisper-bin/Release/whisper-server.exe
```

But `findExecutable()` in `binary.ts` looks for it at:

```
~/.cache/freestyle/whisper-bin/whisper-server.exe
```

This mismatch causes the binary lookup to fail, preventing the local Whisper server from starting on Windows.

## Fix

After extracting the zip, check if a `Release/` subdirectory exists inside the bin dir. If so, move all files from it up to the bin dir root and remove the empty `Release/` directory. This keeps all callers of `getBinDir()` working correctly without needing to change the path resolution logic.

## Why not change `getBinDir()`?

The issue suggested modifying `getBinDir()` to append `Release/` on Windows. However, `getBinDir()` is also used as the extraction **destination** in `downloadWindowsBinaries()`. Changing it would cause the extraction to target `whisper-bin/Release/`, and the zip's internal `Release/` folder would create `whisper-bin/Release/Release/` — double nesting.

Flattening after extraction is the correct fix because it works regardless of the zip's internal directory structure and doesn't affect any other callers.

## Testing

- Build passes
- Server tests pass (36/36)
- Verified against the reproduction steps in #123