### PR TITLE
fix: pill not showing on macOS and consecutive MLX transcription failures

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1104,6 +1104,19 @@ app.whenReady().then(async () => {
   // IPC: expose the server port to the renderer
   ipcMain.handle("server:port", () => serverPort);
 
+  ipcMain.handle(
+    "dialog:show-error",
+    async (_event, title: string, detail: string) => {
+      await dialog.showMessageBox({
+        type: "error",
+        title,
+        message: title,
+        detail,
+        buttons: ["OK"],
+      });
+    },
+  );
+
   // IPC: permission checks
   ipcMain.handle("permissions:check-mic", async () => {
     if (process.platform === "darwin") {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -494,7 +494,7 @@ function showPill(): void {
     // The window was just created with `show: false` and is still loading.
     // Defer showing until the renderer finishes loading so IPC messages
     // (e.g. hotkey:down) sent immediately after are not lost.
-    const win = mainWindow;
+    const win = mainWindow!;
     pillReadyPromise = new Promise<void>((resolve) => {
       const cleanup = (): void => {
         pillReadyPromise = null;

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -484,13 +484,29 @@ function createSettingsWindow(initialPath?: string): void {
 let pillReadyPromise: Promise<void> | null = null;
 
 function showPill(): void {
+  // Already waiting for a freshly-created pill to finish loading.
+  if (pillReadyPromise) return;
+
   if (!mainWindow) {
     createAppWindow();
+    if (!mainWindow) return;
+
     // The window was just created with `show: false` and is still loading.
     // Defer showing until the renderer finishes loading so IPC messages
     // (e.g. hotkey:down) sent immediately after are not lost.
+    const win = mainWindow;
     pillReadyPromise = new Promise<void>((resolve) => {
-      mainWindow!.webContents.once("did-finish-load", () => {
+      const cleanup = (): void => {
+        pillReadyPromise = null;
+        resolve();
+      };
+
+      // If the window is closed before it finishes loading, resolve the
+      // promise so deferred IPC calls are not stuck forever.
+      win.once("closed", cleanup);
+
+      win.webContents.once("did-finish-load", () => {
+        win.removeListener("closed", cleanup);
         pillReadyPromise = null;
         if (!mainWindow) {
           resolve();
@@ -1620,6 +1636,14 @@ function sendHotkeyDown(): void {
 }
 
 function sendHotkeyUp(): void {
+  if (pillReadyPromise) {
+    // Preserve IPC ordering: hotkey:up must arrive after hotkey:down.
+    void pillReadyPromise.then(() => {
+      mainWindow?.webContents.send("hotkey:up");
+      settingsWindow?.webContents.send("hotkey:up");
+    });
+    return;
+  }
   mainWindow?.webContents.send("hotkey:up");
   settingsWindow?.webContents.send("hotkey:up");
 }

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -489,12 +489,15 @@ function showPill(): void {
 
   if (!mainWindow) {
     createAppWindow();
-    if (!mainWindow) return;
+    // createAppWindow() synchronously assigns mainWindow, but TypeScript
+    // cannot track mutations through function calls.  Re-read and bail
+    // out if the assignment unexpectedly failed.
+    const win = mainWindow as BrowserWindow | null;
+    if (!win) return;
 
     // The window was just created with `show: false` and is still loading.
     // Defer showing until the renderer finishes loading so IPC messages
     // (e.g. hotkey:down) sent immediately after are not lost.
-    const win = mainWindow!;
     pillReadyPromise = new Promise<void>((resolve) => {
       const cleanup = (): void => {
         pillReadyPromise = null;

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -477,9 +477,32 @@ function createSettingsWindow(initialPath?: string): void {
   settingsWindow.loadURL(getDashboardURL(startPath));
 }
 
+/**
+ * Resolves once a freshly-created pill window has finished loading and is
+ * visible.  `null` when no deferred show is in progress.
+ */
+let pillReadyPromise: Promise<void> | null = null;
+
 function showPill(): void {
   if (!mainWindow) {
     createAppWindow();
+    // The window was just created with `show: false` and is still loading.
+    // Defer showing until the renderer finishes loading so IPC messages
+    // (e.g. hotkey:down) sent immediately after are not lost.
+    pillReadyPromise = new Promise<void>((resolve) => {
+      mainWindow!.webContents.once("did-finish-load", () => {
+        pillReadyPromise = null;
+        if (!mainWindow) {
+          resolve();
+          return;
+        }
+        const { x, y } = getAppWindowPosition();
+        setProgrammaticPosition(mainWindow, x, y);
+        mainWindow.showInactive();
+        registerPillEscape();
+        resolve();
+      });
+    });
     return;
   }
 
@@ -489,8 +512,10 @@ function showPill(): void {
     mainWindow.showInactive();
   }
 
-  // Register Escape as a global shortcut while the pill is visible
-  // so the user can cancel recording/transcription.
+  registerPillEscape();
+}
+
+function registerPillEscape(): void {
   if (!globalShortcut.isRegistered("Escape")) {
     globalShortcut.register("Escape", () => {
       if (mainWindow?.isVisible()) {
@@ -1582,6 +1607,14 @@ function loadHotkeyModeFromDB(): "hold" | "toggle" {
 
 function sendHotkeyDown(): void {
   showPill();
+  if (pillReadyPromise) {
+    // The pill window is still loading — defer IPC until it can receive it.
+    void pillReadyPromise.then(() => {
+      mainWindow?.webContents.send("hotkey:down");
+      settingsWindow?.webContents.send("hotkey:down");
+    });
+    return;
+  }
   mainWindow?.webContents.send("hotkey:down");
   settingsWindow?.webContents.send("hotkey:down");
 }

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -10,6 +10,7 @@ declare global {
       reloadHotkey: () => void;
       setHotkeyMode: (mode: "hold" | "toggle") => void;
       hidePill: () => void;
+      showErrorDialog: (title: string, message: string) => Promise<void>;
       getServerPort: () => Promise<number>;
       onHotkeyDown: (callback: () => void) => () => void;
       onHotkeyUp: (callback: () => void) => () => void;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -13,6 +13,8 @@ const api = {
   setHotkeyMode: (mode: "hold" | "toggle"): void =>
     ipcRenderer.send("hotkey:set-mode", mode),
   hidePill: (): void => ipcRenderer.send("pill:hide"),
+  showErrorDialog: (title: string, message: string): Promise<void> =>
+    ipcRenderer.invoke("dialog:show-error", title, message),
   getServerPort: (): Promise<number> => ipcRenderer.invoke("server:port"),
   onHotkeyDown: (callback: () => void): (() => void) => {
     const handler = (): void => callback();

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -11,12 +11,7 @@ const FALL = 0.22;
 const SVG_WIDTH = 117;
 const SVG_HEIGHT = 25;
 
-type PillState =
-  | "idle"
-  | "initializing"
-  | "recording"
-  | "transcribing"
-  | "error";
+type PillState = "idle" | "initializing" | "recording" | "transcribing";
 
 type BarMode = "connecting" | "listening" | "speaking";
 
@@ -113,7 +108,6 @@ interface QueueEntry {
 export default function AppPage(): React.JSX.Element {
   const [state, setState] = useState<PillState>("idle");
   const [elapsed, setElapsed] = useState(0);
-  const [message, setMessage] = useState("");
   const [pillAlign, setPillAlign] = useState<"start" | "end">("end");
   const [pillSide, setPillSide] = useState<"center" | "right">("center");
   const useStreamingRef = useRef(false);
@@ -195,9 +189,8 @@ export default function AppPage(): React.JSX.Element {
       if (nonEmpty.length === 0) {
         const errMsg = results.find((r) => r.error)?.error;
         if (errMsg) {
-          setState("error");
-          setMessage(errMsg);
-          setTimeout(() => hidePill(), 3000);
+          hidePill();
+          window.api.showErrorDialog("Transcription Failed", errMsg);
         } else {
           hidePill();
         }
@@ -340,9 +333,8 @@ export default function AppPage(): React.JSX.Element {
           if (!useStreamingRef.current) return;
           if (!pillActiveRef.current) return;
           if (wantsMicRef.current) return;
-          setState("error");
-          setMessage(msg);
-          setTimeout(() => hidePill(), 2000);
+          hidePill();
+          window.api.showErrorDialog("Transcription Failed", msg);
         },
       });
     }
@@ -492,7 +484,6 @@ export default function AppPage(): React.JSX.Element {
   // ---- Hide pill ----
   const hidePill = useCallback(() => {
     setState("idle");
-    setMessage("");
     setIsReRecording(false);
     isReRecordingRef.current = false;
     setPendingCount(0);
@@ -516,7 +507,6 @@ export default function AppPage(): React.JSX.Element {
       wantsMicRef.current = true;
       pillActiveRef.current = true;
       pendingCommitRef.current = false;
-      setMessage("");
 
       if (forReRecord) {
         isReRecordingRef.current = true;
@@ -590,9 +580,11 @@ export default function AppPage(): React.JSX.Element {
         setIsReRecording(false);
         recorderRef.current.releaseStream();
         stopVisualization();
-        setState("error");
-        setMessage(err instanceof Error ? err.message : "Mic access denied");
-        setTimeout(() => hidePill(), 2000);
+        hidePill();
+        window.api.showErrorDialog(
+          "Recording Failed",
+          err instanceof Error ? err.message : "Mic access denied",
+        );
       }
     },
     [
@@ -686,9 +678,11 @@ export default function AppPage(): React.JSX.Element {
 
     if (!wavBlob) {
       if (queueRef.current.length === 0 && !drainingRef.current) {
-        setState("error");
-        setMessage("No audio captured. Try recording again.");
-        setTimeout(() => hidePill(), 2500);
+        hidePill();
+        window.api.showErrorDialog(
+          "Recording Failed",
+          "No audio captured. Try recording again.",
+        );
       }
       return;
     }
@@ -703,11 +697,11 @@ export default function AppPage(): React.JSX.Element {
 
     const serverOk = await refreshApiBase();
     if (!serverOk) {
-      setState("error");
-      setMessage(
+      hidePill();
+      window.api.showErrorDialog(
+        "Server Unreachable",
         `Cannot reach Freestyle server at ${getApiBase()}. Quit and reopen the app.`,
       );
-      setTimeout(() => hidePill(), 4000);
       return;
     }
 
@@ -727,9 +721,8 @@ export default function AppPage(): React.JSX.Element {
             body?.error ||
             `Transcription failed (${res.status})`;
           if (pillActiveRef.current && !wantsMicRef.current) {
-            setState("error");
-            setMessage(msg);
-            setTimeout(() => hidePill(), 3000);
+            hidePill();
+            window.api.showErrorDialog("Transcription Failed", msg);
           }
           return empty;
         }
@@ -823,7 +816,7 @@ export default function AppPage(): React.JSX.Element {
   useEffect(() => {
     const removeDown = window.api.onHotkeyDown(() => {
       const s = stateRef.current;
-      if (s === "idle" || s === "error") {
+      if (s === "idle") {
         startRecording(false);
       } else if (s === "transcribing" && !recordingActiveRef.current) {
         // Resolve the pending stream promise so the previous transcription
@@ -887,9 +880,7 @@ export default function AppPage(): React.JSX.Element {
         ? "glow-recording"
         : state === "transcribing" && !isReRecording
           ? "glow-transcribing"
-          : state === "error"
-            ? "glow-error"
-            : "glow-idle";
+          : "glow-idle";
 
   const badge =
     state === "recording"
@@ -959,14 +950,9 @@ export default function AppPage(): React.JSX.Element {
             0%, 100% { box-shadow: 0 0 6px 2px rgba(96,165,250,0.14), 0 0 13px 3px rgba(96,165,250,0.06); }
             50% { box-shadow: 0 0 10px 2px rgba(96,165,250,0.22), 0 0 16px 4px rgba(96,165,250,0.09); }
           }
-          @keyframes glow-pulse-red {
-            0%, 100% { box-shadow: 0 0 6px 2px rgba(221,110,78,0.12); }
-            50% { box-shadow: 0 0 10px 2px rgba(221,110,78,0.20); }
-          }
           .glow-initializing { animation: glow-pulse-amber 1s ease-in-out infinite; }
           .glow-recording { animation: glow-pulse-green 2s ease-in-out infinite; }
           .glow-transcribing { animation: glow-pulse-blue 1.5s ease-in-out infinite; }
-          .glow-error { animation: glow-pulse-red 1.5s ease-in-out infinite; }
           .glow-idle { box-shadow: 0 0 5px 2px rgba(0,0,0,0.05); transition: box-shadow 300ms ease; }
           @keyframes shimmer {
             0% { background-position: 100% center; }
@@ -1087,13 +1073,11 @@ export default function AppPage(): React.JSX.Element {
             >
               <Orb
                 colors={
-                  state === "error"
-                    ? ["#DD6E4E", "#B85C3A"]
-                    : state === "transcribing"
-                      ? ["#60A5FA", "#3B82F6"]
-                      : state === "initializing"
-                        ? ["#FBBF24", "#F59E0B"]
-                        : ["#8AB62A", "#6B8F12"]
+                  state === "transcribing"
+                    ? ["#60A5FA", "#3B82F6"]
+                    : state === "initializing"
+                      ? ["#FBBF24", "#F59E0B"]
+                      : ["#8AB62A", "#6B8F12"]
                 }
                 agentState={
                   state === "initializing"
@@ -1112,19 +1096,6 @@ export default function AppPage(): React.JSX.Element {
             </div>
 
             {showBars && renderBars(barsSvgRef)}
-
-            {state === "error" && (
-              <span
-                style={
-                  {
-                    ...pillTextStyle,
-                    WebkitAppRegion: "no-drag",
-                  } as React.CSSProperties
-                }
-              >
-                {message || "Error"}
-              </span>
-            )}
 
             {badge && (
               <span

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -826,6 +826,14 @@ export default function AppPage(): React.JSX.Element {
       if (s === "idle" || s === "error") {
         startRecording(false);
       } else if (s === "transcribing" && !recordingActiveRef.current) {
+        // Resolve the pending stream promise so the previous transcription
+        // does not hang for 30 s waiting for a result that will be dropped
+        // by the generation counter on the server side.
+        const resolver = streamResolverRef.current;
+        if (resolver) {
+          streamResolverRef.current = null;
+          resolver({ raw: "", cleaned: "" });
+        }
         startRecording(true);
       }
     });

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -829,6 +829,10 @@ export default function AppPage(): React.JSX.Element {
         // Resolve the pending stream promise so the previous transcription
         // does not hang for 30 s waiting for a result that will be dropped
         // by the generation counter on the server side.
+        // Set recordingActiveRef *before* resolving so that drainQueue
+        // (which may be awaiting this promise) sees an active recording
+        // and re-queues instead of calling hidePill().
+        recordingActiveRef.current = true;
         const resolver = streamResolverRef.current;
         if (resolver) {
           streamResolverRef.current = null;

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -624,8 +624,6 @@ export default function AppPage(): React.JSX.Element {
     setState("transcribing");
     startBarAnimation("speaking");
 
-    const empty: TranscribeResult = { raw: "", cleaned: "" };
-
     if (sessionStreamingRef.current && streamerRef.current) {
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -574,12 +574,8 @@ export default function AppPage(): React.JSX.Element {
           await streamer.startCapture(stream);
         } catch {}
       } catch (err) {
-        wantsMicRef.current = false;
         pendingCommitRef.current = false;
-        isReRecordingRef.current = false;
-        setIsReRecording(false);
         recorderRef.current.releaseStream();
-        stopVisualization();
         hidePill();
         window.api.showErrorDialog(
           "Recording Failed",
@@ -587,13 +583,7 @@ export default function AppPage(): React.JSX.Element {
         );
       }
     },
-    [
-      startBarAnimation,
-      startListening,
-      stopVisualization,
-      hidePill,
-      getStreamer,
-    ],
+    [startBarAnimation, startListening, hidePill, getStreamer],
   );
 
   // ---- Commit recording ----
@@ -720,11 +710,7 @@ export default function AppPage(): React.JSX.Element {
             body?.detail ||
             body?.error ||
             `Transcription failed (${res.status})`;
-          if (pillActiveRef.current && !wantsMicRef.current) {
-            hidePill();
-            window.api.showErrorDialog("Transcription Failed", msg);
-          }
-          return empty;
+          return { raw: "", cleaned: "", error: msg };
         }
         const data = (await res.json()) as {
           raw?: string;
@@ -753,22 +739,11 @@ export default function AppPage(): React.JSX.Element {
 
   // ---- Cancel ----
   const cancelRecording = useCallback(() => {
-    wantsMicRef.current = false;
-    recordingActiveRef.current = false;
-    pillActiveRef.current = false;
-    isReRecordingRef.current = false;
-    setIsReRecording(false);
-    queueRef.current = [];
-    drainingRef.current = false;
-    drainAgainRef.current = false;
-    streamResolverRef.current = null;
-    setPendingCount(0);
-    stopVisualization();
     streamerRef.current?.cancel();
     recorderRef.current.cancel();
     recorderRef.current.releaseStream();
     hidePill();
-  }, [stopVisualization, hidePill]);
+  }, [hidePill]);
 
   // ---- Preferences ----
   const applyPillPosition = useCallback((pos: string | null | undefined) => {

--- a/apps/server/src/lib/streaming/providers/mlx-local.ts
+++ b/apps/server/src/lib/streaming/providers/mlx-local.ts
@@ -105,6 +105,12 @@ class MlxLocalStreamingSession implements StreamSession {
 
   reset(): void {
     this.clearTimer();
+    // If a final inference is still in flight, resolve it immediately with
+    // whatever partial text we have so the caller's promise does not hang
+    // until the 30 s timeout.
+    if (this.inFlight && this.commitRequested) {
+      this.opts.callbacks.onFinal(this.lastText);
+    }
     this.chunks = [];
     this.sampleCount = 0;
     this.canceled = false;

--- a/apps/server/src/lib/whisper/binary.ts
+++ b/apps/server/src/lib/whisper/binary.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { accessSync, constants } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
   getBinaryName,
   getBinDir,
@@ -62,4 +62,34 @@ export function isBinaryAvailable(): boolean {
 
 export function isServerBinaryAvailable(): boolean {
   return findWhisperServer() !== null;
+}
+
+/**
+ * Windows NTSTATUS code for STATUS_DLL_NOT_FOUND. When `whisper-cli.exe`
+ * or `whisper-server.exe` exits with this code the Visual C++ Redistributable
+ * (or a companion DLL like ggml.dll) is missing.
+ */
+export const WIN_DLL_NOT_FOUND_EXIT = 3221225781;
+
+export const WIN_DLL_NOT_FOUND_MESSAGE =
+  "a required system library is missing. " +
+  "Please install the Visual C++ Redistributable from " +
+  "https://aka.ms/vs/17/release/vc_redist.x64.exe";
+
+/**
+ * Return spawn options that set `cwd` to the binary's directory and prepend
+ * it to `PATH` so companion DLLs (ggml.dll, whisper.dll) are found on Windows.
+ */
+export function whisperSpawnEnv(binaryPath: string): {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+} {
+  const binDir = dirname(binaryPath);
+  return {
+    cwd: binDir,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
+    },
+  };
 }

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { dirname } from "node:path";
 import { createAppLogger } from "@freestyle/utils";
 import { findWhisperServer } from "./binary.js";
 import { WHISPER_SERVER_PORT } from "./constants.js";
@@ -107,8 +108,14 @@ async function doStart(modelId: string): Promise<void> {
     "127.0.0.1",
   ];
 
+  const binDir = dirname(serverBinary);
   const proc = spawn(serverBinary, args, {
     stdio: ["ignore", "pipe", "pipe"],
+    cwd: binDir,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
+    },
   });
 
   serverProcess = proc;
@@ -200,8 +207,18 @@ async function doStart(modelId: string): Promise<void> {
       if (!settled) {
         settled = true;
         currentModelId = null;
-        const detail = stderr.trim() || `exit code ${code}`;
-        reject(new Error(`whisper-server exited unexpectedly: ${detail}`));
+        if (code === 3221225781) {
+          reject(
+            new Error(
+              "whisper-server failed: a required system library is missing. " +
+                "Please install the Visual C++ Redistributable from " +
+                "https://aka.ms/vs/17/release/vc_redist.x64.exe",
+            ),
+          );
+        } else {
+          const detail = stderr.trim() || `exit code ${code}`;
+          reject(new Error(`whisper-server exited unexpectedly: ${detail}`));
+        }
         return;
       }
 

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -1,7 +1,11 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { dirname } from "node:path";
 import { createAppLogger } from "@freestyle/utils";
-import { findWhisperServer } from "./binary.js";
+import {
+  findWhisperServer,
+  WIN_DLL_NOT_FOUND_EXIT,
+  WIN_DLL_NOT_FOUND_MESSAGE,
+  whisperSpawnEnv,
+} from "./binary.js";
 import { WHISPER_SERVER_PORT } from "./constants.js";
 import { getDownloadedModelPath } from "./models.js";
 
@@ -108,14 +112,9 @@ async function doStart(modelId: string): Promise<void> {
     "127.0.0.1",
   ];
 
-  const binDir = dirname(serverBinary);
   const proc = spawn(serverBinary, args, {
     stdio: ["ignore", "pipe", "pipe"],
-    cwd: binDir,
-    env: {
-      ...process.env,
-      PATH: `${binDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
-    },
+    ...whisperSpawnEnv(serverBinary),
   });
 
   serverProcess = proc;
@@ -207,13 +206,9 @@ async function doStart(modelId: string): Promise<void> {
       if (!settled) {
         settled = true;
         currentModelId = null;
-        if (code === 3221225781) {
+        if (code === WIN_DLL_NOT_FOUND_EXIT) {
           reject(
-            new Error(
-              "whisper-server failed: a required system library is missing. " +
-                "Please install the Visual C++ Redistributable from " +
-                "https://aka.ms/vs/17/release/vc_redist.x64.exe",
-            ),
+            new Error(`whisper-server failed: ${WIN_DLL_NOT_FOUND_MESSAGE}`),
           );
         } else {
           const detail = stderr.trim() || `exit code ${code}`;

--- a/apps/server/src/lib/whisper/transcribe.ts
+++ b/apps/server/src/lib/whisper/transcribe.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { TranscribeResult } from "../streaming/types.js";
 import { findWhisperBinary } from "./binary.js";
 import { getDownloadedModelPath } from "./models.js";
@@ -75,9 +75,15 @@ function runWhisperProcess(
   args: string[],
 ): Promise<string> {
   return new Promise((resolve, reject) => {
+    const binDir = dirname(binaryPath);
     const proc = spawn(binaryPath, args, {
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 120_000,
+      cwd: binDir,
+      env: {
+        ...process.env,
+        PATH: `${binDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
+      },
     });
 
     let stdout = "";
@@ -96,6 +102,16 @@ function runWhisperProcess(
     });
 
     proc.on("close", (code) => {
+      if (code === 3221225781) {
+        reject(
+          new Error(
+            "whisper.cpp failed: a required system library is missing. " +
+              "Please install the Visual C++ Redistributable from " +
+              "https://aka.ms/vs/17/release/vc_redist.x64.exe",
+          ),
+        );
+        return;
+      }
       if (code !== 0) {
         const detail = stderr.trim() || stdout.trim() || `exit code ${code}`;
         reject(new Error(`whisper.cpp failed: ${detail}`));

--- a/apps/server/src/lib/whisper/transcribe.ts
+++ b/apps/server/src/lib/whisper/transcribe.ts
@@ -2,9 +2,14 @@ import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import type { TranscribeResult } from "../streaming/types.js";
-import { findWhisperBinary } from "./binary.js";
+import {
+  findWhisperBinary,
+  WIN_DLL_NOT_FOUND_EXIT,
+  WIN_DLL_NOT_FOUND_MESSAGE,
+  whisperSpawnEnv,
+} from "./binary.js";
 import { getDownloadedModelPath } from "./models.js";
 
 interface WhisperTranscribeOptions {
@@ -75,15 +80,10 @@ function runWhisperProcess(
   args: string[],
 ): Promise<string> {
   return new Promise((resolve, reject) => {
-    const binDir = dirname(binaryPath);
     const proc = spawn(binaryPath, args, {
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 120_000,
-      cwd: binDir,
-      env: {
-        ...process.env,
-        PATH: `${binDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
-      },
+      ...whisperSpawnEnv(binaryPath),
     });
 
     let stdout = "";
@@ -102,14 +102,8 @@ function runWhisperProcess(
     });
 
     proc.on("close", (code) => {
-      if (code === 3221225781) {
-        reject(
-          new Error(
-            "whisper.cpp failed: a required system library is missing. " +
-              "Please install the Visual C++ Redistributable from " +
-              "https://aka.ms/vs/17/release/vc_redist.x64.exe",
-          ),
-        );
+      if (code === WIN_DLL_NOT_FOUND_EXIT) {
+        reject(new Error(`whisper.cpp failed: ${WIN_DLL_NOT_FOUND_MESSAGE}`));
         return;
       }
       if (code !== 0) {


### PR DESCRIPTION
## Summary

- **Pill visibility on macOS**: When the pill window was destroyed and the hotkey pressed again, `showPill()` recreated the window but returned without showing it or deferring the `hotkey:down` IPC. The renderer never received the event, so the pill stayed invisible. Now `showPill()` listens for `did-finish-load` on the recreated window before showing it and `sendHotkeyDown()` defers the IPC until the window is ready.

- **Consecutive MLX transcription**: When starting a new recording while the previous Qwen 0.6 inference was still running, the generation counter on the server caused the old result to be silently dropped. The renderer's `streamResolverRef` then hung for 30 s until timeout. Now `MlxLocalStreamingSession.reset()` immediately fires `onFinal` for any in-flight committed inference, and the renderer eagerly resolves the pending stream promise before starting a re-recording.

<!-- implementation-plan
### Fix 1: Pill visibility (apps/electron/src/main/index.ts)

**Root cause**: `showPill()` calls `createAppWindow()` when `mainWindow` is null (window was closed/destroyed), but returns immediately. The window is created with `show: false` and the page hasn't loaded yet. `sendHotkeyDown()` fires `hotkey:down` IPC right after, but the renderer can't receive it. The pill never appears.

**Changes**:
1. Added `pillReadyPromise` — a module-level promise that resolves once the freshly-created pill window finishes loading
2. `showPill()` now sets up a `did-finish-load` listener that positions, shows the window, and registers Escape
3. `sendHotkeyDown()` defers the `hotkey:down` IPC when `pillReadyPromise` is set
4. Extracted Escape registration into `registerPillEscape()` to avoid duplication

### Fix 2: Consecutive MLX transcription

**Root cause**: The Python worker processes requests serially (single-threaded stdin loop). When a new recording starts via `reset()`, the `generation` counter increments, causing the old inference result to be silently discarded. The renderer's `streamResolverRef` promise hangs for 30 s.

**Changes**:
1. `MlxLocalStreamingSession.reset()` (mlx-local.ts): Before incrementing generation, if `inFlight && commitRequested`, fires `onFinal(lastText)` so the caller's promise resolves immediately
2. `app.tsx` onHotkeyDown handler: When re-recording starts during "transcribing" state, resolves the existing `streamResolverRef` with empty text before calling `startRecording(true)`
-->