### PR TITLE
fix: add structured Winston logger and fix EPIPE crash on Linux AppImage

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -28,6 +28,7 @@
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@freestyle/server": "workspace:*",
+    "@freestyle/utils": "workspace:*",
     "@freestyle/validations": "workspace:*",
     "@hono/node-server": "^2.0.4",
     "@hookform/resolvers": "^5.4.0",
@@ -48,6 +49,7 @@
     "tailwind-merge": "^3.6.0",
     "three": "^0.184.0",
     "tw-animate-css": "^1.4.0",
+    "winston": "^3.17.0",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/apps/electron/src/main/hotkey-recorder.ts
+++ b/apps/electron/src/main/hotkey-recorder.ts
@@ -7,8 +7,11 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
+import { createAppLogger } from "@freestyle/utils";
 import type { WebContents } from "electron";
 import { getNativeBinaryPath } from "./native-binary";
+
+const log = createAppLogger("hotkey-recorder");
 
 export interface HotkeyCombo {
   modifiers: string[];
@@ -111,9 +114,7 @@ export class HotkeyRecorder {
     });
 
     this.process.stderr?.on("data", (data: Buffer) => {
-      if (process.env.NODE_ENV !== "production") {
-        console.log(`[hotkey-recorder] ${data.toString().trim()}`);
-      }
+      log.debug(data.toString().trim());
     });
 
     this.process.on("close", () => {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1,3 +1,12 @@
+// Prevent EPIPE crashes when stdout/stderr is a closed pipe (e.g. Linux
+// AppImage launched detached from a terminal).
+for (const stream of [process.stdout, process.stderr]) {
+  stream?.on?.("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EPIPE") return;
+    throw err;
+  });
+}
+
 // GUI apps on macOS inherit the minimal launchd PATH (/usr/bin:/bin:/usr/sbin:/sbin)
 // which excludes Homebrew directories where cmake and other tools live.
 if (process.platform === "darwin") {
@@ -23,6 +32,7 @@ import server, {
   autoStartWhisperServer,
   reconcileUnsupportedMlxVoiceDefault,
 } from "@freestyle/server";
+import { createAppLogger } from "@freestyle/utils";
 import { serve } from "@hono/node-server";
 import {
   app,
@@ -49,6 +59,10 @@ import { normalizeAccelerator } from "./hotkey-utils";
 import { NativeKeyListener } from "./key-listener";
 import { MicListener } from "./mic-listener";
 import { pasteIntoFocusedApp } from "./paste";
+
+const log = createAppLogger("electron");
+const hotkeyLog = createAppLogger("hotkey");
+const hotkeyRecorderLog = createAppLogger("hotkey-recorder");
 
 const DEFAULT_PORT = 4649;
 const APP_WIDTH = 260;
@@ -878,7 +892,7 @@ app.whenReady().then(async () => {
         registerHotkey(currentHotkeyAccel ?? undefined);
       },
       onError: (message) => {
-        console.warn("[hotkey-recorder]", message);
+        hotkeyRecorderLog.warn(message);
       },
     });
     hotkeyRecorder.start(target);
@@ -917,18 +931,16 @@ app.whenReady().then(async () => {
       },
       (info) => {
         serverPort = info.port;
-        console.log(`Server running on http://localhost:${info.port}`);
+        log.info(`Server running on http://localhost:${info.port}`);
       },
     );
 
     httpServer.on("error", (err: NodeJS.ErrnoException) => {
       if (err.code === "EADDRINUSE" && port === DEFAULT_PORT) {
-        console.warn(
-          `Port ${DEFAULT_PORT} in use, falling back to random port`,
-        );
+        log.warn(`Port ${DEFAULT_PORT} in use, falling back to random port`);
         startServer(0);
       } else {
-        console.error("Server failed to start:", err);
+        log.error(`Server failed to start: ${err}`);
       }
     });
   }
