### PR TITLE
fix: improve paste handling on Linux for Wayland and X11 

### DIFF
--- a/apps/electron/native/linux-fast-paste.c
+++ b/apps/electron/native/linux-fast-paste.c
@@ -534,19 +534,16 @@ int main(int argc, char *argv[]) {
     if (use_portal) {
 #ifdef HAVE_GIO
         int shift = force_terminal;
-        if (!shift) {
+        if (!shift && target_window != None) {
             Display *dpy = XOpenDisplay(NULL);
             if (dpy) {
-                Window win = (target_window != None) ? target_window : get_active_window(dpy);
-                if (win != None) {
-                    XClassHint hint;
-                    if (XGetClassHint(dpy, win, &hint)) {
-                        shift = is_terminal(hint.res_class) || is_terminal(hint.res_name);
-                        XFree(hint.res_name);
-                        XFree(hint.res_class);
-                    } else {
-                        shift = check_parent_terminal(dpy, win);
-                    }
+                XClassHint hint;
+                if (XGetClassHint(dpy, target_window, &hint)) {
+                    shift = is_terminal(hint.res_class) || is_terminal(hint.res_name);
+                    XFree(hint.res_name);
+                    XFree(hint.res_class);
+                } else {
+                    shift = check_parent_terminal(dpy, target_window);
                 }
                 XCloseDisplay(dpy);
             }
@@ -561,19 +558,16 @@ int main(int argc, char *argv[]) {
     if (use_uinput) {
 #ifdef HAVE_UINPUT
         int shift = force_terminal;
-        if (!shift) {
+        if (!shift && target_window != None) {
             Display *dpy = XOpenDisplay(NULL);
             if (dpy) {
-                Window win = (target_window != None) ? target_window : get_active_window(dpy);
-                if (win != None) {
-                    XClassHint hint;
-                    if (XGetClassHint(dpy, win, &hint)) {
-                        shift = is_terminal(hint.res_class) || is_terminal(hint.res_name);
-                        XFree(hint.res_name);
-                        XFree(hint.res_class);
-                    } else {
-                        shift = check_parent_terminal(dpy, win);
-                    }
+                XClassHint hint;
+                if (XGetClassHint(dpy, target_window, &hint)) {
+                    shift = is_terminal(hint.res_class) || is_terminal(hint.res_name);
+                    XFree(hint.res_name);
+                    XFree(hint.res_class);
+                } else {
+                    shift = check_parent_terminal(dpy, target_window);
                 }
                 XCloseDisplay(dpy);
             }

--- a/apps/electron/src/main/hotkey-recorder.ts
+++ b/apps/electron/src/main/hotkey-recorder.ts
@@ -121,17 +121,13 @@ export class HotkeyRecorder {
       const unexpected = this.target !== null;
       this.process = null;
       if (unexpected) {
-        this.sendCancel();
+        this.callbacks.onError?.("Hotkey recorder process exited");
       }
     });
 
     this.process.on("error", (err) => {
       this.callbacks.onError?.(`Hotkey recorder process error: ${err.message}`);
-      const unexpected = this.target !== null;
       this.process = null;
-      if (unexpected) {
-        this.sendCancel();
-      }
     });
 
     return true;

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -673,6 +673,10 @@ function hidePill(): void {
   } catch {}
 }
 
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function resetOnboarding(): void {
   writeSettings({ onboardingComplete: false });
   showSettingsWindow("/onboarding");
@@ -1023,7 +1027,10 @@ app.whenReady().then(async () => {
 
   // IPC: paste text at cursor
   ipcMain.handle("paste:text", async (_event, text: string) => {
-    await pasteIntoFocusedApp(text);
+    await pasteIntoFocusedApp(text, async () => {
+      hidePill();
+      await wait(0);
+    });
   });
 
   // IPC: copy text to clipboard

--- a/apps/electron/src/main/paste.ts
+++ b/apps/electron/src/main/paste.ts
@@ -11,6 +11,17 @@ function execAsync(cmd: string): Promise<void> {
   });
 }
 
+async function tryExecAsync(cmd: string, label: string): Promise<boolean> {
+  try {
+    await execAsync(cmd);
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`${label} failed: ${message}`);
+    return false;
+  }
+}
+
 function execFileAsync(path: string, args: string[] = []): Promise<number> {
   return new Promise((resolve, reject) => {
     execFile(path, args, (err) => {
@@ -32,6 +43,13 @@ function execFileAsync(path: string, args: string[] = []): Promise<number> {
       }
     });
   });
+}
+
+function isWaylandSession(): boolean {
+  return (
+    process.env.XDG_SESSION_TYPE?.toLowerCase() === "wayland" ||
+    Boolean(process.env.WAYLAND_DISPLAY)
+  );
 }
 
 async function pasteMac(): Promise<"native" | "legacy"> {
@@ -72,32 +90,59 @@ async function pasteWindows(): Promise<"native" | "legacy"> {
   return "legacy";
 }
 
-async function pasteLinux(): Promise<"native" | "legacy"> {
+type PasteMethod = "native" | "legacy";
+
+async function pasteLinux(): Promise<PasteMethod> {
   const binaryPath = getNativeBinaryPath("linux-fast-paste");
+  const wayland = isWaylandSession();
+
+  if (wayland) {
+    return pasteLinuxWayland(binaryPath);
+  }
+
   if (binaryPath) {
-    const args: string[] = [];
-    if (process.env.XDG_SESSION_TYPE === "wayland") {
-      args.push("--portal");
-    }
-    const exitCode = await execFileAsync(binaryPath, args);
+    const exitCode = await execFileAsync(binaryPath);
     if (exitCode !== 0) {
       log.warn(
-        `Native paste failed (exit ${exitCode}), falling back to xdotool/wtype`,
+        `Native paste failed (exit ${exitCode}), falling back to xdotool`,
       );
-      await pasteLinuxLegacy();
+      await pasteLinuxLegacy(false);
       return "legacy";
     }
     return "native";
   }
-  await pasteLinuxLegacy();
+  await pasteLinuxLegacy(false);
   return "legacy";
 }
 
-async function pasteLinuxLegacy(): Promise<void> {
-  try {
+async function pasteLinuxWayland(
+  binaryPath: string | null,
+): Promise<PasteMethod> {
+  if (binaryPath) {
+    const exitCode = await execFileAsync(binaryPath, ["--uinput"]);
+    if (exitCode === 0) {
+      return "legacy";
+    }
+    log.warn(
+      `Native uinput paste failed (exit ${exitCode}), falling back to wtype`,
+    );
+  }
+
+  await pasteLinuxLegacy(true);
+  return "legacy";
+}
+
+async function pasteLinuxLegacy(wayland: boolean): Promise<void> {
+  if (wayland) {
+    const pasted = await tryExecAsync(
+      "wtype -M ctrl -P v -p v -m ctrl",
+      "wtype paste",
+    );
+    if (!pasted) {
+      throw new Error("No supported Wayland paste backend succeeded");
+    }
+  } else {
     await execAsync("xdotool key ctrl+v");
-  } catch {
-    await execAsync("wtype -M ctrl -P v -p v -m ctrl");
   }
 }
 
@@ -117,25 +162,20 @@ const PASTE_SETTLE_LEGACY_MS: Record<string, number> = {
   linux: 300,
 };
 
-export async function pasteIntoFocusedApp(text: string): Promise<void> {
+export async function pasteIntoFocusedApp(
+  text: string,
+  beforePaste?: () => Promise<void> | void,
+): Promise<void> {
   log.debug(`text: ${JSON.stringify(text)}`);
   if (!text?.trim()) return;
 
   const prior = clipboard.readText();
   clipboard.writeText(text);
 
-  // Verify the clipboard write actually took effect before pasting.
-  // Electron's clipboard API is synchronous on the main thread, but a
-  // short spin-wait guards against external clipboard managers that may
-  // overwrite the value immediately after our write.
-  for (let i = 0; i < 5; i++) {
-    if (clipboard.readText() === text) break;
-    await new Promise((r) => setTimeout(r, 10));
-    clipboard.writeText(text);
-  }
-
   try {
-    let method: "native" | "legacy" = "legacy";
+    await beforePaste?.();
+
+    let method: PasteMethod = "legacy";
     switch (process.platform) {
       case "darwin":
         method = await pasteMac();

--- a/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
+++ b/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
@@ -82,7 +82,7 @@ const CAPTURED_MODIFIER_KEYS: Record<string, string> = {
   RightSuper: "Super",
 };
 
-/** macOS: compound keys (Alt+Space) via DOM; Fn/right-mod via native IPC */
+/** Fallback capture inside Settings when native global recording is unavailable. */
 const USE_DOM_CAPTURE = true;
 
 const DOM_MODIFIER_KEYS = new Set([
@@ -323,6 +323,13 @@ export function useHotkeyRecorder(
     setInvalidReleaseNotice(false);
   }, [clearWarningTimer, showInvalidReleaseNotice]);
 
+  const hasDraftCombo = useCallback(() => {
+    return (
+      draftComboRef.current.key !== null ||
+      draftComboRef.current.modifiers.length > 0
+    );
+  }, []);
+
   // Global capture: native listener (all platforms) + DOM on macOS for Alt+Space etc.
   useEffect(() => {
     if (state !== "recording" || !window.api) return;
@@ -339,6 +346,7 @@ export function useHotkeyRecorder(
     });
 
     const removeReleased = window.api.onHotkeyRecordReleased(() => {
+      if (!hasDraftCombo()) return;
       completeRecording();
     });
 
@@ -356,7 +364,7 @@ export function useHotkeyRecorder(
       removeReleased();
       removeCancel();
     };
-  }, [state, completeRecording, updateDraftCombo]);
+  }, [state, completeRecording, hasDraftCombo, updateDraftCombo]);
 
   useEffect(() => {
     if (state !== "recording" || !USE_DOM_CAPTURE) return;
@@ -394,6 +402,7 @@ export function useHotkeyRecorder(
       e.stopPropagation();
 
       if (e.key === "Escape") return;
+      if (!hasDraftCombo()) return;
       completeRecording();
     };
 
@@ -403,7 +412,13 @@ export function useHotkeyRecorder(
       window.removeEventListener("keydown", handleKeyDown, true);
       window.removeEventListener("keyup", handleKeyUp, true);
     };
-  }, [state, cancelRecording, completeRecording, updateDraftCombo]);
+  }, [
+    state,
+    cancelRecording,
+    completeRecording,
+    hasDraftCombo,
+    updateDraftCombo,
+  ]);
 
   // Stop main process recording only if we started it (avoids re-registering hotkey on every settings navigation)
   useEffect(() => {


### PR DESCRIPTION
## Summary

  - Update Linux paste backend selection:
    - Wayland: try native `linux-fast-paste --uinput` first, then `wtype`
    - X11: use native XTest paste first, then `xdotool`
  - Stop using the RemoteDesktop portal as the default Wayland paste path because its permission/session flow is difficult to manage reliably and is not supported consistently across Wayland desktops
  - Write clipboard contents before hiding the pill so paste mode preserves the transcribed text before focus returns to the target app
  - Avoid probing arbitrary X windows from native `--uinput` / `--portal` paths when no target window is provided
  - Keep the hotkey recorder open when the native recorder exits early, allowing the DOM capture fallback to complete recording

  ## Notes

  - Linux Wayland behavior varies by distro, compositor, and clipboard/security implementation. This improves coverage for common setups, but does not guarantee paste support across every Wayland environment.
  - `uinput` requires `/dev/uinput` write access.
  - `wtype` requires compositor support for the virtual keyboard protocol.