### PR TITLE
Add CI Status summary job to satisfy ruleset required check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,3 +226,22 @@ jobs:
             apps/electron/dist/latest*.yml
             apps/electron/dist/*.blockmap
           if-no-files-found: warn
+
+  ci-status:
+    name: CI Status
+    if: always()
+    needs:
+      - lint
+      - typecheck
+      - test-server
+      - test-electron
+      - build-linux
+      - build-mac
+      - build-windows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CI result
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo "CI failed, was cancelled, or a required job was skipped"
+          exit 1


### PR DESCRIPTION
## Summary

- Adds a `CI Status` summary job to the `Build & Test` workflow that aggregates all other job results into a single pass/fail check
- Fixes the "Expected — Waiting for status to be reported" issue caused by the `default` ruleset requiring a `CI Status` check that no workflow job was reporting

## Details

The `default` ruleset requires a status check named `CI Status` to pass before merging to `main`. None of the existing workflow jobs (`Lint`, `Typecheck`, `Test (Server API)`, etc.) matched that name, so the check was never reported.

The new `ci-status` job:
- Uses `if: always()` so it runs regardless of upstream job results
- Depends on all 7 existing jobs via `needs`
- Fails if any upstream job failed, was cancelled, or was skipped
- Passes (implicitly, by not hitting the failure step) only when all upstream jobs succeed