### PR TITLE
Fix transcription language in streaming path + macOS Accessibility prompt/URL

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -765,10 +765,15 @@ app.whenReady().then(async () => {
     return true;
   });
 
-  ipcMain.on("permissions:open-accessibility", () => {
+  ipcMain.on("permissions:open-accessibility", async () => {
     if (process.platform === "darwin") {
+      // Passing `true` pops the native "would like to control this computer"
+      // prompt and adds Freestyle to the Accessibility list automatically, so
+      // the user only has to flip the toggle (macOS never lets us flip it).
+      const { systemPreferences } = await import("electron");
+      systemPreferences.isTrustedAccessibilityClient(true);
       shell.openExternal(
-        "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+        "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility",
       );
     }
   });

--- a/apps/server/src/lib/streaming-stt.ts
+++ b/apps/server/src/lib/streaming-stt.ts
@@ -14,10 +14,11 @@ export function openStreamingSession(opts: {
   providerId: string;
   apiKey: string;
   model: string;
+  language?: string;
   bias?: AsrVocabularyBias | null;
   callbacks: StreamCallbacks;
 }): StreamSession {
-  const { providerId, apiKey, model, bias, callbacks } = opts;
+  const { providerId, apiKey, model, language, bias, callbacks } = opts;
 
   const provider = getProvider(providerId);
   if (!provider) {
@@ -32,7 +33,13 @@ export function openStreamingSession(opts: {
     );
   }
 
-  return provider.openStreamingSession({ apiKey, model, bias, callbacks });
+  return provider.openStreamingSession({
+    apiKey,
+    model,
+    language,
+    bias,
+    callbacks,
+  });
 }
 
 export function getApiKeyForProvider(providerId: string): string | null {

--- a/apps/server/src/lib/streaming/providers/deepgram.ts
+++ b/apps/server/src/lib/streaming/providers/deepgram.ts
@@ -74,7 +74,7 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
   }
 
   openStreamingSession(opts: StreamingSessionOptions): StreamSession {
-    const { apiKey, model, bias, callbacks } = opts;
+    const { apiKey, model, language, bias, callbacks } = opts;
 
     let accumulatedText = "";
     let partialText = "";
@@ -101,6 +101,7 @@ export class DeepgramTranscriptionProvider implements TranscriptionProvider {
       endpointing: "false",
       vad_events: "false",
     });
+    if (language && language !== "auto") params.set("language", language);
     appendDeepgramBiasToParams(params, bias);
 
     const ws = new WebSocket(`${DEEPGRAM_LISTEN_URL}?${params}`, {

--- a/apps/server/src/lib/streaming/providers/elevenlabs.ts
+++ b/apps/server/src/lib/streaming/providers/elevenlabs.ts
@@ -111,7 +111,7 @@ export class ElevenLabsTranscriptionProvider implements TranscriptionProvider {
   }
 
   openStreamingSession(opts: StreamingSessionOptions): StreamSession {
-    const { apiKey, model, bias, callbacks } = opts;
+    const { apiKey, model, language, bias, callbacks } = opts;
 
     let accumulatedText = "";
     let partialText = "";
@@ -167,6 +167,9 @@ export class ElevenLabsTranscriptionProvider implements TranscriptionProvider {
           audio_format: "pcm_16000",
           commit_strategy: "manual",
         });
+        if (language && language !== "auto") {
+          params.set("language_code", language);
+        }
         appendElevenLabsBiasToParams(params, bias);
 
         ws = new WebSocket(`${ELEVENLABS_STT_URL}?${params}`);

--- a/apps/server/src/lib/streaming/providers/mlx-local.ts
+++ b/apps/server/src/lib/streaming/providers/mlx-local.ts
@@ -62,6 +62,8 @@ export class MlxLocalTranscriptionProvider implements TranscriptionProvider {
     const modelId = stripProviderPrefix(opts.model);
     return new MlxLocalStreamingSession({
       modelId,
+      language:
+        opts.language && opts.language !== "auto" ? opts.language : undefined,
       context: opts.bias?.kind === "prompt" ? opts.bias.text : undefined,
       callbacks: opts.callbacks,
     });
@@ -84,6 +86,7 @@ class MlxLocalStreamingSession implements StreamSession {
   constructor(
     private readonly opts: {
       modelId: string;
+      language?: string;
       context?: string;
       callbacks: StreamCallbacks;
     },
@@ -236,6 +239,7 @@ class MlxLocalStreamingSession implements StreamSession {
           modelId: this.opts.modelId,
           pcm: new Uint8Array(audio),
           sampleRate: STREAM_SAMPLE_RATE,
+          language: this.opts.language,
           context: this.opts.context,
           live: !final,
           deferUnload: true,

--- a/apps/server/src/lib/streaming/providers/openai.ts
+++ b/apps/server/src/lib/streaming/providers/openai.ts
@@ -25,7 +25,7 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
   }
 
   openStreamingSession(opts: StreamingSessionOptions): StreamSession {
-    const { apiKey, model, bias, callbacks } = opts;
+    const { apiKey, model, language, bias, callbacks } = opts;
     const short = stripProviderPrefix(model);
     let partialText = "";
     let configured = false;
@@ -39,6 +39,7 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
 
     ws.on("open", () => {
       const transcription: Record<string, unknown> = { model: short };
+      if (language && language !== "auto") transcription.language = language;
       if (bias?.kind === "prompt") transcription.prompt = bias.text;
 
       ws.send(

--- a/apps/server/src/lib/streaming/types.ts
+++ b/apps/server/src/lib/streaming/types.ts
@@ -44,6 +44,8 @@ export interface TranscribeResult {
 export interface StreamingSessionOptions {
   apiKey: string;
   model: string;
+  /** ISO-639-1 language hint; omitted or "auto" lets the model auto-detect. */
+  language?: string;
   /** ASR-only vocabulary bias for the first recognition pass. */
   bias?: AsrVocabularyBias | null;
   callbacks: StreamCallbacks;

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -137,11 +137,17 @@ const stream = new Hono().get(
         true,
       );
 
+      const langSetting = getDb()
+        .prepare("SELECT value FROM settings WHERE key = 'language'")
+        .get() as { value: string } | undefined;
+      const language = langSetting?.value || undefined;
+
       const token = ++readyToken;
       const session = openStreamingSession({
         providerId: defaults.voice.provider,
         apiKey,
         model: defaults.voice.model_id,
+        language,
         bias,
         callbacks: {
           onReady: (readyModel) => {


### PR DESCRIPTION
Two independent bug fixes, both verified locally (`pnpm biome check .`, `pnpm --filter @freestyle/electron typecheck`, and `pnpm --filter @freestyle/server test` → 36/36 pass).

## 1. Streaming transcription ignores the Language setting

**Symptom:** With a specific language chosen under *Settings → Recording → Language*, dictation still sometimes comes out in the wrong language.

**Cause:** Only the batch `POST /transcribe` path read the `language` setting. The streaming `/stream` path called `openStreamingSession()` without it, so streaming-capable models (OpenAI realtime, Deepgram, ElevenLabs, local MLX) always auto-detected.

**Fix:** Thread the existing `language` setting through `StreamingSessionOptions` into each streaming provider's upstream request:
- OpenAI realtime → `input_audio_transcription.language`
- Deepgram → `language` query param
- ElevenLabs → `language_code` query param
- MLX local worker → `language`

An unset/`"auto"` value preserves auto-detection, so default behavior is unchanged.

## 2. macOS: Accessibility "Open Settings" goes to the wrong pane and never prompts

**Symptom:** The in-app *Open Settings* button opens the **Accessibility features** pane (VoiceOver/Zoom/…) instead of **Privacy & Security → Accessibility**, and the app never appears in the list on its own.

**Cause:** It used the legacy `x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility` URL (lands on the wrong pane on recent macOS) and only ever called `isTrustedAccessibilityClient(false)` (never prompts).

**Fix:** Call `isTrustedAccessibilityClient(true)` to fire the native "control your computer" prompt (which auto-adds the app to the list), and open the modern `com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)