### PR TITLE
fix: gate tray setContextMenu to Linux only to preserve macOS click behavior

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -885,17 +885,20 @@ function createTray(): void {
   tray = new Tray(trayImage);
   tray.setToolTip("Freestyle");
 
-  // Set the context menu natively so Linux desktop panels register it automatically
-  tray.setContextMenu(buildTrayContextMenu());
+  if (process.platform === "linux") {
+    // Linux desktop panels often don't fire the right-click event, so
+    // assign the menu natively so the OS can register it via DBusMenu.
+    tray.setContextMenu(buildTrayContextMenu());
+  } else {
+    // macOS/Windows: left-click opens settings, right-click shows menu.
+    // Using setContextMenu on macOS would override the click handler.
+    tray.on("right-click", () => {
+      tray!.popUpContextMenu(buildTrayContextMenu());
+    });
+  }
 
-  // Maintain the left-click behavior for macOS and Windows users
   tray.on("click", () => {
     showSettingsWindow();
-  });
-
-  // Right-click: show context menu (rebuilt each time for up-to-date labels)
-  tray.on("right-click", () => {
-    tray!.popUpContextMenu(buildTrayContextMenu());
   });
 }
 
@@ -960,8 +963,11 @@ function rebuildMenus(): void {
   ]);
   Menu.setApplicationMenu(appMenu);
 
-  // Keep the static tray menu (used by Linux panels) in sync with update state
-  tray?.setContextMenu(buildTrayContextMenu());
+  // On Linux the tray menu is static (setContextMenu), so rebuild it
+  // when update state changes. macOS/Windows rebuild on every right-click.
+  if (process.platform === "linux") {
+    tray?.setContextMenu(buildTrayContextMenu());
+  }
 }
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
Follow-up to #162. On macOS, `tray.setContextMenu()` overrides the `click` event — so left-clicking the tray icon shows the context menu instead of opening settings. This PR gates `setContextMenu` to Linux only (where it's needed for DBusMenu panel registration) and keeps the existing `right-click` + `popUpContextMenu` pattern for macOS/Windows.

- Linux: `tray.setContextMenu()` for native panel integration, rebuilt in `rebuildMenus()` when update state changes
- macOS/Windows: `tray.on("right-click")` + `popUpContextMenu()` (rebuilt each time for fresh labels), `tray.on("click")` opens settings

## Testing

Verify on macOS: left-click tray opens settings, right-click shows context menu. On Linux (if available): tray menu appears via native panel interaction.

<!--
## Plan

PR #162 added `tray.setContextMenu(buildTrayContextMenu())` unconditionally to fix Linux tray panels that don't fire right-click events. However, on macOS, setContextMenu causes the context menu to appear on left-click, overriding the click handler that opens settings.

Fix: Gate setContextMenu to `process.platform === "linux"` in both createTray() and rebuildMenus(). On non-Linux platforms, keep the original right-click + popUpContextMenu pattern.
-->