### PR TITLE
fix(macos): use modern System Settings URL for microphone privacy pane

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -836,7 +836,7 @@ app.whenReady().then(async () => {
   ipcMain.on("permissions:open-mic-settings", () => {
     if (process.platform === "darwin") {
       shell.openExternal(
-        "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+        "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Microphone",
       );
     }
   });


### PR DESCRIPTION
The microphone settings deep link used the legacy `com.apple.preference.security?Privacy_Microphone` URL scheme, which can open the wrong pane on macOS Ventura+. Update to the modern `com.apple.settings.PrivacySecurity.extension?Privacy_Microphone` scheme, matching the accessibility URL fix in #149.

## Testing
TypeScript type-check passes. One-line string change — verified the new URL scheme matches the pattern used by the accessibility handler.