### PR TITLE
fix: remove subtext on the settings page

### DIFF
--- a/apps/electron/src/renderer/src/pages/settings/general.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/general.tsx
@@ -433,9 +433,6 @@ export default function GeneralSettingsPage(): React.JSX.Element {
             <span className="serif-italic text-primary">Settings</span>
             <span>. </span>
           </h1>
-          <p className="text-muted-foreground mt-2.5 max-w-[580px] text-[14px] leading-[1.5]">
-            Configure how Freestyle listens, speaks, and looks.
-          </p>
         </div>
 
         {updateAvailable && (


### PR DESCRIPTION
Closes #182

## Overview
Removes the subtitle text on the settings page for simplicity.
## Changes
- Dropped the `p` tag present in `apps/electron/src/renderer/src/pages/settings/general.tsx`
## Validation
All validation checks listed in `CONTRIBUTING.md` pass.