### PR TITLE
fix: update download button not triggering download or showing progress

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -588,6 +588,15 @@ function restartAndUpdate(): void {
   autoUpdater.quitAndInstall();
 }
 
+/** Mark state as downloading, notify the settings window, and kick off the download. */
+function triggerDownloadUpdate(): void {
+  updateDownloadState = "downloading";
+  settingsWindow?.webContents.send("updater:downloading");
+  autoUpdater.downloadUpdate().catch((err) => {
+    log.warn(`downloadUpdate rejected: ${err}`);
+  });
+}
+
 async function checkForUpdatesFromMenu(): Promise<void> {
   if (is.dev) {
     dialog.showMessageBox({
@@ -619,9 +628,7 @@ async function checkForUpdatesFromMenu(): Promise<void> {
         cancelId: 1,
       });
       if (response === 0) {
-        updateDownloadState = "downloading";
-        settingsWindow?.webContents.send("updater:downloading");
-        autoUpdater.downloadUpdate().catch(() => {});
+        triggerDownloadUpdate();
       }
     } else {
       dialog.showMessageBox({
@@ -1081,8 +1088,7 @@ app.whenReady().then(async () => {
   }
 
   ipcMain.on("updater:download", () => {
-    updateDownloadState = "downloading";
-    autoUpdater.downloadUpdate().catch(() => {});
+    triggerDownloadUpdate();
   });
 
   ipcMain.on("updater:install", () => {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -619,7 +619,9 @@ async function checkForUpdatesFromMenu(): Promise<void> {
         cancelId: 1,
       });
       if (response === 0) {
-        autoUpdater.downloadUpdate();
+        updateDownloadState = "downloading";
+        settingsWindow?.webContents.send("updater:downloading");
+        autoUpdater.downloadUpdate().catch(() => {});
       }
     } else {
       dialog.showMessageBox({
@@ -1080,7 +1082,7 @@ app.whenReady().then(async () => {
 
   ipcMain.on("updater:download", () => {
     updateDownloadState = "downloading";
-    autoUpdater.downloadUpdate();
+    autoUpdater.downloadUpdate().catch(() => {});
   });
 
   ipcMain.on("updater:install", () => {


### PR DESCRIPTION
The "Download" button in the native update dialog (tray menu → "Check for Updates...") called `autoUpdater.downloadUpdate()` without updating `updateDownloadState` or notifying the settings window via IPC. This caused two problems:

1. **No state tracking**: `updateDownloadState` stayed `"idle"`, so if the user opened the settings page during a download, the banner showed "Download" instead of "Downloading...".
2. **Unhandled promise rejection**: The Promise returned by `downloadUpdate()` was never caught, so download failures could surface as unhandled rejections instead of being routed through the `autoUpdater` error event.

The fix sets `updateDownloadState = "downloading"` and sends `updater:downloading` to the settings window before starting the download (matching what the IPC `updater:download` handler already does), and catches the returned Promise in both code paths.

## Testing
Manual — trigger "Check for Updates..." from the tray menu, click "Download", then open Settings to verify the banner shows "Downloading..." state. Also verify download errors surface in the settings banner.

Closes #156

<!--
## Plan
1. In `checkForUpdatesFromMenu()` (~line 622): set `updateDownloadState = "downloading"`,
   send `updater:downloading` to settingsWindow, and `.catch(() => {})` the downloadUpdate() Promise.
2. In the `updater:download` IPC handler (~line 1083): add `.catch(() => {})` to the
   `downloadUpdate()` call to prevent unhandled rejections.
-->