### PR TITLE
Feat/history filter panel

### DIFF
--- a/apps/electron/src/renderer/src/pages/history.tsx
+++ b/apps/electron/src/renderer/src/pages/history.tsx
@@ -1,3 +1,9 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@renderer/components/ui/sheet";
 import { getClient } from "@renderer/lib/api";
 import { cn } from "@renderer/lib/utils";
 import {
@@ -6,6 +12,7 @@ import {
   ChevronRight,
   Clock,
   Copy,
+  Filter,
   Search,
   Trash2,
 } from "lucide-react";
@@ -65,6 +72,13 @@ function formatCost(cost: number): string {
   return `$${cost.toFixed(3)}`;
 }
 
+function getLocalDateString(d: Date): string {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 /** Get a date key for grouping: "Today", "Yesterday", or "Day, Mon DD" */
 function getDateGroup(iso: string): string {
   const d = new Date(`${iso}Z`);
@@ -92,6 +106,15 @@ export default function HistoryPage(): React.JSX.Element {
   const [search, setSearch] = useState("");
   const [stats, setStats] = useState<Stats | null>(null);
   const [loading, setLoading] = useState(true);
+  const [startDate, setStartDate] = useState(() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 7);
+    return getLocalDateString(d);
+  });
+  const [endDate, setEndDate] = useState(() => {
+    return getLocalDateString(new Date());
+  });
+  const [filterOpen, setFilterOpen] = useState(false);
 
   const loadData = useCallback(async () => {
     try {
@@ -101,11 +124,17 @@ export default function HistoryPage(): React.JSX.Element {
         orderBy: "-created_at",
       };
       if (search) query.search = search;
+      if (startDate) query.start_date = startDate;
+      if (endDate) query.end_date = endDate;
+
+      const statsQuery: Record<string, string> = {};
+      if (startDate) statsQuery.start_date = startDate;
+      if (endDate) statsQuery.end_date = endDate;
 
       const client = getClient();
       const [histRes, statsRes] = await Promise.all([
         client.api.history.$get({ query }),
-        client.api.history.stats.$get(),
+        client.api.history.stats.$get({ query: statsQuery }),
       ]);
       if (histRes.ok) {
         const data = await histRes.json();
@@ -118,7 +147,7 @@ export default function HistoryPage(): React.JSX.Element {
     } finally {
       setLoading(false);
     }
-  }, [page, search]);
+  }, [page, search, startDate, endDate]);
 
   useEffect(() => {
     loadData();
@@ -166,7 +195,20 @@ export default function HistoryPage(): React.JSX.Element {
     );
   }
 
-  const isEmpty = total === 0 && !search;
+  const todayStr = getLocalDateString(new Date());
+  const start7 = new Date();
+  start7.setDate(start7.getDate() - 7);
+  const start7Str = getLocalDateString(start7);
+  const start30 = new Date();
+  start30.setDate(start30.getDate() - 30);
+  const start30Str = getLocalDateString(start30);
+
+  const isTodayPreset = startDate === todayStr && endDate === todayStr;
+  const isWeeklyPreset = startDate === start7Str && endDate === todayStr;
+  const isMonthlyPreset = startDate === start30Str && endDate === todayStr;
+  const isAllTimePreset = startDate === "" && endDate === "";
+
+  const isGenuineEmpty = total === 0 && !search && !startDate && !endDate;
 
   return (
     <div
@@ -180,7 +222,7 @@ export default function HistoryPage(): React.JSX.Element {
       >
         <PageHeader title="History" />
 
-        {isEmpty ? (
+        {isGenuineEmpty ? (
           <EmptyState />
         ) : (
           <>
@@ -188,7 +230,7 @@ export default function HistoryPage(): React.JSX.Element {
             <div className="border-border mb-7 grid grid-cols-2 gap-2.5 border-b pb-7 md:grid-cols-4">
               <Stat
                 n={(stats?.total_words ?? 0).toLocaleString()}
-                l="words all time"
+                l={startDate || endDate ? "words filtered" : "words all time"}
               />
               <Stat n={String(stats?.total_sessions ?? 0)} l="sessions" />
               <Stat
@@ -202,30 +244,58 @@ export default function HistoryPage(): React.JSX.Element {
               <Stat
                 accent
                 n={`$${(stats?.total_cost_usd ?? 0).toFixed(2)}`}
-                l="cost · all time"
+                l={startDate || endDate ? "cost · filtered" : "cost · all time"}
               />
             </div>
 
-            {/* Search */}
-            <div className="border-border bg-card mb-6 flex items-center gap-2 rounded-lg border px-3 py-2">
-              <Search className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-              <input
-                type="text"
-                value={search}
-                onChange={(e) => {
-                  setSearch(e.target.value);
-                  setPage(0);
-                }}
-                placeholder={`Search ${total} transcript${total === 1 ? "" : "s"}…`}
-                className="placeholder:text-muted-foreground/80 text-foreground flex-1 bg-transparent text-[13px] outline-none"
-              />
-              <span className="mono text-muted-foreground text-[10px]">
-                ⌘ K
-              </span>
+            {/* Search & Filter Row */}
+            <div className="mb-6 flex gap-2">
+              <div className="border-border bg-card flex flex-1 items-center gap-2 rounded-lg border px-3 py-2">
+                <Search className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => {
+                    setSearch(e.target.value);
+                    setPage(0);
+                  }}
+                  placeholder={`Search ${total} transcript${total === 1 ? "" : "s"}…`}
+                  className="placeholder:text-muted-foreground/80 text-foreground flex-1 bg-transparent text-[13px] outline-none"
+                />
+                <span className="mono text-muted-foreground text-[10px]">
+                  ⌘ K
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={() => setFilterOpen(true)}
+                className={cn(
+                  "border-border bg-card hover:bg-accent hover:text-foreground text-muted-foreground flex items-center gap-1.5 rounded-lg border px-3.5 py-2 text-[13px] font-medium transition-colors cursor-pointer",
+                  (startDate || endDate) &&
+                    "border-primary text-primary bg-primary/5",
+                )}
+              >
+                <Filter className="h-3.5 w-3.5" />
+                <span>Filters</span>
+                {(startDate || endDate) && (
+                  <span className="bg-primary text-primary-foreground flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[9px] font-bold">
+                    ✓
+                  </span>
+                )}
+              </button>
             </div>
 
             {entries.length === 0 ? (
-              <NoSearchResults />
+              <NoSearchResults
+                hasSearch={!!search}
+                hasDates={!!(startDate || endDate)}
+                onClear={() => {
+                  setSearch("");
+                  setStartDate("");
+                  setEndDate("");
+                  setPage(0);
+                }}
+              />
             ) : (
               groups.map((group) =>
                 group.items.length === 0 ? null : (
@@ -286,6 +356,158 @@ export default function HistoryPage(): React.JSX.Element {
           </>
         )}
       </div>
+
+      <Sheet open={filterOpen} onOpenChange={setFilterOpen}>
+        <SheetContent className="flex flex-col p-6 w-[340px] sm:w-[400px]">
+          <SheetHeader className="p-0 mb-4">
+            <SheetTitle className="text-lg font-semibold">
+              Filter History
+            </SheetTitle>
+          </SheetHeader>
+
+          <div className="flex flex-col gap-5 flex-1">
+            <div className="flex flex-col gap-2">
+              <label
+                htmlFor="start-date-input"
+                className="mono text-muted-foreground text-[10px] uppercase tracking-wider"
+              >
+                Start Date
+              </label>
+              <input
+                id="start-date-input"
+                type="date"
+                value={startDate}
+                max={endDate || undefined}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  if (endDate && val > endDate) {
+                    setStartDate(endDate);
+                  } else {
+                    setStartDate(val);
+                  }
+                  setPage(0);
+                }}
+                className="bg-card border-border text-foreground w-full rounded-md border px-3 py-2 text-sm outline-none focus:border-primary"
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label
+                htmlFor="end-date-input"
+                className="mono text-muted-foreground text-[10px] uppercase tracking-wider"
+              >
+                End Date
+              </label>
+              <input
+                id="end-date-input"
+                type="date"
+                value={endDate}
+                min={startDate || undefined}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  if (startDate && val < startDate) {
+                    setEndDate(startDate);
+                  } else {
+                    setEndDate(val);
+                  }
+                  setPage(0);
+                }}
+                className="bg-card border-border text-foreground w-full rounded-md border px-3 py-2 text-sm outline-none focus:border-primary"
+              />
+            </div>
+
+            {/* Quick Presets */}
+            <div className="flex flex-col gap-2 mt-2">
+              <span className="mono text-muted-foreground text-[10px] uppercase tracking-wider">
+                Presets
+              </span>
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setStartDate(todayStr);
+                    setEndDate(todayStr);
+                    setPage(0);
+                  }}
+                  className={cn(
+                    "bg-card border-border hover:bg-accent text-foreground rounded border py-1.5 text-xs transition-colors cursor-pointer text-center font-medium",
+                    isTodayPreset &&
+                      "border-primary bg-primary/10 text-primary",
+                  )}
+                >
+                  Today
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setStartDate(start7Str);
+                    setEndDate(todayStr);
+                    setPage(0);
+                  }}
+                  className={cn(
+                    "bg-card border-border hover:bg-accent text-foreground rounded border py-1.5 text-xs transition-colors cursor-pointer text-center font-medium",
+                    isWeeklyPreset &&
+                      "border-primary bg-primary/10 text-primary",
+                  )}
+                >
+                  Last 7 Days
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setStartDate(start30Str);
+                    setEndDate(todayStr);
+                    setPage(0);
+                  }}
+                  className={cn(
+                    "bg-card border-border hover:bg-accent text-foreground rounded border py-1.5 text-xs transition-colors cursor-pointer text-center font-medium",
+                    isMonthlyPreset &&
+                      "border-primary bg-primary/10 text-primary",
+                  )}
+                >
+                  Last 30 Days
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setStartDate("");
+                    setEndDate("");
+                    setPage(0);
+                  }}
+                  className={cn(
+                    "bg-card border-border hover:bg-accent text-foreground rounded border py-1.5 text-xs transition-colors cursor-pointer text-center font-medium",
+                    isAllTimePreset &&
+                      "border-primary bg-primary/10 text-primary",
+                  )}
+                >
+                  All Time
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-auto pt-4 border-t border-border flex gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                setStartDate("");
+                setEndDate("");
+                setPage(0);
+              }}
+              className="border-border bg-card hover:bg-accent hover:text-foreground text-muted-foreground flex-1 rounded-md border py-2 text-sm font-medium transition-colors cursor-pointer text-center"
+            >
+              Clear All
+            </button>
+            <button
+              type="button"
+              onClick={() => setFilterOpen(false)}
+              className="bg-primary text-primary-foreground hover:bg-primary/90 flex-1 py-2 rounded-md text-sm font-medium transition-colors cursor-pointer text-center"
+            >
+              Apply Filters
+            </button>
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }
@@ -449,12 +671,35 @@ function EmptyState(): React.JSX.Element {
   );
 }
 
