### PR TITLE
fix: address MLX streaming parallel-load follow-ups

### DIFF
--- a/apps/server/src/lib/mlx-asr/server.ts
+++ b/apps/server/src/lib/mlx-asr/server.ts
@@ -544,6 +544,11 @@ export async function stopMlxServer(): Promise<void> {
     try {
       proc.stdin?.write(`${JSON.stringify({ type: "shutdown" })}\n`, () => {
         proc.stdin?.end();
+        try {
+          proc.kill(process.platform === "win32" ? undefined : "SIGTERM");
+        } catch {
+          // Process may have already exited after reading the shutdown message.
+        }
       });
     } catch {
       clearTimeout(killTimeout);

--- a/apps/server/src/lib/streaming/providers/mlx-local.ts
+++ b/apps/server/src/lib/streaming/providers/mlx-local.ts
@@ -121,6 +121,10 @@ class MlxLocalStreamingSession implements StreamSession {
   commit(): void {
     this.clearTimer();
     this.commitRequested = true;
+    // When no partial has been shown yet and enough audio is buffered, run a
+    // non-final (partial) inference first so the user sees intermediate text
+    // while the final pass runs.  The commitRequested flag causes the final
+    // pass to start automatically in runInference's .finally() handler.
     if (
       !this.inFlight &&
       !this.lastText &&

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -336,14 +336,22 @@ const stream = new Hono().get(
               if (upstream.reset) {
                 upstream.reset();
                 const voice = voiceDefaults ?? getDefaultModels().voice;
-                if (voice && upstream.waitUntilReady) {
+                if (voice) {
                   const token = ++readyToken;
-                  afterSessionReady(
-                    ws,
-                    upstream,
-                    stripProviderPrefix(voice.model_id),
-                    token,
-                  );
+                  if (upstream.waitUntilReady) {
+                    afterSessionReady(
+                      ws,
+                      upstream,
+                      stripProviderPrefix(voice.model_id),
+                      token,
+                    );
+                  } else {
+                    notifySessionReady(
+                      ws,
+                      stripProviderPrefix(voice.model_id),
+                      token,
+                    );
+                  }
                 }
               } else {
                 upstream.close();


### PR DESCRIPTION
Follow-up to #143 (MLX Streaming + Parallel loading). Addresses three issues identified during review:

1. **Restore SIGTERM in `stopMlxServer`** — PR #143 replaced the `SIGTERM` with `stdin.end()`, leaving the 5-second `SIGKILL` as the only fallback if the Python worker ignores the shutdown JSON message. This restores `SIGTERM` after the stdin write completes.

2. **Send `session.ready` to cloud providers on reset** — The `"start"` handler's reset path only called `afterSessionReady` for providers with `waitUntilReady` (i.e. MLX), silently skipping `session.ready` for Deepgram, ElevenLabs, and OpenAI after a session reset. Now calls `notifySessionReady` directly for providers without `waitUntilReady`.

3. **Clarify `commit()` preview heuristic** — Added a comment explaining why `commit()` runs a non-final inference before the final pass when no partial has been emitted yet.

## Testing

Build passes (`pnpm build`). Biome lint clean on all changed files.

<!--
## Plan
1. Restore SIGTERM fallback in stopMlxServer after stdin shutdown write callback
2. Fix cloud provider reset path to send session.ready via notifySessionReady when waitUntilReady is absent
3. Add clarifying comment on the commit() preview heuristic in mlx-local.ts
-->