### PR TITLE
fix: navigate to settings page when clicking update notifications

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -401,7 +401,7 @@ function createAppWindow(): void {
   mainWindow.loadURL(getPillURL());
 }
 
-function createSettingsWindow(): void {
+function createSettingsWindow(initialPath?: string): void {
   settingsWindow = new BrowserWindow({
     width: 1152,
     height: 648,
@@ -471,9 +471,8 @@ function createSettingsWindow(): void {
     }
   }
 
-  settingsWindow.loadURL(
-    getDashboardURL(onboardingDone ? "/today" : "/onboarding"),
-  );
+  const startPath = !onboardingDone ? "/onboarding" : (initialPath ?? "/today");
+  settingsWindow.loadURL(getDashboardURL(startPath));
 }
 
 function showPill(): void {
@@ -755,10 +754,13 @@ async function factoryReset(): Promise<void> {
   }
 }
 
-function showSettingsWindow(): void {
+function showSettingsWindow(path?: string): void {
   if (!settingsWindow) {
-    createSettingsWindow();
+    createSettingsWindow(path);
     return;
+  }
+  if (path) {
+    settingsWindow.loadURL(getDashboardURL(path));
   }
   if (process.platform === "darwin") {
     app.dock?.show();
@@ -1294,7 +1296,7 @@ app.whenReady().then(async () => {
             ? `Version ${info.version} is downloading…`
             : `Version ${info.version} is available. Open settings to download.`,
         });
-        note.on("click", () => showSettingsWindow());
+        note.on("click", () => showSettingsWindow("/settings"));
         note.show();
       }
     });
@@ -1314,7 +1316,7 @@ app.whenReady().then(async () => {
           title: "Update Ready to Install",
           body: `Version ${info.version} has been downloaded. Restart to update.`,
         });
-        note.on("click", () => showSettingsWindow());
+        note.on("click", () => showSettingsWindow("/settings"));
         note.show();
       }
       // No need to keep polling once the update is downloaded
@@ -1354,7 +1356,7 @@ app.whenReady().then(async () => {
           title: "Move Freestyle to Applications",
           body: "Freestyle can\u2019t update from this location. Move it to your Applications folder and relaunch.",
         });
-        note.on("click", () => showSettingsWindow());
+        note.on("click", () => showSettingsWindow("/settings"));
         note.show();
       }
     } else {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -675,13 +675,7 @@ function hidePill(): void {
 
 function resetOnboarding(): void {
   writeSettings({ onboardingComplete: false });
-  if (settingsWindow) {
-    settingsWindow.loadURL(getDashboardURL("/onboarding"));
-    settingsWindow.show();
-    settingsWindow.focus();
-  } else {
-    showSettingsWindow();
-  }
+  showSettingsWindow("/onboarding");
 }
 
 async function factoryReset(): Promise<void> {
@@ -760,7 +754,7 @@ function showSettingsWindow(path?: string): void {
     return;
   }
   if (path) {
-    settingsWindow.loadURL(getDashboardURL(path));
+    void settingsWindow.loadURL(getDashboardURL(path));
   }
   if (process.platform === "darwin") {
     app.dock?.show();


### PR DESCRIPTION
## Summary

- Clicking a native OS update notification (update available, update downloaded, move-to-Applications) now opens the settings page (`/settings`) instead of the default `/today` route
- Added an optional `path` parameter to `showSettingsWindow` and `createSettingsWindow` so callers can specify which page to navigate to
- All other callers (tray menu, onboarding flow, etc.) are unaffected — they continue opening to `/today`