### PR TITLE
Use Huggingface Hub for model downloads

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -27,6 +27,7 @@
     "@hono/mcp": "^0.3.0",
     "@hono/node-server": "^2.0.4",
     "@hono/zod-validator": "^0.8.0",
+    "@huggingface/hub": "^2.13.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ai": "^6.0.191",
     "hono": "^4.12.22",

--- a/apps/server/src/lib/hf/progress.ts
+++ b/apps/server/src/lib/hf/progress.ts
@@ -1,0 +1,60 @@
+/**
+ * Progress-tracking wrapper around `fetch`, used to drive the download progress
+ * UI while delegating the actual transfer + caching to `@huggingface/hub`.
+ *
+ * The hub download helpers accept a custom `fetch`. We pass one that streams the
+ * response body through a byte counter (with the same 500ms speed window the
+ * legacy raw-fetch path used) and is bound to an AbortSignal for cancellation.
+ *
+ * `bytesTotal` is owned by the caller (set from the model's known size) rather
+ * than read from `content-length`, because the hub client may issue several
+ * requests (metadata + blob) and only the blob carries the real size.
+ */
+export interface ProgressSink {
+  bytesDownloaded: number;
+  bytesTotal: number;
+  speedBps: number;
+  lastUpdate: number;
+  lastBytes: number;
+}
+
+export function progressFetch(
+  sink: ProgressSink,
+  signal: AbortSignal,
+): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const res = await fetch(input, { ...init, signal, redirect: "follow" });
+    if (!res.ok || !res.body) return res;
+
+    const reader = res.body.getReader();
+    const tracked = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          return;
+        }
+        sink.bytesDownloaded += value.byteLength;
+        const now = Date.now();
+        const elapsed = now - sink.lastUpdate;
+        if (elapsed >= 500) {
+          sink.speedBps = Math.round(
+            ((sink.bytesDownloaded - sink.lastBytes) / elapsed) * 1000,
+          );
+          sink.lastUpdate = now;
+          sink.lastBytes = sink.bytesDownloaded;
+        }
+        controller.enqueue(value);
+      },
+      cancel(reason) {
+        reader.cancel(reason).catch(() => {});
+      },
+    });
+
+    return new Response(tracked, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+    });
+  }) as typeof fetch;
+}

--- a/apps/server/src/lib/whisper/constants.ts
+++ b/apps/server/src/lib/whisper/constants.ts
@@ -12,10 +12,15 @@ export interface WhisperModelDef {
   speed: string;
   quality: string;
   quantized: boolean;
-  url: string;
 }
 
