### PR TITLE
fix: kill whisper-server and other child processes on app quit

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -50,6 +50,8 @@ import server, {
   closeDb,
   prefetchManagedMlxRuntimeForAppRelease,
   reconcileUnsupportedMlxVoiceDefault,
+  stopMlxServer,
+  stopWhisperServer,
 } from "@freestyle/server";
 import { createAppLogger } from "@freestyle/utils";
 import { serve } from "@hono/node-server";
@@ -694,12 +696,8 @@ async function factoryReset(): Promise<void> {
   if (response !== 1) return;
 
   try {
-    await fetch(`http://127.0.0.1:${serverPort}/api/whisper/server/stop`, {
-      method: "POST",
-    }).catch(() => {});
-    await fetch(`http://127.0.0.1:${serverPort}/api/mlx-asr/server/stop`, {
-      method: "POST",
-    }).catch(() => {});
+    await stopWhisperServer().catch(() => {});
+    await stopMlxServer().catch(() => {});
 
     if (keyListener) {
       keyListener.stop();
@@ -1733,12 +1731,18 @@ let isQuitting = false;
 let updateDownloadState: "idle" | "downloading" | "downloaded" = "idle";
 
 function cleanupBeforeQuit(): void {
-  fetch(`http://127.0.0.1:${serverPort}/api/whisper/server/stop`, {
-    method: "POST",
-  }).catch(() => {});
-  fetch(`http://127.0.0.1:${serverPort}/api/mlx-asr/server/stop`, {
-    method: "POST",
-  }).catch(() => {});
+  stopWhisperServer().catch(() => {});
+  stopMlxServer().catch(() => {});
+  if (keyListener) {
+    keyListener.stop();
+    keyListener = null;
+  }
+  if (micListener) {
+    micListener.stop();
+    micListener = null;
+  }
+  stopHotkeyRecorderProcess();
+  globalShortcut.unregisterAll();
   if (httpServer) {
     httpServer.close();
     httpServer = null;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -82,6 +82,8 @@ const app = new Hono()
   .route("/stream", stream);
 
 export { closeDb } from "./lib/db.js";
+export { stopMlxServer } from "./lib/mlx-asr/server.js";
+export { stopServer as stopWhisperServer } from "./lib/whisper/server.js";
 export {
   activateManagedMlxRuntimeForAppVersion,
   autoStartMlxAsrServer,

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -19,6 +19,18 @@ let restartCount = 0;
 let stabilityTimer: ReturnType<typeof setTimeout> | null = null;
 let serverFailed = false;
 
+function stopServerOnExit(): void {
+  const proc = serverProcess;
+  if (!proc) return;
+  try {
+    proc.kill(process.platform === "win32" ? undefined : "SIGTERM");
+  } catch {
+    // best effort during process teardown
+  }
+}
+
+process.once("exit", stopServerOnExit);
+
 export function isServerRunning(): boolean {
   return serverProcess !== null && serverReady;
 }


### PR DESCRIPTION
Fixes orphaned `whisper-server` processes remaining in memory on macOS after quitting the app. The root cause was a race condition: `cleanupBeforeQuit()` sent HTTP fetch requests to stop child processes, but immediately called `httpServer.close()` and `app.exit(0)` — tearing down the server before the stop requests could be processed.

This PR adds a synchronous `process.once("exit")` safety net for whisper-server (matching the existing MLX ASR pattern), replaces the HTTP-based cleanup with direct function calls, and moves key-listener/mic-listener/hotkey-recorder cleanup into `cleanupBeforeQuit()` since the `will-quit` handler is bypassed by `app.exit(0)`.

## Testing
Build and test suite pass (`pnpm build && pnpm test` — 44 tests).

Closes #192

<!--
## Plan

### Root cause
`cleanupBeforeQuit()` used fire-and-forget HTTP fetch requests to `http://127.0.0.1:{port}/api/whisper/server/stop` to stop the whisper-server process on quit. This raced against `httpServer.close()` (which tears down the HTTP server receiving those requests) and `app.exit(0)` (which terminates the process immediately). The whisper-server child process was never signaled and became an orphan.

### Changes

1. **`apps/server/src/lib/whisper/server.ts`**: Added `process.once("exit", stopServerOnExit)` handler that synchronously sends SIGTERM to the whisper-server child process when the Node.js process exits. This mirrors the existing pattern in `apps/server/src/lib/mlx-asr/server.ts:73`.

2. **`apps/server/src/index.ts`**: Exported `stopMlxServer` and `stopWhisperServer` so the Electron main process can call them directly without HTTP.

3. **`apps/electron/src/main/index.ts`**:
   - `cleanupBeforeQuit()`: Replaced HTTP fetch calls with direct `stopWhisperServer()`/`stopMlxServer()` calls. Added cleanup for key-listener, mic-listener, hotkey-recorder, and globalShortcut — these were previously only cleaned up in the `will-quit` handler, which is bypassed when `before-quit` calls `app.exit(0)`.
   - `factoryReset()`: Same HTTP-to-direct-call fix for consistency.

### Why this works
- `stopWhisperServer()` and `stopMlxServer()` deliver `proc.kill("SIGTERM")` synchronously inside the Promise executor, before `app.exit(0)` fires.
- The `process.once("exit")` handler is a redundant safety net: if the process exits without going through normal cleanup (e.g., uncaught exception), it still sends SIGTERM to any surviving child process.
- `key-listener.stop()`, `mic-listener.stop()`, and `hotkeyRecorder.stop()` all use synchronous `proc.kill("SIGTERM")` internally.
-->