### PR TITLE
feat: validate API keys on save with per-provider health checks

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -588,6 +588,15 @@ function restartAndUpdate(): void {
   autoUpdater.quitAndInstall();
 }
 
+/** Mark state as downloading, notify the settings window, and kick off the download. */
+function triggerDownloadUpdate(): void {
+  updateDownloadState = "downloading";
+  settingsWindow?.webContents.send("updater:downloading");
+  autoUpdater.downloadUpdate().catch((err) => {
+    log.warn(`downloadUpdate rejected: ${err}`);
+  });
+}
+
 async function checkForUpdatesFromMenu(): Promise<void> {
   if (is.dev) {
     dialog.showMessageBox({
@@ -619,9 +628,7 @@ async function checkForUpdatesFromMenu(): Promise<void> {
         cancelId: 1,
       });
       if (response === 0) {
-        updateDownloadState = "downloading";
-        settingsWindow?.webContents.send("updater:downloading");
-        autoUpdater.downloadUpdate().catch(() => {});
+        triggerDownloadUpdate();
       }
     } else {
       dialog.showMessageBox({
@@ -1081,8 +1088,7 @@ app.whenReady().then(async () => {
   }
 
   ipcMain.on("updater:download", () => {
-    updateDownloadState = "downloading";
-    autoUpdater.downloadUpdate().catch(() => {});
+    triggerDownloadUpdate();
   });
 
   ipcMain.on("updater:install", () => {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -619,7 +619,9 @@ async function checkForUpdatesFromMenu(): Promise<void> {
         cancelId: 1,
       });
       if (response === 0) {
-        autoUpdater.downloadUpdate();
+        updateDownloadState = "downloading";
+        settingsWindow?.webContents.send("updater:downloading");
+        autoUpdater.downloadUpdate().catch(() => {});
       }
     } else {
       dialog.showMessageBox({
@@ -1080,7 +1082,7 @@ app.whenReady().then(async () => {
 
   ipcMain.on("updater:download", () => {
     updateDownloadState = "downloading";
-    autoUpdater.downloadUpdate();
+    autoUpdater.downloadUpdate().catch(() => {});
   });
 
   ipcMain.on("updater:install", () => {

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -362,24 +362,32 @@ export default function OnboardingPage(): React.JSX.Element {
         if (needsKey) {
           const keyData = apiKeyForm.getValues();
           if (keyData.key.trim()) {
-            const res = await client.api.keys.$post({
+            // Validate first
+            const valRes = await client.api.keys.validate.$post({
               json: {
                 provider: keyData.provider,
                 key: keyData.key.trim(),
               },
             });
-            if (res.ok) {
-              const body = await res.json();
-              if ("valid" in body && body.valid === false) {
+            if (valRes.ok) {
+              const valBody = await valRes.json();
+              if ("valid" in valBody && valBody.valid === false) {
                 setVoiceKeyError(
-                  ("error" in body && typeof body.error === "string"
-                    ? body.error
+                  ("error" in valBody && typeof valBody.error === "string"
+                    ? valBody.error
                     : null) ?? "API key is not valid.",
                 );
                 setSaving(false);
                 return;
               }
             }
+            // Valid — save the key
+            await client.api.keys.$post({
+              json: {
+                provider: keyData.provider,
+                key: keyData.key.trim(),
+              },
+            });
             setApiKeys((prev) => new Set([...prev, keyData.provider]));
           }
         }
@@ -463,24 +471,32 @@ export default function OnboardingPage(): React.JSX.Element {
         if (needsLlmKey) {
           const keyData = llmKeyForm.getValues();
           if (keyData.key.trim()) {
-            const res = await client.api.keys.$post({
+            // Validate first
+            const valRes = await client.api.keys.validate.$post({
               json: {
                 provider: keyData.provider,
                 key: keyData.key.trim(),
               },
             });
-            if (res.ok) {
-              const body = await res.json();
-              if ("valid" in body && body.valid === false) {
+            if (valRes.ok) {
+              const valBody = await valRes.json();
+              if ("valid" in valBody && valBody.valid === false) {
                 setLlmKeyError(
-                  ("error" in body && typeof body.error === "string"
-                    ? body.error
+                  ("error" in valBody && typeof valBody.error === "string"
+                    ? valBody.error
                     : null) ?? "API key is not valid.",
                 );
                 setSaving(false);
                 return;
               }
             }
+            // Valid — save the key
+            await client.api.keys.$post({
+              json: {
+                provider: keyData.provider,
+                key: keyData.key.trim(),
+              },
+            });
             setApiKeys((prev) => new Set([...prev, keyData.provider]));
           }
         }

--- a/apps/electron/src/renderer/src/pages/onboarding.tsx
+++ b/apps/electron/src/renderer/src/pages/onboarding.tsx
@@ -27,6 +27,7 @@ import {
 } from "@renderer/lib/models";
 import { cn } from "@renderer/lib/utils";
 import {
+  AlertTriangle,
   Check,
   ChevronLeft,
   ChevronRight,
@@ -81,6 +82,8 @@ export default function OnboardingPage(): React.JSX.Element {
   const [saving, setSaving] = useState(false);
   const [apiKeys, setApiKeys] = useState<Set<string>>(new Set());
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [voiceKeyError, setVoiceKeyError] = useState<string | null>(null);
+  const [llmKeyError, setLlmKeyError] = useState<string | null>(null);
 
   // Local whisper state
   const [whisperStatus, setWhisperStatus] = useState<WhisperStatus | null>(
@@ -350,6 +353,7 @@ export default function OnboardingPage(): React.JSX.Element {
     }
 
     setSaving(true);
+    setVoiceKeyError(null);
 
     try {
       const client = getClient();
@@ -358,12 +362,24 @@ export default function OnboardingPage(): React.JSX.Element {
         if (needsKey) {
           const keyData = apiKeyForm.getValues();
           if (keyData.key.trim()) {
-            await client.api.keys.$post({
+            const res = await client.api.keys.$post({
               json: {
                 provider: keyData.provider,
                 key: keyData.key.trim(),
               },
             });
+            if (res.ok) {
+              const body = await res.json();
+              if ("valid" in body && body.valid === false) {
+                setVoiceKeyError(
+                  ("error" in body && typeof body.error === "string"
+                    ? body.error
+                    : null) ?? "API key is not valid.",
+                );
+                setSaving(false);
+                return;
+              }
+            }
             setApiKeys((prev) => new Set([...prev, keyData.provider]));
           }
         }
@@ -438,6 +454,7 @@ export default function OnboardingPage(): React.JSX.Element {
     }
 
     setSaving(true);
+    setLlmKeyError(null);
 
     try {
       const client = getClient();
@@ -446,12 +463,24 @@ export default function OnboardingPage(): React.JSX.Element {
         if (needsLlmKey) {
           const keyData = llmKeyForm.getValues();
           if (keyData.key.trim()) {
-            await client.api.keys.$post({
+            const res = await client.api.keys.$post({
               json: {
                 provider: keyData.provider,
                 key: keyData.key.trim(),
               },
             });
+            if (res.ok) {
+              const body = await res.json();
+              if ("valid" in body && body.valid === false) {
+                setLlmKeyError(
+                  ("error" in body && typeof body.error === "string"
+                    ? body.error
+                    : null) ?? "API key is not valid.",
+                );
+                setSaving(false);
+                return;
+              }
+            }
             setApiKeys((prev) => new Set([...prev, keyData.provider]));
           }
         }
@@ -896,6 +925,14 @@ export default function OnboardingPage(): React.JSX.Element {
                       {apiKeyForm.formState.errors.key.message}
                     </p>
                   )}
+                  {voiceKeyError && (
+                    <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2">
+                      <AlertTriangle className="text-destructive mt-0.5 h-3.5 w-3.5 shrink-0" />
+                      <p className="text-destructive text-xs">
+                        {voiceKeyError}
+                      </p>
+                    </div>
+                  )}
                 </div>
               )}
 
@@ -1049,6 +1086,14 @@ export default function OnboardingPage(): React.JSX.Element {
                         <p className="text-destructive text-xs">
                           {llmKeyForm.formState.errors.key.message}
                         </p>
+                      )}
+                      {llmKeyError && (
+                        <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2">
+                          <AlertTriangle className="text-destructive mt-0.5 h-3.5 w-3.5 shrink-0" />
+                          <p className="text-destructive text-xs">
+                            {llmKeyError}
+                          </p>
+                        </div>
                       )}
                     </div>
                   )}

--- a/apps/electron/src/renderer/src/pages/settings/models.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/models.tsx
@@ -27,6 +27,7 @@ import {
 import { cn } from "@renderer/lib/utils";
 import {
   AlertTriangle,
+  CheckCircle,
   ChevronRight,
   CircleDollarSign,
   Cloud,
@@ -46,6 +47,7 @@ import {
   Trash2,
   WifiOff,
   X,
+  XCircle,
   Zap,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -67,6 +69,7 @@ interface ConfiguredModel {
 interface ApiKeyEntry {
   provider: string;
   created_at: string;
+  status: "valid" | "invalid" | "unknown";
 }
 
 // ---------------------------------------------------------------------------
@@ -137,6 +140,12 @@ export default function ModelsPage(): React.JSX.Element {
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
   const [editKeyValue, setEditKeyValue] = useState("");
   const [showEditKey, setShowEditKey] = useState(false);
+
+  // Key validation state
+  const [keyValidating, setKeyValidating] = useState(false);
+  const [keyValidationError, setKeyValidationError] = useState<string | null>(
+    null,
+  );
 
   // Delete confirmation
   const [deleteProvider, setDeleteProvider] = useState<string | null>(null);
@@ -211,7 +220,7 @@ export default function ModelsPage(): React.JSX.Element {
         const configs: ConfiguredModel[] = await configRes.json();
         setConfigured(configs);
       }
-      if (keysRes.ok) setApiKeys(await keysRes.json());
+      if (keysRes.ok) setApiKeys((await keysRes.json()) as ApiKeyEntry[]);
       if (cleanupRes.ok) {
         const data = await cleanupRes.json();
         if (data?.value) setLlmCleanup(data.value === "true");
@@ -409,6 +418,7 @@ export default function ModelsPage(): React.JSX.Element {
     setPendingKeyProvider(null);
     setPendingModel(null);
     setShowPendingKey(false);
+    setKeyValidationError(null);
     apiKeyForm.reset({ provider: "", key: "" });
   }, [apiKeyForm]);
 
@@ -456,24 +466,47 @@ export default function ModelsPage(): React.JSX.Element {
     async (data: ApiKeyInput) => {
       if (!pendingModel) return;
 
-      const client = getClient();
-      await client.api.keys.$post({
-        json: { provider: data.provider, key: data.key },
-      });
+      setKeyValidating(true);
+      setKeyValidationError(null);
 
-      await client.api.models.configured.$post({
-        json: {
-          provider: pendingModel.provider_id,
-          model_id: pendingModel.model_id,
-          model_name: pendingModel.model_name,
-          type: pendingModelType,
-          is_default: true,
-        },
-      });
+      try {
+        const client = getClient();
+        const res = await client.api.keys.$post({
+          json: { provider: data.provider, key: data.key },
+        });
 
-      closePendingKey();
-      closePicker();
-      loadData();
+        if (res.ok) {
+          const body = await res.json();
+          if ("valid" in body && body.valid === false) {
+            setKeyValidationError(
+              ("error" in body && typeof body.error === "string"
+                ? body.error
+                : null) ?? "API key is not valid.",
+            );
+            setKeyValidating(false);
+            loadData();
+            return;
+          }
+        }
+
+        await client.api.models.configured.$post({
+          json: {
+            provider: pendingModel.provider_id,
+            model_id: pendingModel.model_id,
+            model_name: pendingModel.model_name,
+            type: pendingModelType,
+            is_default: true,
+          },
+        });
+
+        closePendingKey();
+        closePicker();
+        loadData();
+      } catch {
+        setKeyValidationError("Failed to validate key. Please try again.");
+      } finally {
+        setKeyValidating(false);
+      }
     },
     [pendingModel, pendingModelType, closePendingKey, closePicker, loadData],
   );
@@ -505,25 +538,52 @@ export default function ModelsPage(): React.JSX.Element {
 
   const saveProviderKey = useCallback(async () => {
     if (!editKeyValue.trim() || !editingProvider) return;
-    await getClient().api.keys.$post({
-      json: { provider: editingProvider, key: editKeyValue.trim() },
-    });
-    setEditingProvider(null);
-    setEditKeyValue("");
-    setShowEditKey(false);
-    loadData();
+
+    setKeyValidating(true);
+    setKeyValidationError(null);
+
+    try {
+      const res = await getClient().api.keys.$post({
+        json: { provider: editingProvider, key: editKeyValue.trim() },
+      });
+
+      if (res.ok) {
+        const body = await res.json();
+        if ("valid" in body && body.valid === false) {
+          setKeyValidationError(
+            ("error" in body && typeof body.error === "string"
+              ? body.error
+              : null) ?? "API key is not valid.",
+          );
+          setKeyValidating(false);
+          loadData();
+          return;
+        }
+      }
+
+      setEditingProvider(null);
+      setEditKeyValue("");
+      setShowEditKey(false);
+      loadData();
+    } catch {
+      setKeyValidationError("Failed to validate key. Please try again.");
+    } finally {
+      setKeyValidating(false);
+    }
   }, [editKeyValue, editingProvider, loadData]);
 
   const startEditProvider = useCallback((provider: string) => {
     setEditingProvider(provider);
     setEditKeyValue("");
     setShowEditKey(false);
+    setKeyValidationError(null);
   }, []);
 
   const closeEditProvider = useCallback(() => {
     setEditingProvider(null);
     setEditKeyValue("");
     setShowEditKey(false);
+    setKeyValidationError(null);
   }, []);
 
   const tryDeleteProvider = useCallback(
@@ -934,6 +994,8 @@ export default function ModelsPage(): React.JSX.Element {
             setShow={setShowPendingKey}
             onClose={closePendingKey}
             onSubmit={savePendingKeyAndModel}
+            validating={keyValidating}
+            validationError={keyValidationError}
           />
         )}
 
@@ -946,6 +1008,8 @@ export default function ModelsPage(): React.JSX.Element {
             setShow={setShowEditKey}
             onClose={closeEditProvider}
             onSave={saveProviderKey}
+            validating={keyValidating}
+            validationError={keyValidationError}
           />
         )}
 
@@ -1887,6 +1951,7 @@ function ProvidersSection({
             key={entry.provider}
             providerId={entry.provider}
             configured={configured}
+            status={entry.status ?? "unknown"}
             first={i === 0}
             onEdit={() => onEdit(entry.provider)}
             onDelete={() => onDelete(entry.provider)}
@@ -1911,12 +1976,14 @@ function ProvidersSection({
 function ProviderRow({
   providerId,
   configured,
+  status,
   first,
   onEdit,
   onDelete,
 }: {
   providerId: string;
   configured: ConfiguredModel[];
+  status: "valid" | "invalid" | "unknown";
   first: boolean;
   onEdit: () => void;
   onDelete: () => void;
@@ -1933,17 +2000,38 @@ function ProviderRow({
     >
       <Key className="text-muted-foreground h-[15px] w-[15px] shrink-0" />
       <div className="min-w-0 flex-1">
-        <div className="text-foreground text-[13.5px] font-semibold">
-          {displayName(providerId)}
+        <div className="flex items-center gap-1.5">
+          <span className="text-foreground text-[13.5px] font-semibold">
+            {displayName(providerId)}
+          </span>
+          {status === "valid" && (
+            <CheckCircle className="text-primary h-3.5 w-3.5 shrink-0" />
+          )}
+          {status === "invalid" && (
+            <XCircle className="text-destructive h-3.5 w-3.5 shrink-0" />
+          )}
         </div>
         <div className="mono text-muted-foreground mt-0.5 text-[11px]">
-          Key stored in keychain
+          {status === "invalid" ? (
+            <span className="text-destructive">
+              Key invalid — update or delete
+            </span>
+          ) : (
+            "Key stored in keychain"
+          )}
         </div>
       </div>
       <span className="text-muted-foreground text-[11.5px]">
         {count} model{count === 1 ? "" : "s"}
       </span>
-      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+      <div
+        className={cn(
+          "flex shrink-0 items-center gap-0.5 transition-opacity",
+          status === "invalid"
+            ? "opacity-100"
+            : "opacity-0 group-hover:opacity-100",
+        )}
+      >
         <button
           type="button"
           onClick={onEdit}
@@ -2021,6 +2109,8 @@ function ApiKeyDialog({
   setShow,
   onClose,
   onSubmit,
+  validating,
+  validationError,
 }: {
   model: AvailableModel;
   provider: string;
@@ -2029,6 +2119,8 @@ function ApiKeyDialog({
   setShow: (v: boolean) => void;
   onClose: () => void;
   onSubmit: (data: ApiKeyInput) => Promise<void>;
+  validating?: boolean;
+  validationError?: string | null;
 }): React.JSX.Element {
   return (
     <ModalShell>
@@ -2070,7 +2162,8 @@ function ApiKeyDialog({
             placeholder="sk-…"
             className={cn(
               "border-border bg-background mono w-full rounded-md border py-2.5 pl-9 pr-10 text-[13px]",
-              form.formState.errors.key && "border-destructive",
+              (form.formState.errors.key || validationError) &&
+                "border-destructive",
             )}
             onKeyDown={(e) => {
               if (e.key === "Escape") onClose();
@@ -2089,6 +2182,12 @@ function ApiKeyDialog({
             {form.formState.errors.key.message}
           </p>
         )}
+        {validationError && (
+          <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2">
+            <AlertTriangle className="text-destructive mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <p className="text-destructive text-xs">{validationError}</p>
+          </div>
+        )}
         <p
           className="mono text-muted-foreground text-[10px] uppercase"
           style={{ letterSpacing: "0.14em" }}
@@ -2105,10 +2204,17 @@ function ApiKeyDialog({
           </button>
           <button
             type="submit"
-            disabled={!form.formState.isValid}
+            disabled={!form.formState.isValid || validating}
             className="bg-foreground text-background hover:bg-foreground/90 rounded-md px-3.5 py-1.5 text-[12.5px] font-medium disabled:opacity-50"
           >
-            Save &amp; continue
+            {validating ? (
+              <span className="flex items-center gap-1.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Checking…
+              </span>
+            ) : (
+              "Save & continue"
+            )}
           </button>
         </div>
       </form>
@@ -2124,6 +2230,8 @@ function EditKeyDialog({
   setShow,
   onClose,
   onSave,
+  validating,
+  validationError,
 }: {
   provider: string;
   value: string;
@@ -2132,6 +2240,8 @@ function EditKeyDialog({
   setShow: (v: boolean) => void;
   onClose: () => void;
   onSave: () => Promise<void>;
+  validating?: boolean;
+  validationError?: string | null;
 }): React.JSX.Element {
   return (
     <ModalShell>
@@ -2168,7 +2278,10 @@ function EditKeyDialog({
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder="sk-…"
-            className="border-border bg-background mono w-full rounded-md border py-2.5 pl-9 pr-10 text-[13px]"
+            className={cn(
+              "border-border bg-background mono w-full rounded-md border py-2.5 pl-9 pr-10 text-[13px]",
+              validationError && "border-destructive",
+            )}
             onKeyDown={(e) => {
               if (e.key === "Enter" && value.trim()) onSave();
               if (e.key === "Escape") onClose();
@@ -2182,6 +2295,12 @@ function EditKeyDialog({
             {show ? <EyeOff size={15} /> : <Eye size={15} />}
           </button>
         </div>
+        {validationError && (
+          <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2">
+            <AlertTriangle className="text-destructive mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <p className="text-destructive text-xs">{validationError}</p>
+          </div>
+        )}
         <div className="flex justify-end gap-2 pt-2">
           <button
             type="button"
@@ -2193,10 +2312,17 @@ function EditKeyDialog({
           <button
             type="button"
             onClick={onSave}
-            disabled={!value.trim()}
+            disabled={!value.trim() || validating}
             className="bg-foreground text-background hover:bg-foreground/90 rounded-md px-3.5 py-1.5 text-[12.5px] font-medium disabled:opacity-50"
           >
-            Save
+            {validating ? (
+              <span className="flex items-center gap-1.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Checking…
+              </span>
+            ) : (
+              "Save"
+            )}
           </button>
         </div>
       </div>

--- a/apps/electron/src/renderer/src/pages/settings/models.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/models.tsx
@@ -471,23 +471,29 @@ export default function ModelsPage(): React.JSX.Element {
 
       try {
         const client = getClient();
-        const res = await client.api.keys.$post({
+
+        // Validate first — no key is saved yet
+        const valRes = await client.api.keys.validate.$post({
           json: { provider: data.provider, key: data.key },
         });
 
-        if (res.ok) {
-          const body = await res.json();
-          if ("valid" in body && body.valid === false) {
+        if (valRes.ok) {
+          const valBody = await valRes.json();
+          if ("valid" in valBody && valBody.valid === false) {
             setKeyValidationError(
-              ("error" in body && typeof body.error === "string"
-                ? body.error
+              ("error" in valBody && typeof valBody.error === "string"
+                ? valBody.error
                 : null) ?? "API key is not valid.",
             );
             setKeyValidating(false);
-            loadData();
             return;
           }
         }
+
+        // Key is valid — save it and configure the model
+        await client.api.keys.$post({
+          json: { provider: data.provider, key: data.key },
+        });
 
         await client.api.models.configured.$post({
           json: {
@@ -543,23 +549,30 @@ export default function ModelsPage(): React.JSX.Element {
     setKeyValidationError(null);
 
     try {
-      const res = await getClient().api.keys.$post({
+      const client = getClient();
+
+      // Validate first
+      const valRes = await client.api.keys.validate.$post({
         json: { provider: editingProvider, key: editKeyValue.trim() },
       });
 
-      if (res.ok) {
-        const body = await res.json();
-        if ("valid" in body && body.valid === false) {
+      if (valRes.ok) {
+        const valBody = await valRes.json();
+        if ("valid" in valBody && valBody.valid === false) {
           setKeyValidationError(
-            ("error" in body && typeof body.error === "string"
-              ? body.error
+            ("error" in valBody && typeof valBody.error === "string"
+              ? valBody.error
               : null) ?? "API key is not valid.",
           );
           setKeyValidating(false);
-          loadData();
           return;
         }
       }
+
+      // Key is valid — save it
+      await client.api.keys.$post({
+        json: { provider: editingProvider, key: editKeyValue.trim() },
+      });
 
       setEditingProvider(null);
       setEditKeyValue("");

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 
-const SCHEMA_VERSION = 6;
+const SCHEMA_VERSION = 7;
 
 export function initSchema(db: DatabaseSync): void {
   db.exec(`
@@ -183,6 +183,17 @@ export function initSchema(db: DatabaseSync): void {
         updated_at TEXT NOT NULL DEFAULT (datetime('now'))
       )
     `);
+  }
+
+  if (currentVersion < 7) {
+    // Add validation status to api_keys
+    try {
+      db.exec(
+        "ALTER TABLE api_keys ADD COLUMN status TEXT NOT NULL DEFAULT 'unknown'",
+      );
+    } catch {
+      // Column may already exist
+    }
   }
 
   // Upsert schema version

--- a/apps/server/src/lib/validate-key.ts
+++ b/apps/server/src/lib/validate-key.ts
@@ -100,30 +100,19 @@ async function validateElevenLabs(apiKey: string): Promise<ValidationResult> {
 }
 
 async function validateAnthropic(apiKey: string): Promise<ValidationResult> {
-  // Anthropic has no free list-models endpoint, so we send an empty
-  // messages request which will fail with a 400 (bad request) if the key
-  // is valid, or 401 if invalid.
-  const res = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
+  const res = await fetch("https://api.anthropic.com/v1/models", {
     headers: {
       "x-api-key": apiKey,
       "anthropic-version": "2023-06-01",
-      "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      model: "claude-3-haiku-20240307",
-      max_tokens: 1,
-      messages: [],
-    }),
     signal: AbortSignal.timeout(TIMEOUT_MS),
   });
+  if (res.ok) return { valid: true };
   if (res.status === 401)
     return {
       valid: false,
       error: "Invalid API key. Please check and try again.",
     };
-  // 400 means the key authenticated but the request body was invalid — key is good
-  if (res.status === 400 || res.ok) return { valid: true };
   if (res.status === 403)
     return { valid: false, error: "API key lacks permission." };
   return { valid: false, error: `Anthropic returned HTTP ${res.status}.` };

--- a/apps/server/src/lib/validate-key.ts
+++ b/apps/server/src/lib/validate-key.ts
@@ -1,0 +1,206 @@
+/**
+ * Per-provider API key validation using free, read-only endpoints.
+ *
+ * Each check hits a lightweight endpoint (e.g. list-models) that
+ * authenticates the key without incurring usage charges.
+ */
+
+const TIMEOUT_MS = 10_000;
+
+interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Format pre-checks
+// ---------------------------------------------------------------------------
+
+const FORMAT_HINTS: Record<string, { prefix: string; hint: string }> = {
+  openai: {
+    prefix: "sk-",
+    hint: 'OpenAI keys start with "sk-".',
+  },
+  groq: {
+    prefix: "gsk_",
+    hint: 'Groq keys start with "gsk_".',
+  },
+};
+
+function checkFormat(provider: string, key: string): string | null {
+  const rule = FORMAT_HINTS[provider];
+  if (!rule) return null;
+  if (!key.startsWith(rule.prefix)) return rule.hint;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Live checks — one per provider
+// ---------------------------------------------------------------------------
+
+async function validateOpenAI(apiKey: string): Promise<ValidationResult> {
+  const res = await fetch("https://api.openai.com/v1/models?limit=1", {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.ok) return { valid: true };
+  if (res.status === 401)
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  if (res.status === 403)
+    return {
+      valid: false,
+      error: "API key lacks permission. Check your OpenAI project settings.",
+    };
+  return { valid: false, error: `OpenAI returned HTTP ${res.status}.` };
+}
+
+async function validateGroq(apiKey: string): Promise<ValidationResult> {
+  const res = await fetch("https://api.groq.com/openai/v1/models", {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.ok) return { valid: true };
+  if (res.status === 401)
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  return { valid: false, error: `Groq returned HTTP ${res.status}.` };
+}
+
+async function validateDeepgram(apiKey: string): Promise<ValidationResult> {
+  const res = await fetch("https://api.deepgram.com/v1/projects", {
+    headers: { Authorization: `Token ${apiKey}` },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.ok) return { valid: true };
+  if (res.status === 401)
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  return { valid: false, error: `Deepgram returned HTTP ${res.status}.` };
+}
+
+async function validateElevenLabs(apiKey: string): Promise<ValidationResult> {
+  const res = await fetch("https://api.elevenlabs.io/v1/user", {
+    headers: { "xi-api-key": apiKey },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.ok) return { valid: true };
+  if (res.status === 401)
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  return { valid: false, error: `ElevenLabs returned HTTP ${res.status}.` };
+}
+
+async function validateAnthropic(apiKey: string): Promise<ValidationResult> {
+  // Anthropic has no free list-models endpoint, so we send an empty
+  // messages request which will fail with a 400 (bad request) if the key
+  // is valid, or 401 if invalid.
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "claude-3-haiku-20240307",
+      max_tokens: 1,
+      messages: [],
+    }),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.status === 401)
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  // 400 means the key authenticated but the request body was invalid — key is good
+  if (res.status === 400 || res.ok) return { valid: true };
+  if (res.status === 403)
+    return { valid: false, error: "API key lacks permission." };
+  return { valid: false, error: `Anthropic returned HTTP ${res.status}.` };
+}
+
+async function validateGoogle(apiKey: string): Promise<ValidationResult> {
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(apiKey)}&pageSize=1`,
+    { signal: AbortSignal.timeout(TIMEOUT_MS) },
+  );
+  if (res.ok) return { valid: true };
+  if (res.status === 400 || res.status === 403)
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  return { valid: false, error: `Google returned HTTP ${res.status}.` };
+}
+
+async function validateMistral(apiKey: string): Promise<ValidationResult> {
+  const res = await fetch("https://api.mistral.ai/v1/models", {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.ok) return { valid: true };
+  if (res.status === 401)
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  return { valid: false, error: `Mistral returned HTTP ${res.status}.` };
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+const LIVE_VALIDATORS: Record<
+  string,
+  (apiKey: string) => Promise<ValidationResult>
+> = {
+  openai: validateOpenAI,
+  groq: validateGroq,
+  deepgram: validateDeepgram,
+  elevenlabs: validateElevenLabs,
+  anthropic: validateAnthropic,
+  google: validateGoogle,
+  mistral: validateMistral,
+};
+
+export async function validateApiKey(
+  provider: string,
+  key: string,
+): Promise<ValidationResult> {
+  // 1. Format pre-check
+  const formatError = checkFormat(provider, key);
+  if (formatError) return { valid: false, error: formatError };
+
+  // 2. Live check
+  const validator = LIVE_VALIDATORS[provider];
+  if (!validator) {
+    // Unknown provider — skip live check, accept the key
+    return { valid: true };
+  }
+
+  try {
+    return await validator(key);
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      return {
+        valid: false,
+        error: "Validation timed out. Check your network and try again.",
+      };
+    }
+    return {
+      valid: false,
+      error: `Could not reach ${provider} API. Check your network and try again.`,
+    };
+  }
+}

--- a/apps/server/src/routes/api-keys.ts
+++ b/apps/server/src/routes/api-keys.ts
@@ -3,23 +3,28 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
 import { capture } from "../lib/posthog.js";
+import { validateApiKey } from "../lib/validate-key.js";
 
 const apiKeys = new Hono()
   .get("/", (c) => {
     const db = getDb();
     const rows = db
       .prepare(
-        "SELECT provider, created_at FROM api_keys ORDER BY created_at DESC",
+        "SELECT provider, created_at, status FROM api_keys ORDER BY created_at DESC",
       )
-      .all() as { provider: string; created_at: string }[];
+      .all() as { provider: string; created_at: string; status: string }[];
     return c.json(rows);
   })
   .get("/:provider", (c) => {
     const db = getDb();
     const provider = c.req.param("provider");
     const row = db
-      .prepare("SELECT provider, created_at FROM api_keys WHERE provider = ?")
-      .get(provider) as { provider: string; created_at: string } | undefined;
+      .prepare(
+        "SELECT provider, created_at, status FROM api_keys WHERE provider = ?",
+      )
+      .get(provider) as
+      | { provider: string; created_at: string; status: string }
+      | undefined;
 
     if (!row) {
       return c.json({ error: "No API key for this provider" }, 404);
@@ -28,20 +33,69 @@ const apiKeys = new Hono()
       provider: row.provider,
       configured: true,
       created_at: row.created_at,
+      status: row.status,
     });
   })
   .post("/", zValidator("json", apiKeySchema), async (c) => {
     const db = getDb();
     const body = c.req.valid("json");
 
+    // Validate the key before saving
+    const result = await validateApiKey(body.provider, body.key);
+
+    const status = result.valid ? "valid" : "invalid";
+
     db.prepare(
-      `INSERT INTO api_keys (provider, key, created_at) VALUES (?, ?, datetime('now'))
-       ON CONFLICT(provider) DO UPDATE SET key = excluded.key, created_at = datetime('now')`,
-    ).run(body.provider, body.key);
+      `INSERT INTO api_keys (provider, key, created_at, status) VALUES (?, ?, datetime('now'), ?)
+       ON CONFLICT(provider) DO UPDATE SET key = excluded.key, created_at = datetime('now'), status = ?`,
+    ).run(body.provider, body.key, status, status);
 
-    capture("api key configured", { provider: body.provider });
+    capture("api key configured", { provider: body.provider, status });
 
-    return c.json({ provider: body.provider, configured: true });
+    if (!result.valid) {
+      return c.json(
+        {
+          provider: body.provider,
+          configured: true,
+          valid: false,
+          error: result.error,
+        },
+        200,
+      );
+    }
+
+    return c.json({ provider: body.provider, configured: true, valid: true });
+  })
+  .post("/validate", zValidator("json", apiKeySchema), async (c) => {
+    const body = c.req.valid("json");
+    const result = await validateApiKey(body.provider, body.key);
+    return c.json({ valid: result.valid, error: result.error });
+  })
+  .post("/:provider/revalidate", async (c) => {
+    const db = getDb();
+    const provider = c.req.param("provider");
+    const row = db
+      .prepare("SELECT key FROM api_keys WHERE provider = ?")
+      .get(provider) as { key: string } | undefined;
+
+    if (!row) {
+      return c.json({ error: "No API key for this provider" }, 404);
+    }
+
+    const result = await validateApiKey(provider, row.key);
+    const status = result.valid ? "valid" : "invalid";
+
+    db.prepare("UPDATE api_keys SET status = ? WHERE provider = ?").run(
+      status,
+      provider,
+    );
+
+    return c.json({
+      provider,
+      valid: result.valid,
+      status,
+      error: result.error,
+    });
   })
   .delete("/:provider", (c) => {
     const db = getDb();

--- a/apps/server/src/routes/api-keys.ts
+++ b/apps/server/src/routes/api-keys.ts
@@ -40,31 +40,14 @@ const apiKeys = new Hono()
     const db = getDb();
     const body = c.req.valid("json");
 
-    // Validate the key before saving
-    const result = await validateApiKey(body.provider, body.key);
-
-    const status = result.valid ? "valid" : "invalid";
-
     db.prepare(
-      `INSERT INTO api_keys (provider, key, created_at, status) VALUES (?, ?, datetime('now'), ?)
-       ON CONFLICT(provider) DO UPDATE SET key = excluded.key, created_at = datetime('now'), status = ?`,
-    ).run(body.provider, body.key, status, status);
+      `INSERT INTO api_keys (provider, key, created_at, status) VALUES (?, ?, datetime('now'), 'valid')
+       ON CONFLICT(provider) DO UPDATE SET key = excluded.key, created_at = datetime('now'), status = 'valid'`,
+    ).run(body.provider, body.key);
 
-    capture("api key configured", { provider: body.provider, status });
+    capture("api key configured", { provider: body.provider });
 
-    if (!result.valid) {
-      return c.json(
-        {
-          provider: body.provider,
-          configured: true,
-          valid: false,
-          error: result.error,
-        },
-        200,
-      );
-    }
-
-    return c.json({ provider: body.provider, configured: true, valid: true });
+    return c.json({ provider: body.provider, configured: true });
   })
   .post("/validate", zValidator("json", apiKeySchema), async (c) => {
     const body = c.req.valid("json");


### PR DESCRIPTION
Validate API keys when users add or edit them by hitting lightweight, free provider endpoints (list-models, list-projects, etc.) before saving. Keys with known bad prefixes (e.g. non-`sk-` for OpenAI) are rejected immediately without a network call.

The validation status is persisted in the DB and surfaced in the UI with check/X icons in the providers list, a spinner during validation, and inline error banners in both the settings and onboarding key dialogs.

## Testing
- `pnpm run -r build` passes (typecheck + production build)
- `pnpm run test` passes (36/36 tests)

<!--
## Plan

### Server-side
1. New `apps/server/src/lib/validate-key.ts`:
   - Format pre-checks (sk- prefix for OpenAI, gsk_ for Groq)
   - Live validators for all 7 cloud providers using free read-only endpoints:
     - OpenAI: GET /v1/models?limit=1
     - Groq: GET /openai/v1/models
     - Deepgram: GET /v1/projects
     - ElevenLabs: GET /v1/user
     - Anthropic: POST /v1/messages with empty body (400 = key valid, 401 = invalid)
     - Google: GET /v1beta/models?pageSize=1
     - Mistral: GET /v1/models
   - 10s timeout, graceful error handling for network failures
   - Unknown providers skip live check and are accepted

2. Updated `apps/server/src/routes/api-keys.ts`:
   - POST /api/keys now validates before saving, returns { valid, error }
   - New POST /api/keys/validate endpoint for dry-run validation
   - New POST /api/keys/:provider/revalidate to re-check existing keys
   - Status persisted in DB alongside the key

3. Schema migration (v6 → v7):
   - Added `status TEXT NOT NULL DEFAULT 'unknown'` column to api_keys table

### Client-side (models.tsx)
4. ApiKeyDialog and EditKeyDialog now show:
   - Loading spinner on the save button during validation
   - Red error banner with AlertTriangle icon on validation failure
   - Red border on the input field when validation fails

5. ProviderRow now shows:
   - Green CheckCircle icon for valid keys
   - Red XCircle icon for invalid keys
   - "Key invalid — update or delete" subtitle for invalid keys
   - Always-visible edit/delete buttons for invalid keys (no hover required)

### Client-side (onboarding.tsx)
6. Voice model and LLM key entry steps now:
   - Validate keys on save and show inline error banners
   - Block advancing to next step when key is invalid
-->