### PR TITLE
fix: wait for native key listener READY before confirming hotkey registration

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1417,7 +1417,7 @@ function handleNativeHotkeyUp(): void {
   }
 }
 
-function registerHotkey(hotkey?: string): void {
+async function registerHotkey(hotkey?: string): Promise<void> {
   // Tear down previous listener
   if (keyListener) {
     keyListener.stop();
@@ -1436,11 +1436,13 @@ function registerHotkey(hotkey?: string): void {
   currentHotkeyAccel = accel;
 
   // Try native key listener binary first (all platforms)
+  let nativeError = "";
   keyListener = new NativeKeyListener({
     hotkey: accel,
     onKeyDown: handleNativeHotkeyDown,
     onKeyUp: handleNativeHotkeyUp,
     onError: (error) => {
+      nativeError = error;
       hotkeyLog.error(`Native key listener error: ${error}`);
     },
     onReady: () => {
@@ -1448,7 +1450,7 @@ function registerHotkey(hotkey?: string): void {
     },
   });
 
-  const started = keyListener.start();
+  const started = await keyListener.start();
 
   if (started) {
     accessibilityConfirmed = true;
@@ -1456,6 +1458,7 @@ function registerHotkey(hotkey?: string): void {
     hotkeyLog.warn(
       "Native key listener unavailable, falling back to Electron globalShortcut (toggle mode).",
     );
+    keyListener.stop();
     keyListener = null;
 
     // Fallback: globalShortcut has no key-up — always use toggle semantics
@@ -1471,9 +1474,14 @@ function registerHotkey(hotkey?: string): void {
     if (registered) {
       accessibilityConfirmed = true;
     } else {
-      const errorPayload = {
-        message: `Could not register hotkey "${accel}". Try a different key combination in Settings.`,
-      };
+      let message = `Could not register hotkey "${accel}". Try a different key combination in Settings.`;
+      if (
+        process.platform === "linux" &&
+        nativeError.includes("No accessible input devices")
+      ) {
+        message = `Hotkey "${accel}" requires access to input devices. Run: sudo usermod -aG input $USER — then log out and back in.`;
+      }
+      const errorPayload = { message };
       mainWindow?.webContents.send("hotkey:error", errorPayload);
       settingsWindow?.webContents.send("hotkey:error", errorPayload);
     }

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1437,7 +1437,7 @@ async function registerHotkey(hotkey?: string): Promise<void> {
 
   // Try native key listener binary first (all platforms)
   let nativeError = "";
-  keyListener = new NativeKeyListener({
+  const listener = new NativeKeyListener({
     hotkey: accel,
     onKeyDown: handleNativeHotkeyDown,
     onKeyUp: handleNativeHotkeyUp,
@@ -1449,8 +1449,16 @@ async function registerHotkey(hotkey?: string): Promise<void> {
       hotkeyLog.debug(`Native key listener ready for "${accel}"`);
     },
   });
+  keyListener = listener;
 
-  const started = await keyListener.start();
+  const started = await listener.start();
+
+  // Another registerHotkey call may have replaced keyListener while we
+  // were awaiting — if so, abandon this attempt.
+  if (keyListener !== listener) {
+    listener.stop();
+    return;
+  }
 
   if (started) {
     accessibilityConfirmed = true;
@@ -1458,7 +1466,7 @@ async function registerHotkey(hotkey?: string): Promise<void> {
     hotkeyLog.warn(
       "Native key listener unavailable, falling back to Electron globalShortcut (toggle mode).",
     );
-    keyListener.stop();
+    listener.stop();
     keyListener = null;
 
     // Fallback: globalShortcut has no key-up — always use toggle semantics

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -135,15 +135,16 @@ export class NativeKeyListener {
 
   /**
    * Start the native key listener binary.
-   * Returns true if the binary was found and spawned.
+   * Resolves true once the binary emits READY, false if it exits or
+   * fails before that.
    */
-  start(): boolean {
-    if (this.destroyed) return false;
+  start(): Promise<boolean> {
+    if (this.destroyed) return Promise.resolve(false);
 
     const binaryName = BINARY_NAMES[process.platform];
     if (!binaryName) {
       this.options.onError?.(`Unsupported platform: ${process.platform}`);
-      return false;
+      return Promise.resolve(false);
     }
 
     const binaryPath = getNativeBinaryPath(binaryName);
@@ -151,7 +152,7 @@ export class NativeKeyListener {
       this.options.onError?.(
         `Native key listener binary not found: ${binaryName}`,
       );
-      return false;
+      return Promise.resolve(false);
     }
 
     const args: string[] = [];
@@ -172,41 +173,61 @@ export class NativeKeyListener {
       this.options.onError?.(
         `Failed to spawn key listener: ${err instanceof Error ? err.message : String(err)}`,
       );
-      return false;
+      return Promise.resolve(false);
     }
 
-    let lineBuffer = "";
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      let stderrOutput = "";
+      let lineBuffer = "";
 
-    this.process.stdout?.on("data", (data: Buffer) => {
-      lineBuffer += data.toString();
-      const lines = lineBuffer.split("\n");
-      lineBuffer = lines.pop() ?? "";
+      this.process!.stdout?.on("data", (data: Buffer) => {
+        lineBuffer += data.toString();
+        const lines = lineBuffer.split("\n");
+        lineBuffer = lines.pop() ?? "";
 
-      for (const line of lines) {
-        this.handleLine(line.trim());
-      }
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!settled && trimmed === "READY") {
+            settled = true;
+            resolve(true);
+          }
+          this.handleLine(trimmed);
+        }
+      });
+
+      this.process!.stderr?.on("data", (data: Buffer) => {
+        const text = data.toString().trim();
+        stderrOutput += text + "\n";
+        log.debug(text);
+      });
+
+      this.process!.on("close", (code) => {
+        this.process = null;
+        if (!settled) {
+          settled = true;
+          if (stderrOutput.trim()) {
+            this.options.onError?.(stderrOutput.trim());
+          }
+          resolve(false);
+        }
+        if (!this.destroyed && code !== 0) {
+          this.scheduleRestart();
+        }
+      });
+
+      this.process!.on("error", (err) => {
+        this.options.onError?.(`Key listener process error: ${err.message}`);
+        this.process = null;
+        if (!settled) {
+          settled = true;
+          resolve(false);
+        }
+        if (!this.destroyed) {
+          this.scheduleRestart();
+        }
+      });
     });
-
-    this.process.stderr?.on("data", (data: Buffer) => {
-      log.debug(data.toString().trim());
-    });
-
-    this.process.on("close", (code) => {
-      this.process = null;
-      if (!this.destroyed && code !== 0) {
-        this.scheduleRestart();
-      }
-    });
-
-    this.process.on("error", (err) => {
-      this.options.onError?.(`Key listener process error: ${err.message}`);
-      this.process = null;
-      if (!this.destroyed) {
-        this.scheduleRestart();
-      }
-    });
-
-    return true;
   }
 
   private handleLine(line: string): void {


### PR DESCRIPTION
On Linux, when the user lacks `/dev/input` permissions, the native key listener binary exits immediately but `start()` already returned `true` — so the `globalShortcut` fallback was never activated and the hotkey silently stopped working.

`start()` now returns a `Promise<boolean>` that resolves `true` only after the binary emits `READY`, or `false` if it exits first. `registerHotkey()` awaits the result and falls back to `globalShortcut` when the native listener fails. stderr is always logged so the `/dev/input` permission hint reaches users. `globalShortcut` cleanup is no longer gated on Windows only.

## Testing
`npm run typecheck` passes (both `:node` and `:web`). Manual testing requires an Ubuntu machine without `input` group membership — the fix ensures the app falls back to `globalShortcut` and shows a descriptive error if both mechanisms fail.

Closes #165

<!--
## Plan

### Root cause
`NativeKeyListener.start()` returned `true` synchronously based solely on `spawn()` success. On Ubuntu, the `linux-key-listener` binary needs read access to `/dev/input/event*` files (requires `input` group). Without permissions the binary exits with code 1, but the main process already set `accessibilityConfirmed = true` and never tried the `globalShortcut` fallback.

### Changes
1. **key-listener.ts** — `start()` returns `Promise<boolean>` that resolves after `READY` is received (true) or the process exits/errors before that (false). stderr is always logged (was dev-only). On early exit, the stderr output is forwarded via `onError`.
2. **index.ts** — `registerHotkey()` is now async. It awaits `start()`, properly falls back to `globalShortcut`, and shows a Linux-specific error message when the input-device permission issue is detected. `globalShortcut.unregisterAll()` and `will-quit` cleanup are no longer gated on `win32`.
-->