### PR TITLE
fix: remove subtext on the models page

### DIFF
--- a/apps/electron/src/renderer/src/pages/settings/models.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/models.tsx
@@ -904,10 +904,7 @@ export default function ModelsPage(): React.JSX.Element {
 
   return (
     <PageShell>
-      <PageHeader
-        title="Models"
-        subtitle="Choose how Freestyle listens — on-device for privacy, or cloud for speed and reach. Add an optional model to clean up what you say."
-      />
+      <PageHeader title="Models" />
       <div className="space-y-4">
         <div ref={pairCardRef}>
           <PairCard


### PR DESCRIPTION
Closes #184

## Overview
Removes the subtitle text on the Models settings page for visual simplicity, as requested in #184.

## Changes
- Dropped the `subtitle` prop from the `PageHeader` on the Models page (`apps/electron/src/renderer/src/pages/settings/models.tsx`). The `PageHeader` already renders the subtitle conditionally, so no other changes are needed and the heading still displays cleanly without it.

## Validation
- `pnpm biome check apps/electron/src/renderer/src/pages/settings/models.tsx` → passes (no fixes needed).
- Change is a minimal one-line JSX edit; pre-existing `typecheck:web` errors (Hono RPC client types from the unbuilt `@freestyle/server` workspace package) are present on `main` as well and are unrelated to this change.