### PR TITLE
Fix hotkey binding

### DIFF
--- a/apps/electron/native/linux-key-listener.c
+++ b/apps/electron/native/linux-key-listener.c
@@ -93,6 +93,8 @@ static int parse_key_name(const char *name) {
     if (strcasecmp(name, "CapsLock") == 0) return KEY_CAPSLOCK;
     if (strcasecmp(name, "Pause") == 0) return KEY_PAUSE;
     if (strcasecmp(name, "Insert") == 0) return KEY_INSERT;
+    if (strcasecmp(name, "MouseButton4") == 0 || strcasecmp(name, "Mouse4") == 0) return BTN_SIDE;
+    if (strcasecmp(name, "MouseButton5") == 0 || strcasecmp(name, "Mouse5") == 0) return BTN_EXTRA;
 
     /* Function keys */
     if (name[0] == 'F' || name[0] == 'f') {
@@ -240,6 +242,8 @@ static const char *keycode_to_record_name(int code) {
     if (code == KEY_CAPSLOCK) return "CapsLock";
     if (code == KEY_PAUSE) return "Pause";
     if (code == KEY_INSERT) return "Insert";
+    if (code == BTN_SIDE) return "MouseButton4";
+    if (code == BTN_EXTRA) return "MouseButton5";
     if (code == KEY_RIGHTALT) return "RightAlt";
     if (code == KEY_RIGHTCTRL) return "RightControl";
     if (code == KEY_RIGHTSHIFT) return "RightShift";
@@ -270,7 +274,16 @@ static const char *keycode_to_record_name(int code) {
 }
 
 static void handle_record_event(int code, int pressed) {
-    if (!pressed) return;
+    int is_mod = is_ctrl(code) || is_alt(code) || is_shift(code) || is_meta(code);
+
+    if (!pressed) {
+        if (is_mod) {
+            update_modifier(code, 0);
+        }
+        printf("RECORD_RELEASE\n");
+        fflush(stdout);
+        return;
+    }
 
     if (code == KEY_ESC) {
         printf("RECORD_CANCEL\n");
@@ -278,7 +291,6 @@ static void handle_record_event(int code, int pressed) {
         return;
     }
 
-    int is_mod = is_ctrl(code) || is_alt(code) || is_shift(code) || is_meta(code);
     if (is_mod) {
         update_modifier(code, 1);
         if (code == KEY_RIGHTALT || code == KEY_RIGHTCTRL ||

--- a/apps/electron/native/macos-key-listener.swift
+++ b/apps/electron/native/macos-key-listener.swift
@@ -234,6 +234,15 @@ guard let monitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, h
     exit(1)
 }
 
+// NSEvent key-down monitor — catches compound shortcuts (e.g. Option+Space) that the CGEvent
+// tap may not surface when another app is focused, because macOS handles them first.
+var keyDownMonitor: Any?
+keyDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+    emitFlags(event.modifierFlags)
+    guard let name = keyCodeToName(event.keyCode) else { return }
+    emit("KEY_DOWN:\(name)")
+}
+
 // CGEvent keyboard tap — reliable KEY_UP delivery (NSEvent global monitors often miss key-up)
 let keyEventMask =
     (1 << CGEventType.keyDown.rawValue) |
@@ -261,9 +270,8 @@ let keyEventTap = CGEvent.tapCreate(
             return Unmanaged.passUnretained(event)
         }
 
-        if type == .keyDown {
-            emit("KEY_DOWN:\(name)")
-        } else if type == .keyUp {
+        // KEY_DOWN is emitted by the NSEvent global monitor above (avoids duplicate events).
+        if type == .keyUp {
             emit("KEY_UP:\(name)")
         }
 
@@ -285,6 +293,9 @@ let signalSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main
 signal(SIGTERM, SIG_IGN)
 signalSource.setEventHandler {
     NSEvent.removeMonitor(monitor)
+    if let keyDownMonitor {
+        NSEvent.removeMonitor(keyDownMonitor)
+    }
     if let keyEventTap {
         CGEvent.tapEnable(tap: keyEventTap, enable: false)
     }

--- a/apps/electron/native/windows-key-listener.c
+++ b/apps/electron/native/windows-key-listener.c
@@ -16,7 +16,9 @@
 #include <string.h>
 
 static HHOOK g_hook = NULL;
+static HHOOK g_mouseHook = NULL;
 static DWORD g_targetVk = 0;
+static DWORD g_targetMouseButton = 0;
 static BOOL g_isKeyDown = FALSE;
 
 static BOOL g_requireCtrl = FALSE;
@@ -159,6 +161,12 @@ static const char* VkToRecordKeyName(DWORD vk) {
     return NULL;
 }
 
+static const char* MouseButtonToRecordKeyName(DWORD button) {
+    if (button == XBUTTON1) return "MouseButton4";
+    if (button == XBUTTON2) return "MouseButton5";
+    return NULL;
+}
+
 DWORD ParseKeyCode(const char* keyName) {
     if (_stricmp(keyName, "F1") == 0) return VK_F1;
     if (_stricmp(keyName, "F2") == 0) return VK_F2;
@@ -228,6 +236,12 @@ DWORD ParseKeyCode(const char* keyName) {
     return (DWORD)atoi(keyName);
 }
 
+DWORD ParseMouseButton(const char* keyName) {
+    if (_stricmp(keyName, "MouseButton4") == 0 || _stricmp(keyName, "Mouse4") == 0) return XBUTTON1;
+    if (_stricmp(keyName, "MouseButton5") == 0 || _stricmp(keyName, "Mouse5") == 0) return XBUTTON2;
+    return 0;
+}
+
 LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
     if (nCode == HC_ACTION) {
         KBDLLHOOKSTRUCT* kbd = (KBDLLHOOKSTRUCT*)lParam;
@@ -270,8 +284,12 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
             return CallNextHookEx(g_hook, nCode, wParam, lParam);
         }
 
-        if (g_record_mode && isUp && isModifierEvent) {
-            UpdateModifierState(kbd->vkCode, FALSE);
+        if (g_record_mode && isUp) {
+            if (isModifierEvent) {
+                UpdateModifierState(kbd->vkCode, FALSE);
+            }
+            printf("RECORD_RELEASE\n");
+            fflush(stdout);
             return CallNextHookEx(g_hook, nCode, wParam, lParam);
         }
 
@@ -287,7 +305,8 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
             fflush(stdout);
         }
 
-        if (g_isKeyDown && !g_useModifiersOnly && kbd->vkCode != g_targetVk &&
+        if (g_isKeyDown && !g_useModifiersOnly && g_targetVk != 0 &&
+            kbd->vkCode != g_targetVk &&
             !(GetAsyncKeyState(g_targetVk) & 0x8000)) {
             g_isKeyDown = FALSE;
             printf("KEY_UP\n");
@@ -336,11 +355,65 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
     return CallNextHookEx(g_hook, nCode, wParam, lParam);
 }
 
+LRESULT CALLBACK LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM lParam) {
+    if (nCode == HC_ACTION) {
+        MSLLHOOKSTRUCT* mouse = (MSLLHOOKSTRUCT*)lParam;
+        BOOL isDown = (wParam == WM_XBUTTONDOWN);
+        BOOL isUp = (wParam == WM_XBUTTONUP);
+
+        if (!isDown && !isUp) {
+            return CallNextHookEx(g_mouseHook, nCode, wParam, lParam);
+        }
+
+        DWORD button = HIWORD(mouse->mouseData);
+
+        if (g_record_mode) {
+            if (isDown) {
+                const char* keyName = MouseButtonToRecordKeyName(button);
+                if (keyName) {
+                    EmitRecordModifiers();
+                    printf("RECORD_KEY:%s\n", keyName);
+                    fflush(stdout);
+                }
+            } else {
+                printf("RECORD_RELEASE\n");
+                fflush(stdout);
+            }
+            return CallNextHookEx(g_mouseHook, nCode, wParam, lParam);
+        }
+
+        if (button != g_targetMouseButton) {
+            return CallNextHookEx(g_mouseHook, nCode, wParam, lParam);
+        }
+
+        if (isDown) {
+            if (!g_isKeyDown && AreRequiredModifiersPressed()) {
+                g_isKeyDown = TRUE;
+                printf("KEY_DOWN\n");
+                fflush(stdout);
+            }
+            if (g_isKeyDown) return 1;
+        } else if (isUp) {
+            if (g_isKeyDown) {
+                g_isKeyDown = FALSE;
+                printf("KEY_UP\n");
+                fflush(stdout);
+                return 1;
+            }
+        }
+    }
+    return CallNextHookEx(g_mouseHook, nCode, wParam, lParam);
+}
+
 BOOL WINAPI ConsoleHandler(DWORD signal) {
     if (signal == CTRL_C_EVENT || signal == CTRL_BREAK_EVENT || signal == CTRL_CLOSE_EVENT) {
         if (g_hook) {
             UnhookWindowsHookEx(g_hook);
             g_hook = NULL;
+        }
+        if (g_mouseHook) {
+            UnhookWindowsHookEx(g_mouseHook);
+            g_mouseHook = NULL;
         }
         ExitProcess(0);
     }
@@ -357,6 +430,7 @@ DWORD ParseCompoundHotkey(const char* hotkey) {
     g_requireShift = FALSE;
     g_requireWin = FALSE;
     g_useModifiersOnly = FALSE;
+    g_targetMouseButton = 0;
 
     DWORD mainKeyVk = 0;
     char* token = strtok(buffer, "+");
@@ -383,7 +457,12 @@ DWORD ParseCompoundHotkey(const char* hotkey) {
                    _stricmp(token, "Cmd") == 0) {
             g_requireWin = TRUE;
         } else {
-            mainKeyVk = ParseKeyCode(token);
+            DWORD mouseButton = ParseMouseButton(token);
+            if (mouseButton != 0) {
+                g_targetMouseButton = mouseButton;
+            } else {
+                mainKeyVk = ParseKeyCode(token);
+            }
         }
 
         token = strtok(NULL, "+");
@@ -428,17 +507,18 @@ int main(int argc, char* argv[]) {
     }
 
     if (!g_record_mode) {
-        if (g_targetVk == 0 && (g_requireCtrl || g_requireAlt || g_requireShift || g_requireWin)) {
+        if (g_targetVk == 0 && g_targetMouseButton == 0 &&
+            (g_requireCtrl || g_requireAlt || g_requireShift || g_requireWin)) {
             g_useModifiersOnly = TRUE;
         }
 
-        if (g_targetVk == 0 && !g_useModifiersOnly) {
+        if (g_targetVk == 0 && g_targetMouseButton == 0 && !g_useModifiersOnly) {
             fprintf(stderr, "Error: Invalid key '%s'\n", argv[1]);
             return 1;
         }
 
-        fprintf(stderr, "Listening for: %s (VK=0x%02X, Ctrl=%d, Alt=%d, Shift=%d, Win=%d, ModOnly=%d)\n",
-                argv[1], g_targetVk, g_requireCtrl, g_requireAlt, g_requireShift, g_requireWin, g_useModifiersOnly);
+        fprintf(stderr, "Listening for: %s (VK=0x%02X, Mouse=%lu, Ctrl=%d, Alt=%d, Shift=%d, Win=%d, ModOnly=%d)\n",
+                argv[1], g_targetVk, (unsigned long)g_targetMouseButton, g_requireCtrl, g_requireAlt, g_requireShift, g_requireWin, g_useModifiersOnly);
     }
 
     SetConsoleCtrlHandler(ConsoleHandler, TRUE);
@@ -453,6 +533,13 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    g_mouseHook = SetWindowsHookEx(WH_MOUSE_LL, LowLevelMouseProc, NULL, 0);
+    if (!g_mouseHook && (g_record_mode || g_targetMouseButton != 0)) {
+        fprintf(stderr, "Error: Failed to install mouse hook (error %lu)\n", GetLastError());
+        UnhookWindowsHookEx(g_hook);
+        return 1;
+    }
+
     printf("READY\n");
     fflush(stdout);
 
@@ -463,5 +550,6 @@ int main(int argc, char* argv[]) {
     }
 
     UnhookWindowsHookEx(g_hook);
+    if (g_mouseHook) UnhookWindowsHookEx(g_mouseHook);
     return 0;
 }

--- a/apps/electron/src/main/hotkey-recorder.ts
+++ b/apps/electron/src/main/hotkey-recorder.ts
@@ -35,6 +35,22 @@ const MAC_RIGHT_MOD_KEYS: Record<string, string> = {
   rightshift: "RightShift",
 };
 
+const RIGHT_MODIFIER_KEYS: Record<string, string> = {
+  RightOption: "Alt",
+  RightAlt: "Alt",
+  RightCommand: "Command",
+  RightControl: "Control",
+  RightShift: "Shift",
+  RightSuper: "Super",
+};
+
+const MAC_FLAG_MODIFIERS: Record<string, string> = {
+  control: "Control",
+  option: "Alt",
+  shift: "Shift",
+  command: "Command",
+};
+
 export class HotkeyRecorder {
   private process: ChildProcess | null = null;
   private target: WebContents | null = null;
@@ -67,6 +83,8 @@ export class HotkeyRecorder {
     const args: string[] = [];
     if (process.platform !== "darwin") {
       args.push("--record");
+    } else {
+      args.push("MouseButton4,MouseButton5");
     }
 
     try {
@@ -141,7 +159,10 @@ export class HotkeyRecorder {
   private sendCaptured(combo: HotkeyCombo): void {
     this.target?.send("hotkey-record:captured", combo);
     this.callbacks.onCaptured(combo);
-    this.stop();
+  }
+
+  private sendReleased(): void {
+    this.target?.send("hotkey-record:released");
   }
 
   private sendCancel(): void {
@@ -173,17 +194,58 @@ export class HotkeyRecorder {
       return;
     }
 
+    if (line.startsWith("RECORD_RELEASE")) {
+      this.sendReleased();
+      return;
+    }
+
     if (process.platform !== "darwin") return;
 
+    if (line.startsWith("FLAGS:")) {
+      const raw = line.slice("FLAGS:".length);
+      const modifiers = raw
+        ? raw
+            .split(",")
+            .map((part) => MAC_FLAG_MODIFIERS[part.trim().toLowerCase()])
+            .filter((part): part is string => Boolean(part))
+        : [];
+      this.sendModifiers(modifiers);
+      return;
+    }
+
     if (line === "FN_DOWN") {
-      this.sendCaptured({ modifiers: [], key: "Fn" });
+      this.sendModifiers([...this.pendingModifiers, "Fn"]);
+      return;
+    }
+
+    if (line === "FN_UP") {
+      this.sendReleased();
+      return;
+    }
+
+    if (line.startsWith("MOUSE_BUTTON_DOWN:")) {
+      const key = line.slice("MOUSE_BUTTON_DOWN:".length);
+      if (key) {
+        this.sendCaptured({ modifiers: [...this.pendingModifiers], key });
+      }
+      return;
+    }
+
+    if (line.startsWith("MOUSE_BUTTON_UP:")) {
+      this.sendReleased();
       return;
     }
 
     if (line.startsWith("RIGHT_MOD_DOWN:")) {
       const modName = line.slice("RIGHT_MOD_DOWN:".length);
       const key = MAC_RIGHT_MOD_KEYS[modName.toLowerCase()] ?? modName;
-      this.sendCaptured({ modifiers: [], key });
+      const modifier = RIGHT_MODIFIER_KEYS[key] ?? key;
+      this.sendModifiers([...this.pendingModifiers, modifier]);
+      return;
+    }
+
+    if (line.startsWith("RIGHT_MOD_UP:") || line.startsWith("MODIFIER_UP:")) {
+      this.sendReleased();
     }
   }
 }

--- a/apps/electron/src/main/hotkey-utils.ts
+++ b/apps/electron/src/main/hotkey-utils.ts
@@ -36,6 +36,8 @@ export function normalizeAccelerator(accel: string): string {
         lower === "rightmeta"
       )
         return "RightSuper";
+      if (lower === "mousebutton4" || lower === "mouse4") return "MouseButton4";
+      if (lower === "mousebutton5" || lower === "mouse5") return "MouseButton5";
       if (/^f\d+$/i.test(p)) return p.toUpperCase();
       if (p.length === 1) return p.toUpperCase();
       if (p === "Up" || p === "Down" || p === "Left" || p === "Right") return p;

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1081,6 +1081,33 @@ app.whenReady().then(async () => {
 });
 
 const DEFAULT_HOTKEY = "Alt+Space";
+const HOTKEY_MODIFIER_PARTS = new Set([
+  "alt",
+  "option",
+  "control",
+  "ctrl",
+  "command",
+  "cmd",
+  "commandorcontrol",
+  "cmdorctrl",
+  "shift",
+  "super",
+  "meta",
+  "win",
+  "fn",
+  "globe",
+  "rightalt",
+  "rightoption",
+  "rightcontrol",
+  "rightctrl",
+  "rightshift",
+  "rightcommand",
+  "rightcmd",
+  "rightsuper",
+  "rightwin",
+  "rightmeta",
+]);
+const HOTKEY_MACRO_MOUSE_PARTS = new Set(["mousebutton4", "mousebutton5"]);
 
 function isValidAccelerator(accel: string): boolean {
   if (!accel || typeof accel !== "string") return false;
@@ -1088,7 +1115,13 @@ function isValidAccelerator(accel: string): boolean {
   if (accel.endsWith("+")) return false;
   const parts = accel.split("+");
   if (parts.some((p) => !p.trim())) return false;
-  return true;
+  return parts.some((part) => {
+    const normalized = part.trim().toLowerCase();
+    return (
+      HOTKEY_MODIFIER_PARTS.has(normalized) ||
+      HOTKEY_MACRO_MOUSE_PARTS.has(normalized)
+    );
+  });
 }
 
 function loadHotkeyFromDB(): string | undefined {

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -41,6 +41,39 @@ function formatHotkeyForBinary(hotkey: string): string {
   return hotkey;
 }
 
+function isMacroMouseButton(key: string | null): boolean {
+  return key === "mousebutton4" || key === "mousebutton5";
+}
+
+function modifierTokenToMacCategory(token: string): string | null {
+  if (token === "alt" || token === "option") {
+    return "option";
+  }
+  if (
+    token === "ctrl" ||
+    token === "control" ||
+    token === "commandorcontrol" ||
+    token === "cmdorctrl"
+  ) {
+    return "control";
+  }
+  if (token === "shift") {
+    return "shift";
+  }
+  if (token === "fn" || token === "globe") {
+    return "fn";
+  }
+  if (
+    token === "meta" ||
+    token === "super" ||
+    token === "command" ||
+    token === "cmd"
+  ) {
+    return "command";
+  }
+  return null;
+}
+
 /**
  * Parse an Electron-style hotkey accelerator into its constituent parts
  * for matching against macOS key listener events.
@@ -50,30 +83,32 @@ function parseHotkeyParts(hotkey: string): {
   key: string | null;
 } {
   const parts = hotkey.split("+").map((p) => p.trim().toLowerCase());
-  const key = parts.length > 0 ? parts[parts.length - 1] : null;
+  let key: string | null = null;
   const modifiers = new Set<string>();
 
-  for (let i = 0; i < parts.length - 1; i++) {
-    const mod = parts[i];
-    if (mod === "alt" || mod === "option") modifiers.add("option");
-    else if (
-      mod === "ctrl" ||
-      mod === "control" ||
-      mod === "commandorcontrol" ||
-      mod === "cmdorctrl"
-    )
-      modifiers.add("control");
-    else if (mod === "shift") modifiers.add("shift");
-    else if (
-      mod === "meta" ||
-      mod === "super" ||
-      mod === "command" ||
-      mod === "cmd"
-    )
-      modifiers.add("command");
+  for (const part of parts) {
+    const modifier = modifierTokenToMacCategory(part);
+    if (modifier) {
+      modifiers.add(modifier);
+    } else if (part) {
+      key = part;
+    }
   }
 
   return { modifiers, key };
+}
+
+function macMouseSuppressionArgs(hotkey: string): string[] {
+  const { key } = parseHotkeyParts(hotkey);
+  if (!isMacroMouseButton(key)) return [];
+  return [key === "mousebutton4" ? "MouseButton4" : "MouseButton5"];
+}
+
+function macRightModifierKey(hotkey: string): string {
+  const aliases: Record<string, string> = {
+    rightalt: "rightoption",
+  };
+  return aliases[hotkey] ?? hotkey;
 }
 
 export class NativeKeyListener {
@@ -88,6 +123,7 @@ export class NativeKeyListener {
   // macOS modifier tracking for hotkey matching
   private macModState = new Set<string>();
   private macFlagState = new Set<string>();
+  private macFnDown = false;
   private macHotkeyActive = false;
 
   constructor(options: KeyListenerOptions) {
@@ -117,9 +153,11 @@ export class NativeKeyListener {
 
     const args: string[] = [];
 
-    // macOS key listener doesn't need hotkey arg -- it reports all events
-    // and the main process filters. Windows and Linux take the hotkey.
-    if (process.platform !== "darwin") {
+    // macOS reports all events and main filters; pass mouse buttons only when
+    // they should be suppressed globally. Windows/Linux take the hotkey.
+    if (process.platform === "darwin") {
+      args.push(...macMouseSuppressionArgs(this.options.hotkey));
+    } else {
       args.push(formatHotkeyForBinary(this.options.hotkey));
     }
 
@@ -191,12 +229,22 @@ export class NativeKeyListener {
     const hotkey = this.options.hotkey.toLowerCase();
 
     // Fn/Globe key
-    if (line === "FN_DOWN" && (hotkey === "fn" || hotkey === "globe")) {
-      this.options.onKeyDown();
+    if (line === "FN_DOWN") {
+      this.macFnDown = true;
+      if (hotkey === "fn" || hotkey === "globe") {
+        this.options.onKeyDown();
+      } else {
+        this.checkMacHotkeyMatch();
+      }
       return;
     }
-    if (line === "FN_UP" && (hotkey === "fn" || hotkey === "globe")) {
-      this.options.onKeyUp();
+    if (line === "FN_UP") {
+      this.macFnDown = false;
+      if (hotkey === "fn" || hotkey === "globe") {
+        this.options.onKeyUp();
+      } else {
+        this.checkMacCompoundRelease();
+      }
       return;
     }
 
@@ -211,8 +259,13 @@ export class NativeKeyListener {
       const modName = line.slice(13);
       this.macModState.delete(modName.toLowerCase());
       if (this.macHotkeyActive) {
-        this.macHotkeyActive = false;
-        this.options.onKeyUp();
+        const hotkey = macRightModifierKey(this.options.hotkey.toLowerCase());
+        if (hotkey === modName.toLowerCase()) {
+          this.macHotkeyActive = false;
+          this.options.onKeyUp();
+        } else {
+          this.checkMacCompoundRelease();
+        }
       }
       return;
     }
@@ -243,6 +296,17 @@ export class NativeKeyListener {
           : [],
       );
       this.checkMacCompoundRelease();
+      this.checkMacHotkeyMatch();
+      return;
+    }
+
+    if (line.startsWith("MOUSE_BUTTON_DOWN:")) {
+      this.handleMacKeyEvent(line.slice("MOUSE_BUTTON_DOWN:".length), true);
+      return;
+    }
+
+    if (line.startsWith("MOUSE_BUTTON_UP:")) {
+      this.handleMacKeyEvent(line.slice("MOUSE_BUTTON_UP:".length), false);
       return;
     }
 
@@ -262,11 +326,12 @@ export class NativeKeyListener {
     if (!this.macHotkeyActive) return;
 
     const { modifiers, key: hotkeyKey } = parseHotkeyParts(this.options.hotkey);
-    if (!hotkeyKey) return;
-    const keyLower = hotkeyKey.toLowerCase();
-    if (keyLower === "fn" || keyLower === "globe") return;
+    if (hotkeyKey) {
+      const keyLower = hotkeyKey.toLowerCase();
+      if (keyLower === "fn" || keyLower === "globe") return;
+    }
 
-    const allModsMatch = [...modifiers].every((m) => this.macFlagState.has(m));
+    const allModsMatch = this.areMacModifiersActive(modifiers);
     if (!allModsMatch) {
       this.macHotkeyActive = false;
       this.options.onKeyUp();
@@ -278,7 +343,7 @@ export class NativeKeyListener {
     const { modifiers, key: hotkeyKey } = parseHotkeyParts(this.options.hotkey);
     if (!hotkeyKey || hotkeyKey.toLowerCase() !== key.toLowerCase()) return;
 
-    const allModsMatch = [...modifiers].every((m) => this.macFlagState.has(m));
+    const allModsMatch = this.areMacModifiersActive(modifiers);
     if (!allModsMatch) return;
 
     if (down) {
@@ -305,13 +370,13 @@ export class NativeKeyListener {
     const { modifiers, key: hotkeyKey } = parseHotkeyParts(this.options.hotkey);
 
     // Direct right-modifier hotkey (e.g., hotkey is literally "RightOption")
-    if (this.macModState.has(hotkey)) {
+    if (this.macModState.has(macRightModifierKey(hotkey))) {
       this.macHotkeyActive = true;
       this.options.onKeyDown();
       return;
     }
 
-    // Compound hotkeys (Alt+Space, etc.) use FLAGS + KEY_DOWN — not modifier-only match
+    // Compound hotkeys (Alt+Space, mouse buttons, etc.) use their own down event.
     if (hotkeyKey) {
       const keyLower = hotkeyKey.toLowerCase();
       if (keyLower !== "fn" && keyLower !== "globe") return;
@@ -319,26 +384,37 @@ export class NativeKeyListener {
 
     if (modifiers.size === 0) return;
 
-    // Map macOS modifier names to categories
-    const modCategoryMap: Record<string, string> = {
-      rightoption: "option",
-      rightcommand: "command",
-      rightcontrol: "control",
-      rightshift: "shift",
-    };
-
-    const activeCategories = new Set<string>();
-    for (const mod of this.macModState) {
-      const category = modCategoryMap[mod];
-      if (category) activeCategories.add(category);
-    }
-
-    // Check if all required modifiers are active
+    const activeCategories = this.currentMacModifierCategories();
     const allModsMatch = [...modifiers].every((m) => activeCategories.has(m));
     if (allModsMatch) {
       this.macHotkeyActive = true;
       this.options.onKeyDown();
     }
+  }
+
+  private currentMacModifierCategories(): Set<string> {
+    const activeCategories = new Set(this.macFlagState);
+    if (this.macFnDown) activeCategories.add("fn");
+
+    const modCategoryMap: Record<string, string> = {
+      rightoption: "option",
+      rightalt: "option",
+      rightcommand: "command",
+      rightcontrol: "control",
+      rightshift: "shift",
+    };
+
+    for (const mod of this.macModState) {
+      const category = modCategoryMap[mod];
+      if (category) activeCategories.add(category);
+    }
+
+    return activeCategories;
+  }
+
+  private areMacModifiersActive(modifiers: Set<string>): boolean {
+    const activeCategories = this.currentMacModifierCategories();
+    return [...modifiers].every((m) => activeCategories.has(m));
   }
 
   private scheduleRestart(): void {

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -29,6 +29,7 @@ declare global {
       onHotkeyRecordCaptured: (
         callback: (combo: { modifiers: string[]; key: string }) => void,
       ) => () => void;
+      onHotkeyRecordReleased: (callback: () => void) => () => void;
       onHotkeyRecordCancel: (callback: () => void) => () => void;
       // Auto-updater
       checkForUpdate: () => Promise<{

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -64,6 +64,11 @@ const api = {
     ipcRenderer.on("hotkey-record:captured", handler);
     return () => ipcRenderer.removeListener("hotkey-record:captured", handler);
   },
+  onHotkeyRecordReleased: (callback: () => void): (() => void) => {
+    const handler = (): void => callback();
+    ipcRenderer.on("hotkey-record:released", handler);
+    return () => ipcRenderer.removeListener("hotkey-record:released", handler);
+  },
   onHotkeyRecordCancel: (callback: () => void): (() => void) => {
     const handler = (): void => callback();
     ipcRenderer.on("hotkey-record:cancel", handler);

--- a/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
+++ b/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
@@ -16,6 +16,7 @@ const MAC_MOD_SYMBOLS: Record<string, string> = {
   Command: "\u2318",
   Alt: "\u2325",
   Shift: "\u21E7",
+  Fn: "\uD83C\uDF10",
 };
 
 const OTHER_MOD_LABELS: Record<string, string> = {
@@ -23,6 +24,8 @@ const OTHER_MOD_LABELS: Record<string, string> = {
   Command: "Super",
   Alt: "Alt",
   Shift: "Shift",
+  Super: "Super",
+  Fn: "Fn",
 };
 
 const KEY_SYMBOLS: Record<string, string> = {
@@ -37,6 +40,8 @@ const KEY_SYMBOLS: Record<string, string> = {
   Left: "\u2190",
   Right: "\u2192",
   Fn: "\uD83C\uDF10",
+  MouseButton4: "Mouse 4",
+  MouseButton5: "Mouse 5",
 };
 
 // ---------------------------------------------------------------------------
@@ -52,7 +57,30 @@ export interface HotkeyCombo {
 // Helpers
 // ---------------------------------------------------------------------------
 
-const MODIFIER_ORDER = ["Control", "Command", "Alt", "Shift"];
+const MODIFIER_ORDER = ["Control", "Command", "Alt", "Shift", "Super", "Fn"];
+const MODIFIER_ALIASES: Record<string, string> = {
+  CommandOrControl: IS_MAC ? "Command" : "Control",
+  CmdOrCtrl: IS_MAC ? "Command" : "Control",
+};
+const MODIFIER_KEYS = new Set([
+  ...MODIFIER_ORDER,
+  "RightAlt",
+  "RightOption",
+  "RightControl",
+  "RightShift",
+  "RightCommand",
+  "RightSuper",
+]);
+const MACRO_MOUSE_BUTTONS = new Set(["MouseButton4", "MouseButton5"]);
+const CAPTURED_MODIFIER_KEYS: Record<string, string> = {
+  Fn: "Fn",
+  RightAlt: "Alt",
+  RightOption: "Alt",
+  RightControl: "Control",
+  RightShift: "Shift",
+  RightCommand: "Command",
+  RightSuper: "Super",
+};
 
 /** macOS: compound keys (Alt+Space) via DOM; Fn/right-mod via native IPC */
 const USE_DOM_CAPTURE = true;
@@ -96,23 +124,72 @@ function isDomModifierKey(e: KeyboardEvent): boolean {
   return DOM_MODIFIER_KEYS.has(e.key) || e.key === "Option";
 }
 
+function orderModifiers(modifiers: string[]): string[] {
+  const unique = new Set(modifiers);
+  return MODIFIER_ORDER.filter((modifier) => unique.has(modifier));
+}
+
+function mergeModifiers(current: string[], incoming: string[]): string[] {
+  return orderModifiers([...current, ...incoming]);
+}
+
+function normalizeCapturedCombo(
+  current: HotkeyCombo,
+  captured: HotkeyCombo,
+): HotkeyCombo {
+  const capturedModifier = captured.key
+    ? CAPTURED_MODIFIER_KEYS[captured.key]
+    : null;
+
+  return {
+    modifiers: mergeModifiers(
+      current.modifiers,
+      capturedModifier
+        ? [...captured.modifiers, capturedModifier]
+        : captured.modifiers,
+    ),
+    key: capturedModifier ? current.key : captured.key,
+  };
+}
+
+function isModifierName(part: string): boolean {
+  return MODIFIER_ORDER.includes(part) || part in MODIFIER_ALIASES;
+}
+
+function modifierName(part: string): string | null {
+  if (MODIFIER_ORDER.includes(part)) return part;
+  return MODIFIER_ALIASES[part] ?? null;
+}
+
 export function comboToAccelerator(combo: HotkeyCombo): string | null {
-  if (!combo.key) return null;
-  return [...combo.modifiers, combo.key].join("+");
+  if (!isValidHotkeyCombo(combo)) return null;
+  return combo.key
+    ? [...combo.modifiers, combo.key].join("+")
+    : combo.modifiers.join("+");
+}
+
+export function isValidHotkeyCombo(combo: HotkeyCombo | null): boolean {
+  if (!combo) return false;
+  if (combo.modifiers.length > 0) return true;
+  return (
+    !!combo.key &&
+    (MODIFIER_KEYS.has(combo.key) || MACRO_MOUSE_BUTTONS.has(combo.key))
+  );
+}
+
+export function needsModifierOrMouseButton(combo: HotkeyCombo | null): boolean {
+  return !!combo && !isValidHotkeyCombo(combo);
 }
 
 export function acceleratorToCombo(accel: string): HotkeyCombo {
   const parts = accel.split("+").map((p) => p.trim());
-  const key = parts[parts.length - 1];
+  const key = parts.every(isModifierName) ? null : parts[parts.length - 1];
   const modifiers: string[] = [];
+  const modifierParts = key ? parts.slice(0, -1) : parts;
 
-  for (let i = 0; i < parts.length - 1; i++) {
-    const p = parts[i];
-    if (p === "CommandOrControl") {
-      modifiers.push(IS_MAC ? "Command" : "Control");
-    } else if (MODIFIER_ORDER.includes(p)) {
-      modifiers.push(p);
-    }
+  for (const p of modifierParts) {
+    const modifier = modifierName(p);
+    if (modifier) modifiers.push(modifier);
   }
 
   return {
@@ -146,83 +223,140 @@ export function formatAccelerator(accel: string): string {
 // Hook -- uses main process IPC for recording (captures fn/globe key)
 // ---------------------------------------------------------------------------
 
-type RecorderState = "idle" | "recording" | "captured";
+type RecorderState = "idle" | "recording";
+const EMPTY_COMBO: HotkeyCombo = { modifiers: [], key: null };
 
 interface UseHotkeyRecorderReturn {
   state: RecorderState;
   liveModifiers: string[];
   capturedCombo: HotkeyCombo | null;
+  canSaveRecording: boolean;
+  needsModifierOrMouseButton: boolean;
+  invalidReleaseNotice: boolean;
   startRecording: () => void;
   cancelRecording: () => void;
-  saveRecording: () => void;
 }
 
 export function useHotkeyRecorder(
   onRecord: (accelerator: string) => void,
 ): UseHotkeyRecorderReturn {
   const [state, setState] = useState<RecorderState>("idle");
-  const [liveModifiers, setLiveModifiers] = useState<string[]>([]);
-  const [capturedCombo, setCapturedCombo] = useState<HotkeyCombo | null>(null);
+  const [draftCombo, setDraftCombo] = useState<HotkeyCombo>(EMPTY_COMBO);
+  const [invalidReleaseNotice, setInvalidReleaseNotice] = useState(false);
   const onRecordRef = useRef(onRecord);
   onRecordRef.current = onRecord;
   const recordingActiveRef = useRef(false);
+  const draftComboRef = useRef<HotkeyCombo>(EMPTY_COMBO);
+  const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const updateDraftCombo = useCallback(
+    (updater: (combo: HotkeyCombo) => HotkeyCombo) => {
+      const next = updater(draftComboRef.current);
+      draftComboRef.current = next;
+      setDraftCombo(next);
+    },
+    [],
+  );
+
+  const clearWarningTimer = useCallback(() => {
+    if (warningTimerRef.current) {
+      clearTimeout(warningTimerRef.current);
+      warningTimerRef.current = null;
+    }
+  }, []);
+
+  const showInvalidReleaseNotice = useCallback(() => {
+    clearWarningTimer();
+    setInvalidReleaseNotice(true);
+    warningTimerRef.current = setTimeout(() => {
+      setInvalidReleaseNotice(false);
+      warningTimerRef.current = null;
+    }, 1800);
+  }, [clearWarningTimer]);
 
   const startRecording = useCallback(() => {
     recordingActiveRef.current = true;
     setState("recording");
-    setLiveModifiers([]);
-    setCapturedCombo(null);
+    draftComboRef.current = EMPTY_COMBO;
+    setDraftCombo(EMPTY_COMBO);
+    setInvalidReleaseNotice(false);
     window.api?.startHotkeyRecording();
   }, []);
 
   const cancelRecording = useCallback(() => {
+    clearWarningTimer();
     recordingActiveRef.current = false;
     setState("idle");
-    setLiveModifiers([]);
-    setCapturedCombo(null);
+    draftComboRef.current = EMPTY_COMBO;
+    setDraftCombo(EMPTY_COMBO);
+    setInvalidReleaseNotice(false);
     window.api?.stopHotkeyRecording();
-  }, []);
+  }, [clearWarningTimer]);
 
-  const saveRecording = useCallback(() => {
-    const accel = capturedCombo?.key ? comboToAccelerator(capturedCombo) : null;
+  const completeRecording = useCallback(() => {
+    const accel = comboToAccelerator(draftComboRef.current);
+    if (!accel) {
+      if (
+        draftComboRef.current.key ||
+        draftComboRef.current.modifiers.length > 0
+      ) {
+        showInvalidReleaseNotice();
+        window.api?.stopHotkeyRecording();
+        recordingActiveRef.current = false;
+        setState("idle");
+        draftComboRef.current = EMPTY_COMBO;
+        setDraftCombo(EMPTY_COMBO);
+      }
+      return;
+    }
+
+    clearWarningTimer();
     if (accel) {
       onRecordRef.current(accel);
     }
     // Re-register the global listener with the new accelerator (single IPC)
-    window.api?.stopHotkeyRecording(accel ?? undefined);
+    window.api?.stopHotkeyRecording(accel);
     recordingActiveRef.current = false;
     setState("idle");
-    setLiveModifiers([]);
-    setCapturedCombo(null);
-  }, [capturedCombo]);
+    draftComboRef.current = EMPTY_COMBO;
+    setDraftCombo(EMPTY_COMBO);
+    setInvalidReleaseNotice(false);
+  }, [clearWarningTimer, showInvalidReleaseNotice]);
 
   // Global capture: native listener (all platforms) + DOM on macOS for Alt+Space etc.
   useEffect(() => {
     if (state !== "recording" || !window.api) return;
 
     const removeModifiers = window.api.onHotkeyRecordModifiers((modifiers) => {
-      setLiveModifiers(modifiers);
+      updateDraftCombo((combo) => ({
+        ...combo,
+        modifiers: mergeModifiers(combo.modifiers, modifiers),
+      }));
     });
 
     const removeCaptured = window.api.onHotkeyRecordCaptured((combo) => {
-      setCapturedCombo(combo);
-      setLiveModifiers([]);
-      setState("captured");
+      updateDraftCombo((current) => normalizeCapturedCombo(current, combo));
+    });
+
+    const removeReleased = window.api.onHotkeyRecordReleased(() => {
+      completeRecording();
     });
 
     const removeCancel = window.api.onHotkeyRecordCancel(() => {
       recordingActiveRef.current = false;
       setState("idle");
-      setLiveModifiers([]);
-      setCapturedCombo(null);
+      draftComboRef.current = EMPTY_COMBO;
+      setDraftCombo(EMPTY_COMBO);
+      setInvalidReleaseNotice(false);
     });
 
     return () => {
       removeModifiers();
       removeCaptured();
+      removeReleased();
       removeCancel();
     };
-  }, [state]);
+  }, [state, completeRecording, updateDraftCombo]);
 
   useEffect(() => {
     if (state !== "recording" || !USE_DOM_CAPTURE) return;
@@ -239,39 +373,60 @@ export function useHotkeyRecorder(
       const modifiers = modifiersFromEvent(e);
 
       if (isDomModifierKey(e)) {
-        setLiveModifiers(modifiers);
+        updateDraftCombo((combo) => ({
+          ...combo,
+          modifiers: mergeModifiers(combo.modifiers, modifiers),
+        }));
         return;
       }
 
       const key = domKeyFromEvent(e);
       if (!key) return;
 
-      setCapturedCombo({ modifiers, key });
-      setLiveModifiers([]);
-      setState("captured");
-      window.api?.pauseHotkeyRecording();
+      updateDraftCombo((combo) => ({
+        modifiers: mergeModifiers(combo.modifiers, modifiers),
+        key,
+      }));
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.key === "Escape") return;
+      completeRecording();
     };
 
     window.addEventListener("keydown", handleKeyDown, true);
-    return () => window.removeEventListener("keydown", handleKeyDown, true);
-  }, [state, cancelRecording]);
+    window.addEventListener("keyup", handleKeyUp, true);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+      window.removeEventListener("keyup", handleKeyUp, true);
+    };
+  }, [state, cancelRecording, completeRecording, updateDraftCombo]);
 
   // Stop main process recording only if we started it (avoids re-registering hotkey on every settings navigation)
   useEffect(() => {
     return () => {
+      clearWarningTimer();
       if (recordingActiveRef.current) {
         recordingActiveRef.current = false;
         window.api?.stopHotkeyRecording();
       }
     };
-  }, []);
+  }, [clearWarningTimer]);
 
   return {
     state,
-    liveModifiers,
-    capturedCombo,
+    liveModifiers: draftCombo.modifiers,
+    capturedCombo:
+      draftCombo.modifiers.length > 0 || draftCombo.key ? draftCombo : null,
+    canSaveRecording: isValidHotkeyCombo(draftCombo),
+    needsModifierOrMouseButton: needsModifierOrMouseButton(
+      draftCombo.key ? draftCombo : null,
+    ),
+    invalidReleaseNotice,
     startRecording,
     cancelRecording,
-    saveRecording,
   };
 }

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -210,9 +210,10 @@ export default function GeneralSettingsPage(): React.JSX.Element {
     state: recorderState,
     liveModifiers,
     capturedCombo,
+    canSaveRecording,
+    needsModifierOrMouseButton,
+    invalidReleaseNotice,
     startRecording: startHotkeyRecording,
-    cancelRecording: cancelHotkeyRecording,
-    saveRecording: saveHotkeyRecording,
   } = useHotkeyRecorder(handleHotkeyRecorded);
 
   // Load available audio input devices
@@ -420,7 +421,12 @@ export default function GeneralSettingsPage(): React.JSX.Element {
 
   // Build display keys for current recorder state
   const liveKeys = liveModifiers.map(keyDisplayLabel);
-  const capturedKeys = capturedCombo ? comboDisplayKeys(capturedCombo) : [];
+  const draftKeys = capturedCombo ? comboDisplayKeys(capturedCombo) : liveKeys;
+  const captureHint = needsModifierOrMouseButton
+    ? "Add a modifier or side mouse button"
+    : canSaveRecording
+      ? "Release to save"
+      : "Press a modifier or side mouse button...";
 
   return (
     <div
@@ -517,60 +523,44 @@ export default function GeneralSettingsPage(): React.JSX.Element {
             }
           >
             {recorderState === "idle" ? (
-              <button
-                type="button"
-                onClick={startHotkeyRecording}
-                className="border-border hover:bg-secondary inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2 transition-colors"
-              >
-                <Keyboard className="text-muted-foreground h-4 w-4 shrink-0" />
-                <KeyComboDisplay keys={formatAcceleratorKeys(hotkey)} />
-                <span className="text-muted-foreground ml-1 text-xs">
-                  Change
-                </span>
-              </button>
-            ) : recorderState === "recording" ? (
-              <div className="border-primary/60 bg-primary/5 inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2">
+              <div className="relative inline-flex">
+                <button
+                  type="button"
+                  onClick={startHotkeyRecording}
+                  className="border-border hover:bg-secondary inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2 transition-colors"
+                >
+                  <Keyboard className="text-muted-foreground h-4 w-4 shrink-0" />
+                  <KeyComboDisplay keys={formatAcceleratorKeys(hotkey)} />
+                  <span className="text-muted-foreground ml-1 text-xs">
+                    Change
+                  </span>
+                </button>
+                {invalidReleaseNotice && (
+                  <div className="bg-popover text-popover-foreground border-border shadow-soft absolute top-[calc(100%+6px)] right-0 z-20 whitespace-nowrap rounded-md border px-2.5 py-1.5 text-xs">
+                    Hotkeys need a modifier or side mouse button
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="border-primary/60 bg-primary/5 relative inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2">
                 <Keyboard className="text-primary h-4 w-4 shrink-0" />
-                {liveKeys.length > 0 ? (
+                {draftKeys.length > 0 ? (
                   <>
-                    <KeyComboDisplay keys={liveKeys} variant="dim" />
-                    <span className="text-muted-foreground animate-pulse text-xs">
-                      + press a key
+                    <KeyComboDisplay keys={draftKeys} variant="dim" />
+                    <span className="text-muted-foreground text-xs">
+                      {captureHint}
                     </span>
                   </>
                 ) : (
                   <span className="text-muted-foreground animate-pulse text-sm">
-                    Press a key combination…
+                    {captureHint}
                   </span>
                 )}
-                <button
-                  type="button"
-                  onClick={cancelHotkeyRecording}
-                  className="border-border hover:bg-secondary ml-2 rounded-md border px-2.5 py-1 text-xs"
-                >
-                  Cancel
-                </button>
-              </div>
-            ) : (
-              <div className="border-primary/60 bg-primary/5 inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2">
-                <Keyboard className="text-primary h-4 w-4 shrink-0" />
-                <KeyComboDisplay keys={capturedKeys} variant="recording" />
-                <div className="ml-2 flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={saveHotkeyRecording}
-                    className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-2.5 py-1 text-xs font-medium"
-                  >
-                    Save
-                  </button>
-                  <button
-                    type="button"
-                    onClick={cancelHotkeyRecording}
-                    className="border-border hover:bg-secondary rounded-md border px-2.5 py-1 text-xs"
-                  >
-                    Cancel
-                  </button>
-                </div>
+                {invalidReleaseNotice && (
+                  <div className="bg-popover text-popover-foreground border-border shadow-soft absolute top-[calc(100%+6px)] right-0 z-20 whitespace-nowrap rounded-md border px-2.5 py-1.5 text-xs">
+                    Hotkeys need a modifier or side mouse button
+                  </div>
+                )}
               </div>
             )}
           </Row>

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -214,6 +214,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
     needsModifierOrMouseButton,
     invalidReleaseNotice,
     startRecording: startHotkeyRecording,
+    cancelRecording: cancelHotkeyRecording,
   } = useHotkeyRecorder(handleHotkeyRecorded);
 
   // Load available audio input devices
@@ -423,10 +424,10 @@ export default function GeneralSettingsPage(): React.JSX.Element {
   const liveKeys = liveModifiers.map(keyDisplayLabel);
   const draftKeys = capturedCombo ? comboDisplayKeys(capturedCombo) : liveKeys;
   const captureHint = needsModifierOrMouseButton
-    ? "Add a modifier or side mouse button"
+    ? "Add a modifier or side mouse button · Esc to cancel"
     : canSaveRecording
-      ? "Release to save"
-      : "Press a modifier or side mouse button...";
+      ? "Release to save · Esc to cancel"
+      : "Press a modifier or side mouse button... · Esc to cancel";
 
   return (
     <div
@@ -561,6 +562,13 @@ export default function GeneralSettingsPage(): React.JSX.Element {
                     Hotkeys need a modifier or side mouse button
                   </div>
                 )}
+                <button
+                  type="button"
+                  onClick={cancelHotkeyRecording}
+                  className="border-border hover:bg-secondary ml-1 rounded-md border px-2.5 py-1 text-xs"
+                >
+                  Cancel
+                </button>
               </div>
             )}
           </Row>


### PR DESCRIPTION
Closes #128

Changed hotkey rebinding so that it saves intuitively upon release, accepts all modifier combinations and mouse macro buttons. Also it ensures that things like "space" or "enter" won't be accepted as a keybind — it requires modifiers or mouse macro buttons to be included.

Tested on mac platform