### PR TITLE
Enhance 111: Adding panning to pill widget

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -175,18 +175,40 @@ function getDashboardURL(path = "/"): string {
   return `app://renderer${path}`;
 }
 
-let isProgrammaticMove = false;
+// Tracks the exact coordinates of the last programmatic setPosition call.
+// The move listener compares reported coords against this target and ignores
+// matching events, eliminating the fixed-timeout race condition.
+let programmaticTarget: { x: number; y: number } | null = null;
+let programmaticCleanupTimer: NodeJS.Timeout | null = null;
 
 function setProgrammaticPosition(
   win: BrowserWindow,
   x: number,
   y: number,
 ): void {
-  isProgrammaticMove = true;
+  programmaticTarget = { x, y };
+  // Safety: clear the target after 1s in case the OS never delivers a settle event.
+  if (programmaticCleanupTimer) clearTimeout(programmaticCleanupTimer);
+  programmaticCleanupTimer = setTimeout(() => {
+    programmaticTarget = null;
+    programmaticCleanupTimer = null;
+  }, 1000);
   win.setPosition(x, y);
-  setTimeout(() => {
-    isProgrammaticMove = false;
-  }, 200);
+}
+
+// Returns the pill alignment token for a custom position, using the actual
+// display the window resides on — safe for multi-monitor setups.
+function getPillAlignmentForCustom(): "custom-top" | "custom-bottom" {
+  if (!mainWindow) return "custom-bottom";
+  const [wx, wy] = mainWindow.getPosition();
+  const display = screen.getDisplayMatching({
+    x: wx,
+    y: wy,
+    width: APP_WIDTH,
+    height: APP_HEIGHT,
+  });
+  const midY = display.workArea.y + display.workArea.height / 2;
+  return wy < midY ? "custom-top" : "custom-bottom";
 }
 
 function getAppWindowPosition(): { x: number; y: number } {
@@ -238,7 +260,14 @@ function getAppWindowPosition(): { x: number; y: number } {
 function createAppWindow(): void {
   const { x, y } = getAppWindowPosition();
 
-  isProgrammaticMove = true;
+  // Mark the initial position as programmatic so the move listener ignores it.
+  programmaticTarget = { x, y };
+  if (programmaticCleanupTimer) clearTimeout(programmaticCleanupTimer);
+  programmaticCleanupTimer = setTimeout(() => {
+    programmaticTarget = null;
+    programmaticCleanupTimer = null;
+  }, 1000);
+
   mainWindow = new BrowserWindow({
     width: APP_WIDTH,
     height: APP_HEIGHT,
@@ -262,10 +291,6 @@ function createAppWindow(): void {
     },
   });
 
-  setTimeout(() => {
-    isProgrammaticMove = false;
-  }, 500);
-
   mainWindow.setAlwaysOnTop(true, "screen-saver");
   mainWindow.setVisibleOnAllWorkspaces(true, {
     visibleOnFullScreen: true,
@@ -273,19 +298,40 @@ function createAppWindow(): void {
 
   let moveTimeout: NodeJS.Timeout | null = null;
   mainWindow.on("move", () => {
-    if (isProgrammaticMove) return;
+    if (!mainWindow) return;
+    const [nx, ny] = mainWindow.getPosition();
+
+    // Ignore events that match the programmatic target (the window settling
+    // after a setProgrammaticPosition call). Clear the target once we see
+    // the first matching position so subsequent real drags are captured.
+    if (
+      programmaticTarget &&
+      nx === programmaticTarget.x &&
+      ny === programmaticTarget.y
+    ) {
+      if (programmaticCleanupTimer) clearTimeout(programmaticCleanupTimer);
+      programmaticTarget = null;
+      programmaticCleanupTimer = null;
+      return;
+    }
+
+    // If programmaticTarget is set but coords don't match yet, the window is
+    // still mid-animation — ignore until it settles.
+    if (programmaticTarget) return;
+
     if (moveTimeout) clearTimeout(moveTimeout);
     moveTimeout = setTimeout(() => {
       if (!mainWindow) return;
-      const [nx, ny] = mainWindow.getPosition();
+      const [fx, fy] = mainWindow.getPosition();
       writeSettings({
         pillPosition: "custom",
-        pillCustomPosition: { x: nx, y: ny },
+        pillCustomPosition: { x: fx, y: fy },
       });
-      mainWindow.webContents.send("settings:pill-position-changed", "custom");
+      const alignment = getPillAlignmentForCustom();
+      mainWindow.webContents.send("settings:pill-position-changed", alignment);
       settingsWindow?.webContents.send(
         "settings:pill-position-changed",
-        "custom",
+        alignment,
       );
     }, 200);
   });
@@ -1296,7 +1342,11 @@ app.whenReady().then(async () => {
 
   // -- Pill position setting --
   ipcMain.handle("settings:pill-position", () => {
-    return (readSettings().pillPosition as string) ?? "bottom-center";
+    const pos = (readSettings().pillPosition as string) ?? "bottom-center";
+    // For a custom position, derive the correct top/bottom alignment token
+    // from the actual window position relative to its display.
+    if (pos === "custom") return getPillAlignmentForCustom();
+    return pos;
   });
 
   ipcMain.handle("settings:has-custom-position", () => {
@@ -1312,15 +1362,18 @@ app.whenReady().then(async () => {
 
   ipcMain.on("settings:set-pill-position", (_event, position: string) => {
     writeSettings({ pillPosition: position });
-    // Reposition the window and notify the renderer for CSS alignment
+    // Reposition the window and notify the renderer for CSS alignment.
     if (mainWindow) {
       const { x, y } = getAppWindowPosition();
       setProgrammaticPosition(mainWindow, x, y);
     }
-    mainWindow?.webContents.send("settings:pill-position-changed", position);
+    // For custom, resolve the live alignment; for presets, send as-is.
+    const broadcast =
+      position === "custom" ? getPillAlignmentForCustom() : position;
+    mainWindow?.webContents.send("settings:pill-position-changed", broadcast);
     settingsWindow?.webContents.send(
       "settings:pill-position-changed",
-      position,
+      broadcast,
     );
   });
 

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -175,6 +175,20 @@ function getDashboardURL(path = "/"): string {
   return `app://renderer${path}`;
 }
 
+let isProgrammaticMove = false;
+
+function setProgrammaticPosition(
+  win: BrowserWindow,
+  x: number,
+  y: number,
+): void {
+  isProgrammaticMove = true;
+  win.setPosition(x, y);
+  setTimeout(() => {
+    isProgrammaticMove = false;
+  }, 200);
+}
+
 function getAppWindowPosition(): { x: number; y: number } {
   const primaryDisplay = screen.getPrimaryDisplay();
   const { width, height } = primaryDisplay.workAreaSize;
@@ -197,6 +211,22 @@ function getAppWindowPosition(): { x: number; y: number } {
         x: width - APP_WIDTH,
         y: height - APP_HEIGHT + bottomOverlap,
       };
+    case "custom": {
+      const custom = readSettings().pillCustomPosition as
+        | { x: number; y: number }
+        | undefined;
+      if (
+        custom &&
+        typeof custom.x === "number" &&
+        typeof custom.y === "number"
+      ) {
+        return custom;
+      }
+      return {
+        x: Math.round((width - APP_WIDTH) / 2),
+        y: height - APP_HEIGHT + bottomOverlap,
+      };
+    }
     default:
       return {
         x: Math.round((width - APP_WIDTH) / 2),
@@ -208,6 +238,7 @@ function getAppWindowPosition(): { x: number; y: number } {
 function createAppWindow(): void {
   const { x, y } = getAppWindowPosition();
 
+  isProgrammaticMove = true;
   mainWindow = new BrowserWindow({
     width: APP_WIDTH,
     height: APP_HEIGHT,
@@ -231,12 +262,39 @@ function createAppWindow(): void {
     },
   });
 
+  setTimeout(() => {
+    isProgrammaticMove = false;
+  }, 500);
+
   mainWindow.setAlwaysOnTop(true, "screen-saver");
   mainWindow.setVisibleOnAllWorkspaces(true, {
     visibleOnFullScreen: true,
   });
 
+  let moveTimeout: NodeJS.Timeout | null = null;
+  mainWindow.on("move", () => {
+    if (isProgrammaticMove) return;
+    if (moveTimeout) clearTimeout(moveTimeout);
+    moveTimeout = setTimeout(() => {
+      if (!mainWindow) return;
+      const [nx, ny] = mainWindow.getPosition();
+      writeSettings({
+        pillPosition: "custom",
+        pillCustomPosition: { x: nx, y: ny },
+      });
+      mainWindow.webContents.send("settings:pill-position-changed", "custom");
+      settingsWindow?.webContents.send(
+        "settings:pill-position-changed",
+        "custom",
+      );
+    }, 200);
+  });
+
   mainWindow.on("closed", () => {
+    if (moveTimeout) {
+      clearTimeout(moveTimeout);
+      moveTimeout = null;
+    }
     mainWindow = null;
   });
 
@@ -331,7 +389,7 @@ function showPill(): void {
 
   if (!mainWindow.isVisible()) {
     const { x, y } = getAppWindowPosition();
-    mainWindow.setPosition(x, y);
+    setProgrammaticPosition(mainWindow, x, y);
     mainWindow.showInactive();
   }
 
@@ -1241,14 +1299,29 @@ app.whenReady().then(async () => {
     return (readSettings().pillPosition as string) ?? "bottom-center";
   });
 
+  ipcMain.handle("settings:has-custom-position", () => {
+    const custom = readSettings().pillCustomPosition as
+      | { x: number; y: number }
+      | undefined;
+    return !!(
+      custom &&
+      typeof custom.x === "number" &&
+      typeof custom.y === "number"
+    );
+  });
+
   ipcMain.on("settings:set-pill-position", (_event, position: string) => {
     writeSettings({ pillPosition: position });
     // Reposition the window and notify the renderer for CSS alignment
     if (mainWindow) {
       const { x, y } = getAppWindowPosition();
-      mainWindow.setPosition(x, y);
+      setProgrammaticPosition(mainWindow, x, y);
     }
     mainWindow?.webContents.send("settings:pill-position-changed", position);
+    settingsWindow?.webContents.send(
+      "settings:pill-position-changed",
+      position,
+    );
   });
 
   // Register hold-to-record hotkey via native platform binary

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -62,6 +62,7 @@ declare global {
       getFrontmostApp: () => Promise<string | null>;
       // Pill position
       getPillPosition: () => Promise<string>;
+      hasCustomPosition: () => Promise<boolean>;
       setPillPosition: (position: string) => void;
       onPillPositionChanged: (
         callback: (position: string) => void,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -133,6 +133,8 @@ const api = {
   // Pill position
   getPillPosition: (): Promise<string> =>
     ipcRenderer.invoke("settings:pill-position"),
+  hasCustomPosition: (): Promise<boolean> =>
+    ipcRenderer.invoke("settings:has-custom-position"),
   setPillPosition: (position: string): void =>
     ipcRenderer.send("settings:set-pill-position", position),
   onPillPositionChanged: (

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -766,12 +766,11 @@ export default function AppPage(): React.JSX.Element {
   }, [stopVisualization, hidePill]);
 
   // ---- Preferences ----
+  // The main process sends either a predefined position string (e.g. "top-center")
+  // or a display-relative alignment token ("custom-top" / "custom-bottom").
+  // Using includes("top") covers both cases correctly on all monitor setups.
   const applyPillPosition = useCallback((pos: string | null | undefined) => {
-    const isTop =
-      pos === "custom"
-        ? window.screenY < window.screen.availHeight / 2
-        : !!pos?.startsWith("top");
-    setPillAlign(isTop ? "start" : "end");
+    setPillAlign(pos?.includes("top") ? "start" : "end");
     setPillSide(pos?.endsWith("right") ? "right" : "center");
   }, []);
 
@@ -1045,13 +1044,17 @@ export default function AppPage(): React.JSX.Element {
             style={pillInnerStyle}
           >
             <div
-              style={{
-                width: 29,
-                height: 29,
-                borderRadius: "50%",
-                overflow: "hidden",
-                flexShrink: 0,
-              }}
+              style={
+                {
+                  width: 29,
+                  height: 29,
+                  borderRadius: "50%",
+                  overflow: "hidden",
+                  flexShrink: 0,
+                  // Allow pointer events on the Orb even though the parent is draggable.
+                  WebkitAppRegion: "no-drag",
+                } as React.CSSProperties
+              }
             >
               <Orb
                 colors={
@@ -1082,20 +1085,33 @@ export default function AppPage(): React.JSX.Element {
             {showBars && renderBars(barsSvgRef)}
 
             {state === "error" && (
-              <span style={pillTextStyle}>{message || "Error"}</span>
+              <span
+                style={
+                  {
+                    ...pillTextStyle,
+                    WebkitAppRegion: "no-drag",
+                  } as React.CSSProperties
+                }
+              >
+                {message || "Error"}
+              </span>
             )}
 
             {badge && (
               <span
                 className="mono"
-                style={{
-                  fontSize: 10,
-                  letterSpacing: "0.06em",
-                  opacity: 0.6,
-                  flexShrink: 0,
-                  color: "var(--muted-foreground)",
-                  paddingRight: 5,
-                }}
+                style={
+                  {
+                    fontSize: 10,
+                    letterSpacing: "0.06em",
+                    opacity: 0.6,
+                    flexShrink: 0,
+                    color: "var(--muted-foreground)",
+                    paddingRight: 5,
+                    // Restore pointer events on the badge label.
+                    WebkitAppRegion: "no-drag",
+                  } as React.CSSProperties
+                }
               >
                 {badge}
               </span>

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -85,7 +85,7 @@ const pillInnerStyle: React.CSSProperties = {
   fontFamily: "'DM Sans', sans-serif",
   fontSize: 13,
   fontWeight: 500,
-  WebkitAppRegion: "no-drag",
+  WebkitAppRegion: "drag",
 } as React.CSSProperties;
 
 const pillTextStyle: React.CSSProperties = {
@@ -767,7 +767,11 @@ export default function AppPage(): React.JSX.Element {
 
   // ---- Preferences ----
   const applyPillPosition = useCallback((pos: string | null | undefined) => {
-    setPillAlign(pos?.startsWith("top") ? "start" : "end");
+    const isTop =
+      pos === "custom"
+        ? window.screenY < window.screen.availHeight / 2
+        : !!pos?.startsWith("top");
+    setPillAlign(isTop ? "start" : "end");
     setPillSide(pos?.endsWith("right") ? "right" : "center");
   }, []);
 

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -22,7 +22,7 @@ import {
   VolumeOff,
 } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -230,10 +230,11 @@ export default function GeneralSettingsPage(): React.JSX.Element {
     window.api
       ?.getPillPosition()
       .then((pos) => {
-        setPillPosition(pos);
-        if (pos === "custom") {
-          setHasCustom(true);
-        }
+        // The main process may return "custom-top" or "custom-bottom" to convey
+        // the display-relative alignment; normalise back to "custom" for the UI.
+        const norm = pos.startsWith("custom") ? "custom" : pos;
+        setPillPosition(norm);
+        if (norm === "custom") setHasCustom(true);
       })
       .catch(() => {});
     window.api
@@ -305,10 +306,10 @@ export default function GeneralSettingsPage(): React.JSX.Element {
 
     // Pill position live changes
     const removePillPos = window.api?.onPillPositionChanged((pos) => {
-      setPillPosition(pos);
-      if (pos === "custom") {
-        setHasCustom(true);
-      }
+      // Normalise custom-top / custom-bottom to "custom" for the dropdown.
+      const norm = pos.startsWith("custom") ? "custom" : pos;
+      setPillPosition(norm);
+      if (norm === "custom") setHasCustom(true);
     });
 
     checkPermissions();
@@ -415,6 +416,19 @@ export default function GeneralSettingsPage(): React.JSX.Element {
     : canSaveRecording
       ? "Release to save · Esc to cancel"
       : "Press a modifier or side mouse button... · Esc to cancel";
+
+  // Build position options once; include "Custom" only if the user has ever
+  // dragged the pill to a custom location.
+  const positionOptions = useMemo<SegmentOption[]>(() => {
+    const opts: SegmentOption[] = [
+      { id: "bottom-center", label: "Bottom · Center" },
+      { id: "bottom-right", label: "Bottom · Right" },
+      { id: "top-center", label: "Top · Center" },
+      { id: "top-right", label: "Top · Right" },
+    ];
+    if (hasCustom) opts.push({ id: "custom", label: "Custom" });
+    return opts;
+  }, [hasCustom]);
 
   return (
     <div
@@ -719,25 +733,12 @@ export default function GeneralSettingsPage(): React.JSX.Element {
             desc="Where the floating pill appears on your screen."
             last
           >
-            {(() => {
-              const positionOptions: SegmentOption[] = [
-                { id: "bottom-center", label: "Bottom · Center" },
-                { id: "bottom-right", label: "Bottom · Right" },
-                { id: "top-center", label: "Top · Center" },
-                { id: "top-right", label: "Top · Right" },
-              ];
-              if (hasCustom) {
-                positionOptions.push({ id: "custom", label: "Custom" });
-              }
-              return (
-                <Segment
-                  compact
-                  options={positionOptions}
-                  active={pillPosition}
-                  onSelect={handlePillPositionChange}
-                />
-              );
-            })()}
+            <Segment
+              compact
+              options={positionOptions}
+              active={pillPosition}
+              onSelect={handlePillPositionChange}
+            />
           </Row>
         </Section>
 

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -52,6 +52,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
   const [language, setLanguage] = useState("auto");
   const [outputMode, setOutputMode] = useState("paste");
   const [pillPosition, setPillPosition] = useState("bottom-center");
+  const [hasCustom, setHasCustom] = useState(false);
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [transcriptionPrompt, setTranscriptionPrompt] = useState("");
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null);
@@ -228,7 +229,16 @@ export default function GeneralSettingsPage(): React.JSX.Element {
       .catch(() => {});
     window.api
       ?.getPillPosition()
-      .then(setPillPosition)
+      .then((pos) => {
+        setPillPosition(pos);
+        if (pos === "custom") {
+          setHasCustom(true);
+        }
+      })
+      .catch(() => {});
+    window.api
+      ?.hasCustomPosition()
+      .then(setHasCustom)
       .catch(() => {});
     getClient()
       .api.settings[":key"].$get({ param: { key: "sound_enabled" } })
@@ -293,6 +303,14 @@ export default function GeneralSettingsPage(): React.JSX.Element {
       })
       .catch(() => {});
 
+    // Pill position live changes
+    const removePillPos = window.api?.onPillPositionChanged((pos) => {
+      setPillPosition(pos);
+      if (pos === "custom") {
+        setHasCustom(true);
+      }
+    });
+
     checkPermissions();
 
     return () => {
@@ -300,6 +318,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
       removeDownloading?.();
       removeDownloaded?.();
       removeError?.();
+      removePillPos?.();
       if (micPollRef.current) clearInterval(micPollRef.current);
       if (accessibilityPollRef.current)
         clearInterval(accessibilityPollRef.current);
@@ -700,17 +719,25 @@ export default function GeneralSettingsPage(): React.JSX.Element {
             desc="Where the floating pill appears on your screen."
             last
           >
-            <Segment
-              compact
-              options={[
+            {(() => {
+              const positionOptions: SegmentOption[] = [
                 { id: "bottom-center", label: "Bottom · Center" },
                 { id: "bottom-right", label: "Bottom · Right" },
                 { id: "top-center", label: "Top · Center" },
                 { id: "top-right", label: "Top · Right" },
-              ]}
-              active={pillPosition}
-              onSelect={handlePillPositionChange}
-            />
+              ];
+              if (hasCustom) {
+                positionOptions.push({ id: "custom", label: "Custom" });
+              }
+              return (
+                <Segment
+                  compact
+                  options={positionOptions}
+                  active={pillPosition}
+                  onSelect={handlePillPositionChange}
+                />
+              );
+            })()}
           </Row>
         </Section>
 


### PR DESCRIPTION
I have fixed the panning issue when playing around with the widget. I've also taken care about the changes in the settings tab. The pill location is automatically saved and can be manually tinkered in the settings. The key changes are in the render sections where the `webkit` has been changed from no-drag to drag so the pill can be moved around.

I've also added a video for the enhancement PR


https://github.com/user-attachments/assets/86ffb6c3-6243-4210-b551-f51f3dcb46c8

