### PR TITLE
refactor: remove subtitle from Vocabulary page header

### DIFF
--- a/apps/electron/src/renderer/src/pages/settings/vocabulary.tsx
+++ b/apps/electron/src/renderer/src/pages/settings/vocabulary.tsx
@@ -235,10 +235,7 @@ export default function VocabularyPage(): React.JSX.Element {
         className="responsive-page-scroll flex-1 overflow-auto"
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
-        <PageHeader
-          title="Vocabulary"
-          subtitle="Names and phrases you say aloud. The speech model uses these during transcription—not voice shortcuts."
-        />
+        <PageHeader title="Vocabulary" />
 
         {isEmpty && !showForm ? (
           <EmptyState


### PR DESCRIPTION
Removes the descriptive subtitle from the Vocabulary settings page

Change:

<img width="1157" height="650" alt="Screenshot 2026-06-06 at 10 16 05 AM" src="https://github.com/user-attachments/assets/55017986-f20f-4b65-b1ab-ffcd2cc8823c" />
