### PR TITLE
fix: detect terminal focus for Linux paste on Wayland

### DIFF
--- a/apps/electron/src/main/linux-terminal-focus.ts
+++ b/apps/electron/src/main/linux-terminal-focus.ts
@@ -1,0 +1,209 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { createAppLogger } from "@freestyle/utils";
+
+const log = createAppLogger("paste");
+
+// Keep in sync with terminal_classes[] in native/linux-fast-paste.c
+const TERMINAL_IDENTIFIERS = [
+  "konsole",
+  "gnome-terminal",
+  "terminal",
+  "kitty",
+  "alacritty",
+  "terminator",
+  "xterm",
+  "urxvt",
+  "rxvt",
+  "tilix",
+  "terminology",
+  "wezterm",
+  "foot",
+  "st-256color",
+  "st-",
+  "yakuake",
+  "ghostty",
+  "guake",
+  "tilda",
+  "hyper",
+  "tabby",
+  "sakura",
+  "warp",
+  "termius",
+];
+
+function matchesTerminal(identifier: string): boolean {
+  const lower = identifier.toLowerCase();
+  return TERMINAL_IDENTIFIERS.some((term) => lower.includes(term));
+}
+
+function execFileCapture(
+  path: string,
+  args: string[] = [],
+  timeoutMs = 1500,
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(path, args, { timeout: timeoutMs }, (err, stdout) => {
+      if (err) {
+        resolve(null);
+        return;
+      }
+      const text = stdout.trim();
+      resolve(text || null);
+    });
+  });
+}
+
+async function detectViaXdotool(): Promise<string | null> {
+  const windowId = await execFileCapture("xdotool", ["getactivewindow"]);
+  if (!windowId) return null;
+
+  const className = await execFileCapture("xdotool", [
+    "getwindowclassname",
+    windowId,
+  ]);
+  if (className && matchesTerminal(className)) return className;
+
+  const windowName = await execFileCapture("xdotool", [
+    "getwindowname",
+    windowId,
+  ]);
+  if (windowName && matchesTerminal(windowName)) return windowName;
+
+  const pid = await execFileCapture("xdotool", ["getwindowpid", windowId]);
+  if (pid) {
+    try {
+      const comm = (await readFile(`/proc/${pid}/comm`, "utf8")).trim();
+      if (matchesTerminal(comm)) return comm;
+    } catch {
+      // Process may have exited.
+    }
+  }
+
+  return className ?? windowName;
+}
+
+async function detectViaHyprland(): Promise<string | null> {
+  const output = await execFileCapture("hyprctl", ["activewindow", "-j"]);
+  if (!output) return null;
+
+  try {
+    const data = JSON.parse(output) as {
+      class?: string;
+      initialClass?: string;
+    };
+    return data.class ?? data.initialClass ?? null;
+  } catch {
+    return null;
+  }
+}
+
+type SwayNode = {
+  focused?: boolean;
+  type?: string;
+  app_id?: string;
+  name?: string;
+  window_properties?: { class?: string };
+  nodes?: SwayNode[];
+  floating_nodes?: SwayNode[];
+};
+
+function findFocusedSwayNode(node: SwayNode): string | null {
+  if (node.focused && node.type === "con") {
+    return node.app_id ?? node.window_properties?.class ?? node.name ?? null;
+  }
+
+  for (const child of node.nodes ?? []) {
+    const found = findFocusedSwayNode(child);
+    if (found) return found;
+  }
+
+  for (const child of node.floating_nodes ?? []) {
+    const found = findFocusedSwayNode(child);
+    if (found) return found;
+  }
+
+  return null;
+}
+
+async function detectViaSway(): Promise<string | null> {
+  const output = await execFileCapture("swaymsg", ["-t", "get_tree"]);
+  if (!output) return null;
+
+  try {
+    const tree = JSON.parse(output) as SwayNode | SwayNode[];
+    const roots = Array.isArray(tree) ? tree : [tree];
+    for (const root of roots) {
+      const found = findFocusedSwayNode(root);
+      if (found) return found;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+async function detectViaGnomeShell(): Promise<string | null> {
+  const output = await execFileCapture("gdbus", [
+    "call",
+    "--session",
+    "--dest",
+    "org.gnome.Shell",
+    "--object-path",
+    "/org/gnome/Shell",
+    "--method",
+    "org.gnome.Shell.Eval",
+    "global.display.focus_window ? global.display.focus_window.get_wm_class() : ''",
+  ]);
+  if (!output) return null;
+
+  const match = output.match(/\('([^']*)'/);
+  return match?.[1] || null;
+}
+
+function orderedDetectors(): Array<() => Promise<string | null>> {
+  const desktop = (process.env.XDG_CURRENT_DESKTOP ?? "").toLowerCase();
+  const ordered: Array<() => Promise<string | null>> = [];
+  const seen = new Set<() => Promise<string | null>>();
+
+  const add = (detect: () => Promise<string | null>) => {
+    if (seen.has(detect)) return;
+    seen.add(detect);
+    ordered.push(detect);
+  };
+
+  if (process.env.HYPRLAND_INSTANCE_SIGNATURE) add(detectViaHyprland);
+  if (process.env.SWAYSOCK) add(detectViaSway);
+  if (desktop.includes("gnome")) add(detectViaGnomeShell);
+
+  add(detectViaXdotool);
+  add(detectViaHyprland);
+  add(detectViaSway);
+  add(detectViaGnomeShell);
+
+  return ordered;
+}
+
+/**
+ * Best-effort detection of whether the currently focused app is a terminal.
+ * Uses compositor-specific APIs on Wayland and xdotool on X11 / XWayland.
+ */
+export async function isLinuxTerminalFocused(): Promise<boolean> {
+  const detectors = orderedDetectors();
+
+  for (const detect of detectors) {
+    try {
+      const identifier = await detect();
+      if (identifier && matchesTerminal(identifier)) {
+        log.debug(`terminal focus detected via ${detect.name}: ${identifier}`);
+        return true;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.debug(`${detect.name} failed: ${message}`);
+    }
+  }
+
+  return false;
+}

--- a/apps/electron/src/main/linux-terminal-focus.ts
+++ b/apps/electron/src/main/linux-terminal-focus.ts
@@ -30,11 +30,35 @@ const TERMINAL_IDENTIFIERS = [
   "sakura",
   "warp",
   "termius",
+  "integrated-terminal",
+];
+
+const IDE_HOST_IDENTIFIERS = [
+  "code",
+  "cursor",
+  "zed",
+  "vscodium",
+  "codium",
+  "windsurf",
+  "fleet",
 ];
 
 function matchesTerminal(identifier: string): boolean {
   const lower = identifier.toLowerCase();
   return TERMINAL_IDENTIFIERS.some((term) => lower.includes(term));
+}
+
+/** Heuristic for VS Code / Zed integrated terminals on Wayland compositors. */
+function matchesIntegratedTerminal(className: string, title?: string): boolean {
+  const cls = className.toLowerCase();
+  if (!IDE_HOST_IDENTIFIERS.some((ide) => cls.includes(ide))) return false;
+  if (!title) return false;
+
+  const normalized = title.toLowerCase();
+  if (/\bterminal\b/.test(normalized)) return true;
+
+  // Shell names commonly appear in integrated terminal tab titles.
+  return /\b(bash|zsh|fish|pwsh|nushell|dash|ash|sh)\b/.test(normalized);
 }
 
 function execFileCapture(
@@ -58,17 +82,33 @@ async function detectViaXdotool(): Promise<string | null> {
   const windowId = await execFileCapture("xdotool", ["getactivewindow"]);
   if (!windowId) return null;
 
-  const className = await execFileCapture("xdotool", [
-    "getwindowclassname",
-    windowId,
-  ]);
-  if (className && matchesTerminal(className)) return className;
+  let currentId = windowId;
+  for (let depth = 0; depth < 20; depth++) {
+    const className = await execFileCapture("xdotool", [
+      "getwindowclassname",
+      currentId,
+    ]);
+    if (className && matchesTerminal(className)) return className;
 
-  const windowName = await execFileCapture("xdotool", [
-    "getwindowname",
-    windowId,
-  ]);
-  if (windowName && matchesTerminal(windowName)) return windowName;
+    const windowName = await execFileCapture("xdotool", [
+      "getwindowname",
+      currentId,
+    ]);
+    if (windowName && matchesTerminal(windowName)) return windowName;
+    if (
+      className &&
+      matchesIntegratedTerminal(className, windowName ?? undefined)
+    ) {
+      return "integrated-terminal";
+    }
+
+    const parentId = await execFileCapture("xdotool", [
+      "getwindowparent",
+      currentId,
+    ]);
+    if (!parentId || parentId === "0" || parentId === currentId) break;
+    currentId = parentId;
+  }
 
   const pid = await execFileCapture("xdotool", ["getwindowpid", windowId]);
   if (pid) {
@@ -80,7 +120,7 @@ async function detectViaXdotool(): Promise<string | null> {
     }
   }
 
-  return className ?? windowName;
+  return null;
 }
 
 async function detectViaHyprland(): Promise<string | null> {
@@ -91,8 +131,14 @@ async function detectViaHyprland(): Promise<string | null> {
     const data = JSON.parse(output) as {
       class?: string;
       initialClass?: string;
+      title?: string;
     };
-    return data.class ?? data.initialClass ?? null;
+    const className = data.class ?? data.initialClass ?? "";
+    if (matchesTerminal(className)) return className;
+    if (matchesIntegratedTerminal(className, data.title)) {
+      return "integrated-terminal";
+    }
+    return className || null;
   } catch {
     return null;
   }
@@ -110,7 +156,14 @@ type SwayNode = {
 
 function findFocusedSwayNode(node: SwayNode): string | null {
   if (node.focused && node.type === "con") {
-    return node.app_id ?? node.window_properties?.class ?? node.name ?? null;
+    const className =
+      node.app_id ?? node.window_properties?.class ?? node.name ?? "";
+    const title = node.name ?? "";
+    if (matchesTerminal(className)) return className;
+    if (matchesIntegratedTerminal(className, title)) {
+      return "integrated-terminal";
+    }
+    return className || null;
   }
 
   for (const child of node.nodes ?? []) {

--- a/apps/electron/src/main/paste.ts
+++ b/apps/electron/src/main/paste.ts
@@ -1,6 +1,7 @@
 import { exec, execFile } from "node:child_process";
 import { createAppLogger } from "@freestyle/utils";
 import { clipboard } from "electron";
+import { isLinuxTerminalFocused } from "./linux-terminal-focus";
 import { getNativeBinaryPath } from "./native-binary";
 
 const log = createAppLogger("paste");
@@ -92,34 +93,48 @@ async function pasteWindows(): Promise<"native" | "legacy"> {
 
 type PasteMethod = "native" | "legacy";
 
-async function pasteLinux(): Promise<PasteMethod> {
+function linuxPasteArgs(wayland: boolean, isTerminal: boolean): string[] {
+  if (wayland) {
+    return isTerminal ? ["--uinput", "--terminal"] : ["--uinput"];
+  }
+  return isTerminal ? ["--terminal"] : [];
+}
+
+async function pasteLinux(isTerminal: boolean): Promise<PasteMethod> {
   const binaryPath = getNativeBinaryPath("linux-fast-paste");
   const wayland = isWaylandSession();
 
   if (wayland) {
-    return pasteLinuxWayland(binaryPath);
+    return pasteLinuxWayland(binaryPath, isTerminal);
   }
 
   if (binaryPath) {
-    const exitCode = await execFileAsync(binaryPath);
+    const exitCode = await execFileAsync(
+      binaryPath,
+      linuxPasteArgs(false, isTerminal),
+    );
     if (exitCode !== 0) {
       log.warn(
         `Native paste failed (exit ${exitCode}), falling back to xdotool`,
       );
-      await pasteLinuxLegacy(false);
+      await pasteLinuxLegacy(false, isTerminal);
       return "legacy";
     }
     return "native";
   }
-  await pasteLinuxLegacy(false);
+  await pasteLinuxLegacy(false, isTerminal);
   return "legacy";
 }
 
 async function pasteLinuxWayland(
   binaryPath: string | null,
+  isTerminal: boolean,
 ): Promise<PasteMethod> {
   if (binaryPath) {
-    const exitCode = await execFileAsync(binaryPath, ["--uinput"]);
+    const exitCode = await execFileAsync(
+      binaryPath,
+      linuxPasteArgs(true, isTerminal),
+    );
     if (exitCode === 0) {
       return "legacy";
     }
@@ -128,21 +143,25 @@ async function pasteLinuxWayland(
     );
   }
 
-  await pasteLinuxLegacy(true);
+  await pasteLinuxLegacy(true, isTerminal);
   return "legacy";
 }
 
-async function pasteLinuxLegacy(wayland: boolean): Promise<void> {
+async function pasteLinuxLegacy(
+  wayland: boolean,
+  isTerminal: boolean,
+): Promise<void> {
   if (wayland) {
-    const pasted = await tryExecAsync(
-      "wtype -M ctrl -P v -p v -m ctrl",
-      "wtype paste",
-    );
+    const cmd = isTerminal
+      ? "wtype -M ctrl -M shift -P v -p v -m shift -m ctrl"
+      : "wtype -M ctrl -P v -p v -m ctrl";
+    const pasted = await tryExecAsync(cmd, "wtype paste");
     if (!pasted) {
       throw new Error("No supported Wayland paste backend succeeded");
     }
   } else {
-    await execAsync("xdotool key ctrl+v");
+    const key = isTerminal ? "ctrl+shift+v" : "ctrl+v";
+    await execAsync(`xdotool key ${key}`);
   }
 }
 
@@ -183,9 +202,14 @@ export async function pasteIntoFocusedApp(
       case "win32":
         method = await pasteWindows();
         break;
-      default:
-        method = await pasteLinux();
+      default: {
+        const isTerminal = await isLinuxTerminalFocused();
+        if (isTerminal) {
+          log.debug("focused app is a terminal, using Ctrl+Shift+V");
+        }
+        method = await pasteLinux(isTerminal);
         break;
+      }
     }
 
     const settleTable =

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,16 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "globalPassThroughEnv": [
+    "DISPLAY",
+    "HYPRLAND_INSTANCE_SIGNATURE",
+    "SWAYSOCK",
+    "WAYLAND_DISPLAY",
+    "XDG_BACKEND",
+    "XDG_CURRENT_DESKTOP",
+    "XDG_SESSION_ID",
+    "XDG_SESSION_TYPE"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- Detect when a terminal is focused on Linux using compositor-specific APIs (Hyprland, Sway, GNOME Shell) with xdotool as fallback
- Send Ctrl+Shift+V for terminals on Wayland (`linux-fast-paste --uinput --terminal`) and in `wtype`/`xdotool` fallbacks
- Fixes paste working in browsers (Ctrl+V) but failing in terminals after #196 removed X11-based terminal detection on Wayland

## Test plan
- [x] Paste into a terminal on Linux (Ctrl+Shift+V path)
- [x] Paste into Chrome / other apps on Linux (Ctrl+V path)
- [ ] Verify on a pure Wayland session (GNOME, KDE, Hyprland)

Fixes #89


Made with [Cursor](https://cursor.com)