### PR TITLE
fix: polish pill panning — drag cursor, bounds checking, custom position lifecycle

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -228,6 +228,9 @@ function getPillAlignmentForCustom(): "custom-top" | "custom-bottom" {
   return wy < midY ? "custom-top" : "custom-bottom";
 }
 
+// Preset positions are relative to the primary display. Custom positions
+// can be on any display — they are saved as absolute screen coordinates
+// and bounds-checked on restore.
 function getAppWindowPosition(): { x: number; y: number } {
   const primaryDisplay = screen.getPrimaryDisplay();
   const { width, height } = primaryDisplay.workAreaSize;
@@ -259,7 +262,26 @@ function getAppWindowPosition(): { x: number; y: number } {
         typeof custom.x === "number" &&
         typeof custom.y === "number"
       ) {
-        return custom;
+        const display = screen.getDisplayMatching({
+          x: custom.x,
+          y: custom.y,
+          width: APP_WIDTH,
+          height: APP_HEIGHT,
+        });
+        const wa = display.workArea;
+        if (
+          custom.x >= wa.x &&
+          custom.x + APP_WIDTH <= wa.x + wa.width &&
+          custom.y >= wa.y - APP_HEIGHT &&
+          custom.y <= wa.y + wa.height
+        ) {
+          return custom;
+        }
+        // Saved position is off-screen; reset to default.
+        writeSettings({
+          pillPosition: "bottom-center",
+          pillCustomPosition: undefined,
+        });
       }
       return {
         x: Math.round((width - APP_WIDTH) / 2),
@@ -335,6 +357,17 @@ function createAppWindow(): void {
     // If programmaticTarget is set but coords don't match yet, the window is
     // still mid-animation — ignore until it settles.
     if (programmaticTarget) return;
+
+    // Ignore sub-threshold moves so accidental bumps don't override the preset.
+    const currentSetting = readSettings().pillPosition as string;
+    if (currentSetting !== "custom") {
+      const presetPos = getAppWindowPosition();
+      if (
+        Math.abs(nx - presetPos.x) < 10 &&
+        Math.abs(ny - presetPos.y) < 10
+      )
+        return;
+    }
 
     if (moveTimeout) clearTimeout(moveTimeout);
     moveTimeout = setTimeout(() => {
@@ -1189,6 +1222,18 @@ app.whenReady().then(async () => {
 
   createAppWindow();
 
+  // Clamp the pill to valid display bounds when monitors change.
+  screen.on("display-removed", () => {
+    if (!mainWindow) return;
+    const { x, y } = getAppWindowPosition();
+    setProgrammaticPosition(mainWindow, x, y);
+  });
+  screen.on("display-metrics-changed", () => {
+    if (!mainWindow) return;
+    const { x, y } = getAppWindowPosition();
+    setProgrammaticPosition(mainWindow, x, y);
+  });
+
   if (readSettings().showDashboardOnLaunch !== false) {
     showSettingsWindow();
   }
@@ -1388,19 +1433,12 @@ app.whenReady().then(async () => {
     return pos;
   });
 
-  ipcMain.handle("settings:has-custom-position", () => {
-    const custom = readSettings().pillCustomPosition as
-      | { x: number; y: number }
-      | undefined;
-    return !!(
-      custom &&
-      typeof custom.x === "number" &&
-      typeof custom.y === "number"
-    );
-  });
-
   ipcMain.on("settings:set-pill-position", (_event, position: string) => {
-    writeSettings({ pillPosition: position });
+    if (position === "custom") {
+      writeSettings({ pillPosition: position });
+    } else {
+      writeSettings({ pillPosition: position, pillCustomPosition: undefined });
+    }
     // Reposition the window and notify the renderer for CSS alignment.
     if (mainWindow) {
       const { x, y } = getAppWindowPosition();

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -272,7 +272,7 @@ function getAppWindowPosition(): { x: number; y: number } {
         if (
           custom.x >= wa.x &&
           custom.x + APP_WIDTH <= wa.x + wa.width &&
-          custom.y >= wa.y - APP_HEIGHT &&
+          custom.y >= wa.y &&
           custom.y <= wa.y + wa.height
         ) {
           return custom;
@@ -1220,16 +1220,19 @@ app.whenReady().then(async () => {
   createAppWindow();
 
   // Clamp the pill to valid display bounds when monitors change.
-  screen.on("display-removed", () => {
+  const repositionPillForDisplayChange = (): void => {
     if (!mainWindow) return;
+    const before = readSettings().pillPosition as string;
     const { x, y } = getAppWindowPosition();
     setProgrammaticPosition(mainWindow, x, y);
-  });
-  screen.on("display-metrics-changed", () => {
-    if (!mainWindow) return;
-    const { x, y } = getAppWindowPosition();
-    setProgrammaticPosition(mainWindow, x, y);
-  });
+    const after = (readSettings().pillPosition as string) ?? "bottom-center";
+    if (before !== after) {
+      mainWindow.webContents.send("settings:pill-position-changed", after);
+      settingsWindow?.webContents.send("settings:pill-position-changed", after);
+    }
+  };
+  screen.on("display-removed", repositionPillForDisplayChange);
+  screen.on("display-metrics-changed", repositionPillForDisplayChange);
 
   if (readSettings().showDashboardOnLaunch !== false) {
     showSettingsWindow();

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -198,18 +198,22 @@ function getDashboardURL(path = "/"): string {
 let programmaticTarget: { x: number; y: number } | null = null;
 let programmaticCleanupTimer: NodeJS.Timeout | null = null;
 
+function markProgrammaticTarget(x: number, y: number): void {
+  programmaticTarget = { x, y };
+  if (programmaticCleanupTimer) clearTimeout(programmaticCleanupTimer);
+  // Safety: clear the target after 1s in case the OS never delivers a settle event.
+  programmaticCleanupTimer = setTimeout(() => {
+    programmaticTarget = null;
+    programmaticCleanupTimer = null;
+  }, 1000);
+}
+
 function setProgrammaticPosition(
   win: BrowserWindow,
   x: number,
   y: number,
 ): void {
-  programmaticTarget = { x, y };
-  // Safety: clear the target after 1s in case the OS never delivers a settle event.
-  if (programmaticCleanupTimer) clearTimeout(programmaticCleanupTimer);
-  programmaticCleanupTimer = setTimeout(() => {
-    programmaticTarget = null;
-    programmaticCleanupTimer = null;
-  }, 1000);
+  markProgrammaticTarget(x, y);
   win.setPosition(x, y);
 }
 
@@ -300,12 +304,7 @@ function createAppWindow(): void {
   const { x, y } = getAppWindowPosition();
 
   // Mark the initial position as programmatic so the move listener ignores it.
-  programmaticTarget = { x, y };
-  if (programmaticCleanupTimer) clearTimeout(programmaticCleanupTimer);
-  programmaticCleanupTimer = setTimeout(() => {
-    programmaticTarget = null;
-    programmaticCleanupTimer = null;
-  }, 1000);
+  markProgrammaticTarget(x, y);
 
   mainWindow = new BrowserWindow({
     width: APP_WIDTH,

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -362,10 +362,7 @@ function createAppWindow(): void {
     const currentSetting = readSettings().pillPosition as string;
     if (currentSetting !== "custom") {
       const presetPos = getAppWindowPosition();
-      if (
-        Math.abs(nx - presetPos.x) < 10 &&
-        Math.abs(ny - presetPos.y) < 10
-      )
+      if (Math.abs(nx - presetPos.x) < 10 && Math.abs(ny - presetPos.y) < 10)
         return;
     }
 

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -198,7 +198,7 @@ export class NativeKeyListener {
 
       this.process!.stderr?.on("data", (data: Buffer) => {
         const text = data.toString().trim();
-        stderrOutput += text + "\n";
+        stderrOutput += `${text}\n`;
         log.debug(text);
       });
 

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -62,7 +62,6 @@ declare global {
       getFrontmostApp: () => Promise<string | null>;
       // Pill position
       getPillPosition: () => Promise<string>;
-      hasCustomPosition: () => Promise<boolean>;
       setPillPosition: (position: string) => void;
       onPillPositionChanged: (
         callback: (position: string) => void,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -133,8 +133,6 @@ const api = {
   // Pill position
   getPillPosition: (): Promise<string> =>
     ipcRenderer.invoke("settings:pill-position"),
-  hasCustomPosition: (): Promise<boolean> =>
-    ipcRenderer.invoke("settings:has-custom-position"),
   setPillPosition: (position: string): void =>
     ipcRenderer.send("settings:set-pill-position", position),
   onPillPositionChanged: (

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -86,6 +86,7 @@ const pillInnerStyle: React.CSSProperties = {
   fontFamily: "'DM Sans', sans-serif",
   fontSize: 13,
   fontWeight: 500,
+  cursor: "grab",
   WebkitAppRegion: "drag",
 } as React.CSSProperties;
 
@@ -777,11 +778,10 @@ export default function AppPage(): React.JSX.Element {
   }, [stopVisualization, hidePill]);
 
   // ---- Preferences ----
-  // The main process sends either a predefined position string (e.g. "top-center")
-  // or a display-relative alignment token ("custom-top" / "custom-bottom").
-  // Using includes("top") covers both cases correctly on all monitor setups.
   const applyPillPosition = useCallback((pos: string | null | undefined) => {
-    setPillAlign(pos?.includes("top") ? "start" : "end");
+    const isTop =
+      pos === "top-center" || pos === "top-right" || pos === "custom-top";
+    setPillAlign(isTop ? "start" : "end");
     setPillSide(pos?.endsWith("right") ? "right" : "center");
   }, []);
 
@@ -897,7 +897,13 @@ export default function AppPage(): React.JSX.Element {
       width={SVG_WIDTH}
       height={SVG_HEIGHT}
       viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
-      style={{ display: "block", flexShrink: 0 }}
+      style={
+        {
+          display: "block",
+          flexShrink: 0,
+          WebkitAppRegion: "no-drag",
+        } as React.CSSProperties
+      }
       role="img"
       aria-label="Audio levels"
     >

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -39,6 +39,10 @@ interface AudioDevice {
   label: string;
 }
 
+function normalizePillPos(pos: string): string {
+  return pos.startsWith("custom") ? "custom" : pos;
+}
+
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
@@ -228,10 +232,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
       .catch(() => {});
     window.api
       ?.getPillPosition()
-      .then((pos) => {
-        const norm = pos.startsWith("custom") ? "custom" : pos;
-        setPillPosition(norm);
-      })
+      .then((pos) => setPillPosition(normalizePillPos(pos)))
       .catch(() => {});
     getClient()
       .api.settings[":key"].$get({ param: { key: "sound_enabled" } })
@@ -298,8 +299,7 @@ export default function GeneralSettingsPage(): React.JSX.Element {
 
     // Pill position live changes
     const removePillPos = window.api?.onPillPositionChanged((pos) => {
-      const norm = pos.startsWith("custom") ? "custom" : pos;
-      setPillPosition(norm);
+      setPillPosition(normalizePillPos(pos));
     });
 
     checkPermissions();

--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -52,7 +52,6 @@ export default function GeneralSettingsPage(): React.JSX.Element {
   const [language, setLanguage] = useState("auto");
   const [outputMode, setOutputMode] = useState("paste");
   const [pillPosition, setPillPosition] = useState("bottom-center");
-  const [hasCustom, setHasCustom] = useState(false);
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [transcriptionPrompt, setTranscriptionPrompt] = useState("");
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null);
@@ -230,16 +229,9 @@ export default function GeneralSettingsPage(): React.JSX.Element {
     window.api
       ?.getPillPosition()
       .then((pos) => {
-        // The main process may return "custom-top" or "custom-bottom" to convey
-        // the display-relative alignment; normalise back to "custom" for the UI.
         const norm = pos.startsWith("custom") ? "custom" : pos;
         setPillPosition(norm);
-        if (norm === "custom") setHasCustom(true);
       })
-      .catch(() => {});
-    window.api
-      ?.hasCustomPosition()
-      .then(setHasCustom)
       .catch(() => {});
     getClient()
       .api.settings[":key"].$get({ param: { key: "sound_enabled" } })
@@ -306,10 +298,8 @@ export default function GeneralSettingsPage(): React.JSX.Element {
 
     // Pill position live changes
     const removePillPos = window.api?.onPillPositionChanged((pos) => {
-      // Normalise custom-top / custom-bottom to "custom" for the dropdown.
       const norm = pos.startsWith("custom") ? "custom" : pos;
       setPillPosition(norm);
-      if (norm === "custom") setHasCustom(true);
     });
 
     checkPermissions();
@@ -417,8 +407,6 @@ export default function GeneralSettingsPage(): React.JSX.Element {
       ? "Release to save · Esc to cancel"
       : "Press a modifier or side mouse button... · Esc to cancel";
 
-  // Build position options once; include "Custom" only if the user has ever
-  // dragged the pill to a custom location.
   const positionOptions = useMemo<SegmentOption[]>(() => {
     const opts: SegmentOption[] = [
       { id: "bottom-center", label: "Bottom · Center" },
@@ -426,9 +414,9 @@ export default function GeneralSettingsPage(): React.JSX.Element {
       { id: "top-center", label: "Top · Center" },
       { id: "top-right", label: "Top · Right" },
     ];
-    if (hasCustom) opts.push({ id: "custom", label: "Custom" });
+    if (pillPosition === "custom") opts.push({ id: "custom", label: "Custom" });
     return opts;
-  }, [hasCustom]);
+  }, [pillPosition]);
 
   return (
     <div

--- a/apps/server/src/lib/mlx-asr/models.ts
+++ b/apps/server/src/lib/mlx-asr/models.ts
@@ -286,8 +286,8 @@ export async function downloadMlxModel(modelId: string): Promise<void> {
     let stdoutBuf = "";
     proc.stdout?.on("data", (data: Buffer) => {
       stdoutBuf += data.toString();
-      let newlineIdx: number;
-      while ((newlineIdx = stdoutBuf.indexOf("\n")) !== -1) {
+      let newlineIdx: number = stdoutBuf.indexOf("\n");
+      while (newlineIdx !== -1) {
         const line = stdoutBuf.slice(0, newlineIdx);
         stdoutBuf = stdoutBuf.slice(newlineIdx + 1);
         try {
@@ -307,6 +307,7 @@ export async function downloadMlxModel(modelId: string): Promise<void> {
         } catch {
           // non-JSON line; ignore
         }
+        newlineIdx = stdoutBuf.indexOf("\n");
       }
     });
 


### PR DESCRIPTION
Follow-up to #164. Addresses review findings from the pill panning feature:

- Add `cursor: grab` to the pill so users discover it's draggable
- Bounds-check saved custom position against connected displays on restore (handles monitor disconnect)
- Listen for `display-removed` / `display-metrics-changed` to reposition the pill in real-time
- Clear `pillCustomPosition` when user selects a preset, so "Custom" disappears from settings
- Add 10px drag threshold to prevent accidental bumps from overwriting presets
- Use explicit position string matching in `applyPillPosition` instead of `includes("top")`
- Add `WebkitAppRegion: "no-drag"` to bars SVG
- Remove redundant `hasCustomPosition` IPC handler and `hasCustom` state

## Testing

Manual — verify pill drag cursor, preset/custom switching, and monitor disconnect behavior in Electron.

<!--
## Plan

### Changes by file

**app.tsx** (3 changes):
- A: Add `cursor: "grab"` to `pillInnerStyle`
- B: Replace `pos?.includes("top")` with explicit check against known position strings
- C: Add `WebkitAppRegion: "no-drag"` to bars SVG element

**main/index.ts** (6 changes):
- D: Add 10px drag threshold in move handler — only when current position is a preset, compare against preset coords and skip if delta < 10px
- E: In `settings:set-pill-position`, clear `pillCustomPosition` when selecting a preset (not "custom")
- F: Bounds-check custom position in `getAppWindowPosition()` using `screen.getDisplayMatching()` — reset to bottom-center if off-screen
- G: Add `screen.on("display-removed")` and `screen.on("display-metrics-changed")` listeners to reposition pill when monitors change
- H: Remove `settings:has-custom-position` IPC handler
- I: Add multi-monitor documentation comment on `getAppWindowPosition()`

**preload/index.ts**: Remove `hasCustomPosition` API method
**preload/index.d.ts**: Remove `hasCustomPosition` type declaration

**settings/general.tsx** (3 changes):
- L: Remove `hasCustom` state
- M: Remove `hasCustomPosition()` call, simplify pill position loading and live change handler
- N: Derive "Custom" option visibility from `pillPosition === "custom"` instead of separate `hasCustom` state
-->