### PR TITLE
fix: use platform-appropriate device copy on Linux and Windows

### DIFF
--- a/apps/electron/src/renderer/src/lib/utils.ts
+++ b/apps/electron/src/renderer/src/lib/utils.ts
@@ -4,3 +4,6 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const ON_DEVICE_PHRASE =
+  process.platform === "darwin" ? "your Mac" : "your device";

--- a/apps/electron/src/renderer/src/onboarding.tsx
+++ b/apps/electron/src/renderer/src/onboarding.tsx
@@ -20,7 +20,7 @@ import {
   type VoiceItem,
   type WhisperStatus,
 } from "@renderer/lib/models";
-import { cn } from "@renderer/lib/utils";
+import { cn, ON_DEVICE_PHRASE } from "@renderer/lib/utils";
 import {
   ArrowRight,
   Check,
@@ -959,7 +959,7 @@ function modelTagline(chosen: VoiceItem | undefined): string {
   }
   const bits: string[] = [];
   if (chosen.note) bits.push(chosen.note);
-  bits.push("Runs on your Mac");
+  bits.push(`Runs on ${ON_DEVICE_PHRASE}`);
   return bits.join(" · ");
 }
 
@@ -1174,7 +1174,7 @@ function ModelSelectorOverlay({
               <span className="text-muted-foreground text-[11.5px]">
                 {source === "cloud"
                   ? "Cloud models need an API key — we'll ask once."
-                  : "On-device models run privately on your Mac."}
+                  : `On-device models run privately on ${ON_DEVICE_PHRASE}.`}
               </span>
               <button
                 type="button"

--- a/apps/electron/src/renderer/src/pages/history.tsx
+++ b/apps/electron/src/renderer/src/pages/history.tsx
@@ -5,7 +5,7 @@ import {
   SheetTitle,
 } from "@renderer/components/ui/sheet";
 import { getClient } from "@renderer/lib/api";
-import { cn } from "@renderer/lib/utils";
+import { cn, ON_DEVICE_PHRASE } from "@renderer/lib/utils";
 import {
   Check,
   ChevronLeft,
@@ -681,8 +681,8 @@ function EmptyState(): React.JSX.Element {
         Nothing recorded yet.
       </h2>
       <p className="text-muted-foreground mx-auto mt-2.5 max-w-[440px] text-[14px] leading-[1.55]">
-        Hold your hotkey anywhere on your Mac, speak, release. Your first
-        transcript will appear here.
+        Hold your hotkey anywhere on {ON_DEVICE_PHRASE}, speak, release. Your
+        first transcript will appear here.
       </p>
     </div>
   );

--- a/apps/electron/src/renderer/src/pages/models/index.tsx
+++ b/apps/electron/src/renderer/src/pages/models/index.tsx
@@ -1,5 +1,5 @@
 import type { AvailableModel } from "@renderer/lib/models";
-import { cn } from "@renderer/lib/utils";
+import { cn, ON_DEVICE_PHRASE } from "@renderer/lib/utils";
 import {
   CheckCircle,
   Key,
@@ -203,8 +203,8 @@ export default function ModelsPage(): React.JSX.Element {
               <span className="text-foreground/80 font-medium">
                 {pendingLocalDelete.name}
               </span>{" "}
-              from this Mac. The weights are deleted from your local cache; you
-              can download them again later.
+              from {ON_DEVICE_PHRASE}. The weights are deleted from your local
+              cache; you can download them again later.
             </>
           }
           onCancel={() => setPendingLocalDelete(null)}


### PR DESCRIPTION
## Summary
- Add shared `ON_DEVICE_PHRASE` constant that shows "your Mac" on macOS and "your device" elsewhere
- Update onboarding, history empty state, and local model deletion dialog to use platform-appropriate copy instead of hardcoded Mac references

## Test plan
- [x] Verified onboarding model step shows "Runs on your device" on Linux
- [x] Verified model selector footer shows "On-device models run privately on your device." on Linux
- [x] Verified history empty state shows "Hold your hotkey anywhere on your device" on Linux
- [x] Verified local model delete dialog shows "from your device" on Linux
- [x] `pnpm biome check .` passes
- [x] `pnpm --filter @freestyle/electron typecheck:web` passes


Made with [Cursor](https://cursor.com)