### PR TITLE
feat: add output mode setting to copy instead of paste

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -705,7 +705,13 @@ app.whenReady().then(async () => {
 
   // IPC: copy text to clipboard
   ipcMain.handle("copy:text", async (_event, text: string) => {
+    if (!text?.trim()) return;
     clipboard.writeText(text);
+  });
+
+  // IPC: broadcast output mode changes to pill window
+  ipcMain.on("settings:output-mode-changed", (_event, mode: string) => {
+    mainWindow?.webContents.send("settings:output-mode-changed", mode);
   });
 
   // IPC: hide the pill window on request from renderer

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -28,6 +28,7 @@ import { serve } from "@hono/node-server";
 import {
   app,
   BrowserWindow,
+  clipboard,
   dialog,
   globalShortcut,
   ipcMain,
@@ -700,6 +701,11 @@ app.whenReady().then(async () => {
   // IPC: paste text at cursor
   ipcMain.handle("paste:text", async (_event, text: string) => {
     await pasteIntoFocusedApp(text);
+  });
+
+  // IPC: copy text to clipboard
+  ipcMain.handle("copy:text", async (_event, text: string) => {
+    clipboard.writeText(text);
   });
 
   // IPC: hide the pill window on request from renderer

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -5,6 +5,7 @@ declare global {
     electron: ElectronAPI;
     api: {
       pasteText: (text: string) => Promise<void>;
+      copyText: (text: string) => Promise<void>;
       updateHotkey: (hotkey: string) => void;
       reloadHotkey: () => void;
       setHotkeyMode: (mode: "hold" | "toggle") => void;

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -66,6 +66,9 @@ declare global {
       onPillPositionChanged: (
         callback: (position: string) => void,
       ) => () => void;
+      // Output mode
+      sendOutputModeChanged: (mode: string) => void;
+      onOutputModeChanged: (callback: (mode: string) => void) => () => void;
       // Hotkey error notifications
       onHotkeyError: (
         callback: (error: { message: string }) => void,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -143,6 +143,15 @@ const api = {
     return () =>
       ipcRenderer.removeListener("settings:pill-position-changed", handler);
   },
+  // Output mode
+  sendOutputModeChanged: (mode: string): void =>
+    ipcRenderer.send("settings:output-mode-changed", mode),
+  onOutputModeChanged: (callback: (mode: string) => void): (() => void) => {
+    const handler = (_: unknown, mode: string): void => callback(mode);
+    ipcRenderer.on("settings:output-mode-changed", handler);
+    return () =>
+      ipcRenderer.removeListener("settings:output-mode-changed", handler);
+  },
   // Hotkey error notifications
   onHotkeyError: (
     callback: (error: { message: string }) => void,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -5,6 +5,8 @@ import { contextBridge, ipcRenderer } from "electron";
 const api = {
   pasteText: (text: string): Promise<void> =>
     ipcRenderer.invoke("paste:text", text),
+  copyText: (text: string): Promise<void> =>
+    ipcRenderer.invoke("copy:text", text),
   updateHotkey: (hotkey: string): void =>
     ipcRenderer.send("hotkey:update", hotkey),
   reloadHotkey: (): void => ipcRenderer.send("hotkey:reload"),

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -24,6 +24,7 @@ type BarMode = "connecting" | "listening" | "speaking";
 // ---------------------------------------------------------------------------
 
 let _soundEnabled = true;
+let _outputMode = "paste";
 let _toneCtx: AudioContext | null = null;
 
 function getToneCtx(): AudioContext {
@@ -243,14 +244,7 @@ export default function AppPage(): React.JSX.Element {
       }
 
       try {
-        const outModeRes = await getClient()
-          .api.settings[":key"].$get({ param: { key: "output_mode" } })
-          .catch(() => null);
-        const outputMode = outModeRes?.ok
-          ? (await outModeRes.json())?.value
-          : "paste";
-
-        if (outputMode === "clipboard") {
+        if (_outputMode === "clipboard") {
           await window.api.copyText(finalText);
         } else {
           await window.api.pasteText(finalText);
@@ -783,14 +777,27 @@ export default function AppPage(): React.JSX.Element {
         if (data?.value === "false") _soundEnabled = false;
       })
       .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "output_mode" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value) _outputMode = data.value;
+      })
+      .catch(() => {});
     window.api
       ?.getPillPosition()
       .then(applyPillPosition)
       .catch(() => {});
 
-    // Listen for live position changes from the settings UI
-    const remove = window.api?.onPillPositionChanged(applyPillPosition);
-    return () => remove?.();
+    // Listen for live changes from the settings UI
+    const removePillPos = window.api?.onPillPositionChanged(applyPillPosition);
+    const removeOutputMode = window.api?.onOutputModeChanged((mode) => {
+      _outputMode = mode;
+    });
+    return () => {
+      removePillPos?.();
+      removeOutputMode?.();
+    };
   }, [applyPillPosition]);
 
   const stateRef = useRef(state);

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -243,9 +243,20 @@ export default function AppPage(): React.JSX.Element {
       }
 
       try {
-        await window.api.pasteText(finalText);
+        const outModeRes = await getClient()
+          .api.settings[":key"].$get({ param: { key: "output_mode" } })
+          .catch(() => null);
+        const outputMode = outModeRes?.ok
+          ? (await outModeRes.json())?.value
+          : "paste";
+
+        if (outputMode === "clipboard") {
+          await window.api.copyText(finalText);
+        } else {
+          await window.api.pasteText(finalText);
+        }
       } catch (err) {
-        console.error("[pill] paste failed:", err);
+        console.error("[pill] paste/copy failed:", err);
       }
       window.api.sendTranscriptionDone();
 

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -101,6 +101,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
   const [hotkey, setHotkey] = useState("Alt+Space");
   const [hotkeyMode, setHotkeyMode] = useState<"hold" | "toggle">("hold");
   const [language, setLanguage] = useState("auto");
+  const [outputMode, setOutputMode] = useState("paste");
   const [pillPosition, setPillPosition] = useState("bottom-center");
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [transcriptionPrompt, setTranscriptionPrompt] = useState("");
@@ -269,6 +270,13 @@ export default function GeneralSettingsPage(): React.JSX.Element {
         if (data?.value) setLanguage(data.value);
       })
       .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "output_mode" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value) setOutputMode(data.value);
+      })
+      .catch(() => {});
     window.api
       ?.getPillPosition()
       .then(setPillPosition)
@@ -374,6 +382,16 @@ export default function GeneralSettingsPage(): React.JSX.Element {
     getClient()
       .api.settings[":key"].$put({
         param: { key: "language" },
+        json: { value },
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleOutputModeChange = useCallback((value: string) => {
+    setOutputMode(value);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "output_mode" },
         json: { value },
       })
       .catch(() => {});
@@ -660,6 +678,21 @@ export default function GeneralSettingsPage(): React.JSX.Element {
                 <option value="uk">Ukrainian</option>
               </select>
             </div>
+          </Row>
+
+          <Row
+            label="Output mode"
+            desc="Paste into the active app, or copy to clipboard."
+          >
+            <Segment
+              compact
+              options={[
+                { id: "paste", label: "Paste into app" },
+                { id: "clipboard", label: "Copy to clipboard" },
+              ]}
+              active={outputMode}
+              onSelect={handleOutputModeChange}
+            />
           </Row>
 
           <Row

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -389,6 +389,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
 
   const handleOutputModeChange = useCallback((value: string) => {
     setOutputMode(value);
+    window.api?.sendOutputModeChanged(value);
     getClient()
       .api.settings[":key"].$put({
         param: { key: "output_mode" },


### PR DESCRIPTION
# Description
Closes #132 
Adds an "Output mode" setting that allows users to choose whether transcribed text is automatically pasted into the active application or copied to the clipboard instead.

This is especially useful for workflows where the user:
- Wants to review transcribed text before pasting it.
- Needs to paste the text into multiple places.
- Uses applications that don't play well with simulated paste keystrokes.

## Changes Made
- **Main Process:** Added a new `copy:text` IPC handler that uses Electron's native `clipboard.writeText()` API.
- **Preload API:** Exposed `window.api.copyText()` to the renderer processes.
- **Frontend (App Logic):** Updated the `drainQueue` transcription handler to fetch the `output_mode` preference from the settings database and route the text to the clipboard if configured.
- **Settings UI:** Added a segment toggle in the **Recording** settings panel for users to switch between "Paste into app" (default) and "Copy to clipboard".

<img width="1129" height="613" alt="image" src="https://github.com/user-attachments/assets/7c761652-a64e-432c-bf3d-79a6120ddbde" />

## Testing Instructions
1. Navigate to **Settings > General > Recording**.
2. Locate the new **Output mode** toggle.
3. Switch it to **Copy to clipboard**.
4. Record a short clip.
5. Verify that after transcription finishes, the text is not pasted into your active window.
6. Press `Ctrl+V` (or `Cmd+V`) and verify the text was successfully copied to your system clipboard.