-const HF_BASE = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main";
+/**
+ * Hugging Face repo the GGML models are fetched from. Each model's `fileName`
+ * (e.g. `ggml-tiny.bin`) doubles as its path within this repo. Pin `WHISPER_REPO_REVISION`
+ * to a commit SHA for fully reproducible downloads; "main" tracks the latest.
+ */
+export const WHISPER_REPO = "ggerganov/whisper.cpp";
+export const WHISPER_REPO_REVISION = "main";
 
 export const WHISPER_MODELS: WhisperModelDef[] = [
   {
@@ -27,7 +32,6 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     speed: "Fastest",
     quality: "Basic",
     quantized: false,
-    url: `${HF_BASE}/ggml-tiny.bin`,
   },
   {
     id: "tiny-q5_1",
@@ -38,7 +42,6 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     speed: "Fastest",
     quality: "Basic",
     quantized: true,
-    url: `${HF_BASE}/ggml-tiny-q5_1.bin`,
   },
   {
     id: "base",
@@ -49,7 +52,6 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     speed: "Fast",
     quality: "Good",
     quantized: false,
-    url: `${HF_BASE}/ggml-base.bin`,
   },
   {
     id: "base-q5_1",
@@ -60,7 +62,6 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     speed: "Very Fast",
     quality: "Good",
     quantized: true,
-    url: `${HF_BASE}/ggml-base-q5_1.bin`,
   },
   {
     id: "small",
@@ -71,7 +72,6 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     speed: "Medium",
     quality: "Better",
     quantized: false,
-    url: `${HF_BASE}/ggml-small.bin`,
   },
   {
     id: "small-q5_1",
@@ -82,7 +82,6 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     speed: "Fast",
     quality: "Better",
     quantized: true,
-    url: `${HF_BASE}/ggml-small-q5_1.bin`,
   },
   {
     id: "medium",
@@ -93,7 +92,6 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     speed: "Slow",
     quality: "High",
     quantized: false,
-    url: `${HF_BASE}/ggml-medium.bin`,
   },
   {
     id: "medium-q5_0",
@@ -104,7 +102,6 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     speed: "Medium",
     quality: "High",
     quantized: true,
-    url: `${HF_BASE}/ggml-medium-q5_0.bin`,
   },
   {
     id: "large",
@@ -115,7 +112,6 @@ export const WHISPER_MODELS: WhisperModelDef[] = [
     speed: "Slow",
     quality: "Best",
     quantized: false,
-    url: `${HF_BASE}/ggml-large-v3-turbo.bin`,
   },
 ];
 

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -16,6 +16,8 @@ import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createAppLogger } from "@freestyle/utils";
+import { downloadFileToCacheDir } from "@huggingface/hub";
+import { progressFetch } from "../hf/progress.js";
 import {
   getBinDir,
   getModelPath,
@@ -23,6 +25,8 @@ import {
   getWhisperModel,
   WHISPER_CPP_VERSION,
   WHISPER_MODELS,
+  WHISPER_REPO,
+  WHISPER_REPO_REVISION,
   type WhisperModelDef,
 } from "./constants.js";
 
@@ -190,27 +194,19 @@ export async function downloadModel(modelId: string): Promise<void> {
   const tempPath = `${destPath}.downloading`;
 
   try {
-    const res = await fetch(model.url, {
-      signal: controller.signal,
-      redirect: "follow",
+    // @huggingface/hub fetches into the HF cache (content-addressed by etag, so
+    // a completed file is verified rather than size-guessed) using our custom
+    // fetch for progress + cancellation.
+    const blobPath = await downloadFileToCacheDir({
+      repo: { type: "model", name: WHISPER_REPO },
+      path: model.fileName,
+      revision: WHISPER_REPO_REVISION,
+      fetch: progressFetch(active, controller.signal),
     });
 
-    if (!res.ok) {
-      throw new Error(`Download failed: HTTP ${res.status} ${res.statusText}`);
-    }
-
-    const contentLength = res.headers.get("content-length");
-    if (contentLength) {
-      active.bytesTotal = Number.parseInt(contentLength, 10);
-    }
-
-    if (!res.body) {
-      throw new Error("No response body received");
-    }
-
-    const fileStream = createWriteStream(tempPath);
-    await pipeline(webBodyToReadable(res.body, active), fileStream);
-
+    // Materialize at the flat path the inference layer loads from. Copy via a
+    // temp file + rename so a partially-written model is never seen as ready.
+    copyFileSync(blobPath, tempPath);
     renameSync(tempPath, destPath);
     activeDownloads.delete(modelId);
   } catch (err) {
@@ -465,15 +461,7 @@ async function downloadWindowsBinaries(): Promise<void> {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function webBodyToReadable(
-  body: ReadableStream<Uint8Array>,
-  progress?: {
-    bytesDownloaded: number;
-    lastUpdate: number;
-    lastBytes: number;
-    speedBps: number;
-  },
-): Readable {
+function webBodyToReadable(body: ReadableStream<Uint8Array>): Readable {
   const reader = body.getReader();
   return new Readable({
     async read() {
@@ -482,17 +470,6 @@ function webBodyToReadable(
         if (done) {
           this.push(null);
           return;
-        }
-        if (progress) {
-          progress.bytesDownloaded += value.byteLength;
-          const now = Date.now();
-          const elapsed = now - progress.lastUpdate;
-          if (elapsed >= 500) {
-            const bytesDelta = progress.bytesDownloaded - progress.lastBytes;
-            progress.speedBps = Math.round((bytesDelta / elapsed) * 1000);
-            progress.lastUpdate = now;
-            progress.lastBytes = progress.bytesDownloaded;
-          }
         }
         this.push(Buffer.from(value));
       } catch (err) {

--- a/docs/specs/hf-hub-download-adoption.md
+++ b/docs/specs/hf-hub-download-adoption.md
@@ -1,0 +1,305 @@
+# Technical Spec: Adopt `@huggingface/hub` for Local Model Downloads
+
+**Status:** Draft
+**Author:** _TBD_
+**Date:** 2026-06-04
+**Scope:** `apps/server` — Whisper and MLX ASR model download layer only. No inference-runtime changes.
+
+---
+
+## 1. Goal
+
+Replace the hand-rolled model **download** plumbing with the official
+[`@huggingface/hub`](https://www.npmjs.com/package/@huggingface/hub) client so that
+downloading local voice models is reliable, integrity-checked, and uses the canonical
+Hugging Face cache layout.
+
+This is a **download-layer refactor only**. Inference (whisper.cpp binaries, the MLX
+Python worker) and the public HTTP API are intentionally untouched. The renderer should
+see no behavioral change other than fewer failed/corrupt downloads.
+
+### Non-goals
+
+- No change to inference runtimes, model selection, or transcription code.
+- No change to the `/api/whisper/*` and `/api/mlx-asr/*` route contracts or the
+  `ModelDownloadState` / `MlxModelDownloadState` shapes consumed by the renderer.
+- Not adopting `sherpa-onnx`/Transformers.js or enabling Windows Parakeet/Qwen (separate effort).
+
+---
+
+## 2. Background — current state
+
+### 2.1 Whisper (the primary target)
+
+`apps/server/src/lib/whisper/models.ts`
+
+- `downloadModel(modelId)` (`:141`) does a raw `fetch(model.url)` → streams into
+  `${destPath}.downloading` → `renameSync` to final path.
+- `model.url` is a hardcoded HF resolve URL built in `constants.ts:18`
+  (`https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-*.bin`).
+- Readiness is decided by `isModelDownloaded()` (`:77`): the file exists **and**
+  `stat.size >= model.sizeBytes * 0.95`, where `sizeBytes` is a hand-maintained constant.
+- Progress is tracked by wrapping the response body in `webBodyToReadable()` (`:468`),
+  which mutates an `ActiveDownload` entry in the in-memory `activeDownloads` map.
+
+### 2.2 MLX ASR (secondary target)
+
+`apps/server/src/lib/mlx-asr/models.ts`
+
+- `downloadMlxModel(modelId)` (`:217`) **already downloads from Hugging Face**, but
+  indirectly: it spawns the Python worker with `--model <hfId> --download-model` (`:276`),
+  which calls `huggingface_hub` internally.
+- Weights land in the standard HF cache (`hfRepoCacheDir()`, `:87`), i.e.
+  `~/.cache/huggingface/hub/models--<repo>/snapshots/<rev>/`.
+- Readiness = snapshot directory exists and is non-empty (`isMlxModelDownloaded`, `:99`).
+- Progress = newline-delimited JSON (`{type:"progress", bytesDownloaded, bytesTotal}`)
+  parsed off the worker's stdout (`:287`).
+- **Coupling problem:** the model download cannot start until the Python runtime is
+  present, so the flow first runs a `building_binary` phase to acquire the runtime
+  (`ensureMlxRuntimeDownloaded`, `:254`) even though weight download is pure HTTP.
+
+---
+
+## 3. Problems with the current approach
+
+| # | Problem | Where | Impact |
+|---|---------|-------|--------|
+| P1 | **No integrity check.** Readiness is a 95%-of-expected-size heuristic. A truncated or corrupt file that happens to be ≥95% reads as `ready`. | `whisper/models.ts:77` | Silent corruption → inference fails at runtime, not download time. |
+| P2 | **No resume / no retry.** A dropped connection on a 1.6 GB model restarts from zero; transient 5xx/network blips fail the whole download. | `whisper/models.ts:193` | The reported "instability." |
+| P3 | **Hand-maintained `sizeBytes`.** Doubles as the progress denominator and the readiness gate; drifts when upstream files change. | `whisper/constants.ts` | False progress %, false readiness. |
+| P4 | **MLX download coupled to Python runtime.** Weights can't download until the runtime is installed; download runs through a spawned subprocess + brittle stdout-JSON parsing. | `mlx-asr/models.ts:244-346` | Extra failure surface; can't pre-fetch weights without the runtime. |
+| P5 | **Two divergent cache layouts** (flat `freestyle/whisper-models` vs HF cache) with two bespoke download code paths to maintain. | both | Duplicated, drift-prone logic. |
+
+---
+
+## 4. Why `@huggingface/hub`
+
+- **Integrity & dedup by design.** `downloadFileToCacheDir` stores content as
+  `blobs/{etag}` with `snapshots/{rev}/{path}` symlinks; the etag is the content hash, so
+  a completed download is content-addressed rather than size-guessed. (Fixes P1.)
+- **Custom `fetch` hook.** All download functions accept a `fetch?: typeof fetch` param,
+  so we can inject a progress-wrapping fetch and **reuse the existing
+  `webBodyToReadable` byte-counter** — the renderer-facing progress contract is preserved.
+- **Pinned revisions.** `revision` lets us pin a commit SHA instead of `main` for
+  reproducible, verifiable downloads. (Fixes P3's drift.)
+- **One cache model for both providers.** Whisper and MLX repos both become HF repos
+  under the same cache. (Addresses P5.)
+- **Pure TypeScript, no native deps** → safe to bundle in the Electron server (see §9).
+
+Confirmed signature (from source):
+
+```ts
+export async function downloadFileToCacheDir(
+  params: {
+    repo: RepoDesignation;     // e.g. { type: "model", name: "ggerganov/whisper.cpp" }
+    path: string;              // e.g. "ggml-tiny.bin"
+    revision?: string;         // defaults to "main"; pin to a commit SHA
+    hubUrl?: string;
+    cacheDir?: string;
+    fetch?: typeof fetch;      // custom fetch — our progress hook goes here
+  } & Partial<CredentialsParams>,
+): Promise<string>             // returns the snapshot symlink path to the blob
+```
+
+> ⚠️ Note: progress callbacks are **not** a first-class feature of the library. We get
+> progress via the injected `fetch`, not an `onProgress` option.
+
+---
+
+## 5. Design
+
+### 5.1 Shared progress-fetch helper
+
+Add `apps/server/src/lib/hf/progress-fetch.ts`:
+
+```ts
+// Returns a fetch wrapper that (a) is bound to an AbortSignal for cancellation and
+// (b) streams response.body through the existing byte-counter into `active`.
+export function makeProgressFetch(
+  active: { bytesDownloaded: number; bytesTotal: number; speedBps: number;
+            lastUpdate: number; lastBytes: number },
+  signal: AbortSignal,
+): typeof fetch {
+  return async (input, init) => {
+    const res = await fetch(input, { ...init, signal, redirect: "follow" });
+    const len = res.headers.get("content-length");
+    if (len) active.bytesTotal += Number.parseInt(len, 10);
+    if (!res.body) return res;
+    // reuse the same 500ms-window speed logic as webBodyToReadable()
+    const tracked = wrapBodyWithProgress(res.body, active);
+    return new Response(tracked, { headers: res.headers, status: res.status });
+  };
+}
+```
+
+This keeps the **exact** progress semantics the renderer already polls for
+(`bytesDownloaded`/`bytesTotal`/`percent`/`speedBps`).
+
+### 5.2 Whisper
+
+**Registry change** (`whisper/constants.ts`): replace the `url: string` field with a
+structured reference, and pin a revision.
+
+```ts
+export interface WhisperModelDef {
+  id: string;
+  fileName: string;          // still the on-disk name the binary loads
+  displayName: string;
+  sizeBytes: number;         // retained for UI display + progress fallback only
+  // ...
+  repo: string;              // "ggerganov/whisper.cpp"
+  repoPath: string;          // "ggml-tiny.bin"
+  revision: string;          // pinned commit SHA
+}
+```
+
+**Download** (`whisper/models.ts:downloadModel`): replace the raw-fetch block (`:192-228`)
+with:
+
+```ts
+const blobPath = await downloadFileToCacheDir({
+  repo: { type: "model", name: model.repo },
+  path: model.repoPath,
+  revision: model.revision,
+  cacheDir: getHfCacheDir(),
+  fetch: makeProgressFetch(active, controller.signal),
+});
+// Materialize at the flat path the inference layer already expects, so binary.ts /
+// server.ts are untouched. Copy (not symlink) for Windows safety — see §10 OQ1.
+copyFileSync(blobPath, getModelPath(model));
+```
+
+**Readiness** (`isModelDownloaded`): prefer "blob present in HF cache for the pinned
+revision"; keep the existing flat-path size check as a **fallback** so already-downloaded
+users are not forced to re-download (see §8 Migration). The fragile 95% gate stops being
+the source of truth.
+
+### 5.3 MLX ASR
+
+Decouple weight download from the Python runtime by downloading the snapshot **in Node**.
+
+**Download** (`mlx-asr/models.ts:downloadMlxModel`): replace the
+`updateManagedMlxRuntimeIfNeeded` → `ensureMlxRuntimeDownloaded` → spawn-`--download-model`
+sequence (`:244-346`) with an HF snapshot download into the same cache mlx-audio reads:
+
+```ts
+active.phase = "downloading_model";
+const files = await listFiles({ repo: { type: "model", name: model.hfId },
+                                revision: model.revision, recursive: true });
+active.bytesTotal = files.reduce((n, f) => n + (f.size ?? 0), 0); // accurate denominator
+for (const f of files) {
+  await downloadFileToCacheDir({
+    repo: { type: "model", name: model.hfId },
+    path: f.path, revision: model.revision,
+    cacheDir: hfCacheRoot(),
+    fetch: makeProgressFetch(active, controller.signal), // cumulative across files
+  });
+}
+```
+
+Result: the Python runtime is needed only at **inference** time, not download time. The
+`building_binary` phase no longer gates weight download. Progress becomes accurate
+(summed from the file manifest) instead of parsed from worker stdout.
+
+> Keep `snapshotDownload` as a simpler fallback if per-file progress proves unnecessary;
+> the explicit `listFiles` + loop is recommended for an accurate progress bar.
+
+### 5.4 Cancellation & deletion
+
+- **Cancel:** the injected `fetch` is bound to the existing `AbortController` in the
+  `ActiveDownload` entry → `cancelDownload`/`cancelMlxDownload` keep working unchanged.
+- **Delete:** MLX `deleteMlxModel` (rm the repo cache dir) is unchanged. Whisper
+  `deleteModel` removes the flat materialized file; optionally also evict the HF blob.
+
+### 5.5 What stays identical
+
+- Routes: `apps/server/src/routes/whisper.ts`, `routes/mlx-asr.ts` — unchanged.
+- Status shapes: `ModelDownloadState`, `MlxModelDownloadState` — unchanged.
+- Renderer polling (`settings/models.tsx`) — unchanged.
+- whisper.cpp binary acquisition (`ensureBinariesDownloaded`, `buildFromSource`,
+  `downloadWindowsBinaries`) — **out of scope**, unchanged. (Could later reuse the same
+  progress-fetch, but not in this spec.)
+
+---
+
+## 6. API contract
+
+No public changes. This is verifiable by diffing the OpenAPI/`hc` client types before and
+after — they must be byte-identical.
+
+---
+
+## 7. Dependencies
+
+- Add `@huggingface/hub` to `apps/server` `package.json` dependencies (pin a version).
+- Pure ESM/TS; **no native binaries** → no `electron-builder` rebuild concerns. Confirm the
+  server bundler (tsup/esbuild/whatever `apps/server` uses) does not externalize it
+  incorrectly, or mark it bundled.
+
+---
+
+## 8. Migration / backward compatibility
+
+- **Existing Whisper files** live at `~/.cache/freestyle/whisper-models/ggml-*.bin`.
+  Keep the flat-path size check as a readiness fallback so existing users are not
+  re-downloaded. New downloads go through the HF cache and are then materialized at the
+  same flat path → no migration script required.
+- **Existing MLX snapshots** already live in the HF cache; the new Node downloader writes
+  to the identical location, so prior downloads are detected as `ready` unchanged.
+- No DB migration. `model_configs` handling in `deleteMlxModel` is untouched.
+
+---
+
+## 9. Bundling / packaging notes
+
+- Verify `@huggingface/hub` resolves at runtime inside the packaged Electron app (asar).
+- The HF cache root continues to honor `HUGGINGFACE_HUB_CACHE` / `HF_HOME` (already read by
+  `hfCacheRoot()` at `mlx-asr/models.ts:78`); reuse that resolver for Whisper too so both
+  providers agree on cache location.
+
+---
+
+## 10. Risks & open questions
+
+- **OQ1 — Windows symlinks.** The HF cache uses `blobs/` + `snapshots/` symlinks. On
+  Windows, symlink creation may require privileges. Mitigation for Whisper: we `copyFileSync`
+  the resolved blob to the flat path anyway. For MLX: confirm mlx-audio reads symlinked
+  snapshots on the platforms it runs (Apple Silicon only today, where symlinks are fine).
+- **OQ2 — Resume.** The JS hub client's resume support is weaker than Python
+  `huggingface_hub`. This refactor fixes integrity and retry-around-failures, but full
+  byte-range resume of a partial file may still be limited. Confirm acceptable, or layer a
+  retry-with-backoff wrapper around the per-file download.
+- **OQ3 — Per-file progress for MLX.** `listFiles` must return `size` for an accurate
+  denominator; verify for `mlx-community/*` repos. Fallback: show indeterminate progress
+  during snapshot download.
+- **OQ4 — Pinned revisions.** Pinning a commit SHA per model improves reproducibility but
+  requires updating the registry when we intentionally bump a model. Decide SHA vs `main`.
+
+---
+
+## 11. Rollout plan (phased)
+
+1. **Phase 0 — Plumbing.** Add dependency; add `lib/hf/progress-fetch.ts` and a shared
+   `getHfCacheDir()`; unit-test the progress wrapper. No behavior change.
+2. **Phase 1 — Whisper.** Migrate `downloadModel` + registry; keep flat-path materialization
+   and the size-check fallback. Ship behind verification on all three platforms.
+3. **Phase 2 — MLX.** Replace the Python `--download-model` path with the Node snapshot
+   downloader; decouple from runtime acquisition. Keep the Python worker for inference.
+4. **Phase 3 — Cleanup.** Remove dead raw-fetch/`webBodyToReadable` code paths once both
+   providers are migrated; unify cache helpers.
+
+Each phase is independently shippable and revertible.
+
+---
+
+## 12. Test plan
+
+- **Unit:** registry resolves to `{repo, path, revision}`; progress-fetch reports correct
+  `bytesDownloaded`/`speedBps`; abort propagates.
+- **Integration:** download `tiny` end-to-end; mid-download cancel leaves no partial in the
+  flat path; deliberately corrupt a blob and confirm readiness now rejects it (P1 regression
+  test).
+- **Cross-platform:** macOS (arm64 + x64), Windows (symlink/copy path), Linux.
+- **Migration:** with a pre-existing flat `ggml-tiny.bin`, status is `ready` without
+  re-download; with a pre-existing MLX snapshot, status is `ready`.
+- **Contract:** generated `hc` types unchanged before/after.

--- a/docs/specs/mlx-hub-download-migration.md
+++ b/docs/specs/mlx-hub-download-migration.md
@@ -1,0 +1,245 @@
+# Technical Spec: Migrate MLX ASR Downloads to `@huggingface/hub`
+
+**Status:** Draft
+**Author:** _TBD_
+**Date:** 2026-06-04
+**Scope:** `apps/server/src/lib/mlx-asr` — MLX (Qwen3-ASR / Parakeet) model **download** path only.
+**Depends on:** the Whisper migration (already shipped) — reuses `lib/hf/progress.ts`.
+
+---
+
+## 1. Goal
+
+Replace the subprocess-based MLX model download (spawn the Python worker with
+`--download-model`, parse progress as JSON off stdout) with a direct Node download via
+`@huggingface/hub`, reusing the `progressFetch` helper introduced for Whisper.
+
+This removes the most brittle parts of the MLX download path and **decouples weight
+download from Python-runtime acquisition** — today you cannot fetch model weights until
+the bundled Python worker/runtime is installed, even though the download is pure HTTP.
+
+### Non-goals
+
+- No change to MLX **inference** (`server.ts`, the Python worker, `mlx_audio.load()`).
+- No change to runtime acquisition itself (`runtime.ts`) — the worker tarball still comes
+  from GitHub releases; only **model weight** download changes.
+- No change to the `/api/mlx-asr/*` route contract or the `MlxModelDownloadState` shape.
+- Apple-Silicon gating (`isAppleSiliconMac()`) is unchanged. This does **not** bring MLX to
+  Windows (that needs a different inference runtime — separate effort).
+
+---
+
+## 2. Why this is safe — equivalence of the download
+
+The current download is **not** doing anything MLX-specific. `scripts/mlx_asr_server.py`:
+
+```python
+def _download_model(model_id: str) -> None:
+    from huggingface_hub import snapshot_download
+    path = snapshot_download(model_id, tqdm_class=_ProgressTqdm)   # :143
+```
+
+`mlx_audio.load(model_id)` later reads that same snapshot from the HF cache. Therefore a
+Node-side `snapshotDownload({ repo: hfId })` writing into the **same** HF cache
+(`~/.cache/huggingface/hub/models--<repo>/snapshots/<rev>/`) is functionally equivalent —
+`load()` cannot tell which client populated the cache.
+
+This is the core de-risking fact: we are swapping *who performs an identical
+`snapshot_download`*, not changing what ends up on disk.
+
+---
+
+## 3. Background — current state
+
+`apps/server/src/lib/mlx-asr/models.ts`
+
+- `downloadMlxModel(modelId)` (`:217`):
+  1. Marks phase `building_binary`, calls `updateManagedMlxRuntimeIfNeeded()` then
+     `getRunner()`; if the runtime/Python is missing, runs `ensureMlxRuntimeDownloaded()`
+     (`runtime.ts`) — **download is gated on the runtime being present**.
+  2. Marks phase `downloading_model`, `spawn(runner, ["--model", hfId, "--download-model"])`.
+  3. Parses newline-delimited JSON `{type:"progress", bytesDownloaded, bytesTotal}` off
+     stdout into the in-memory `ActiveMlxDownload` (`:287-312`); reports via
+     `getMlxModelStatus`.
+- Readiness: `isMlxModelDownloaded()` (`:99`) — HF snapshot dir exists and is non-empty.
+- `getRunner()` (`:113`) resolves the bundled worker or a system Python+mlx-audio — used
+  **only** by `downloadMlxModel`.
+- `cancelMlxDownload()` (`:349`) — `proc.kill()`, plus `cancelMlxRuntimeDownload()` if still
+  in `building_binary`.
+- `deleteMlxModel()` (`:360`) — `rm -rf` the repo cache dir + clear `model_configs` row.
+
+### 3.1 The status choreography (the thing to be careful about)
+
+`getMlxModelStatus()` (`:142-204`) resolves, in order:
+
+1. active download error → `error`
+2. active download → `downloading` (uses runtime progress during `building_binary`, else
+   `active.bytes*`)
+3. `describeMlxSetupBlocker()` returns non-null (no Apple Silicon / no worker / no Python /
+   mlx-audio missing) → `not_downloaded` if the runtime is installable, else `error`
+4. `isMlxModelDownloaded()` → `ready`
+5. else → `not_downloaded`
+
+**Key consequence:** step 3 runs *before* step 4. So with the current code, weights on disk
+but no runtime ⇒ status is `error`/`not_downloaded`, never `ready`. Any change that lets
+weights download without the runtime must decide what this state should report (see §5.2).
+
+---
+
+## 4. Problems being fixed
+
+| # | Problem | Where |
+|---|---------|-------|
+| M1 | **Brittle progress transport.** Progress is JSON parsed from worker stdout; any stray/partial line, buffering, or worker-version drift breaks the bar. | `models.ts:287-312` |
+| M2 | **Download gated on the runtime.** Must install the ~hundreds-of-MB Python worker before any weights download, even though weights are plain HTTP from HF. | `models.ts:244-261` |
+| M3 | **Subprocess failure surface.** spawn/env/exit-code/stderr handling for what is fundamentally a file download. | `models.ts:275-346` |
+| M4 | **No integrity beyond "dir non-empty."** A partial snapshot reads as present. | `models.ts:99` |
+
+`@huggingface/hub` addresses M1/M3 (no subprocess, progress via `progressFetch`), M4
+(content-addressed blobs), and enables M2's fix (§5.2).
+
+---
+
+## 5. Design
+
+### 5.1 Phase 1 — swap the transport (recommended first, low risk)
+
+Keep the **existing choreography** (runtime still ensured first, phases unchanged) and
+replace only the spawn with a Node snapshot download. This is the smallest change that
+kills the subprocess + stdout-JSON parsing.
+
+In `downloadMlxModel`, after the runtime is ensured and phase flips to `downloading_model`,
+replace the `spawn(...)` Promise (`:275-346`) with:
+
+```ts
+const repo = { type: "model", name: model.hfId } as const;
+
+// Accurate denominator for the progress bar (sum of LFS + regular file sizes).
+const files = await listFiles({ repo, recursive: true });
+active.bytesTotal = files.reduce((n, f) => n + (f.size ?? 0), 0);
+
+// progressFetch wraps every blob fetch, so cumulative bytes accrue automatically.
+await snapshotDownload({
+  repo,
+  cacheDir: hfCacheRoot(),
+  fetch: progressFetch(active, active.controller.signal),
+});
+```
+
+`ActiveMlxDownload` changes: drop `proc: ChildProcess | null`, add
+`controller: AbortController` (mirrors the Whisper `ActiveDownload`). `cancelMlxDownload`
+switches `active.proc?.kill()` → `active.controller.abort()`. The `building_binary` branch
+of cancel (calls `cancelMlxRuntimeDownload()`) is unchanged.
+
+**Removed by Phase 1:** the spawn Promise (~72 lines), the stdout JSON parser, the `stderr`
+field, and — since it was only used for download — `getRunner()` (~28 lines) plus its
+`python.ts` imports used solely there. Net ≈ **−90 lines**.
+
+**Behavioral parity:** runtime is still acquired during `building_binary`, so
+`getMlxModelStatus` semantics are **identical** to today. Lowest-risk increment.
+
+### 5.2 Phase 2 — decouple weights from the runtime (optional, behavior change)
+
+Once Phase 1 is proven, drop the runtime-ensure from the *download* path so users can fetch
+weights without first installing the Python worker (fixes M2). The runtime is then acquired
+lazily at **inference** (server start already calls `canRunMlxAsr()` / ensures the worker).
+
+This requires updating the status choreography so "weights present, runtime absent" is not
+reported as a hard `error`. Proposed change to `getMlxModelStatus` (§3.1 step ordering):
+
+- Move the `isMlxModelDownloaded()` check **before** `describeMlxSetupBlocker()`, so a
+  downloaded model reports `ready` regardless of runtime state.
+- Surface "runtime still needed to run" through the **already-existing** top-level
+  `runtime` / `blockedReason` fields on `GET /api/mlx-asr/status` (route `:54`, `:70`),
+  which the renderer already receives — i.e. readiness of *weights* and readiness of the
+  *runtime* become independent signals, which is more truthful than today.
+
+> Phase 2 touches renderer-visible status semantics, so it needs a UI review: confirm the
+> settings screen distinguishes "model downloaded" from "runtime installed." If that
+> distinction isn't wanted, **stop after Phase 1** — it already removes the brittle code.
+
+### 5.3 Progress denominator & phases
+
+- `building_binary` (runtime) progress continues to come from
+  `getMlxRuntimeDownloadStatus()` exactly as today (`models.ts:158-161`).
+- `downloading_model` denominator now comes from `listFiles` sum instead of the worker's
+  reported `bytesTotal`. `progressFetch` only accumulates `bytesDownloaded`/`speedBps`
+  (it does not trust per-request `content-length`, matching the Whisper helper).
+
+### 5.4 Unchanged
+
+`isMlxModelDownloaded`, `deleteMlxModel` (rm cache dir + DB row), `hfCacheRoot`/
+`hfRepoCacheDir`, the route handlers, `MlxModelDownloadState`, runtime acquisition
+(`runtime.ts`), and the Python worker (still used for inference, and still supports
+`--download-model` as a fallback we simply stop calling).
+
+---
+
+## 6. API contract
+
+No public change. `MlxModelDownloadState` and the `/api/mlx-asr/*` routes are identical.
+Phase 2 changes only *which* status a given on-disk state maps to (weights-ready vs
+runtime-blocked), not the response shape.
+
+---
+
+## 7. Edge cases & risks
+
+- **OQ1 — `listFiles` sizes.** Need `f.size` populated for safetensors/LFS to get an
+  accurate bar. Verify for `mlx-community/*`. Fallback: indeterminate progress (omit
+  `downloadProgress` denominator, as the code already tolerates `bytesTotal === 0`).
+- **OQ2 — `snapshotDownload` + custom `fetch`.** Confirm `snapshotDownload` forwards the
+  `fetch` option to its per-file downloads (it shares the download-file core that
+  `downloadFileToCacheDir` uses). If not, fall back to an explicit `listFiles` +
+  per-file `downloadFileToCacheDir` loop accumulating into the same `active` sink.
+- **OQ3 — Cancellation granularity.** Aborting mid-snapshot leaves a partial cache;
+  `isMlxModelDownloaded` (dir non-empty) could then read as present. Mitigation: on abort,
+  `rmSync(hfRepoCacheDir(model.hfId), {recursive:true,force:true})` in `cancelMlxDownload`
+  (the Python path effectively restarted cleanly too). Decide whether to also prune on the
+  next download attempt.
+- **OQ4 — Concurrency with runtime download.** Today both share the single
+  `activeDownload` in `runtime.ts`. Phase 1 keeps runtime-then-weights sequential, so no
+  new concurrency. Phase 2 must ensure a weights download and a lazy runtime fetch don't
+  race the same progress slot.
+- **OQ5 — `mlx_audio.load()` revision.** `snapshot_download(model_id)` defaults to `main`;
+  match it (no `revision`, or pin per model in `MlxAsrModelDef` for reproducibility).
+
+---
+
+## 8. Test plan (Apple Silicon required)
+
+- **Unit:** `ActiveMlxDownload` cancel aborts the controller; `getMlxModelStatus` mapping
+  for each state (Phase 2: add the weights-ready/runtime-absent case).
+- **Integration (smoke, mirrors the Whisper smoke test):** Node `snapshotDownload` of
+  `mlx-community/Qwen3-ASR-0.6B-5bit` (smallest, ~450 MB) into the HF cache; assert the
+  snapshot dir matches what `snapshot_download` produces and `isMlxModelDownloaded` → true.
+- **Inference parity:** after a Node download, start the MLX server and transcribe a clip —
+  confirm `mlx_audio.load()` loads from cache with no re-download.
+- **Cancel:** abort mid-download; assert no partial snapshot is left that reads as `ready`
+  (OQ3).
+- **Migration:** a pre-existing snapshot (downloaded by the old Python path) still reports
+  `ready` and runs — verified by leaving an existing user's cache untouched.
+
+---
+
+## 9. Rollout
+
+1. **Phase 1** — transport swap, behavior-identical. Ship and verify on Apple Silicon.
+2. **Phase 2** — decouple from runtime + status reorder, **only if** the UI should show
+   weights-downloaded independent of runtime-installed. Otherwise stop at Phase 1.
+3. **Cleanup** — optionally drop `--download-model` from `scripts/mlx_asr_server.py` once no
+   caller remains (keep `--model-status`/inference paths).
+
+Each phase is independently shippable and revertible.
+
+---
+
+## 10. Estimated impact
+
+- **Code:** ≈ −90 lines net in `models.ts` (Phase 1): remove spawn + stdout parser +
+  `getRunner`; add ~12 lines of `listFiles`/`snapshotDownload`. No new files (reuses
+  `lib/hf/progress.ts`).
+- **Reliability:** removes the subprocess + stdout-JSON transport (M1/M3) and adds
+  content-addressed integrity (M4).
+- **Architecture:** Phase 2 lets weights download without the Python runtime (M2) — the
+  most meaningful UX win, at the cost of a status-semantics change requiring UI sign-off.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@hono/zod-validator':
         specifier: ^0.8.0
         version: 0.8.0(hono@4.12.22)(zod@4.4.3)
+      '@huggingface/hub':
+        specifier: ^2.13.0
+        version: 2.13.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -1111,6 +1114,20 @@ packages:
     resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
     peerDependencies:
       react-hook-form: ^7.55.0
+
+  '@huggingface/blake3-jit@0.0.2':
+    resolution: {integrity: sha512-Bq7B5qabyjrJfhBsl85Jd2QBtf+HzRD7h7A9GfN2lzrrsABhOa5evVPgzoCTxR7Ub0QFj7YDK1YkYRWBU25+2w==}
+
+  '@huggingface/hub@2.13.0':
+    resolution: {integrity: sha512-IAoqdpTV9HeMyooxKVvVGWirOJ+S2IAKnU2FSQSMz62ehPTKzxADAATy1fwAlYYQdHCV119GHFf4p9+ECQ+I5g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@huggingface/tasks@0.21.8':
+    resolution: {integrity: sha512-+XNkgBks3dPVzSrnngHwsfB0BBjRZKmvmO6f45UDrvjygmZuzPTQN3+vbaMbxsAW2CHfEF6YQT3dAUvVNUGgug==}
+
+  '@huggingface/xetchunk-wasm@0.0.6':
+    resolution: {integrity: sha512-LoYPl7jvUvOnkysrhMjAeBzK5mVe2GFu8O3IsZb1w7l7v+NqjDsyRduwct3yraPAGmzTxxdb/2aIORL98Y949g==}
 
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
@@ -2730,6 +2747,10 @@ packages:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
+  cli-progress@3.12.0:
+    resolution: {integrity: sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==}
+    engines: {node: '>=4'}
+
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
@@ -3297,6 +3318,9 @@ packages:
 
   fuzzysort@3.1.0:
     resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
+
+  gearhash-jit@1.0.2:
+    resolution: {integrity: sha512-UhzJL4KXSdqAKepy/tZwmi2Rcy0YMmtiC4DQS4SURCuIWdh8ECZtnXK2ePRMLigfB61hRKdLK/Vgg2bSw73izQ==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -5800,6 +5824,22 @@ snapshots:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.76.1(react@19.2.6)
 
+  '@huggingface/blake3-jit@0.0.2': {}
+
+  '@huggingface/hub@2.13.0':
+    dependencies:
+      '@huggingface/tasks': 0.21.8
+      '@huggingface/xetchunk-wasm': 0.0.6
+    optionalDependencies:
+      cli-progress: 3.12.0
+
+  '@huggingface/tasks@0.21.8': {}
+
+  '@huggingface/xetchunk-wasm@0.0.6':
+    dependencies:
+      '@huggingface/blake3-jit': 0.0.2
+      gearhash-jit: 1.0.2
+
   '@inquirer/ansi@2.0.5': {}
 
   '@inquirer/confirm@6.0.13(@types/node@22.19.19)':
@@ -7510,6 +7550,11 @@ snapshots:
     dependencies:
       restore-cursor: 5.1.0
 
+  cli-progress@3.12.0:
+    dependencies:
+      string-width: 4.2.3
+    optional: true
+
   cli-spinners@2.9.2: {}
 
   cli-truncate@2.1.0:
@@ -8201,6 +8246,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   fuzzysort@3.1.0: {}
+
+  gearhash-jit@1.0.2: {}
 
   gensync@1.0.0-beta.2: {}
 


### PR DESCRIPTION
# Overview

Right now when we are downloading local models we are doing a fetch method directly. This is less reliable as we have to write all of our custom error handlers. This is what `@huggingface/hub` is supposed to handle for us, that download reliability. 

In this PR we replaced our fetch logic with methods from `@huggingface/hub`.
