### PR TITLE
fix: register Escape cancel shortcut on all platforms, not just Windows

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -871,9 +871,7 @@ app.whenReady().then(async () => {
       keyListener.stop();
       keyListener = null;
     }
-    if (process.platform === "win32") {
-      globalShortcut.unregisterAll();
-    }
+    globalShortcut.unregisterAll();
 
     stopHotkeyRecorderProcess();
     const target =
@@ -1321,9 +1319,7 @@ function registerHotkey(hotkey?: string): void {
     keyListener = null;
   }
   hotkeyPressed = false;
-  if (process.platform === "win32") {
-    globalShortcut.unregisterAll();
-  }
+  globalShortcut.unregisterAll();
 
   if (!hotkey) {
     hotkey = loadHotkeyFromDB();
@@ -1389,9 +1385,7 @@ app.on("will-quit", () => {
     micListener.stop();
     micListener = null;
   }
-  if (process.platform === "win32") {
-    globalShortcut.unregisterAll();
-  }
+  globalShortcut.unregisterAll();
 });
 
 // Keep app running in background when windows are closed (tray stays active)

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -333,16 +333,14 @@ function showPill(): void {
     mainWindow.showInactive();
   }
 
-  // On Windows, register Escape as a global shortcut while the pill
-  // is visible so the user can cancel recording/transcription.
-  if (process.platform === "win32") {
-    if (!globalShortcut.isRegistered("Escape")) {
-      globalShortcut.register("Escape", () => {
-        if (mainWindow?.isVisible()) {
-          mainWindow.webContents.send("pill:cancel");
-        }
-      });
-    }
+  // Register Escape as a global shortcut while the pill is visible
+  // so the user can cancel recording/transcription.
+  if (!globalShortcut.isRegistered("Escape")) {
+    globalShortcut.register("Escape", () => {
+      if (mainWindow?.isVisible()) {
+        mainWindow.webContents.send("pill:cancel");
+      }
+    });
   }
 }
 
@@ -515,12 +513,10 @@ function hidePill(): void {
   if (mainWindow?.isVisible()) {
     mainWindow.hide();
   }
-  // Unregister Escape shortcut when pill is hidden (Windows only)
-  if (process.platform === "win32") {
-    try {
-      globalShortcut.unregister("Escape");
-    } catch {}
-  }
+  // Unregister Escape shortcut when pill is hidden
+  try {
+    globalShortcut.unregister("Escape");
+  } catch {}
 }
 
 function resetOnboarding(): void {


### PR DESCRIPTION
The Escape key cancellation during transcription was only registered on Windows via a `process.platform === "win32"` guard. On macOS and Linux, pressing Escape during recording/transcription did nothing — the pill stayed visible and transcription continued.

This removes the platform guard so the `globalShortcut.register("Escape", ...)` call in `showPill()` and the matching `globalShortcut.unregister("Escape")` in `hidePill()` run on all platforms.

## Testing
Manual — verify Escape cancels recording/transcription on macOS, Windows, and Linux.

<!--
## Plan
1. In `showPill()` (apps/electron/src/main/index.ts ~line 336): remove the
   `if (process.platform === "win32")` wrapper around the Escape global shortcut
   registration, keeping the `isRegistered` guard.
2. In `hidePill()` (~line 518): remove the `if (process.platform === "win32")`
   wrapper around the Escape unregistration.
3. Update the associated comments to remove Windows-specific wording.
-->