@@ -945,7 +957,7 @@ app.whenReady().then(async () => {
 
   if (existingServer) {
     serverPort = DEFAULT_PORT;
-    console.log(
+    log.info(
       `Reusing existing Freestyle server on http://localhost:${DEFAULT_PORT}`,
     );
   } else {
@@ -982,6 +994,7 @@ app.whenReady().then(async () => {
     const autoUpdateEnabled = readSettings().autoUpdate !== false;
     autoUpdater.autoDownload = autoUpdateEnabled;
     autoUpdater.autoInstallOnAppQuit = true;
+    autoUpdater.logger = createAppLogger("updater");
 
     autoUpdater.on("update-available", (info) => {
       settingsWindow?.webContents.send("updater:available", {
@@ -1331,12 +1344,10 @@ function registerHotkey(hotkey?: string): void {
     onKeyDown: handleNativeHotkeyDown,
     onKeyUp: handleNativeHotkeyUp,
     onError: (error) => {
-      console.error("[hotkey] Native key listener error:", error);
+      hotkeyLog.error(`Native key listener error: ${error}`);
     },
     onReady: () => {
-      if (process.env.NODE_ENV !== "production") {
-        console.log(`[hotkey] Native key listener ready for "${accel}"`);
-      }
+      hotkeyLog.debug(`Native key listener ready for "${accel}"`);
     },
   });
 
@@ -1345,8 +1356,8 @@ function registerHotkey(hotkey?: string): void {
   if (started) {
     accessibilityConfirmed = true;
   } else {
-    console.warn(
-      "[hotkey] Native key listener unavailable, falling back to Electron globalShortcut (toggle mode).",
+    hotkeyLog.warn(
+      "Native key listener unavailable, falling back to Electron globalShortcut (toggle mode).",
     );
     keyListener = null;
 

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -11,7 +11,10 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
+import { createAppLogger } from "@freestyle/utils";
 import { getNativeBinaryPath } from "./native-binary";
+
+const log = createAppLogger("key-listener");
 
 type KeyEventCallback = () => void;
 
@@ -185,9 +188,7 @@ export class NativeKeyListener {
     });
 
     this.process.stderr?.on("data", (data: Buffer) => {
-      if (process.env.NODE_ENV !== "production") {
-        console.log(`[key-listener] ${data.toString().trim()}`);
-      }
+      log.debug(data.toString().trim());
     });
 
     this.process.on("close", (code) => {

--- a/apps/electron/src/main/mic-listener.ts
+++ b/apps/electron/src/main/mic-listener.ts
@@ -10,7 +10,10 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
+import { createAppLogger } from "@freestyle/utils";
 import { getNativeBinaryPath } from "./native-binary";
+
+const log = createAppLogger("mic-listener");
 
 export type MicState = "active" | "inactive" | "unknown";
 
@@ -55,11 +58,7 @@ export class MicListener {
 
     const binaryPath = getNativeBinaryPath(binaryName);
     if (!binaryPath) {
-      if (process.env.NODE_ENV !== "production") {
-        console.log(
-          `[mic-listener] Binary not found: ${binaryName}, mic detection unavailable`,
-        );
-      }
+      log.debug(`Binary not found: ${binaryName}, mic detection unavailable`);
       return false;
     }
 
@@ -90,11 +89,7 @@ export class MicListener {
         stdio: ["pipe", "pipe", "pipe"],
       });
     } catch {
-      if (process.env.NODE_ENV !== "production") {
-        console.log(
-          "[mic-listener] pactl not available, mic detection unavailable on Linux",
-        );
-      }
+      log.debug("pactl not available, mic detection unavailable on Linux");
       return false;
     }
 
@@ -148,9 +143,7 @@ export class MicListener {
     });
 
     this.process.stderr?.on("data", (data: Buffer) => {
-      if (process.env.NODE_ENV !== "production") {
-        console.log(`[mic-listener] ${data.toString().trim()}`);
-      }
+      log.debug(data.toString().trim());
     });
 
     this.process.on("close", (code) => {
@@ -171,9 +164,7 @@ export class MicListener {
 
   private handleLine(line: string): void {
     if (line === "READY") {
-      if (process.env.NODE_ENV !== "production") {
-        console.log("[mic-listener] Ready");
-      }
+      log.debug("Ready");
       return;
     }
 

--- a/apps/electron/src/main/paste.ts
+++ b/apps/electron/src/main/paste.ts
@@ -1,6 +1,9 @@
 import { exec, execFile } from "node:child_process";
+import { createAppLogger } from "@freestyle/utils";
 import { clipboard } from "electron";
 import { getNativeBinaryPath } from "./native-binary";
+
+const log = createAppLogger("paste");
 
 function execAsync(cmd: string): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -36,8 +39,8 @@ async function pasteMac(): Promise<"native" | "legacy"> {
   if (binaryPath) {
     const exitCode = await execFileAsync(binaryPath);
     if (exitCode === 2) {
-      console.warn(
-        "[paste] No accessibility permission (native binary exit 2), falling back to osascript",
+      log.warn(
+        "No accessibility permission (native binary exit 2), falling back to osascript",
       );
       await execAsync(
         `osascript -e 'tell application "System Events" to keystroke "v" using {command down}'`,
@@ -78,8 +81,8 @@ async function pasteLinux(): Promise<"native" | "legacy"> {
     }
     const exitCode = await execFileAsync(binaryPath, args);
     if (exitCode !== 0) {
-      console.warn(
-        `[paste] Native paste failed (exit ${exitCode}), falling back to xdotool/wtype`,
+      log.warn(
+        `Native paste failed (exit ${exitCode}), falling back to xdotool/wtype`,
       );
       await pasteLinuxLegacy();
       return "legacy";
@@ -115,9 +118,7 @@ const PASTE_SETTLE_LEGACY_MS: Record<string, number> = {
 };
 
 export async function pasteIntoFocusedApp(text: string): Promise<void> {
-  if (process.env.NODE_ENV !== "production") {
-    console.log("[paste] text:", JSON.stringify(text));
-  }
+  log.debug(`text: ${JSON.stringify(text)}`);
   if (!text?.trim()) return;
 
   const prior = clipboard.readText();

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,6 +22,7 @@
     "@ai-sdk/groq": "^3.0.39",
     "@ai-sdk/mistral": "^3.0.37",
     "@ai-sdk/openai": "^3.0.65",
+    "@freestyle/utils": "workspace:*",
     "@freestyle/validations": "workspace:*",
     "@hono/mcp": "^0.3.0",
     "@hono/node-server": "^2.0.4",
@@ -31,6 +32,7 @@
     "hono": "^4.12.22",
     "hono-rate-limiter": "^0.5.3",
     "posthog-node": "^5.35.8",
+    "winston": "^3.17.0",
     "ws": "^8.21.0",
     "zod": "^4.4.3"
   },

--- a/apps/server/src/lib/mlx-asr/reconcile.ts
+++ b/apps/server/src/lib/mlx-asr/reconcile.ts
@@ -1,9 +1,11 @@
+import { createAppLogger } from "@freestyle/utils";
 import { getDb } from "../db.js";
 import { WHISPER_MODELS, WHISPER_PROVIDER_ID } from "../whisper/constants.js";
 import { getModelStatus as getWhisperModelStatus } from "../whisper/models.js";
 import { MLX_ASR_PROVIDER_ID } from "./constants.js";
 import { canRunMlxAsr, stopMlxServer } from "./server.js";
 
+const log = createAppLogger("mlx-asr");
 const PREFERRED_WHISPER_FALLBACK_ID = "base-q5_1";
 
 function pickWhisperFallbackId(): string {
@@ -62,11 +64,9 @@ export function reconcileUnsupportedMlxVoiceDefault(): boolean {
 
   stopMlxServer().catch(() => {});
 
-  if (process.env.NODE_ENV !== "production") {
-    console.log(
-      `[mlx-asr] Default voice was MLX but this machine cannot run it; switched to Whisper ${whisperId}`,
-    );
-  }
+  log.debug(
+    `Default voice was MLX but this machine cannot run it; switched to Whisper ${whisperId}`,
+  );
 
   return true;
 }

--- a/apps/server/src/lib/mlx-asr/server.ts
+++ b/apps/server/src/lib/mlx-asr/server.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { mkdir, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createAppLogger } from "@freestyle/utils";
 import { getDb } from "../db.js";
 import { getMlxAsrModel, isAppleSiliconMac } from "./constants.js";
 import {
@@ -14,6 +15,7 @@ import {
   isMlxAudioInstalled,
 } from "./python.js";
 
+const log = createAppLogger("mlx-asr");
 const START_TIMEOUT_MS = 120_000;
 const TRANSCRIBE_TIMEOUT_MS = 300_000;
 const DEFAULT_KEEP_ALIVE_MINUTES = 10;
@@ -107,10 +109,10 @@ export function startMlxInBackground(modelId: string): void {
   workerFailed = false;
   ensureMlxServerRunning(modelId)
     .then(() => {
-      console.log("[mlx-asr] Worker ready");
+      log.info("Worker ready");
     })
     .catch((err: Error) => {
-      console.error("[mlx-asr] Background worker start failed:", err.message);
+      log.error(`Background worker start failed: ${err.message}`);
     });
 }
 
@@ -279,7 +281,7 @@ async function spawnWorkerProcess(
   proc.stderr?.on("data", (data: Buffer) => {
     const text = data.toString().trimEnd();
     if (!text) return;
-    console.warn("[mlx-asr]", text);
+    log.warn(text);
   });
 
   proc.on("error", (err) => {
@@ -341,18 +343,12 @@ async function startWorker(modelId: string): Promise<void> {
     workerFailed = false;
     try {
       await spawnWorkerProcess(candidate.command, candidate.spawnArgs);
-      if (isDevOrLogging()) {
-        console.log(`[mlx-asr] started via ${candidate.label}`);
-      }
+      log.debug(`started via ${candidate.label}`);
       return;
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
       await stopMlxServer().catch(() => undefined);
-      if (isDevOrLogging()) {
-        console.warn(
-          `[mlx-asr] ${candidate.label} failed: ${lastError.message}`,
-        );
-      }
+      log.debug(`${candidate.label} failed: ${lastError.message}`);
     }
   }
 
@@ -363,18 +359,12 @@ async function startWorker(modelId: string): Promise<void> {
   );
 }
 
-function isDevOrLogging(): boolean {
-  return process.env.NODE_ENV !== "production";
-}
-
 function handleWorkerLine(line: string): void {
   let message: WorkerResponse;
   try {
     message = JSON.parse(line) as WorkerResponse;
   } catch {
-    if (process.env.NODE_ENV !== "production") {
-      console.log("[mlx-asr]", line);
-    }
+    log.debug(line);
     return;
   }
 
@@ -485,14 +475,14 @@ function scheduleUnload(): void {
 
   if (delayMs <= 0) {
     stopMlxServer().catch((err: Error) => {
-      console.error("[mlx-asr] Failed to unload worker:", err.message);
+      log.error(`Failed to unload worker: ${err.message}`);
     });
     return;
   }
 
   unloadTimer = setTimeout(() => {
     stopMlxServer().catch((err: Error) => {
-      console.error("[mlx-asr] Failed to unload idle worker:", err.message);
+      log.error(`Failed to unload idle worker: ${err.message}`);
     });
   }, delayMs);
   unloadTimer.unref?.();

--- a/apps/server/src/lib/post-process.ts
+++ b/apps/server/src/lib/post-process.ts
@@ -1,8 +1,11 @@
+import { createAppLogger } from "@freestyle/utils";
 import { generateText } from "ai";
 import { getModelCost, isCleanupModelSupported } from "../routes/models.js";
 import { getDb } from "./db.js";
 import { capture, captureException } from "./posthog.js";
 import { createChatModel, getDefaultModels } from "./providers.js";
+
+const log = createAppLogger("post-process");
 
 /** Build a context string from the raw x-app-context header for matching */
 function buildMatchContext(rawContext: string | null): string {
@@ -128,7 +131,7 @@ export async function postProcess(
         defaults.llm.model_id,
       ))
     ) {
-      console.warn(
+      log.warn(
         `Skipping LLM cleanup: unsupported cleanup model ${defaults.llm.provider}/${defaults.llm.model_id}`,
       );
     } else {
@@ -183,7 +186,7 @@ IMPORTANT: Your entire response must be the cleaned text and nothing else. No qu
           provider: defaults.llm!.provider,
           model: defaults.llm!.model_id,
         });
-        console.error("LLM cleanup failed:", err);
+        log.error(`LLM cleanup failed: ${err}`);
       }
     }
   }

--- a/apps/server/src/lib/streaming/providers/mlx-local.ts
+++ b/apps/server/src/lib/streaming/providers/mlx-local.ts
@@ -1,3 +1,4 @@
+import { createAppLogger } from "@freestyle/utils";
 import { MLX_ASR_PROVIDER_ID } from "../../mlx-asr/constants.js";
 import { getMlxModelStatus } from "../../mlx-asr/models.js";
 import { describeMlxSetupBlocker } from "../../mlx-asr/python.js";
@@ -18,6 +19,7 @@ import type {
 } from "../types.js";
 import { stripProviderPrefix } from "../types.js";
 
+const log = createAppLogger("mlx-asr");
 const STREAM_SAMPLE_RATE = 16_000;
 const PARTIAL_INTERVAL_MS = 1_500;
 const MIN_PARTIAL_AUDIO_MS = 800;
@@ -27,7 +29,6 @@ export class MlxLocalTranscriptionProvider implements TranscriptionProvider {
 
   async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
     const modelId = stripProviderPrefix(opts.model);
-    const isDev = process.env.NODE_ENV !== "production";
 
     if (!canRunMlxAsr()) {
       throw new Error(
@@ -47,9 +48,7 @@ export class MlxLocalTranscriptionProvider implements TranscriptionProvider {
       context: opts.bias?.kind === "prompt" ? opts.bias.text : undefined,
     });
 
-    if (isDev) {
-      console.log(`[mlx-asr] inference took ${Date.now() - t0}ms`);
-    }
+    log.debug(`inference took ${Date.now() - t0}ms`);
 
     return { text: text.trim() };
   }

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -1,3 +1,4 @@
+import { createAppLogger } from "@freestyle/utils";
 import {
   isBinaryAvailable,
   isServerBinaryAvailable,
@@ -17,6 +18,8 @@ import type {
 } from "../types.js";
 import { stripProviderPrefix } from "../types.js";
 
+const log = createAppLogger("whisper");
+
 export class WhisperLocalTranscriptionProvider
   implements TranscriptionProvider
 {
@@ -24,7 +27,6 @@ export class WhisperLocalTranscriptionProvider
 
   async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
     const modelId = stripProviderPrefix(opts.model);
-    const isDev = process.env.NODE_ENV !== "production";
 
     if (
       !isBinaryAvailable() &&
@@ -40,19 +42,15 @@ export class WhisperLocalTranscriptionProvider
       }
     }
 
-    if (isDev) {
-      console.log(
-        `[whisper] transcribe: serverRunning=${isServerRunning()} serverBinary=${isServerBinaryAvailable()} cli=${isBinaryAvailable()}`,
-      );
-    }
+    log.debug(
+      `transcribe: serverRunning=${isServerRunning()} serverBinary=${isServerBinaryAvailable()} cli=${isBinaryAvailable()}`,
+    );
 
     if (isServerRunning()) {
       try {
         const t0 = Date.now();
         const result = await transcribeViaServer(opts.audio, getServerPort());
-        if (isDev) {
-          console.log(`[whisper] server inference took ${Date.now() - t0}ms`);
-        }
+        log.debug(`server inference took ${Date.now() - t0}ms`);
         return result;
       } catch {
         // fall through to CLI
@@ -66,9 +64,7 @@ export class WhisperLocalTranscriptionProvider
         modelId,
         language: opts.language,
       });
-      if (isDev) {
-        console.log(`[whisper] CLI inference took ${Date.now() - t0}ms`);
-      }
+      log.debug(`CLI inference took ${Date.now() - t0}ms`);
 
       if (isServerBinaryAvailable() && !isServerRunning()) {
         startInBackground(modelId);

--- a/apps/server/src/lib/vocabulary.ts
+++ b/apps/server/src/lib/vocabulary.ts
@@ -1,4 +1,7 @@
+import { createAppLogger } from "@freestyle/utils";
 import { getDb } from "./db.js";
+
+const log = createAppLogger("vocabulary");
 
 export interface VocabularyRow {
   id: number;
@@ -19,7 +22,7 @@ export function loadVocabularyTerms(): string[] {
       .all() as { term: string }[];
     return rows.map((r) => r.term.trim()).filter(Boolean);
   } catch (err) {
-    console.error("[vocabulary] Failed to load vocabulary terms:", err);
+    log.error(`Failed to load vocabulary terms: ${err}`);
     return [];
   }
 }

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -15,6 +15,7 @@ import {
 import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { createAppLogger } from "@freestyle/utils";
 import {
   getBinDir,
   getModelPath,
@@ -24,6 +25,8 @@ import {
   WHISPER_MODELS,
   type WhisperModelDef,
 } from "./constants.js";
+
+const log = createAppLogger("whisper");
 
 export type DownloadStatus =
   | "not_downloaded"
@@ -298,7 +301,7 @@ async function buildFromSource(): Promise<void> {
   const tarballUrl = `https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${WHISPER_CPP_VERSION}.tar.gz`;
   const tarPath = join(binDir, `whisper-${WHISPER_CPP_VERSION}.tar.gz`);
 
-  console.log("[whisper] Downloading whisper.cpp source...");
+  log.info("Downloading whisper.cpp source...");
 
   const res = await fetch(tarballUrl, {
     redirect: "follow",
@@ -313,7 +316,7 @@ async function buildFromSource(): Promise<void> {
   const fileStream = createWriteStream(tarPath);
   await pipeline(webBodyToReadable(res.body), fileStream);
 
-  console.log("[whisper] Extracting source...");
+  log.info("Extracting source...");
 
   if (existsSync(srcDir)) {
     rmSync(srcDir, { recursive: true, force: true });
@@ -336,7 +339,7 @@ async function buildFromSource(): Promise<void> {
     unlinkSync(tarPath);
   } catch {}
 
-  console.log("[whisper] Building whisper.cpp (this may take a minute)...");
+  log.info("Building whisper.cpp (this may take a minute)...");
 
   try {
     mkdirSync(buildDir, { recursive: true });
@@ -402,7 +405,7 @@ async function buildFromSource(): Promise<void> {
     );
   }
 
-  console.log("[whisper] Build complete");
+  log.info("Build complete");
 }
 
 async function downloadWindowsBinaries(): Promise<void> {
@@ -412,7 +415,7 @@ async function downloadWindowsBinaries(): Promise<void> {
   const archiveUrl = `https://github.com/ggml-org/whisper.cpp/releases/download/v${WHISPER_CPP_VERSION}/whisper-bin-x64.zip`;
   const tmpZip = join(binDir, "whisper-bin.zip");
 
-  console.log("[whisper] Downloading pre-built Windows binaries...");
+  log.info("Downloading pre-built Windows binaries...");
 
   const res = await fetch(archiveUrl, {
     redirect: "follow",
@@ -455,7 +458,7 @@ async function downloadWindowsBinaries(): Promise<void> {
     rmSync(releaseDir, { recursive: true, force: true });
   }
 
-  console.log("[whisper] Windows binaries downloaded");
+  log.info("Windows binaries downloaded");
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -1,8 +1,11 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { createAppLogger } from "@freestyle/utils";
 import { findWhisperServer } from "./binary.js";
 import { WHISPER_SERVER_PORT } from "./constants.js";
 import { getDownloadedModelPath } from "./models.js";
 
+const log = createAppLogger("whisper");
+const serverLog = createAppLogger("whisper-server");
 const MAX_RESTARTS = 3;
 const RESTART_COOLDOWN_MS = 3_000;
 const STABILITY_THRESHOLD_MS = 30_000;
@@ -38,10 +41,10 @@ export function startInBackground(modelId: string): void {
 
   ensureServerRunning(modelId)
     .then(() => {
-      console.log("[whisper] Server ready on port", WHISPER_SERVER_PORT);
+      log.info(`Server ready on port ${WHISPER_SERVER_PORT}`);
     })
     .catch((err) => {
-      console.error("[whisper] Background server start failed:", err.message);
+      log.error(`Background server start failed: ${err.message}`);
     });
 }
 
@@ -101,8 +104,6 @@ async function doStart(modelId: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let settled = false;
     let stderr = "";
-    const isDev = process.env.NODE_ENV !== "production";
-
     const timeout = setTimeout(() => {
       if (settled) return;
       settled = true;
@@ -138,14 +139,14 @@ async function doStart(modelId: string): Promise<void> {
 
     proc.stdout?.on("data", (data: Buffer) => {
       const text = data.toString();
-      if (isDev) console.log("[whisper-server:stdout]", text.trimEnd());
+      serverLog.debug(`stdout: ${text.trimEnd()}`);
       checkReady(text);
     });
 
     proc.stderr?.on("data", (data: Buffer) => {
       const text = data.toString();
       stderr += text;
-      if (isDev) console.log("[whisper-server:stderr]", text.trimEnd());
+      serverLog.debug(`stderr: ${text.trimEnd()}`);
       checkReady(text);
     });
 
@@ -204,23 +205,21 @@ async function doStart(modelId: string): Promise<void> {
 function scheduleRestart(modelId: string): void {
   restartCount++;
   if (restartCount > MAX_RESTARTS) {
-    console.error(
-      `[whisper] Server crashed ${MAX_RESTARTS} times, not restarting`,
-    );
+    log.error(`Server crashed ${MAX_RESTARTS} times, not restarting`);
     serverFailed = true;
     autoRestart = false;
     currentModelId = null;
     return;
   }
 
-  console.log(
-    `[whisper] Server crashed, restarting in ${RESTART_COOLDOWN_MS / 1000}s (attempt ${restartCount}/${MAX_RESTARTS})`,
+  log.info(
+    `Server crashed, restarting in ${RESTART_COOLDOWN_MS / 1000}s (attempt ${restartCount}/${MAX_RESTARTS})`,
   );
 
   setTimeout(() => {
     if (!autoRestart) return;
     ensureServerRunning(modelId).catch((err) => {
-      console.error("[whisper] Restart failed:", err.message);
+      log.error(`Restart failed: ${err.message}`);
     });
   }, RESTART_COOLDOWN_MS);
 }

--- a/apps/server/src/routes/mlx-asr.ts
+++ b/apps/server/src/routes/mlx-asr.ts
@@ -1,3 +1,4 @@
+import { createAppLogger } from "@freestyle/utils";
 import { Hono } from "hono";
 import {
   isAppleSiliconMac,
@@ -36,6 +37,8 @@ import {
 } from "../lib/mlx-asr/server.js";
 import { getDefaultModels } from "../lib/providers.js";
 import { stripProviderPrefix } from "../lib/streaming/types.js";
+
+const log = createAppLogger("mlx-asr");
 
 const mlxAsr = new Hono()
   .get("/status", (c) => {
@@ -172,19 +175,13 @@ export function autoStartMlxAsrServer(): void {
     const defaults = getDefaultModels();
     if (defaults.voice?.provider !== MLX_ASR_PROVIDER_ID) return;
     if (!canRunMlxAsr()) {
-      if (process.env.NODE_ENV !== "production") {
-        console.log(
-          "[mlx-asr] Skipping auto-start — Python or mlx-audio not available",
-        );
-      }
+      log.debug("Skipping auto-start — Python or mlx-audio not available");
       return;
     }
 
     const modelId = stripProviderPrefix(defaults.voice.model_id);
     if (getMlxModelStatus(modelId)?.status !== "ready") return;
-    if (process.env.NODE_ENV !== "production") {
-      console.log("[mlx-asr] Auto-starting server for model:", modelId);
-    }
+    log.debug(`Auto-starting server for model: ${modelId}`);
     startMlxInBackground(modelId);
   } catch {
     // DB not ready — skip

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -1,3 +1,4 @@
+import { createAppLogger } from "@freestyle/utils";
 import { upgradeWebSocket } from "@hono/node-server";
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
@@ -13,6 +14,7 @@ import {
 } from "../lib/streaming-stt.js";
 import { resolveAsrVocabularyBias } from "../lib/vocabulary-bias.js";
 
+const log = createAppLogger("stream");
 const LOG_STREAM_PARTIALS = process.env.FREESTYLE_LOG_STREAM_PARTIALS === "1";
 
 const stream = new Hono().get(
@@ -158,8 +160,8 @@ const stream = new Hono().get(
           onPartial: (text) => {
             if (upstream !== session) return;
             if (LOG_STREAM_PARTIALS) {
-              console.log(
-                `[stream partial] ${defaults.voice!.provider}/${modelShort}: ${text}`,
+              log.info(
+                `partial ${defaults.voice!.provider}/${modelShort}: ${text}`,
               );
             }
             ws.send(JSON.stringify({ type: "partial", text }));
@@ -209,7 +211,7 @@ const stream = new Hono().get(
                     pp.costUsd,
                   );
                 } catch (err) {
-                  console.error("Failed to save history:", err);
+                  log.error(`Failed to save history: ${err}`);
                 }
               })
               .catch((err) => {

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -1,3 +1,4 @@
+import { createAppLogger } from "@freestyle/utils";
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
 import { postProcess } from "../lib/post-process.js";
@@ -6,6 +7,8 @@ import { getDefaultModels } from "../lib/providers.js";
 import { getProvider } from "../lib/streaming/registry.js";
 import { getApiKeyForProvider } from "../lib/streaming-stt.js";
 import { resolveAsrVocabularyBias } from "../lib/vocabulary-bias.js";
+
+const log = createAppLogger("transcribe");
 
 const transcribeRoute = new Hono().post("/", async (c) => {
   const start = Date.now();
@@ -77,8 +80,6 @@ const transcribeRoute = new Hono().post("/", async (c) => {
     );
   }
 
-  const isDev = process.env.NODE_ENV !== "production";
-
   try {
     const bias = resolveAsrVocabularyBias(
       defaults.voice.provider,
@@ -93,11 +94,9 @@ const transcribeRoute = new Hono().post("/", async (c) => {
       bias,
     });
     rawText = result.text;
-    if (isDev) {
-      console.log(
-        `[transcribe] STT took ${Date.now() - t0}ms | rawText=${JSON.stringify(rawText).slice(0, 120)}`,
-      );
-    }
+    log.debug(
+      `STT took ${Date.now() - t0}ms | rawText=${JSON.stringify(rawText).slice(0, 120)}`,
+    );
   } catch (err) {
     captureException(err, {
       provider: defaults.voice.provider,
@@ -148,7 +147,7 @@ const transcribeRoute = new Hono().post("/", async (c) => {
         );
       })
       .catch((err) => {
-        console.error("Failed to save history:", err);
+        log.error(`Failed to save history: ${err}`);
       });
 
     capture("transcription completed", {
@@ -169,11 +168,9 @@ const transcribeRoute = new Hono().post("/", async (c) => {
 
   const ppStart = Date.now();
   const pp = await postProcess(rawText, appContext);
-  if (isDev) {
-    console.log(
-      `[transcribe] post-process took ${Date.now() - ppStart}ms | cleaned=${JSON.stringify(pp.cleaned).slice(0, 120)}`,
-    );
-  }
+  log.debug(
+    `post-process took ${Date.now() - ppStart}ms | cleaned=${JSON.stringify(pp.cleaned).slice(0, 120)}`,
+  );
 
   Promise.resolve()
     .then(() => {
@@ -196,12 +193,10 @@ const transcribeRoute = new Hono().post("/", async (c) => {
       );
     })
     .catch((err) => {
-      console.error("Failed to save history:", err);
+      log.error(`Failed to save history: ${err}`);
     });
 
-  if (isDev) {
-    console.log(`[transcribe] total ${Date.now() - start}ms`);
-  }
+  log.debug(`total ${Date.now() - start}ms`);
 
   capture("transcription completed", {
     provider: voiceProvider,

--- a/apps/server/src/routes/whisper.ts
+++ b/apps/server/src/routes/whisper.ts
@@ -1,7 +1,11 @@
+import { createAppLogger } from "@freestyle/utils";
 import { Hono } from "hono";
 import { capture } from "../lib/posthog.js";
 import { getDefaultModels } from "../lib/providers.js";
 import { stripProviderPrefix } from "../lib/streaming/types.js";
+
+const log = createAppLogger("whisper");
+
 import {
   isBinaryAvailable,
   isServerBinaryAvailable,
@@ -126,17 +130,13 @@ export function autoStartWhisperServer(): void {
     const modelId = stripProviderPrefix(defaults.voice.model_id);
 
     if (!hasServer) {
-      if (process.env.NODE_ENV !== "production") {
-        console.log(
-          "[whisper] whisper-server binary not found, skipping auto-start (CLI will be used)",
-        );
-      }
+      log.debug(
+        "whisper-server binary not found, skipping auto-start (CLI will be used)",
+      );
       return;
     }
 
-    if (process.env.NODE_ENV !== "production") {
-      console.log("[whisper] Auto-starting server for model:", modelId);
-    }
+    log.debug(`Auto-starting server for model: ${modelId}`);
     startInBackground(modelId);
   } catch {
     // DB not ready or other init issue — silently skip

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@freestyle/utils",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "main": "./src/index.ts",
+  "peerDependencies": {
+    "winston": "^3.17.0"
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,1 @@
+export { createAppLogger } from "./logger.js";

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,0 +1,20 @@
+import winston from "winston";
+
+const isDev = process.env.NODE_ENV !== "production";
+
+export function createAppLogger(namespace: string): winston.Logger {
+  return winston.createLogger({
+    level: isDev ? "debug" : "info",
+    format: winston.format.combine(
+      winston.format.timestamp({ format: "HH:mm:ss.SSS" }),
+      winston.format.printf(({ timestamp, level, message }) => {
+        return `${timestamp as string} ${level} [${namespace}] ${message as string}`;
+      }),
+    ),
+    transports: [
+      new winston.transports.Console({
+        stderrLevels: ["error"],
+      }),
+    ],
+  });
+}

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "declaration": false,
+    "noEmit": true,
+    "outDir": "dist/",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": ["./src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@freestyle/server':
         specifier: workspace:*
         version: link:../server
+      '@freestyle/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       '@freestyle/validations':
         specifier: workspace:*
         version: link:../../packages/validations
@@ -95,6 +98,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      winston:
+        specifier: ^3.17.0
+        version: 3.19.0
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -174,6 +180,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.65
         version: 3.0.65(zod@4.4.3)
+      '@freestyle/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       '@freestyle/validations':
         specifier: workspace:*
         version: link:../../packages/validations
@@ -201,6 +210,9 @@ importers:
       posthog-node:
         specifier: ^5.35.8
         version: 5.35.8
+      winston:
+        specifier: ^3.17.0
+        version: 3.19.0
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -226,6 +238,12 @@ importers:
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(msw@2.14.6(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+
+  packages/utils:
+    dependencies:
+      winston:
+        specifier: ^3.17.0
+        version: 3.19.0
 
   packages/validations:
     dependencies:
@@ -503,6 +521,13 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@colors/colors@1.6.0':
+    resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
+    engines: {node: '>=0.1.90'}
+
+  '@dabh/diagnostics@2.0.8':
+    resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
 
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
@@ -2256,6 +2281,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@so-ric/colorspace@1.1.6':
+    resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2483,6 +2511,9 @@ packages:
 
   '@types/three@0.184.1':
     resolution: {integrity: sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==}
+
+  '@types/triple-beam@1.3.5':
+    resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2833,8 +2864,24 @@ packages:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
+  color-convert@3.1.3:
+    resolution: {integrity: sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==}
+    engines: {node: '>=14.6'}
+
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-name@2.1.0:
+    resolution: {integrity: sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==}
+    engines: {node: '>=12.20'}
+
+  color-string@2.1.4:
+    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
+    engines: {node: '>=18'}
+
+  color@5.0.3:
+    resolution: {integrity: sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==}
+    engines: {node: '>=18'}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -3102,6 +3149,9 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  enabled@2.0.0:
+    resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -3272,6 +3322,9 @@ packages:
       picomatch:
         optional: true
 
+  fecha@4.2.3:
+    resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -3299,6 +3352,9 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  fn.name@1.1.0:
+    resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -3728,6 +3784,9 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  kuler@2.0.0:
+    resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
+
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
 
@@ -3824,6 +3883,10 @@ packages:
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
+
+  logform@2.7.0:
+    resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
+    engines: {node: '>= 12.0.0'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -4062,6 +4125,9 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  one-time@1.0.0:
+    resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -4372,6 +4438,10 @@ packages:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
     hasBin: true
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
@@ -4457,6 +4527,13 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -4580,6 +4657,9 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  stack-trace@0.0.10:
+    resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -4617,6 +4697,9 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
@@ -4684,6 +4767,9 @@ packages:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
     engines: {node: '>=6.0.0'}
 
+  text-hex@1.0.0:
+    resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
+
   three-mesh-bvh@0.8.3:
     resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
     peerDependencies:
@@ -4746,6 +4832,10 @@ packages:
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  triple-beam@1.4.1:
+    resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
+    engines: {node: '>= 14.0.0'}
 
   troika-three-text@0.52.4:
     resolution: {integrity: sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==}
@@ -5003,6 +5093,14 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  winston-transport@4.9.0:
+    resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
+    engines: {node: '>= 12.0.0'}
+
+  winston@3.19.0:
+    resolution: {integrity: sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==}
+    engines: {node: '>= 12.0.0'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -5418,6 +5516,14 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.15':
     optional: true
+
+  '@colors/colors@1.6.0': {}
+
+  '@dabh/diagnostics@2.0.8':
+    dependencies:
+      '@so-ric/colorspace': 1.1.6
+      enabled: 2.0.0
+      kuler: 2.0.0
 
   '@develar/schema-utils@2.6.5':
     dependencies:
@@ -7047,6 +7153,11 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@so-ric/colorspace@1.1.6':
+    dependencies:
+      color: 5.0.3
+      text-hex: 1.0.0
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -7256,6 +7367,8 @@ snapshots:
       '@types/webxr': 0.5.24
       fflate: 0.8.3
       meshoptimizer: 1.1.1
+
+  '@types/triple-beam@1.3.5': {}
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -7656,7 +7769,22 @@ snapshots:
     dependencies:
       color-name: 1.1.4
 
+  color-convert@3.1.3:
+    dependencies:
+      color-name: 2.1.0
+
   color-name@1.1.4: {}
+
+  color-name@2.1.0: {}
+
+  color-string@2.1.4:
+    dependencies:
+      color-name: 2.1.0
+
+  color@5.0.3:
+    dependencies:
+      color-convert: 3.1.3
+      color-string: 2.1.4
 
   combined-stream@1.0.8:
     dependencies:
@@ -7940,6 +8068,8 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  enabled@2.0.0: {}
+
   encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
@@ -8214,6 +8344,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fecha@4.2.3: {}
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -8247,6 +8379,8 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  fn.name@1.1.0: {}
 
   form-data@4.0.5:
     dependencies:
@@ -8632,6 +8766,8 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  kuler@2.0.0: {}
+
   lazy-val@1.0.5: {}
 
   lie@3.3.0:
@@ -8699,6 +8835,15 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
+
+  logform@2.7.0:
+    dependencies:
+      '@colors/colors': 1.6.0
+      '@types/triple-beam': 1.3.5
+      fecha: 4.2.3
+      ms: 2.1.3
+      safe-stable-stringify: 2.5.0
+      triple-beam: 1.4.1
 
   long@5.3.2: {}
 
@@ -8934,6 +9079,10 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  one-time@1.0.0:
+    dependencies:
+      fn.name: 1.1.0
 
   onetime@5.1.2:
     dependencies:
@@ -9300,6 +9449,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   recast@0.23.11:
     dependencies:
       ast-types: 0.16.1
@@ -9411,6 +9566,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
+
+  safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
 
@@ -9580,6 +9739,8 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  stack-trace@0.0.10: {}
+
   stackback@0.0.2: {}
 
   stat-mode@1.0.0: {}
@@ -9610,6 +9771,10 @@ snapshots:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-object@5.0.0:
     dependencies:
@@ -9673,6 +9838,8 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.6.3
 
+  text-hex@1.0.0: {}
+
   three-mesh-bvh@0.8.3(three@0.184.0):
     dependencies:
       three: 0.184.0
@@ -9729,6 +9896,8 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.1.0
+
+  triple-beam@1.4.1: {}
 
   troika-three-text@0.52.4(three@0.184.0):
     dependencies:
@@ -9943,6 +10112,26 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  winston-transport@4.9.0:
+    dependencies:
+      logform: 2.7.0
+      readable-stream: 3.6.2
+      triple-beam: 1.4.1
+
+  winston@3.19.0:
+    dependencies:
+      '@colors/colors': 1.6.0
+      '@dabh/diagnostics': 2.0.8
+      async: 3.2.6
+      is-stream: 2.0.1
+      logform: 2.7.0
+      one-time: 1.0.0
+      readable-stream: 3.6.2
+      safe-stable-stringify: 2.5.0
+      stack-trace: 0.0.10
+      triple-beam: 1.4.1
+      winston-transport: 4.9.0
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
Adds a new `@freestyle/utils` workspace package with a Winston-based `createAppLogger` factory and migrates all logging across the server and Electron apps to use it. This fixes an EPIPE (broken pipe) crash that occurs when the Electron app runs as a Linux AppImage detached from a terminal — the `electron-updater` library writes to `stdout` via `console.info` during update checks, and when `stdout` is a closed pipe the unhandled error kills the process.

## Changes

- **`packages/utils/`** — new `@freestyle/utils` package exporting `createAppLogger(namespace)`, producing named Winston loggers with console transport (level: `debug` in dev, `info` in production)
- **EPIPE guard** — global `process.stdout`/`process.stderr` error handler at the top of the Electron main process that swallows `EPIPE` and re-throws everything else
- **`autoUpdater.logger`** — set to a Winston logger instead of the default `console`
- **Logging migration** — all 57 `console.log`/`warn`/`error` calls across 16 files replaced with structured `log.info`/`warn`/`error`/`debug` calls using 12 named namespaces
- **Dev-guard cleanup** — manual `NODE_ENV !== "production"` / `isDev` checks around debug logs replaced by `logger.debug()`, controlled by log level automatically

## Testing

- `pnpm build` — server and Electron typecheck + bundle successfully
- `pnpm test` — all 36 server API tests pass
- CI — Lint, Typecheck, Server API, Electron E2E, Linux/macOS/Windows builds all green