### PR TITLE
fix: allow deleting inactive cleanup providers

### DIFF
--- a/apps/electron/src/renderer/src/pages/models.tsx
+++ b/apps/electron/src/renderer/src/pages/models.tsx
@@ -603,12 +603,12 @@ export default function ModelsPage(): React.JSX.Element {
       const activeModels: string[] = [];
       if (defaultVoice?.provider === provider)
         activeModels.push(`Voice: ${defaultVoice.model_name}`);
-      if (defaultLlm?.provider === provider)
+      if (llmCleanup && defaultLlm?.provider === provider)
         activeModels.push(`LLM: ${defaultLlm.model_name}`);
       setDeleteProvider(provider);
       setDeleteBlockedBy(activeModels);
     },
-    [defaultVoice, defaultLlm],
+    [defaultVoice, defaultLlm, llmCleanup],
   );
 
   const confirmDeleteProvider = useCallback(async () => {


### PR DESCRIPTION
Minor fix addressing #198 

Summary: 
  - Allow deleting the selected LLM provider when post-processing is disabled
  - Continue blocking deletion when the provider supplies the active voice model
  - Continue blocking deletion when post-processing is enabled and uses the provider
  - Remove the provider API key and its configured models after confirmation