### PR TITLE
feat: add real progress tracking for MLX model weight downloads

### DIFF
--- a/apps/server/src/lib/mlx-asr/models.ts
+++ b/apps/server/src/lib/mlx-asr/models.ts
@@ -55,6 +55,8 @@ interface ActiveMlxDownload {
   bytesDownloaded: number;
   bytesTotal: number;
   speedBps: number;
+  lastUpdate: number;
+  lastBytes: number;
   error?: string;
   stderr: string;
 }
@@ -225,12 +227,15 @@ export async function downloadMlxModel(modelId: string): Promise<void> {
 
   if (isMlxModelDownloaded(model)) return;
 
+  const now = Date.now();
   const active: ActiveMlxDownload = {
     proc: null,
     phase: "building_binary",
     bytesDownloaded: 0,
     bytesTotal: 0,
     speedBps: 0,
+    lastUpdate: now,
+    lastBytes: 0,
     stderr: "",
   };
   activeDownloads.set(modelId, active);
@@ -253,6 +258,11 @@ export async function downloadMlxModel(modelId: string): Promise<void> {
   }
 
   active.phase = "downloading_model";
+  active.bytesDownloaded = 0;
+  active.bytesTotal = 0;
+  active.speedBps = 0;
+  active.lastUpdate = Date.now();
+  active.lastBytes = 0;
 
   await new Promise<void>((resolve, reject) => {
     const proc = spawn(
@@ -264,6 +274,33 @@ export async function downloadMlxModel(modelId: string): Promise<void> {
       },
     );
     active.proc = proc;
+
+    let stdoutBuf = "";
+    proc.stdout?.on("data", (data: Buffer) => {
+      stdoutBuf += data.toString();
+      let newlineIdx: number;
+      while ((newlineIdx = stdoutBuf.indexOf("\n")) !== -1) {
+        const line = stdoutBuf.slice(0, newlineIdx);
+        stdoutBuf = stdoutBuf.slice(newlineIdx + 1);
+        try {
+          const msg = JSON.parse(line);
+          if (msg.type === "progress") {
+            active.bytesDownloaded = msg.bytesDownloaded ?? 0;
+            active.bytesTotal = msg.bytesTotal ?? 0;
+            const ts = Date.now();
+            const elapsed = ts - active.lastUpdate;
+            if (elapsed >= 500) {
+              const delta = active.bytesDownloaded - active.lastBytes;
+              active.speedBps = Math.round((delta / elapsed) * 1000);
+              active.lastUpdate = ts;
+              active.lastBytes = active.bytesDownloaded;
+            }
+          }
+        } catch {
+          // non-JSON line; ignore
+        }
+      }
+    });
 
     proc.stderr?.on("data", (data: Buffer) => {
       active.stderr = `${active.stderr}${data.toString()}`.slice(-2_000);

--- a/scripts/mlx_asr_server.py
+++ b/scripts/mlx_asr_server.py
@@ -43,11 +43,76 @@ def _send(payload: dict[str, Any]) -> None:
     print(json.dumps(payload, ensure_ascii=True), flush=True)
 
 
+class _DownloadProgress:
+    """Holds aggregate download state and emits JSON progress to stdout."""
+
+    def __init__(self) -> None:
+        self.bytes_downloaded: int = 0
+        self.bytes_total: int = 0
+
+    def emit(self) -> None:
+        if self.bytes_total > 0:
+            _send({
+                "type": "progress",
+                "bytesDownloaded": self.bytes_downloaded,
+                "bytesTotal": self.bytes_total,
+            })
+
+
+_dl_progress: _DownloadProgress | None = None
+
+
+class _ProgressTqdm:
+    """Minimal tqdm replacement that emits JSON progress lines to stdout.
+
+    ``huggingface_hub.snapshot_download`` uses this class in two roles:
+
+    1. **Aggregate bytes bar** — created once via ``_create_progress_bar``.
+       The internal ``_AggregatedTqdm`` helper mutates ``.total`` and calls
+       ``.update(n)`` / ``.refresh()`` as each file chunk arrives.
+    2. **File-listing bar** — created by ``thread_map`` to show how many
+       files have been fetched.  We ignore this bar.
+
+    Only the aggregate bytes bar emits progress JSON to the Node caller.
+    """
+
+    def __init__(self, *_args: Any, total: int | None = None, **_kwargs: Any) -> None:
+        self.total: int = total or 0
+        self.n: int = _kwargs.get("initial", 0)
+        self._is_bytes = _kwargs.get("unit") == "B"
+
+    def update(self, n: int | float | None = 1) -> None:
+        if n:
+            self.n += int(n)
+        if self._is_bytes and _dl_progress is not None and self.total > 0:
+            _dl_progress.bytes_downloaded = self.n
+            _dl_progress.bytes_total = self.total
+            _dl_progress.emit()
+
+    def refresh(self) -> None:
+        pass
+
+    def set_description(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def __enter__(self) -> "_ProgressTqdm":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        self.close()
+
+
 def _download_model(model_id: str) -> None:
+    global _dl_progress
     from huggingface_hub import snapshot_download
 
+    _dl_progress = _DownloadProgress()
     _log(f"downloading {model_id} ...")
-    path = snapshot_download(model_id)
+    path = snapshot_download(model_id, tqdm_class=_ProgressTqdm)
+    _dl_progress = None
     _send({"type": "downloaded", "model": model_id, "path": path})
 
 

--- a/scripts/mlx_asr_server.py
+++ b/scripts/mlx_asr_server.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import threading
 from inspect import Parameter, signature
 from pathlib import Path
 from typing import Any
@@ -71,26 +72,53 @@ class _ProgressTqdm:
        The internal ``_AggregatedTqdm`` helper mutates ``.total`` and calls
        ``.update(n)`` / ``.refresh()`` as each file chunk arrives.
     2. **File-listing bar** — created by ``thread_map`` to show how many
-       files have been fetched.  We ignore this bar.
+       files have been fetched.  We ignore this bar (``_is_bytes=False``).
 
     Only the aggregate bytes bar emits progress JSON to the Node caller.
+    Thread safety: ``+= total`` and ``update(n)`` are called from up to 8
+    download threads.  Minor races on ``self.n``/``self.total`` are
+    acceptable for a progress bar.
     """
 
-    def __init__(self, *_args: Any, total: int | None = None, **_kwargs: Any) -> None:
+    _lock = threading.RLock()
+
+    @classmethod
+    def get_lock(cls) -> threading.RLock:
+        return cls._lock
+
+    @classmethod
+    def set_lock(cls, lock: Any) -> None:
+        cls._lock = lock
+
+    def __init__(self, iterable: Any = None, *, total: int | None = None, **_kwargs: Any) -> None:
+        self._iterable = iterable
         self.total: int = total or 0
         self.n: int = _kwargs.get("initial", 0)
         self._is_bytes = _kwargs.get("unit") == "B"
 
+    def __iter__(self) -> Any:
+        if self._iterable is None:
+            return
+        for item in self._iterable:
+            self.update(1)
+            yield item
+
+    def __len__(self) -> int:
+        return self.total
+
     def update(self, n: int | float | None = 1) -> None:
         if n:
             self.n += int(n)
+        self._emit()
+
+    def _emit(self) -> None:
         if self._is_bytes and _dl_progress is not None and self.total > 0:
             _dl_progress.bytes_downloaded = self.n
             _dl_progress.bytes_total = self.total
             _dl_progress.emit()
 
     def refresh(self) -> None:
-        pass
+        self._emit()
 
     def set_description(self, *_args: Any, **_kwargs: Any) -> None:
         pass


### PR DESCRIPTION
The MLX model download phase showed an indeterminate "Downloading model weights..." message with no progress data because the Python worker's `snapshot_download` call had no progress reporting. This adds a custom tqdm replacement that emits JSON progress lines so the frontend can show a real progress bar with byte counts, speed, and percentage.

## Changes

- **`scripts/mlx_asr_server.py`** — `_ProgressTqdm` class replaces tqdm in `snapshot_download`, emits `{"type": "progress", "bytesDownloaded": N, "bytesTotal": M}` JSON lines to stdout as chunks arrive
- **`apps/server/src/lib/mlx-asr/models.ts`** — parses stdout JSON from the worker subprocess to populate `active.bytesDownloaded`/`bytesTotal`/`speedBps` with 500ms speed sampling

## Testing
Manual — requires macOS Apple Silicon with MLX dependencies to trigger a model download.

<!--
## Plan

### Problem
During the `downloading_model` phase of MLX model downloads, the Python worker calls
`huggingface_hub.snapshot_download()` with no progress callbacks. The Node.js side never
receives progress data, so `bytesDownloaded`/`bytesTotal`/`speedBps` stay at 0. The
frontend falls through to "Downloading model weights..." with no progress bar.

### Approach
Provide a custom tqdm class (`_ProgressTqdm`) to `snapshot_download(tqdm_class=...)`.
`huggingface_hub` internally creates an `_AggregatedTqdm` that mutates the aggregate
bytes bar's `.total` and calls `.update(n)` per chunk. Our class emits JSON progress
lines to stdout which the Node side parses.

Key design decisions:
- The `_is_bytes` flag (checks `unit == "B"`) distinguishes the aggregate bytes bar
  from the file-listing bar created by `thread_map`, preventing the latter from
  emitting misleading progress.
- Speed calculation uses 500ms sampling intervals, matching the existing runtime
  download pattern in `runtime.ts`.
- Progress fields are reset when transitioning from `building_binary` to
  `downloading_model` phase to avoid stale data.

### Files changed
- `scripts/mlx_asr_server.py` — `_DownloadProgress`, `_ProgressTqdm` classes + modified `_download_model`
- `apps/server/src/lib/mlx-asr/models.ts` — stdout parser + `lastUpdate`/`lastBytes` fields on `ActiveMlxDownload`
-->