-function NoSearchResults(): React.JSX.Element {
+function NoSearchResults({
+  hasSearch,
+  hasDates,
+  onClear,
+}: {
+  hasSearch: boolean;
+  hasDates: boolean;
+  onClear: () => void;
+}): React.JSX.Element {
   return (
-    <div className="text-muted-foreground py-10 text-center">
-      <span className="serif-italic text-[20px]">
-        no transcripts match that search.
-      </span>
+    <div className="border-border bg-card/30 mt-4 rounded-[14px] border border-dashed px-9 py-12 text-center">
+      <div className="text-muted-foreground mb-3">
+        <span className="serif-italic text-[20px]">
+          {hasSearch && hasDates
+            ? "no transcripts match that search and date range."
+            : hasSearch
+              ? "no transcripts match that search."
+              : "no transcripts found for this date range."}
+        </span>
+      </div>
+      {(hasSearch || hasDates) && (
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-primary hover:text-primary/80 text-xs font-semibold underline cursor-pointer"
+        >
+          Clear filters and search
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/electron/src/renderer/src/pages/history.tsx
+++ b/apps/electron/src/renderer/src/pages/history.tsx
@@ -142,7 +142,6 @@ export default function HistoryPage(): React.JSX.Element {
   const isTodayPreset = activePreset === "today";
   const isWeeklyPreset = activePreset === "weekly";
   const isMonthlyPreset = activePreset === "monthly";
-  const isAllTimePreset = activePreset === "all-time";
 
   const getTimeLabel = (): string => {
     if (activePreset === "weekly") return "past 7 days";
@@ -153,7 +152,7 @@ export default function HistoryPage(): React.JSX.Element {
   };
   const timeLabel = getTimeLabel();
 
-  const filterCount = activePreset !== "weekly" ? 1 : 0;
+  const filterCount = activePreset !== "all-time" ? 1 : 0;
 
   const loadData = useCallback(async () => {
     try {
@@ -316,10 +315,10 @@ export default function HistoryPage(): React.JSX.Element {
             {entries.length === 0 ? (
               <NoSearchResults
                 hasSearch={!!search}
-                hasDates={!!(startDate || endDate)}
+                hasDates={activePreset !== "all-time"}
                 onClear={() => {
                   setSearch("");
-                  setActivePreset("weekly");
+                  setActivePreset("all-time");
                   setCustomStartDate("");
                   setCustomEndDate("");
                   setPage(0);
@@ -456,7 +455,7 @@ export default function HistoryPage(): React.JSX.Element {
               <span className="mono text-muted-foreground text-[10px] uppercase tracking-wider">
                 Presets
               </span>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-3 gap-2">
                 <button
                   type="button"
                   onClick={() => {
@@ -499,20 +498,6 @@ export default function HistoryPage(): React.JSX.Element {
                 >
                   Last 30 Days
                 </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setActivePreset("all-time");
-                    setPage(0);
-                  }}
-                  className={cn(
-                    "bg-card border-border hover:bg-accent text-foreground rounded border py-1.5 text-xs transition-colors cursor-pointer text-center font-medium",
-                    isAllTimePreset &&
-                      "border-primary bg-primary/10 text-primary",
-                  )}
-                >
-                  All Time
-                </button>
               </div>
             </div>
           </div>
@@ -521,7 +506,7 @@ export default function HistoryPage(): React.JSX.Element {
             <button
               type="button"
               onClick={() => {
-                setActivePreset("weekly");
+                setActivePreset("all-time");
                 setCustomStartDate("");
                 setCustomEndDate("");
                 setPage(0);
@@ -729,7 +714,11 @@ function NoSearchResults({
           onClick={onClear}
           className="text-primary hover:text-primary/80 text-xs font-semibold underline cursor-pointer"
         >
-          Clear filters and search
+          {hasSearch && hasDates
+            ? "Clear filters and search"
+            : hasSearch
+              ? "Clear search"
+              : "Clear filters"}
         </button>
       )}
     </div>

--- a/apps/electron/src/renderer/src/pages/history.tsx
+++ b/apps/electron/src/renderer/src/pages/history.tsx
@@ -44,6 +44,7 @@ interface Stats {
   total_words: number;
   today_sessions: number;
   today_cost: number;
+  unfiltered_total_sessions: number;
 }
 
 function formatClock(iso: string): string {
@@ -106,15 +107,53 @@ export default function HistoryPage(): React.JSX.Element {
   const [search, setSearch] = useState("");
   const [stats, setStats] = useState<Stats | null>(null);
   const [loading, setLoading] = useState(true);
-  const [startDate, setStartDate] = useState(() => {
-    const d = new Date();
-    d.setDate(d.getDate() - 7);
-    return getLocalDateString(d);
-  });
-  const [endDate, setEndDate] = useState(() => {
-    return getLocalDateString(new Date());
-  });
+  const [activePreset, setActivePreset] = useState<
+    "today" | "weekly" | "monthly" | "all-time" | "custom"
+  >("weekly");
+  const [customStartDate, setCustomStartDate] = useState("");
+  const [customEndDate, setCustomEndDate] = useState("");
   const [filterOpen, setFilterOpen] = useState(false);
+
+  // Calculate preset dates dynamically on every render
+  const todayStr = getLocalDateString(new Date());
+  const start7 = new Date();
+  start7.setDate(start7.getDate() - 7);
+  const start7Str = getLocalDateString(start7);
+  const start30 = new Date();
+  start30.setDate(start30.getDate() - 30);
+  const start30Str = getLocalDateString(start30);
+
+  let startDate = "";
+  let endDate = "";
+  if (activePreset === "today") {
+    startDate = todayStr;
+    endDate = todayStr;
+  } else if (activePreset === "weekly") {
+    startDate = start7Str;
+    endDate = todayStr;
+  } else if (activePreset === "monthly") {
+    startDate = start30Str;
+    endDate = todayStr;
+  } else if (activePreset === "custom") {
+    startDate = customStartDate;
+    endDate = customEndDate;
+  }
+
+  const isTodayPreset = activePreset === "today";
+  const isWeeklyPreset = activePreset === "weekly";
+  const isMonthlyPreset = activePreset === "monthly";
+  const isAllTimePreset = activePreset === "all-time";
+
+  const getTimeLabel = (): string => {
+    if (activePreset === "weekly") return "past 7 days";
+    if (activePreset === "today") return "today";
+    if (activePreset === "monthly") return "past 30 days";
+    if (activePreset === "all-time") return "all time";
+    return "filtered"; // custom range
+  };
+  const timeLabel = getTimeLabel();
+
+  const filterCount = activePreset !== "weekly" ? 1 : 0;
 
   const loadData = useCallback(async () => {
     try {
@@ -195,20 +234,7 @@ export default function HistoryPage(): React.JSX.Element {
     );
   }
 
-  const todayStr = getLocalDateString(new Date());
-  const start7 = new Date();
-  start7.setDate(start7.getDate() - 7);
-  const start7Str = getLocalDateString(start7);
-  const start30 = new Date();
-  start30.setDate(start30.getDate() - 30);
-  const start30Str = getLocalDateString(start30);
-
-  const isTodayPreset = startDate === todayStr && endDate === todayStr;
-  const isWeeklyPreset = startDate === start7Str && endDate === todayStr;
-  const isMonthlyPreset = startDate === start30Str && endDate === todayStr;
-  const isAllTimePreset = startDate === "" && endDate === "";
-
-  const isGenuineEmpty = total === 0 && !search && !startDate && !endDate;
+  const isGenuineEmpty = stats?.unfiltered_total_sessions === 0;
 
   return (
     <div
@@ -230,9 +256,12 @@ export default function HistoryPage(): React.JSX.Element {
             <div className="border-border mb-7 grid grid-cols-2 gap-2.5 border-b pb-7 md:grid-cols-4">
               <Stat
                 n={(stats?.total_words ?? 0).toLocaleString()}
-                l={startDate || endDate ? "words filtered" : "words all time"}
+                l={`words · ${timeLabel}`}
               />
-              <Stat n={String(stats?.total_sessions ?? 0)} l="sessions" />
+              <Stat
+                n={String(stats?.total_sessions ?? 0)}
+                l={`sessions · ${timeLabel}`}
+              />
               <Stat
                 n={
                   stats && stats.avg_duration_ms > 0
@@ -244,7 +273,7 @@ export default function HistoryPage(): React.JSX.Element {
               <Stat
                 accent
                 n={`$${(stats?.total_cost_usd ?? 0).toFixed(2)}`}
-                l={startDate || endDate ? "cost · filtered" : "cost · all time"}
+                l={`cost · ${timeLabel}`}
               />
             </div>
 
@@ -271,15 +300,14 @@ export default function HistoryPage(): React.JSX.Element {
                 onClick={() => setFilterOpen(true)}
                 className={cn(
                   "border-border bg-card hover:bg-accent hover:text-foreground text-muted-foreground flex items-center gap-1.5 rounded-lg border px-3.5 py-2 text-[13px] font-medium transition-colors cursor-pointer",
-                  (startDate || endDate) &&
-                    "border-primary text-primary bg-primary/5",
+                  filterCount > 0 && "border-primary text-primary bg-primary/5",
                 )}
               >
                 <Filter className="h-3.5 w-3.5" />
                 <span>Filters</span>
-                {(startDate || endDate) && (
+                {filterCount > 0 && (
                   <span className="bg-primary text-primary-foreground flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[9px] font-bold">
-                    ✓
+                    {filterCount}
                   </span>
                 )}
               </button>
@@ -291,8 +319,9 @@ export default function HistoryPage(): React.JSX.Element {
                 hasDates={!!(startDate || endDate)}
                 onClear={() => {
                   setSearch("");
-                  setStartDate("");
-                  setEndDate("");
+                  setActivePreset("weekly");
+                  setCustomStartDate("");
+                  setCustomEndDate("");
                   setPage(0);
                 }}
               />
@@ -380,10 +409,13 @@ export default function HistoryPage(): React.JSX.Element {
                 max={endDate || undefined}
                 onChange={(e) => {
                   const val = e.target.value;
+                  setActivePreset("custom");
                   if (endDate && val > endDate) {
-                    setStartDate(endDate);
+                    setCustomStartDate(endDate);
+                    setCustomEndDate(endDate);
                   } else {
-                    setStartDate(val);
+                    setCustomStartDate(val);
+                    setCustomEndDate(endDate);
                   }
                   setPage(0);
                 }}
@@ -405,10 +437,13 @@ export default function HistoryPage(): React.JSX.Element {
                 min={startDate || undefined}
                 onChange={(e) => {
                   const val = e.target.value;
+                  setActivePreset("custom");
                   if (startDate && val < startDate) {
-                    setEndDate(startDate);
+                    setCustomEndDate(startDate);
+                    setCustomStartDate(startDate);
                   } else {
-                    setEndDate(val);
+                    setCustomEndDate(val);
+                    setCustomStartDate(startDate);
                   }
                   setPage(0);
                 }}
@@ -425,8 +460,7 @@ export default function HistoryPage(): React.JSX.Element {
                 <button
                   type="button"
                   onClick={() => {
-                    setStartDate(todayStr);
-                    setEndDate(todayStr);
+                    setActivePreset("today");
                     setPage(0);
                   }}
                   className={cn(
@@ -440,8 +474,7 @@ export default function HistoryPage(): React.JSX.Element {
                 <button
                   type="button"
                   onClick={() => {
-                    setStartDate(start7Str);
-                    setEndDate(todayStr);
+                    setActivePreset("weekly");
                     setPage(0);
                   }}
                   className={cn(
@@ -455,8 +488,7 @@ export default function HistoryPage(): React.JSX.Element {
                 <button
                   type="button"
                   onClick={() => {
-                    setStartDate(start30Str);
-                    setEndDate(todayStr);
+                    setActivePreset("monthly");
                     setPage(0);
                   }}
                   className={cn(
@@ -470,8 +502,7 @@ export default function HistoryPage(): React.JSX.Element {
                 <button
                   type="button"
                   onClick={() => {
-                    setStartDate("");
-                    setEndDate("");
+                    setActivePreset("all-time");
                     setPage(0);
                   }}
                   className={cn(
@@ -490,8 +521,9 @@ export default function HistoryPage(): React.JSX.Element {
             <button
               type="button"
               onClick={() => {
-                setStartDate("");
-                setEndDate("");
+                setActivePreset("weekly");
+                setCustomStartDate("");
+                setCustomEndDate("");
                 setPage(0);
               }}
               className="border-border bg-card hover:bg-accent hover:text-foreground text-muted-foreground flex-1 rounded-md border py-2 text-sm font-medium transition-colors cursor-pointer text-center"
@@ -503,7 +535,7 @@ export default function HistoryPage(): React.JSX.Element {
               onClick={() => setFilterOpen(false)}
               className="bg-primary text-primary-foreground hover:bg-primary/90 flex-1 py-2 rounded-md text-sm font-medium transition-colors cursor-pointer text-center"
             >
-              Apply Filters
+              Done
             </button>
           </div>
         </SheetContent>

--- a/apps/server/src/routes/history.ts
+++ b/apps/server/src/routes/history.ts
@@ -30,6 +30,8 @@ const history = new Hono()
     const limit = Math.min(Number(c.req.query("limit") || 50), 200);
     const offset = Number(c.req.query("offset") || 0);
     const search = c.req.query("search")?.trim() || "";
+    const start_date = c.req.query("start_date");
+    const end_date = c.req.query("end_date");
     const orderByParam = c.req.query("orderBy") || "-created_at";
 
     // Parse orderBy: "-created_at" means DESC, "created_at" means ASC
@@ -40,39 +42,40 @@ const history = new Hono()
       : "created_at";
     const orderDir = desc ? "DESC" : "ASC";
 
-    let rows: HistoryRow[];
-    let countRow: { count: number };
+    // Dynamically build WHERE conditions
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
 
     if (search) {
       const pattern = `%${search}%`;
-      rows = db
-        .prepare(
-          `SELECT * FROM transcription_history WHERE raw_text LIKE ? OR cleaned_text LIKE ? OR voice_model LIKE ? ORDER BY ${orderColumn} ${orderDir} LIMIT ? OFFSET ?`,
-        )
-        .all(
-          pattern,
-          pattern,
-          pattern,
-          limit,
-          offset,
-        ) as unknown as HistoryRow[];
-
-      countRow = db
-        .prepare(
-          `SELECT COUNT(*) as count FROM transcription_history WHERE raw_text LIKE ? OR cleaned_text LIKE ? OR voice_model LIKE ?`,
-        )
-        .get(pattern, pattern, pattern) as { count: number };
-    } else {
-      rows = db
-        .prepare(
-          `SELECT * FROM transcription_history ORDER BY ${orderColumn} ${orderDir} LIMIT ? OFFSET ?`,
-        )
-        .all(limit, offset) as unknown as HistoryRow[];
-
-      countRow = db
-        .prepare("SELECT COUNT(*) as count FROM transcription_history")
-        .get() as { count: number };
+      conditions.push(
+        "(raw_text LIKE ? OR cleaned_text LIKE ? OR voice_model LIKE ?)",
+      );
+      params.push(pattern, pattern, pattern);
     }
+
+    if (start_date) {
+      conditions.push("date(created_at,'localtime') >= ? ");
+      params.push(start_date);
+    }
+
+    if (end_date) {
+      conditions.push("date(created_at,'localtime') <= ? ");
+      params.push(end_date);
+    }
+
+    const whereClause =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    //Query rows
+    const rowsQuery = `SELECT * FROM transcription_history ${whereClause} ORDER BY ${orderColumn} ${orderDir} LIMIT ? OFFSET ?`;
+    const rows = db
+      .prepare(rowsQuery)
+      .all(...params, limit, offset) as unknown as HistoryRow[];
+
+    //Query total count
+    const countQuery = `SELECT COUNT(*) as count FROM transcription_history ${whereClause}`;
+    const countRow = db.prepare(countQuery).get(...params) as { count: number };
 
     return c.json({
       items: rows,
@@ -84,9 +87,26 @@ const history = new Hono()
   .get("/stats", (c) => {
     const db = getDb();
 
-    const stats = db
-      .prepare(
-        `SELECT
+    const startDate = c.req.query("start_date");
+    const endDate = c.req.query("end_date");
+
+    const conditions: string[] = [];
+    const params: string[] = [];
+
+    if (startDate) {
+      conditions.push("date(created_at, 'localtime') >= ?");
+      params.push(startDate);
+    }
+    if (endDate) {
+      conditions.push("date(created_at, 'localtime') <= ?");
+      params.push(endDate);
+    }
+
+    const whereClause =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    const statsQuery = `
+        SELECT
           COUNT(*) as total_sessions,
           COALESCE(SUM(duration_ms), 0) as total_duration_ms,
           COALESCE(SUM(input_tokens), 0) as total_input_tokens,
@@ -101,9 +121,11 @@ const history = new Hono()
                 + 1
             END
           ), 0) as total_words
-        FROM transcription_history`,
-      )
-      .get() as {
+        FROM transcription_history
+        ${whereClause}
+        `;
+
+    const stats = db.prepare(statsQuery).get(...params) as {
       total_sessions: number;
       total_duration_ms: number;
       total_input_tokens: number;

--- a/apps/server/src/routes/history.ts
+++ b/apps/server/src/routes/history.ts
@@ -24,10 +24,11 @@ const ALLOWED_ORDER_COLUMNS = new Set([
   "cost_usd",
 ]);
 
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
 const history = new Hono()
   .get("/", (c) => {
     const db = getDb();
-    const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
     const limit = Math.min(Number(c.req.query("limit") || 50), 200);
     const offset = Number(c.req.query("offset") || 0);
     const search = c.req.query("search")?.trim() || "";
@@ -94,7 +95,6 @@ const history = new Hono()
   .get("/stats", (c) => {
     const db = getDb();
 
-    const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
     const startDateParam = c.req.query("start_date");
     const endDateParam = c.req.query("end_date");
     const startDate =

--- a/apps/server/src/routes/history.ts
+++ b/apps/server/src/routes/history.ts
@@ -27,11 +27,18 @@ const ALLOWED_ORDER_COLUMNS = new Set([
 const history = new Hono()
   .get("/", (c) => {
     const db = getDb();
+    const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
     const limit = Math.min(Number(c.req.query("limit") || 50), 200);
     const offset = Number(c.req.query("offset") || 0);
     const search = c.req.query("search")?.trim() || "";
-    const start_date = c.req.query("start_date");
-    const end_date = c.req.query("end_date");
+    const start_date_param = c.req.query("start_date");
+    const end_date_param = c.req.query("end_date");
+    const start_date =
+      start_date_param && DATE_REGEX.test(start_date_param)
+        ? start_date_param
+        : null;
+    const end_date =
+      end_date_param && DATE_REGEX.test(end_date_param) ? end_date_param : null;
     const orderByParam = c.req.query("orderBy") || "-created_at";
 
     // Parse orderBy: "-created_at" means DESC, "created_at" means ASC
@@ -67,13 +74,13 @@ const history = new Hono()
     const whereClause =
       conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-    //Query rows
+    // Query rows
     const rowsQuery = `SELECT * FROM transcription_history ${whereClause} ORDER BY ${orderColumn} ${orderDir} LIMIT ? OFFSET ?`;
     const rows = db
       .prepare(rowsQuery)
       .all(...params, limit, offset) as unknown as HistoryRow[];
 
-    //Query total count
+    // Query total count
     const countQuery = `SELECT COUNT(*) as count FROM transcription_history ${whereClause}`;
     const countRow = db.prepare(countQuery).get(...params) as { count: number };
 
@@ -87,8 +94,13 @@ const history = new Hono()
   .get("/stats", (c) => {
     const db = getDb();
 
-    const startDate = c.req.query("start_date");
-    const endDate = c.req.query("end_date");
+    const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+    const startDateParam = c.req.query("start_date");
+    const endDateParam = c.req.query("end_date");
+    const startDate =
+      startDateParam && DATE_REGEX.test(startDateParam) ? startDateParam : null;
+    const endDate =
+      endDateParam && DATE_REGEX.test(endDateParam) ? endDateParam : null;
 
     const conditions: string[] = [];
     const params: string[] = [];
@@ -135,6 +147,10 @@ const history = new Hono()
       total_words: number;
     };
 
+    const unfilteredCount = db
+      .prepare("SELECT COUNT(*) as count FROM transcription_history")
+      .get() as { count: number };
+
     // Use localtime to match the user's timezone for "today" boundary
     const today = db
       .prepare(
@@ -148,6 +164,7 @@ const history = new Hono()
       ...stats,
       today_sessions: today.sessions,
       today_cost: today.cost,
+      unfiltered_total_sessions: unfilteredCount.count,
     });
   })
   .get("/:id", (c) => {

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -420,10 +420,10 @@ describe("History", () => {
 
     const formatDate = (d: Date, daysAgo = 0) => {
       const target = new Date(d);
-      target.setDate(target.getDate() - daysAgo);
-      const year = target.getFullYear();
-      const month = String(target.getMonth() + 1).padStart(2, "0");
-      const day = String(target.getDate()).padStart(2, "0");
+      target.setUTCDate(target.getUTCDate() - daysAgo);
+      const year = target.getUTCFullYear();
+      const month = String(target.getUTCMonth() + 1).padStart(2, "0");
+      const day = String(target.getUTCDate()).padStart(2, "0");
       return `${year}-${month}-${day} 12:00:00`;
     };
 

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import app from "../src/index.js";
+import { getDb } from "../src/lib/db.js";
 
 // ---------------------------------------------------------------------------
 // Helper – shorthand for making requests against the Hono app
@@ -378,6 +379,11 @@ describe("API Keys", () => {
 // ---------------------------------------------------------------------------
 
 describe("History", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.exec("DELETE FROM transcription_history");
+  });
+
   it("GET /api/history returns empty list initially", async () => {
     const res = await req("/api/history");
     expect(res.status).toBe(200);
@@ -397,5 +403,117 @@ describe("History", () => {
   it("GET /api/history/:id returns 404 for missing entry", async () => {
     const res = await req("/api/history/9999");
     expect(res.status).toBe(404);
+  });
+
+  it("GET /api/history and /stats with date filters", async () => {
+    const db = getDb();
+
+    // Insert mock history records
+    const insertStmt = db.prepare(`
+      INSERT INTO transcription_history (
+        raw_text, cleaned_text, voice_provider, voice_model, llm_provider, llm_model, 
+        duration_ms, audio_duration_ms, input_tokens, output_tokens, cost_usd, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const now = new Date();
+
+    const formatDate = (d: Date, daysAgo = 0) => {
+      const target = new Date(d);
+      target.setDate(target.getDate() - daysAgo);
+      const year = target.getFullYear();
+      const month = String(target.getMonth() + 1).padStart(2, "0");
+      const day = String(target.getDate()).padStart(2, "0");
+      return `${year}-${month}-${day} 12:00:00`;
+    };
+
+    const date10DaysAgo = formatDate(now, 10);
+    const date2DaysAgo = formatDate(now, 2);
+    const dateToday = formatDate(now, 0);
+
+    // Insert 10 days ago (cost 1.50)
+    insertStmt.run(
+      "Text 10 days ago",
+      "Clean 1",
+      "voice",
+      "model",
+      "llm",
+      "model",
+      1000,
+      1000,
+      10,
+      10,
+      1.5,
+      date10DaysAgo,
+    );
+    // Insert 2 days ago (cost 0.50)
+    insertStmt.run(
+      "Text 2 days ago",
+      "Clean 2",
+      "voice",
+      "model",
+      "llm",
+      "model",
+      1000,
+      1000,
+      10,
+      10,
+      0.5,
+      date2DaysAgo,
+    );
+    // Insert today (cost 2.00)
+    insertStmt.run(
+      "Text today",
+      "Clean 3",
+      "voice",
+      "model",
+      "llm",
+      "model",
+      1000,
+      1000,
+      10,
+      10,
+      2.0,
+      dateToday,
+    );
+
+    const todayStr = dateToday.split(" ")[0];
+    const start7DaysAgoStr = formatDate(now, 7).split(" ")[0];
+
+    // 1. Test unfiltered stats returns unfiltered_total_sessions = 3
+    const statsResAll = await req("/api/history/stats");
+    const statsAll = await statsResAll.json();
+    expect(statsAll.unfiltered_total_sessions).toBe(3);
+    expect(statsAll.total_sessions).toBe(3);
+    expect(statsAll.total_cost_usd).toBe(4.0);
+
+    // 2. Test GET /api/history filtering to past 7 days (weekly default)
+    const historyWeeklyRes = await req(
+      `/api/history?start_date=${start7DaysAgoStr}&end_date=${todayStr}`,
+    );
+    const historyWeekly = await historyWeeklyRes.json();
+    expect(historyWeekly.total).toBe(2);
+    expect(historyWeekly.items.map((i: any) => i.raw_text)).toContain(
+      "Text 2 days ago",
+    );
+    expect(historyWeekly.items.map((i: any) => i.raw_text)).toContain(
+      "Text today",
+    );
+
+    // 3. Test GET /api/history/stats filtering to past 7 days
+    const statsWeeklyRes = await req(
+      `/api/history/stats?start_date=${start7DaysAgoStr}&end_date=${todayStr}`,
+    );
+    const statsWeekly = await statsWeeklyRes.json();
+    expect(statsWeekly.unfiltered_total_sessions).toBe(3);
+    expect(statsWeekly.total_sessions).toBe(2);
+    expect(statsWeekly.total_cost_usd).toBe(2.5);
+
+    // 4. Test start_date validation fails (ignored if invalid format)
+    const statsInvalidRes = await req(
+      `/api/history/stats?start_date=invalid-date&end_date=${todayStr}`,
+    );
+    const statsInvalid = await statsInvalidRes.json();
+    expect(statsInvalid.total_sessions).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

This PR addresses #181 to implement a general-purpose date range filter panel for the transcription history page.

Following feedback from @MathurAditya724 , I skipped the cost-card dropdown and implemented a proper slide-in filter panel drawer. This allows users to set custom date ranges to filter both the list and the metrics, that includes showing the transcription costs as per the filtered data.

## Changes Made

### Backend Updates (history.ts)
- GET `/api/history`: Added optional `start_date` and `end_date` parameters. SQL queries dynamically append WHERE conditions comparing `date(created_at, 'localtime')` to filter the items.
- GET `/api/history/stats`: Added optional `start_date` and `end_date` support to aggregate transcription stats (sessions, total words, average latency, and costs) dynamically for the active range.

### Frontend UI & Integration(history.tsx)
- **Default Weekly View:** Set default view of the history page to the past 7 days (Weekly preset) instead of showing all-time records.
- **Filter Drawer:** Added a slide-in panel from the right, providing Start Date and End Date calendar inputs, quick presets (Today, Last 7 Days, Last 30 Days, All Time), and a footer action layout containing "Clear All" and "Apply Filters".
- **Interactive Highlights:** Added highlighting for the active-preset buttons by dynamically matching active dates to preset ranges.
- **Clamping Date Constraints:** Added validation guards on both inputs (min on End Date, max on Start Date, and automatic handler clamping) to prevent setting a Start Date that exceeds the End Date.
- **UX Fix (Empty States):** Split the empty states into two separate components:
  - EmptyState (onboarding guide): Retained only for the initial fresh-user state when the database is completely empty and no filters are set.
  - NoSearchResults: A new, dedicated empty state designed specifically for cases when filters or search queries yield 0 items. This preserves the search and filter controls on the screen and features a "Clear filters and search" action link.
- **Stats Cards:** Changed the stat labels from static "all time" labels to dynamic "words filtered" and "cost · filtered" whenever a date filter is applied.

## Manual Verification

- **Default State:** Loaded the history page and verified it automatically filters to the past 7 days.
- **Preset Toggles:** Clicked presets ("Today", "Last 30 Days", "All Time") and verified that buttons highlight correctly and active date bounds align.
- **Date Constraints:** Set a Start Date past the selected End Date and verified that inputs clamp the date bounds correctly.
- **Empty State Reset:** Filtered to a future date range with 0 entries, verified the filter/search controls remained on-screen, and clicked "Clear filters and search" to restore the list.