### PR TITLE
fix: remove onboarding skip, stop repeated update notifications, dynamic menu labels

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -533,6 +533,28 @@ function showSettingsWindow(): void {
   settingsWindow.focus();
 }
 
+function isRunningFromReadOnlyLocation(): boolean {
+  if (process.platform !== "darwin") return false;
+  const exePath = app.getPath("exe");
+  return (
+    exePath.startsWith("/Volumes/") || exePath.includes("/AppTranslocation/")
+  );
+}
+
+const READ_ONLY_UPDATE_RE = /EROFS|EACCES|read.only|permission denied/i;
+
+function showMoveToApplicationsDialog(): void {
+  dialog.showMessageBox({
+    type: "warning",
+    title: "Move to Applications",
+    message:
+      "Freestyle is running from a read-only location and can\u2019t update itself.",
+    detail:
+      "Please drag Freestyle into your Applications folder and relaunch it from there.",
+    buttons: ["OK"],
+  });
+}
+
 function restartAndUpdate(): void {
   isUpdaterQuitting = true;
   autoUpdater.quitAndInstall();
@@ -575,12 +597,17 @@ async function checkForUpdatesFromMenu(): Promise<void> {
         detail: `Current version: v${app.getVersion()}`,
       });
     }
-  } catch {
-    dialog.showMessageBox({
-      type: "error",
-      title: "Update Check Failed",
-      message: "Unable to check for updates. Please try again later.",
-    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "";
+    if (READ_ONLY_UPDATE_RE.test(msg) && isRunningFromReadOnlyLocation()) {
+      showMoveToApplicationsDialog();
+    } else {
+      dialog.showMessageBox({
+        type: "error",
+        title: "Update Check Failed",
+        message: "Unable to check for updates. Please try again later.",
+      });
+    }
   }
 }
 
@@ -996,9 +1023,16 @@ app.whenReady().then(async () => {
       if (updateDownloadState === "downloading") {
         updateDownloadState = "idle";
       }
-      settingsWindow?.webContents.send("updater:error", {
-        message: err?.message ?? "Update failed",
-      });
+      const msg = err?.message ?? "Update failed";
+      if (READ_ONLY_UPDATE_RE.test(msg) && isRunningFromReadOnlyLocation()) {
+        showMoveToApplicationsDialog();
+        settingsWindow?.webContents.send("updater:error", {
+          message:
+            "Freestyle is running from a read-only location. Move it to Applications and relaunch.",
+        });
+      } else {
+        settingsWindow?.webContents.send("updater:error", { message: msg });
+      }
     });
 
     autoUpdater.checkForUpdatesAndNotify();

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -16,7 +16,7 @@ if (process.platform === "darwin") {
 }
 
 import { execFile } from "node:child_process";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { electronApp, is, optimizer } from "@electron-toolkit/utils";
 import server, {
@@ -536,14 +536,28 @@ function showSettingsWindow(): void {
 function isRunningFromReadOnlyLocation(): boolean {
   if (process.platform !== "darwin") return false;
   const exePath = app.getPath("exe");
-  return (
-    exePath.startsWith("/Volumes/") || exePath.includes("/AppTranslocation/")
-  );
+  if (
+    exePath.startsWith("/Volumes/") ||
+    exePath.includes("/AppTranslocation/")
+  ) {
+    return true;
+  }
+  try {
+    const { accessSync, constants } = require("node:fs");
+    accessSync(dirname(exePath), constants.W_OK);
+    return false;
+  } catch {
+    return true;
+  }
 }
 
 const READ_ONLY_UPDATE_RE = /EROFS|EACCES|read[- ]only|permission denied/i;
 
+let readOnlyDialogShown = false;
+
 function showMoveToApplicationsDialog(): void {
+  if (readOnlyDialogShown) return;
+  readOnlyDialogShown = true;
   dialog.showMessageBox({
     type: "warning",
     title: "Move to Applications",
@@ -567,6 +581,10 @@ async function checkForUpdatesFromMenu(): Promise<void> {
       title: "Check for Updates",
       message: "Update checking is not available in development mode.",
     });
+    return;
+  }
+  if (isRunningFromReadOnlyLocation()) {
+    showMoveToApplicationsDialog();
     return;
   }
   if (updateDownloadState === "downloaded") {
@@ -1019,10 +1037,19 @@ app.whenReady().then(async () => {
       }
     });
 
-    autoUpdater.checkForUpdatesAndNotify();
-
-    // Always start periodic background checking regardless of auto-update setting
-    startUpdateCheckInterval();
+    if (isRunningFromReadOnlyLocation()) {
+      if (Notification.isSupported()) {
+        const note = new Notification({
+          title: "Move Freestyle to Applications",
+          body: "Freestyle can\u2019t update from this location. Move it to your Applications folder and relaunch.",
+        });
+        note.on("click", () => showSettingsWindow());
+        note.show();
+      }
+    } else {
+      autoUpdater.checkForUpdatesAndNotify();
+      startUpdateCheckInterval();
+    }
   }
 
   ipcMain.on("updater:download", () => {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -533,6 +533,11 @@ function showSettingsWindow(): void {
   settingsWindow.focus();
 }
 
+function restartAndUpdate(): void {
+  isUpdaterQuitting = true;
+  autoUpdater.quitAndInstall();
+}
+
 async function checkForUpdatesFromMenu(): Promise<void> {
   if (is.dev) {
     dialog.showMessageBox({
@@ -540,6 +545,10 @@ async function checkForUpdatesFromMenu(): Promise<void> {
       title: "Check for Updates",
       message: "Update checking is not available in development mode.",
     });
+    return;
+  }
+  if (updateDownloadState === "downloaded") {
+    restartAndUpdate();
     return;
   }
   try {
@@ -575,23 +584,24 @@ async function checkForUpdatesFromMenu(): Promise<void> {
   }
 }
 
-function createTray(): void {
-  const trayImage = nativeImage.createFromPath(trayIconPath);
-  // Mark as template so macOS adapts to menu bar light/dark
-  trayImage.setTemplateImage(true);
+function buildTrayContextMenu(): Menu {
+  const updateItem =
+    updateDownloadState === "downloaded"
+      ? {
+          label: "Restart & Update",
+          click: () => restartAndUpdate(),
+        }
+      : {
+          label: "Check for Updates...",
+          click: () => checkForUpdatesFromMenu(),
+        };
 
-  tray = new Tray(trayImage);
-  tray.setToolTip("Freestyle");
-
-  const contextMenu = Menu.buildFromTemplate([
+  return Menu.buildFromTemplate([
     {
       label: "Settings",
       click: () => showSettingsWindow(),
     },
-    {
-      label: "Check for Updates...",
-      click: () => checkForUpdatesFromMenu(),
-    },
+    updateItem,
     ...(is.dev
       ? [
           { type: "separator" as const },
@@ -609,32 +619,40 @@ function createTray(): void {
       },
     },
   ]);
+}
+
+function createTray(): void {
+  const trayImage = nativeImage.createFromPath(trayIconPath);
+  // Mark as template so macOS adapts to menu bar light/dark
+  trayImage.setTemplateImage(true);
+
+  tray = new Tray(trayImage);
+  tray.setToolTip("Freestyle");
 
   // Left-click: open the settings window
   tray.on("click", () => {
     showSettingsWindow();
   });
 
-  // Right-click: show context menu
+  // Right-click: show context menu (rebuilt each time for up-to-date labels)
   tray.on("right-click", () => {
-    tray!.popUpContextMenu(contextMenu);
+    tray!.popUpContextMenu(buildTrayContextMenu());
   });
 }
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
-app.whenReady().then(async () => {
-  // Set app user model id for windows
-  electronApp.setAppUserModelId("com.freestyle.app");
+// Rebuild the application menu so update-related labels stay current.
+function rebuildMenus(): void {
+  const updateMenuItem =
+    updateDownloadState === "downloaded"
+      ? {
+          label: "Restart & Update",
+          click: () => restartAndUpdate(),
+        }
+      : {
+          label: "Check for Updates...",
+          click: () => checkForUpdatesFromMenu(),
+        };
 
-  // Override app.name so macOS menu shows "Freestyle" instead of the package name
-  app.setName("Freestyle");
-
-  // Register the custom app:// protocol for production SPA support
-  registerAppProtocol();
-
-  // Set a minimal application menu
   const appMenu = Menu.buildFromTemplate([
     ...(process.platform === "darwin"
       ? [
@@ -649,10 +667,7 @@ app.whenReady().then(async () => {
                 click: () => showSettingsWindow(),
               },
               { type: "separator" as const },
-              {
-                label: "Check for Updates...",
-                click: () => checkForUpdatesFromMenu(),
-              },
+              updateMenuItem,
               ...(is.dev
                 ? [
                     { type: "separator" as const },
@@ -690,6 +705,22 @@ app.whenReady().then(async () => {
     },
   ]);
   Menu.setApplicationMenu(appMenu);
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.whenReady().then(async () => {
+  // Set app user model id for windows
+  electronApp.setAppUserModelId("com.freestyle.app");
+
+  // Override app.name so macOS menu shows "Freestyle" instead of the package name
+  app.setName("Freestyle");
+
+  // Register the custom app:// protocol for production SPA support
+  registerAppProtocol();
+
+  rebuildMenus();
 
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.
@@ -910,7 +941,6 @@ app.whenReady().then(async () => {
   // Track the version we already notified about so periodic checks don't
   // spam the user with repeat notifications every 5 minutes.
   let notifiedVersion: string | null = null;
-  let updateDownloadState: "idle" | "downloading" | "downloaded" = "idle";
 
   if (!is.dev) {
     const autoUpdateEnabled = readSettings().autoUpdate !== false;
@@ -944,7 +974,9 @@ app.whenReady().then(async () => {
       settingsWindow?.webContents.send("updater:downloaded", {
         version: info.version,
       });
-      if (Notification.isSupported()) {
+      // Only show a native notification once per version
+      if (Notification.isSupported() && notifiedVersion !== info.version) {
+        notifiedVersion = info.version;
         const note = new Notification({
           title: "Update Ready to Install",
           body: `Version ${info.version} has been downloaded. Restart to update.`,
@@ -952,6 +984,12 @@ app.whenReady().then(async () => {
         note.on("click", () => showSettingsWindow());
         note.show();
       }
+      // No need to keep polling once the update is downloaded
+      if (updateCheckTimer) {
+        clearInterval(updateCheckTimer);
+        updateCheckTimer = null;
+      }
+      rebuildMenus();
     });
 
     autoUpdater.on("error", (err) => {
@@ -975,8 +1013,7 @@ app.whenReady().then(async () => {
   });
 
   ipcMain.on("updater:install", () => {
-    isUpdaterQuitting = true;
-    autoUpdater.quitAndInstall();
+    restartAndUpdate();
   });
 
   ipcMain.handle("updater:check", async () => {
@@ -1309,6 +1346,8 @@ app.on("activate", () => {
 // Gracefully shut down the HTTP server and flush Sentry before quitting
 let isUpdaterQuitting = false;
 let isQuitting = false;
+
+let updateDownloadState: "idle" | "downloading" | "downloaded" = "idle";
 
 function cleanupBeforeQuit(): void {
   fetch(`http://127.0.0.1:${serverPort}/api/whisper/server/stop`, {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -967,9 +967,11 @@ app.whenReady().then(async () => {
   }
 
   // -- Auto-updater with IPC notifications --
-  // Track the version we already notified about so periodic checks don't
-  // spam the user with repeat notifications every 5 minutes.
-  let notifiedVersion: string | null = null;
+  // Track versions we already notified about so periodic checks don't spam.
+  // Separate flags for "available" vs "downloaded" because both events fire
+  // for the same version and each deserves one notification.
+  let notifiedAvailableVersion: string | null = null;
+  let notifiedDownloadedVersion: string | null = null;
 
   if (!is.dev) {
     const autoUpdateEnabled = readSettings().autoUpdate !== false;
@@ -985,8 +987,11 @@ app.whenReady().then(async () => {
         settingsWindow?.webContents.send("updater:downloading");
       }
       // Only show a native notification once per discovered version
-      if (Notification.isSupported() && notifiedVersion !== info.version) {
-        notifiedVersion = info.version;
+      if (
+        Notification.isSupported() &&
+        notifiedAvailableVersion !== info.version
+      ) {
+        notifiedAvailableVersion = info.version;
         const note = new Notification({
           title: "Freestyle Update Available",
           body: autoUpdater.autoDownload
@@ -1004,8 +1009,11 @@ app.whenReady().then(async () => {
         version: info.version,
       });
       // Only show a native notification once per version
-      if (Notification.isSupported() && notifiedVersion !== info.version) {
-        notifiedVersion = info.version;
+      if (
+        Notification.isSupported() &&
+        notifiedDownloadedVersion !== info.version
+      ) {
+        notifiedDownloadedVersion = info.version;
         const note = new Notification({
           title: "Update Ready to Install",
           body: `Version ${info.version} has been downloaded. Restart to update.`,

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -541,7 +541,7 @@ function isRunningFromReadOnlyLocation(): boolean {
   );
 }
 
-const READ_ONLY_UPDATE_RE = /EROFS|EACCES|read.only|permission denied/i;
+const READ_ONLY_UPDATE_RE = /EROFS|EACCES|read[- ]only|permission denied/i;
 
 function showMoveToApplicationsDialog(): void {
   dialog.showMessageBox({
@@ -611,24 +611,19 @@ async function checkForUpdatesFromMenu(): Promise<void> {
   }
 }
 
-function buildTrayContextMenu(): Menu {
-  const updateItem =
-    updateDownloadState === "downloaded"
-      ? {
-          label: "Restart & Update",
-          click: () => restartAndUpdate(),
-        }
-      : {
-          label: "Check for Updates...",
-          click: () => checkForUpdatesFromMenu(),
-        };
+function buildUpdateMenuItem(): { label: string; click: () => void } {
+  return updateDownloadState === "downloaded"
+    ? { label: "Restart & Update", click: () => restartAndUpdate() }
+    : { label: "Check for Updates...", click: () => checkForUpdatesFromMenu() };
+}
 
+function buildTrayContextMenu(): Menu {
   return Menu.buildFromTemplate([
     {
       label: "Settings",
       click: () => showSettingsWindow(),
     },
-    updateItem,
+    buildUpdateMenuItem(),
     ...(is.dev
       ? [
           { type: "separator" as const },
@@ -669,17 +664,6 @@ function createTray(): void {
 
 // Rebuild the application menu so update-related labels stay current.
 function rebuildMenus(): void {
-  const updateMenuItem =
-    updateDownloadState === "downloaded"
-      ? {
-          label: "Restart & Update",
-          click: () => restartAndUpdate(),
-        }
-      : {
-          label: "Check for Updates...",
-          click: () => checkForUpdatesFromMenu(),
-        };
-
   const appMenu = Menu.buildFromTemplate([
     ...(process.platform === "darwin"
       ? [
@@ -694,7 +678,7 @@ function rebuildMenus(): void {
                 click: () => showSettingsWindow(),
               },
               { type: "separator" as const },
-              updateMenuItem,
+              buildUpdateMenuItem(),
               ...(is.dev
                 ? [
                     { type: "separator" as const },

--- a/apps/electron/src/renderer/src/components/key-combo.tsx
+++ b/apps/electron/src/renderer/src/components/key-combo.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@renderer/lib/utils";
+
+export function KeyBadge({
+  label,
+  variant = "default",
+}: {
+  label: string;
+  variant?: "default" | "recording" | "dim";
+}) {
+  return (
+    <kbd
+      className={cn(
+        "inline-flex select-none items-center justify-center",
+        "min-w-[26px] rounded-md px-1.5 py-1",
+        "font-mono text-xs font-medium leading-none",
+        "border shadow-[0_1px_0_0_hsl(var(--border))]",
+        variant === "default" && "border-border bg-muted text-foreground",
+        variant === "recording" &&
+          "border-primary/40 bg-primary/10 text-primary",
+        variant === "dim" &&
+          "border-border/50 bg-muted/50 text-muted-foreground",
+      )}
+    >
+      {label}
+    </kbd>
+  );
+}
+
+export function KeyComboDisplay({
+  keys,
+  variant = "default",
+}: {
+  keys: string[];
+  variant?: "default" | "recording" | "dim";
+}) {
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-1">
+      {keys.map((k, i) => (
+        <span key={i} className="flex items-center gap-1">
+          {i > 0 && (
+            <span className="text-muted-foreground text-[10px]">+</span>
+          )}
+          <KeyBadge label={k} variant={variant} />
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/electron/src/renderer/src/components/key-combo.tsx
+++ b/apps/electron/src/renderer/src/components/key-combo.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@renderer/lib/utils";
 
-export function KeyBadge({
+function KeyBadge({
   label,
   variant = "default",
 }: {

--- a/apps/electron/src/renderer/src/components/model-row.tsx
+++ b/apps/electron/src/renderer/src/components/model-row.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@renderer/lib/utils";
 import { Check, Key, Sparkles } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 export const PROVIDER_FILTER_MARKS: Record<string, string> = {
   openai: "OAI",
@@ -81,10 +82,15 @@ export function LlmModelRow({
           {selected && <Check size={15} className="text-primary" />}
         </div>
         <div className="mt-2 flex flex-wrap items-center gap-4">
-          <span className="text-muted-foreground inline-flex min-w-0 items-center gap-1.5 text-[11.5px]">
-            <Sparkles className="h-3 w-3 shrink-0" />
-            <span className="min-w-0 truncate">{modelId}</span>
-          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="text-muted-foreground inline-flex min-w-0 items-center gap-1.5 text-[11.5px]">
+                <Sparkles className="h-3 w-3 shrink-0" />
+                <span className="min-w-0 truncate">{modelId}</span>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>Model identifier</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/apps/electron/src/renderer/src/components/voice-row.tsx
+++ b/apps/electron/src/renderer/src/components/voice-row.tsx
@@ -14,6 +14,7 @@ import {
   X,
   Zap,
 } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 export function Meter({ value }: { value?: number }): React.JSX.Element | null {
   if (value == null) return null;
@@ -143,34 +144,77 @@ export function VoiceRow({
 
         <div className="mt-2 flex flex-wrap items-center gap-4">
           {item.speed != null && (
-            <span className="inline-flex items-center gap-1.5">
-              <Zap className="text-muted-foreground h-3 w-3" />
-              <Meter value={item.speed} />
-            </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex items-center gap-1.5">
+                  <Zap className="text-muted-foreground h-3 w-3" />
+                  <Meter value={item.speed} />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Speed</TooltipContent>
+            </Tooltip>
           )}
           {item.quality != null && (
-            <span className="inline-flex items-center gap-1.5">
-              <Target className="text-muted-foreground h-3 w-3" />
-              <Meter value={item.quality} />
-            </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex items-center gap-1.5">
+                  <Target className="text-muted-foreground h-3 w-3" />
+                  <Meter value={item.quality} />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Quality</TooltipContent>
+            </Tooltip>
           )}
           {local ? (
             <>
               {item.sizeBytes != null && (
-                <StatPair icon={Download} label={formatBytes(item.sizeBytes)} />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <StatPair
+                        icon={Download}
+                        label={formatBytes(item.sizeBytes)}
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>Download size</TooltipContent>
+                </Tooltip>
               )}
-              {item.ram && <StatPair icon={Cpu} label={`${item.ram} RAM`} />}
+              {item.ram && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <StatPair icon={Cpu} label={`${item.ram} RAM`} />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>Memory required</TooltipContent>
+                </Tooltip>
+              )}
             </>
           ) : (
             <>
               {item.cost != null && (
-                <StatPair
-                  icon={CircleDollarSign}
-                  label={`$${item.cost.toFixed(2)}/hr`}
-                />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <StatPair
+                        icon={CircleDollarSign}
+                        label={`$${item.cost.toFixed(2)}/hr`}
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>Estimated cost</TooltipContent>
+                </Tooltip>
               )}
               {item.streaming && (
-                <StatPair icon={Wifi} label="Streaming" accent />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <StatPair icon={Wifi} label="Streaming" accent />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>Real-time streaming</TooltipContent>
+                </Tooltip>
               )}
             </>
           )}

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -814,17 +814,6 @@ export default function OnboardingPage(): React.JSX.Element {
                 {saving ? "Setting up..." : "Continue"}
                 {!saving && <ChevronRight size={16} />}
               </button>
-
-              <button
-                type="button"
-                onClick={() => {
-                  window.api?.setOnboardingComplete();
-                  navigate("/today", { replace: true });
-                }}
-                className="text-muted-foreground hover:text-foreground w-full py-2 text-center text-xs"
-              >
-                Skip for now
-              </button>
             </div>
           )}
 

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -127,10 +127,10 @@ export default function OnboardingPage(): React.JSX.Element {
   const liveKeys = liveModifiers.map(keyDisplayLabel);
   const draftKeys = capturedCombo ? comboDisplayKeys(capturedCombo) : liveKeys;
   const captureHint = needsModifierOrMouseButton
-    ? "Add a modifier or side mouse button"
+    ? "Add a modifier or side mouse button · Esc to cancel"
     : canSaveRecording
-      ? "Release to save"
-      : "Press a modifier or side mouse button...";
+      ? "Release to save · Esc to cancel"
+      : "Press a modifier or side mouse button... · Esc to cancel";
 
   // Load permissions + saved hotkey
   useEffect(() => {
@@ -689,8 +689,9 @@ export default function OnboardingPage(): React.JSX.Element {
                         <button
                           type="button"
                           onClick={startHotkeyRecording}
-                          className="border-border hover:bg-secondary inline-flex items-center gap-3 rounded-lg border px-3.5 py-2 transition-colors"
+                          className="border-border hover:bg-secondary inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2 transition-colors"
                         >
+                          <Keyboard className="text-muted-foreground h-4 w-4 shrink-0" />
                           <KeyComboDisplay
                             keys={formatAcceleratorKeys(hotkey)}
                           />
@@ -705,7 +706,7 @@ export default function OnboardingPage(): React.JSX.Element {
                         )}
                       </div>
                     ) : (
-                      <div className="border-primary/60 bg-primary/5 relative inline-flex items-center gap-3 rounded-lg border px-3.5 py-2">
+                      <div className="border-primary/60 bg-primary/5 relative inline-flex max-w-full flex-wrap items-center gap-3 rounded-lg border px-3.5 py-2">
                         <Keyboard className="text-primary h-4 w-4 shrink-0" />
                         {draftKeys.length > 0 ? (
                           <>

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -2,6 +2,7 @@ import { apiKeySchema } from "@freestyle/validations";
 import { zodResolver } from "@hookform/resolvers/zod";
 import markDark from "@renderer/assets/mark-dark.svg";
 import markLight from "@renderer/assets/mark-light.svg";
+import { KeyComboDisplay } from "@renderer/components/key-combo";
 import {
   LlmModelRow,
   MODEL_ROW_PAGE_SIZE,
@@ -9,6 +10,12 @@ import {
   ShowMoreModelRowsButton,
 } from "@renderer/components/model-row";
 import { Toggle, VoiceRow } from "@renderer/components/voice-row";
+import {
+  comboDisplayKeys,
+  formatAcceleratorKeys,
+  keyDisplayLabel,
+  useHotkeyRecorder,
+} from "@renderer/hooks/use-hotkey-recorder";
 import { getClient } from "@renderer/lib/api";
 import {
   type AvailableModel,
@@ -93,7 +100,39 @@ export default function OnboardingPage(): React.JSX.Element {
     Record<string, number>
   >({});
 
-  // Load permissions
+  // Hotkey recorder state
+  const [hotkey, setHotkey] = useState("Alt+Space");
+
+  const handleHotkeyRecorded = useCallback((accelerator: string) => {
+    setHotkey(accelerator);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "hotkey" },
+        json: { value: accelerator },
+      })
+      .catch(() => {});
+  }, []);
+
+  const {
+    state: recorderState,
+    liveModifiers,
+    capturedCombo,
+    canSaveRecording,
+    needsModifierOrMouseButton,
+    invalidReleaseNotice,
+    startRecording: startHotkeyRecording,
+    cancelRecording: cancelHotkeyRecording,
+  } = useHotkeyRecorder(handleHotkeyRecorded);
+
+  const liveKeys = liveModifiers.map(keyDisplayLabel);
+  const draftKeys = capturedCombo ? comboDisplayKeys(capturedCombo) : liveKeys;
+  const captureHint = needsModifierOrMouseButton
+    ? "Add a modifier or side mouse button"
+    : canSaveRecording
+      ? "Release to save"
+      : "Press a modifier or side mouse button...";
+
+  // Load permissions + saved hotkey
   useEffect(() => {
     window.api
       ?.checkMicPermission()
@@ -106,6 +145,13 @@ export default function OnboardingPage(): React.JSX.Element {
     window.api
       ?.getLaunchAtStartup()
       .then(setLaunchAtStartup)
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "hotkey" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value) setHotkey(data.value as string);
+      })
       .catch(() => {});
   }, []);
 
@@ -627,19 +673,66 @@ export default function OnboardingPage(): React.JSX.Element {
                 </div>
               )}
 
-              {/* Hotkey info */}
+              {/* Hotkey */}
               <div className="border-border rounded-lg border p-4">
                 <div className="flex items-start gap-3">
                   <Keyboard className="text-muted-foreground mt-0.5 h-5 w-5 shrink-0" />
-                  <div className="flex-1">
-                    <div className="text-sm font-medium">
-                      Default Hotkey: Alt + Space
-                    </div>
+                  <div className="flex-1 space-y-2">
+                    <div className="text-sm font-medium">Hotkey</div>
                     <p className="text-muted-foreground text-xs">
                       {IS_MAC
-                        ? "Hold to record, release to transcribe. You can change this in Settings later."
-                        : "Press once to start recording, press again to stop and transcribe. You can change this in Settings later."}
+                        ? "Hold to record, release to transcribe."
+                        : "Press once to start recording, press again to stop and transcribe."}
                     </p>
+                    {recorderState === "idle" ? (
+                      <div className="relative inline-flex">
+                        <button
+                          type="button"
+                          onClick={startHotkeyRecording}
+                          className="border-border hover:bg-secondary inline-flex items-center gap-3 rounded-lg border px-3.5 py-2 transition-colors"
+                        >
+                          <KeyComboDisplay
+                            keys={formatAcceleratorKeys(hotkey)}
+                          />
+                          <span className="text-muted-foreground text-xs">
+                            Change
+                          </span>
+                        </button>
+                        {invalidReleaseNotice && (
+                          <div className="bg-popover text-popover-foreground border-border shadow-soft absolute top-[calc(100%+6px)] right-0 z-20 whitespace-nowrap rounded-md border px-2.5 py-1.5 text-xs">
+                            Hotkeys need a modifier or side mouse button
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="border-primary/60 bg-primary/5 relative inline-flex items-center gap-3 rounded-lg border px-3.5 py-2">
+                        <Keyboard className="text-primary h-4 w-4 shrink-0" />
+                        {draftKeys.length > 0 ? (
+                          <>
+                            <KeyComboDisplay keys={draftKeys} variant="dim" />
+                            <span className="text-muted-foreground text-xs">
+                              {captureHint}
+                            </span>
+                          </>
+                        ) : (
+                          <span className="text-muted-foreground animate-pulse text-sm">
+                            {captureHint}
+                          </span>
+                        )}
+                        {invalidReleaseNotice && (
+                          <div className="bg-popover text-popover-foreground border-border shadow-soft absolute top-[calc(100%+6px)] right-0 z-20 whitespace-nowrap rounded-md border px-2.5 py-1.5 text-xs">
+                            Hotkeys need a modifier or side mouse button
+                          </div>
+                        )}
+                        <button
+                          type="button"
+                          onClick={cancelHotkeyRecording}
+                          className="border-border hover:bg-secondary ml-1 rounded-md border px-2.5 py-1 text-xs"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -695,7 +695,7 @@ export default function OnboardingPage(): React.JSX.Element {
                           <KeyComboDisplay
                             keys={formatAcceleratorKeys(hotkey)}
                           />
-                          <span className="text-muted-foreground text-xs">
+                          <span className="text-muted-foreground ml-1 text-xs">
                             Change
                           </span>
                         </button>

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -1,3 +1,4 @@
+import { KeyComboDisplay } from "@renderer/components/key-combo";
 import {
   comboDisplayKeys,
   formatAcceleratorKeys,
@@ -22,58 +23,6 @@ import {
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useRef, useState } from "react";
-
-// ---------------------------------------------------------------------------
-// KeyBadge: renders a single key as a physical-key-style badge
-// ---------------------------------------------------------------------------
-
-function KeyBadge({
-  label,
-  variant = "default",
-}: {
-  label: string;
-  variant?: "default" | "recording" | "dim";
-}) {
-  return (
-    <kbd
-      className={cn(
-        "inline-flex select-none items-center justify-center",
-        "min-w-[26px] rounded-md px-1.5 py-1",
-        "font-mono text-xs font-medium leading-none",
-        "border shadow-[0_1px_0_0_hsl(var(--border))]",
-        variant === "default" && "border-border bg-muted text-foreground",
-        variant === "recording" &&
-          "border-primary/40 bg-primary/10 text-primary",
-        variant === "dim" &&
-          "border-border/50 bg-muted/50 text-muted-foreground",
-      )}
-    >
-      {label}
-    </kbd>
-  );
-}
-
-/** Renders an array of key labels as badges with + separators */
-function KeyComboDisplay({
-  keys,
-  variant = "default",
-}: {
-  keys: string[];
-  variant?: "default" | "recording" | "dim";
-}) {
-  return (
-    <div className="flex min-w-0 flex-wrap items-center gap-1">
-      {keys.map((k, i) => (
-        <span key={i} className="flex items-center gap-1">
-          {i > 0 && (
-            <span className="text-muted-foreground text-[10px]">+</span>
-          )}
-          <KeyBadge label={k} variant={variant} />
-        </span>
-      ))}
-    </div>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Constants


### PR DESCRIPTION
Remove the "Skip for now" button from the voice model onboarding step so users must configure a voice model before proceeding. Fix repeated native update notifications by guarding the `update-downloaded` handler with the existing `notifiedVersion` flag and stopping the 5-minute poll once the update is downloaded. Rebuild tray and application menus dynamically so the label changes from "Check for Updates..." to "Restart & Update" when a download is ready.

## Testing
TypeScript type-checking passes for both `tsconfig.node.json` and `tsconfig.web.json`.

<!--
## Plan
1. Remove "Skip for now" button from onboarding voice model step (onboarding.tsx:818-827)
   - The "Continue" button is already gated by `canAdvanceFromModel` which requires a model selection
2. Guard update-downloaded notification with `notifiedVersion` (index.ts update-downloaded handler)
   - Reuse the existing `notifiedVersion` flag so native notifications only fire once per version
   - Stop the 5-minute `setInterval` poll once the update is downloaded (no longer needed)
3. Refactor tray menu to rebuild dynamically (index.ts createTray)
   - Extract `buildTrayContextMenu()` so the menu is rebuilt on each right-click
   - Show "Restart & Update" when `updateDownloadState === "downloaded"`, otherwise "Check for Updates..."
4. Extract app menu into `rebuildMenus()` (index.ts app menu)
   - Called at startup and from the `update-downloaded` handler
   - Same dynamic label logic as the tray menu
5. Extract `restartAndUpdate()` helper to consolidate `isUpdaterQuitting + quitAndInstall` logic
6. Hoist `updateDownloadState` to module scope so menu functions can access it
-->