### PR TITLE
fix: percent-encode x-app-context header to avoid fetch failure on non-Latin1 window titles

### DIFF
--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -106,6 +106,17 @@ interface TranscribeResult {
   error?: string;
 }
 
+/**
+ * The app context (process name + window title) can contain characters
+ * outside ISO-8859-1 — e.g. a Cyrillic file path in the Notepad++ title
+ * bar. HTTP header values only allow Latin-1, so passing the raw JSON
+ * makes fetch() throw "Failed to execute 'fetch'". Percent-encode it so
+ * the header is always byte-safe; the server decodes it back.
+ */
+function encodeAppContext(context: string): string {
+  return encodeURIComponent(context);
+}
+
 interface QueueEntry {
   promise: Promise<TranscribeResult>;
 }
@@ -314,7 +325,9 @@ export default function AppPage(): React.JSX.Element {
                 "x-audio-duration-ms": String(durationMs),
               };
               if (appContextRef.current)
-                headers["x-app-context"] = appContextRef.current;
+                headers["x-app-context"] = encodeAppContext(
+                  appContextRef.current,
+                );
               if (queueRef.current.length > 0 || drainingRef.current)
                 headers["x-skip-post-process"] = "true";
               fetch(`${getApiBase()}/api/transcribe`, {
@@ -698,7 +711,8 @@ export default function AppPage(): React.JSX.Element {
       "Content-Type": "audio/wav",
       "x-audio-duration-ms": String(recordingDuration),
     };
-    if (appContextRef.current) headers["x-app-context"] = appContextRef.current;
+    if (appContextRef.current)
+      headers["x-app-context"] = encodeAppContext(appContextRef.current);
     if (isSubsequent) headers["x-skip-post-process"] = "true";
 
     const serverOk = await refreshApiBase();

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -10,6 +10,20 @@ import { resolveAsrVocabularyBias } from "../lib/vocabulary-bias.js";
 
 const log = createAppLogger("transcribe");
 
+/**
+ * The client percent-encodes the x-app-context header so non-Latin1
+ * characters (e.g. a Cyrillic window title) survive transport. Decode it
+ * back here, tolerating values that were sent unencoded by older clients.
+ */
+function decodeAppContext(raw: string | undefined): string | null {
+  if (!raw) return null;
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
 const transcribeRoute = new Hono().post("/", async (c) => {
   const start = Date.now();
 
@@ -31,7 +45,7 @@ const transcribeRoute = new Hono().post("/", async (c) => {
     return c.json({ error: "Empty audio data" }, 400);
   }
 
-  const appContext = c.req.header("x-app-context") ?? null;
+  const appContext = decodeAppContext(c.req.header("x-app-context"));
 
   let audioDurationMs = 0;
   if (audioData.length > 44) {


### PR DESCRIPTION
## Problem

Dictating into some apps (e.g. Notepad++) fails with `failed to execute fetch` and no text is inserted.

The pill sends the focused window context in the `x-app-context` HTTP header of `POST /api/transcribe`. On Windows that value is JSON containing the window title, which for editors like Notepad++ includes the full path of the open file. When the path contains characters outside ISO-8859-1 (for example a Cyrillic file name), the browser's `fetch()` throws synchronously:

```
TypeError: Failed to execute 'fetch' on 'Window': Invalid value
```

because HTTP header values are restricted to Latin-1. Apps whose window title is plain ASCII are unaffected, which is why the failure only shows up on some apps.

## Fix

- Client (`app.tsx`): percent-encode the `x-app-context` value before putting it in the header (both the main transcribe path and the post-stream fallback).
- Server (`transcribe.ts`): decode the value back with `decodeURIComponent`, falling back to the raw string for compatibility with older clients.

The decoded JSON is passed to `postProcess` unchanged, so context-aware formatting keeps working.

## Testing

- `biome check` clean on the changed files
- `typecheck` passes for both server and electron
- Server test suite green (pre-existing macOS-only `mlx-runtime` failures are unrelated and also fail on `main` in my Windows environment)
