### PR TITLE
fix: prevent MLX ASR worker unload while transcriptions are in flight

### DIFF
--- a/apps/server/src/lib/mlx-asr/server.ts
+++ b/apps/server/src/lib/mlx-asr/server.ts
@@ -404,6 +404,8 @@ function sendTranscribeRequest(opts: {
   stream?: boolean;
   onPartial?: (text: string) => void;
 }): Promise<string> {
+  clearUnloadTimer();
+
   const proc = workerProcess;
   if (!proc?.stdin || !workerReady) {
     return Promise.reject(new Error("mlx-asr worker is not running"));
@@ -470,6 +472,7 @@ function clearUnloadTimer(): void {
 function scheduleUnload(): void {
   clearUnloadTimer();
   if (!workerProcess) return;
+  if (pending.size > 0) return;
   const minutes = getMlxAsrKeepAliveMinutes();
   const delayMs = minutes * 60_000;
 
@@ -481,6 +484,7 @@ function scheduleUnload(): void {
   }
 
   unloadTimer = setTimeout(() => {
+    if (pending.size > 0) return;
     stopMlxServer().catch((err: Error) => {
       log.error(`Failed to unload idle worker: ${err.message}`);
     });


### PR DESCRIPTION
Fixes a race condition where `scheduleUnload` could stop the MLX ASR worker process while transcription requests were still pending, causing `mlx-asr worker stopped` errors during active transcription.

The idle-unload timer and `scheduleUnload` did not check whether requests were in flight before killing the worker. When a transcription was active and the unload timer fired (or `scheduleUnload` was called from a streaming session's cancel/close), `stopMlxServer` would terminate the process and reject all pending requests.

## Changes

Three guards added to `apps/server/src/lib/mlx-asr/server.ts`:

- **`scheduleUnload`** — skip entirely when `pending.size > 0`
- **Unload timer callback** — re-check `pending.size` before stopping (a new request may have arrived between scheduling and firing)
- **`sendTranscribeRequest`** — cancel any pending unload timer before adding the request to the `pending` map

## Testing

- `pnpm build` passes (server + Electron typecheck and bundle)
- `pnpm test` — all 36 server API tests pass