### PR TITLE
feat(linux): pause media while recording

### DIFF
--- a/apps/electron/src/main/audio-ducker.ts
+++ b/apps/electron/src/main/audio-ducker.ts
@@ -1,0 +1,117 @@
+import { execFile, execFileSync } from "node:child_process";
+import { getNativeBinaryPath } from "./native-binary";
+
+const DUCKED_VOLUME = 0.15;
+
+interface VolumeSnapshot {
+  deviceId: number;
+  previousVolume: number;
+}
+
+function execFileText(path: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(path, args, { encoding: "utf8" }, (err, stdout, stderr) => {
+      if (err) {
+        const detail = typeof stderr === "string" ? stderr.trim() : "";
+        reject(new Error(detail || err.message));
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+function execFileTextSync(path: string, args: string[]): string {
+  return execFileSync(path, args, { encoding: "utf8" }).trim();
+}
+
+function parseSnapshot(stdout: string): VolumeSnapshot {
+  const data = JSON.parse(stdout) as {
+    deviceId?: unknown;
+    volume?: unknown;
+  };
+  if (typeof data.deviceId !== "number" || typeof data.volume !== "number") {
+    throw new Error("Invalid macOS audio-duck response");
+  }
+  return { deviceId: data.deviceId, previousVolume: data.volume };
+}
+
+export class AudioDucker {
+  private snapshot: VolumeSnapshot | null = null;
+  private active = false;
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  async duck(): Promise<boolean> {
+    if (process.platform !== "darwin") return false;
+    if (this.active) return true;
+
+    const binaryPath = getNativeBinaryPath("macos-audio-duck");
+    if (!binaryPath) return false;
+
+    const snapshot = parseSnapshot(await execFileText(binaryPath, ["get"]));
+    if (snapshot.previousVolume > DUCKED_VOLUME) {
+      await execFileText(binaryPath, [
+        "set",
+        String(DUCKED_VOLUME),
+        String(snapshot.deviceId),
+      ]);
+    }
+
+    this.snapshot = snapshot;
+    this.active = true;
+    return true;
+  }
+
+  async restore(): Promise<void> {
+    if (process.platform !== "darwin") return;
+    if (!this.active) return;
+
+    const snapshot = this.snapshot;
+    this.snapshot = null;
+    this.active = false;
+    if (!snapshot) return;
+
+    const binaryPath = getNativeBinaryPath("macos-audio-duck");
+    if (!binaryPath) return;
+
+    try {
+      await execFileText(binaryPath, [
+        "set",
+        String(snapshot.previousVolume),
+        String(snapshot.deviceId),
+      ]);
+    } catch {
+      await execFileText(binaryPath, ["set", String(snapshot.previousVolume)]);
+    }
+  }
+
+  restoreSync(): void {
+    if (process.platform !== "darwin") return;
+    if (!this.active) return;
+
+    const snapshot = this.snapshot;
+    this.snapshot = null;
+    this.active = false;
+    if (!snapshot) return;
+
+    const binaryPath = getNativeBinaryPath("macos-audio-duck");
+    if (!binaryPath) return;
+
+    try {
+      execFileTextSync(binaryPath, [
+        "set",
+        String(snapshot.previousVolume),
+        String(snapshot.deviceId),
+      ]);
+    } catch {
+      try {
+        execFileTextSync(binaryPath, ["set", String(snapshot.previousVolume)]);
+      } catch {
+        // Quit cleanup should never block app shutdown on audio restore failure.
+      }
+    }
+  }
+}

--- a/apps/electron/src/main/audio-pauser.ts
+++ b/apps/electron/src/main/audio-pauser.ts
@@ -1,0 +1,69 @@
+import { execFile, execFileSync } from "node:child_process";
+import { getNativeBinaryPath } from "./native-binary";
+
+function execFileText(path: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(path, args, { encoding: "utf8" }, (err, stdout, stderr) => {
+      if (err) {
+        const detail = typeof stderr === "string" ? stderr.trim() : "";
+        reject(new Error(detail || err.message));
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+function execFileTextSync(path: string, args: string[]): string {
+  return execFileSync(path, args, { encoding: "utf8" }).trim();
+}
+
+export class AudioPauser {
+  private active = false;
+
+  async pause(): Promise<boolean> {
+    if (process.platform !== "darwin") return false;
+    if (this.active) return true;
+
+    const binaryPath = getNativeBinaryPath("macos-media-control");
+    if (!binaryPath) return false;
+
+    try {
+      await execFileText(binaryPath, ["pause"]);
+      this.active = true;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async restore(): Promise<void> {
+    if (process.platform !== "darwin") return;
+    if (!this.active) return;
+
+    this.active = false;
+    const binaryPath = getNativeBinaryPath("macos-media-control");
+    if (!binaryPath) return;
+
+    try {
+      await execFileText(binaryPath, ["resume"]);
+    } catch {
+      // A media session may disappear while recording. Nothing to restore then.
+    }
+  }
+
+  restoreSync(): void {
+    if (process.platform !== "darwin") return;
+    if (!this.active) return;
+
+    this.active = false;
+    const binaryPath = getNativeBinaryPath("macos-media-control");
+    if (!binaryPath) return;
+
+    try {
+      execFileTextSync(binaryPath, ["resume"]);
+    } catch {
+      // Quit cleanup should never block app shutdown on media restore failure.
+    }
+  }
+}

--- a/apps/electron/src/main/audio-playback-controller.ts
+++ b/apps/electron/src/main/audio-playback-controller.ts
@@ -1,0 +1,90 @@
+import type { ActiveAudioPlaybackMode } from "../shared/audio-playback";
+import * as linuxAudioDucker from "./linux-audio-ducker";
+import * as linuxMediaPlayback from "./linux-media-playback";
+
+export class AudioPlaybackController {
+  private paused = false;
+  private ducked = false;
+
+  async prepare(mode: ActiveAudioPlaybackMode): Promise<void> {
+    if (process.platform !== "linux") return;
+    if (this.paused || this.ducked) return;
+
+    const duckPromise = this.duckSafely();
+    if (mode === "pause") {
+      const [ducked, paused] = await Promise.all([
+        duckPromise,
+        this.pauseSafely(),
+      ]);
+      this.ducked = ducked;
+      this.paused = paused;
+      return;
+    }
+
+    this.ducked = await duckPromise;
+  }
+
+  async duck(): Promise<void> {
+    await this.prepare("duck");
+  }
+
+  private async duckSafely(): Promise<boolean> {
+    try {
+      return await linuxAudioDucker.duckVolume();
+    } catch {
+      return false;
+    }
+  }
+
+  private async pauseSafely(): Promise<boolean> {
+    try {
+      return await linuxMediaPlayback.pausePlayback();
+    } catch {
+      return false;
+    }
+  }
+
+  async restore(): Promise<void> {
+    if (process.platform !== "linux") return;
+    if (!this.paused && !this.ducked) return;
+
+    const shouldResume = this.paused;
+    const shouldRestoreDuck = this.ducked;
+    this.paused = false;
+    this.ducked = false;
+
+    if (shouldRestoreDuck) {
+      try {
+        await linuxAudioDucker.restoreVolume();
+      } catch {
+        // Still try to resume media below if Freestyle paused it.
+      }
+    }
+
+    if (shouldResume) {
+      try {
+        await linuxMediaPlayback.resumePlayback();
+      } catch {
+        // A media session may disappear while recording.
+      }
+    }
+  }
+
+  restoreSync(): void {
+    if (process.platform !== "linux") return;
+    if (!this.paused && !this.ducked) return;
+
+    const shouldResume = this.paused;
+    const shouldRestoreDuck = this.ducked;
+    this.paused = false;
+    this.ducked = false;
+
+    if (shouldRestoreDuck) {
+      linuxAudioDucker.restoreVolumeSync();
+    }
+
+    if (shouldResume) {
+      void linuxMediaPlayback.resumePlayback();
+    }
+  }
+}

--- a/apps/electron/src/main/audio-playback-controller.ts
+++ b/apps/electron/src/main/audio-playback-controller.ts
@@ -1,13 +1,21 @@
 import type { ActiveAudioPlaybackMode } from "../shared/audio-playback";
+import { AudioDucker } from "./audio-ducker";
+import { AudioPauser } from "./audio-pauser";
 import * as linuxAudioDucker from "./linux-audio-ducker";
 import * as linuxMediaPlayback from "./linux-media-playback";
 
 export class AudioPlaybackController {
+  private readonly ducker = new AudioDucker();
+  private readonly pauser = new AudioPauser();
   private paused = false;
   private ducked = false;
 
+  private supportsBackgroundAudio(): boolean {
+    return process.platform === "darwin" || process.platform === "linux";
+  }
+
   async prepare(mode: ActiveAudioPlaybackMode): Promise<void> {
-    if (process.platform !== "linux") return;
+    if (!this.supportsBackgroundAudio()) return;
     if (this.paused || this.ducked) return;
 
     const duckPromise = this.duckSafely();
@@ -30,7 +38,13 @@ export class AudioPlaybackController {
 
   private async duckSafely(): Promise<boolean> {
     try {
-      return await linuxAudioDucker.duckVolume();
+      if (process.platform === "darwin") {
+        return await this.ducker.duck();
+      }
+      if (process.platform === "linux") {
+        return await linuxAudioDucker.duckVolume();
+      }
+      return false;
     } catch {
       return false;
     }
@@ -38,14 +52,20 @@ export class AudioPlaybackController {
 
   private async pauseSafely(): Promise<boolean> {
     try {
-      return await linuxMediaPlayback.pausePlayback();
+      if (process.platform === "darwin") {
+        return await this.pauser.pause();
+      }
+      if (process.platform === "linux") {
+        return await linuxMediaPlayback.pausePlayback();
+      }
+      return false;
     } catch {
       return false;
     }
   }
 
   async restore(): Promise<void> {
-    if (process.platform !== "linux") return;
+    if (!this.supportsBackgroundAudio()) return;
     if (!this.paused && !this.ducked) return;
 
     const shouldResume = this.paused;
@@ -55,7 +75,11 @@ export class AudioPlaybackController {
 
     if (shouldRestoreDuck) {
       try {
-        await linuxAudioDucker.restoreVolume();
+        if (process.platform === "darwin") {
+          await this.ducker.restore();
+        } else if (process.platform === "linux") {
+          await linuxAudioDucker.restoreVolume();
+        }
       } catch {
         // Still try to resume media below if Freestyle paused it.
       }
@@ -63,7 +87,11 @@ export class AudioPlaybackController {
 
     if (shouldResume) {
       try {
-        await linuxMediaPlayback.resumePlayback();
+        if (process.platform === "darwin") {
+          await this.pauser.restore();
+        } else if (process.platform === "linux") {
+          await linuxMediaPlayback.resumePlayback();
+        }
       } catch {
         // A media session may disappear while recording.
       }
@@ -71,7 +99,7 @@ export class AudioPlaybackController {
   }
 
   restoreSync(): void {
-    if (process.platform !== "linux") return;
+    if (!this.supportsBackgroundAudio()) return;
     if (!this.paused && !this.ducked) return;
 
     const shouldResume = this.paused;
@@ -80,11 +108,19 @@ export class AudioPlaybackController {
     this.ducked = false;
 
     if (shouldRestoreDuck) {
-      linuxAudioDucker.restoreVolumeSync();
+      if (process.platform === "darwin") {
+        this.ducker.restoreSync();
+      } else if (process.platform === "linux") {
+        linuxAudioDucker.restoreVolumeSync();
+      }
     }
 
     if (shouldResume) {
-      void linuxMediaPlayback.resumePlayback();
+      if (process.platform === "darwin") {
+        this.pauser.restoreSync();
+      } else if (process.platform === "linux") {
+        void linuxMediaPlayback.resumePlayback();
+      }
     }
   }
 }

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -81,6 +81,8 @@ import { normalizeAccelerator } from "./hotkey-utils";
 import { NativeKeyListener } from "./key-listener";
 import * as linuxAutostart from "./linux-autostart";
 import { checkLinuxSetup } from "./linux-setup";
+import { AudioPlaybackController } from "./audio-playback-controller";
+import { isActiveAudioPlaybackMode } from "../shared/audio-playback";
 import { MicListener } from "./mic-listener";
 import { isWaylandSession, pasteIntoFocusedApp } from "./paste";
 
@@ -147,6 +149,7 @@ let currentHotkeyAccel: string | null = null;
 let hotkeyActivationMode: "hold" | "toggle" = "hold";
 let micListener: MicListener | null = null;
 let hotkeyRecorder: HotkeyRecorder | null = null;
+const audioPlaybackController = new AudioPlaybackController();
 
 function stopHotkeyRecorderProcess(): void {
   hotkeyRecorder?.stop();
@@ -1142,6 +1145,28 @@ app.whenReady().then(async () => {
   // IPC: expose the server port to the renderer
   ipcMain.handle("server:port", () => serverPort);
 
+  // IPC: background audio while recording (Linux duck / pause)
+  ipcMain.handle("audio:prepare", async (_event, mode: unknown) => {
+    if (!isActiveAudioPlaybackMode(mode)) return;
+    await audioPlaybackController.prepare(mode);
+  });
+
+  ipcMain.handle("audio:duck", async () => {
+    await audioPlaybackController.duck();
+  });
+
+  ipcMain.handle("audio:restore", async () => {
+    await audioPlaybackController.restore();
+  });
+
+  ipcMain.on("settings:audio-ducking-changed", (_event, enabled: boolean) => {
+    mainWindow?.webContents.send("settings:audio-ducking-changed", enabled);
+  });
+
+  ipcMain.on("settings:audio-playback-mode-changed", (_event, mode: string) => {
+    mainWindow?.webContents.send("settings:audio-playback-mode-changed", mode);
+  });
+
   ipcMain.handle(
     "dialog:show-error",
     async (_event, title: string, detail: string) => {
@@ -1965,6 +1990,7 @@ let isQuitting = false;
 let updateDownloadState: "idle" | "downloading" | "downloaded" = "idle";
 
 function cleanupBeforeQuit(): void {
+  audioPlaybackController.restoreSync();
   stopWhisperServer().catch(() => {});
   stopMlxServer().catch(() => {});
   if (keyListener) {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -75,14 +75,14 @@ import { autoUpdater } from "electron-updater";
 import { WebSocketServer } from "ws";
 import icon from "../../resources/icon.png?asset";
 import trayIconPath from "../../resources/tray/logoTemplate.png?asset";
+import { isActiveAudioPlaybackMode } from "../shared/audio-playback";
 import { getDefaultHotkey } from "../shared/hotkey-defaults";
+import { AudioPlaybackController } from "./audio-playback-controller";
 import { HotkeyRecorder } from "./hotkey-recorder";
 import { normalizeAccelerator } from "./hotkey-utils";
 import { NativeKeyListener } from "./key-listener";
 import * as linuxAutostart from "./linux-autostart";
 import { checkLinuxSetup } from "./linux-setup";
-import { AudioPlaybackController } from "./audio-playback-controller";
-import { isActiveAudioPlaybackMode } from "../shared/audio-playback";
 import { MicListener } from "./mic-listener";
 import { isWaylandSession, pasteIntoFocusedApp } from "./paste";
 

--- a/apps/electron/src/main/linux-audio-ducker.ts
+++ b/apps/electron/src/main/linux-audio-ducker.ts
@@ -111,11 +111,7 @@ async function writeVolume(
 
 function writeVolumeSync(method: SinkMethod, volume: number): void {
   if (method === "wpctl") {
-    runCmdSync("wpctl", [
-      "set-volume",
-      "@DEFAULT_AUDIO_SINK@",
-      String(volume),
-    ]);
+    runCmdSync("wpctl", ["set-volume", "@DEFAULT_AUDIO_SINK@", String(volume)]);
     return;
   }
 

--- a/apps/electron/src/main/linux-audio-ducker.ts
+++ b/apps/electron/src/main/linux-audio-ducker.ts
@@ -1,0 +1,198 @@
+/**
+ * Lower default output volume while dictating on Linux (PipeWire / PulseAudio).
+ */
+
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+import { createAppLogger } from "@freestyle/utils";
+
+const log = createAppLogger("linux-audio-ducker");
+const execFileAsync = promisify(execFile);
+
+const CMD_TIMEOUT_MS = 3000;
+const DUCKED_VOLUME = 0.15;
+
+type SinkMethod = "wpctl" | "pactl";
+
+interface VolumeSnapshot {
+  method: SinkMethod;
+  previousVolume: number;
+}
+
+let snapshot: VolumeSnapshot | null = null;
+let active = false;
+
+async function runCmd(
+  command: string,
+  args: string[],
+): Promise<{ stdout: string; ok: boolean }> {
+  try {
+    const { stdout } = await execFileAsync(command, args, {
+      timeout: CMD_TIMEOUT_MS,
+    });
+    return { stdout: stdout.trim(), ok: true };
+  } catch {
+    return { stdout: "", ok: false };
+  }
+}
+
+function runCmdSync(command: string, args: string[]): string {
+  return execFileSync(command, args, {
+    encoding: "utf8",
+    timeout: CMD_TIMEOUT_MS,
+  }).trim();
+}
+
+async function commandExists(command: string): Promise<boolean> {
+  const { ok } = await runCmd("sh", ["-c", `command -v ${command}`]);
+  return ok;
+}
+
+function parseWpctlVolume(stdout: string): number | null {
+  const match = stdout.match(/Volume:\s*([\d.]+)/);
+  if (!match) return null;
+  const value = Number.parseFloat(match[1] ?? "");
+  return Number.isFinite(value) ? value : null;
+}
+
+function parsePactlVolume(stdout: string): number | null {
+  const match = stdout.match(/(\d+)%/);
+  if (!match) return null;
+  const value = Number.parseInt(match[1] ?? "", 10);
+  return Number.isFinite(value) ? value : null;
+}
+
+async function readVolume(): Promise<VolumeSnapshot | null> {
+  if (await commandExists("wpctl")) {
+    const { stdout, ok } = await runCmd("wpctl", [
+      "get-volume",
+      "@DEFAULT_AUDIO_SINK@",
+    ]);
+    const volume = ok ? parseWpctlVolume(stdout) : null;
+    if (volume !== null) {
+      return { method: "wpctl", previousVolume: volume };
+    }
+  }
+
+  if (await commandExists("pactl")) {
+    const { stdout, ok } = await runCmd("pactl", [
+      "get-sink-volume",
+      "@DEFAULT_SINK@",
+    ]);
+    const volume = ok ? parsePactlVolume(stdout) : null;
+    if (volume !== null) {
+      return { method: "pactl", previousVolume: volume };
+    }
+  }
+
+  return null;
+}
+
+async function writeVolume(
+  method: SinkMethod,
+  volume: number,
+): Promise<boolean> {
+  if (method === "wpctl") {
+    const { ok } = await runCmd("wpctl", [
+      "set-volume",
+      "@DEFAULT_AUDIO_SINK@",
+      String(volume),
+    ]);
+    return ok;
+  }
+
+  const { ok } = await runCmd("pactl", [
+    "set-sink-volume",
+    "@DEFAULT_SINK@",
+    `${Math.round(volume)}%`,
+  ]);
+  return ok;
+}
+
+function writeVolumeSync(method: SinkMethod, volume: number): void {
+  if (method === "wpctl") {
+    runCmdSync("wpctl", [
+      "set-volume",
+      "@DEFAULT_AUDIO_SINK@",
+      String(volume),
+    ]);
+    return;
+  }
+
+  runCmdSync("pactl", [
+    "set-sink-volume",
+    "@DEFAULT_SINK@",
+    `${Math.round(volume)}%`,
+  ]);
+}
+
+function targetDuckedVolume(current: VolumeSnapshot): number {
+  if (current.method === "wpctl") {
+    return Math.min(current.previousVolume, DUCKED_VOLUME);
+  }
+  const duckedPercent = Math.round(DUCKED_VOLUME * 100);
+  return Math.min(current.previousVolume, duckedPercent);
+}
+
+export async function duckVolume(): Promise<boolean> {
+  if (process.platform !== "linux") return false;
+  if (active) return true;
+
+  const current = await readVolume();
+  if (!current) {
+    log.warn("duck_volume failed: no wpctl or pactl sink volume available");
+    return false;
+  }
+
+  const ducked = targetDuckedVolume(current);
+  if (ducked < current.previousVolume) {
+    const ok = await writeVolume(current.method, ducked);
+    if (!ok) return false;
+  }
+
+  snapshot = current;
+  active = true;
+  log.info(
+    `Ducked sink volume ${current.previousVolume} -> ${ducked} (${current.method})`,
+  );
+  return true;
+}
+
+export async function restoreVolume(): Promise<void> {
+  if (process.platform !== "linux") return;
+  if (!active) return;
+
+  const current = snapshot;
+  snapshot = null;
+  active = false;
+  if (!current) return;
+
+  try {
+    await writeVolume(current.method, current.previousVolume);
+    log.info(
+      `Restored sink volume to ${current.previousVolume} (${current.method})`,
+    );
+  } catch {
+    log.warn("restore_volume failed");
+  }
+}
+
+export function restoreVolumeSync(): void {
+  if (process.platform !== "linux") return;
+  if (!active) return;
+
+  const current = snapshot;
+  snapshot = null;
+  active = false;
+  if (!current) return;
+
+  try {
+    writeVolumeSync(current.method, current.previousVolume);
+  } catch {
+    // Quit cleanup should never block app shutdown on audio restore failure.
+  }
+}
+
+export function isDuckActive(): boolean {
+  return active;
+}

--- a/apps/electron/src/main/linux-media-playback.ts
+++ b/apps/electron/src/main/linux-media-playback.ts
@@ -1,0 +1,188 @@
+/**
+ * Pause background media while dictating on Linux.
+ *
+ * 1. MPRIS pause via D-Bus (busctl) — Spotify, browser media, VLC, etc.
+ * 2. Optional playerctl when installed
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createAppLogger } from "@freestyle/utils";
+
+const log = createAppLogger("linux-media-playback");
+const execFileAsync = promisify(execFile);
+
+const CMD_TIMEOUT_MS = 3000;
+const MPRIS_PREFIX = "org.mpris.MediaPlayer2.";
+const MPRIS_PATH = "/org/mpris/MediaPlayer2";
+const MPRIS_PLAYER = "org.mpris.MediaPlayer2.Player";
+
+let pausedMprisServices: string[] = [];
+
+async function runCmd(
+  command: string,
+  args: string[],
+): Promise<{ stdout: string; ok: boolean }> {
+  try {
+    const { stdout } = await execFileAsync(command, args, {
+      timeout: CMD_TIMEOUT_MS,
+    });
+    return { stdout: stdout.trim(), ok: true };
+  } catch {
+    return { stdout: "", ok: false };
+  }
+}
+
+async function commandExists(command: string): Promise<boolean> {
+  const { ok } = await runCmd("sh", ["-c", `command -v ${command}`]);
+  return ok;
+}
+
+// ---------------------------------------------------------------------------
+// D-Bus MPRIS (busctl)
+// ---------------------------------------------------------------------------
+
+async function listMprisServices(): Promise<string[]> {
+  const { stdout, ok } = await runCmd("busctl", ["--user", "list"]);
+  if (!ok || !stdout) return [];
+
+  const services: string[] = [];
+  for (const line of stdout.split("\n")) {
+    const service = line.split(/\s+/)[0];
+    if (service?.startsWith(MPRIS_PREFIX)) {
+      services.push(service);
+    }
+  }
+  return services;
+}
+
+function parseDBusString(stdout: string): string {
+  const match = stdout.match(/"([^"]*)"/);
+  return match?.[1] ?? "";
+}
+
+async function getMprisStatus(service: string): Promise<string> {
+  const { stdout } = await runCmd("busctl", [
+    "--user",
+    "get-property",
+    service,
+    MPRIS_PATH,
+    MPRIS_PLAYER,
+    "PlaybackStatus",
+  ]);
+  return parseDBusString(stdout);
+}
+
+async function mprisPause(service: string): Promise<boolean> {
+  const { ok } = await runCmd("busctl", [
+    "--user",
+    "call",
+    service,
+    MPRIS_PATH,
+    MPRIS_PLAYER,
+    "Pause",
+  ]);
+  return ok;
+}
+
+async function mprisPlay(service: string): Promise<boolean> {
+  const { ok } = await runCmd("busctl", [
+    "--user",
+    "call",
+    service,
+    MPRIS_PATH,
+    MPRIS_PLAYER,
+    "Play",
+  ]);
+  return ok;
+}
+
+async function pauseMprisViaDBus(): Promise<string[]> {
+  const services = await listMprisServices();
+  const paused: string[] = [];
+
+  for (const service of services) {
+    const status = await getMprisStatus(service);
+    if (status === "Playing" && (await mprisPause(service))) {
+      paused.push(service);
+    }
+  }
+
+  return paused;
+}
+
+// ---------------------------------------------------------------------------
+// playerctl (optional)
+// ---------------------------------------------------------------------------
+
+async function listPlayerctlPlayers(): Promise<string[]> {
+  const { stdout, ok } = await runCmd("playerctl", ["--list-all"]);
+  if (!ok || !stdout) return [];
+  return stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+async function pausePlayerctl(): Promise<string[]> {
+  if (!(await commandExists("playerctl"))) return [];
+
+  const players = await listPlayerctlPlayers();
+  const paused: string[] = [];
+
+  for (const player of players) {
+    const { stdout } = await runCmd("playerctl", ["-p", player, "status"]);
+    if (stdout === "Playing") {
+      const { ok } = await runCmd("playerctl", ["-p", player, "pause"]);
+      if (ok) paused.push(player);
+    }
+  }
+
+  return paused;
+}
+
+async function playPlayerctl(player: string): Promise<void> {
+  await runCmd("playerctl", ["-p", player, "play"]);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Pause MPRIS media sessions. Returns true if at least one player was paused.
+ */
+export async function pausePlayback(): Promise<boolean> {
+  if (pausedMprisServices.length > 0) {
+    await resumePlayback();
+  }
+
+  const dbusPaused = await pauseMprisViaDBus();
+  const playerctlPaused = await pausePlayerctl();
+  pausedMprisServices = [...new Set([...dbusPaused, ...playerctlPaused])];
+
+  if (pausedMprisServices.length > 0) {
+    log.info(`Paused ${pausedMprisServices.length} MPRIS target(s)`);
+  }
+
+  return pausedMprisServices.length > 0;
+}
+
+/**
+ * Restore playback paused by {@link pausePlayback}.
+ */
+export async function resumePlayback(): Promise<void> {
+  if (pausedMprisServices.length === 0) return;
+
+  for (const target of pausedMprisServices) {
+    if (target.startsWith(MPRIS_PREFIX)) {
+      await mprisPlay(target);
+    } else {
+      await playPlayerctl(target);
+    }
+  }
+
+  log.info(`Resumed ${pausedMprisServices.length} MPRIS target(s)`);
+
+  pausedMprisServices = [];
+}

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -85,7 +85,9 @@ declare global {
       sendOutputModeChanged: (mode: string) => void;
       onOutputModeChanged: (callback: (mode: string) => void) => () => void;
       sendAudioDuckingChanged: (enabled: boolean) => void;
-      onAudioDuckingChanged: (callback: (enabled: boolean) => void) => () => void;
+      onAudioDuckingChanged: (
+        callback: (enabled: boolean) => void,
+      ) => () => void;
       sendAudioPlaybackModeChanged: (
         mode: import("../shared/audio-playback").AudioPlaybackMode,
       ) => void;

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -9,6 +9,11 @@ declare global {
       defaultHotkey: string;
       pasteText: (text: string) => Promise<void>;
       copyText: (text: string) => Promise<void>;
+      prepareSystemAudio: (
+        mode: import("../shared/audio-playback").ActiveAudioPlaybackMode,
+      ) => Promise<void>;
+      duckSystemAudio: () => Promise<void>;
+      restoreSystemAudio: () => Promise<void>;
       updateHotkey: (hotkey: string) => void;
       reloadHotkey: () => void;
       setHotkeyMode: (mode: "hold" | "toggle") => void;
@@ -79,6 +84,16 @@ declare global {
       // Output mode
       sendOutputModeChanged: (mode: string) => void;
       onOutputModeChanged: (callback: (mode: string) => void) => () => void;
+      sendAudioDuckingChanged: (enabled: boolean) => void;
+      onAudioDuckingChanged: (callback: (enabled: boolean) => void) => () => void;
+      sendAudioPlaybackModeChanged: (
+        mode: import("../shared/audio-playback").AudioPlaybackMode,
+      ) => void;
+      onAudioPlaybackModeChanged: (
+        callback: (
+          mode: import("../shared/audio-playback").AudioPlaybackMode,
+        ) => void,
+      ) => () => void;
       // Hotkey error notifications
       onHotkeyError: (
         callback: (error: { message: string }) => void,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -1,5 +1,9 @@
 import { electronAPI } from "@electron-toolkit/preload";
 import { contextBridge, ipcRenderer } from "electron";
+import type {
+  ActiveAudioPlaybackMode,
+  AudioPlaybackMode,
+} from "../shared/audio-playback";
 import { getDefaultHotkey } from "../shared/hotkey-defaults";
 
 // Custom APIs for renderer
@@ -13,6 +17,10 @@ const api = {
     ipcRenderer.invoke("paste:text", text),
   copyText: (text: string): Promise<void> =>
     ipcRenderer.invoke("copy:text", text),
+  prepareSystemAudio: (mode: ActiveAudioPlaybackMode): Promise<void> =>
+    ipcRenderer.invoke("audio:prepare", mode),
+  duckSystemAudio: (): Promise<void> => ipcRenderer.invoke("audio:duck"),
+  restoreSystemAudio: (): Promise<void> => ipcRenderer.invoke("audio:restore"),
   updateHotkey: (hotkey: string): void =>
     ipcRenderer.send("hotkey:update", hotkey),
   reloadHotkey: (): void => ipcRenderer.send("hotkey:reload"),
@@ -165,6 +173,30 @@ const api = {
     ipcRenderer.on("settings:output-mode-changed", handler);
     return () =>
       ipcRenderer.removeListener("settings:output-mode-changed", handler);
+  },
+  sendAudioDuckingChanged: (enabled: boolean): void =>
+    ipcRenderer.send("settings:audio-ducking-changed", enabled),
+  onAudioDuckingChanged: (
+    callback: (enabled: boolean) => void,
+  ): (() => void) => {
+    const handler = (_: unknown, enabled: boolean): void => callback(enabled);
+    ipcRenderer.on("settings:audio-ducking-changed", handler);
+    return () =>
+      ipcRenderer.removeListener("settings:audio-ducking-changed", handler);
+  },
+  sendAudioPlaybackModeChanged: (mode: AudioPlaybackMode): void =>
+    ipcRenderer.send("settings:audio-playback-mode-changed", mode),
+  onAudioPlaybackModeChanged: (
+    callback: (mode: AudioPlaybackMode) => void,
+  ): (() => void) => {
+    const handler = (_: unknown, mode: AudioPlaybackMode): void =>
+      callback(mode);
+    ipcRenderer.on("settings:audio-playback-mode-changed", handler);
+    return () =>
+      ipcRenderer.removeListener(
+        "settings:audio-playback-mode-changed",
+        handler,
+      );
   },
   // Hotkey error notifications
   onHotkeyError: (

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -157,10 +157,13 @@ export default function AppPage(): React.JSX.Element {
   );
   const drainAgainRef = useRef(false);
 
-  const isTranscriptionIdle = (): boolean =>
-    queueRef.current.length === 0 &&
-    !drainingRef.current &&
-    streamResolverRef.current === null;
+  const isTranscriptionIdle = useCallback(
+    (): boolean =>
+      queueRef.current.length === 0 &&
+      !drainingRef.current &&
+      streamResolverRef.current === null,
+    [],
+  );
 
   const getInputVolume = useCallback(() => volumeRef.current, []);
 
@@ -540,7 +543,13 @@ export default function AppPage(): React.JSX.Element {
       startBarAnimation("speaking");
       void drainQueue();
     }
-  }, [hidePill, setPillState, startBarAnimation, drainQueue]);
+  }, [
+    hidePill,
+    setPillState,
+    startBarAnimation,
+    drainQueue,
+    isTranscriptionIdle,
+  ]);
 
   // ---- Start recording ----
   const startRecording = useCallback(
@@ -801,6 +810,7 @@ export default function AppPage(): React.JSX.Element {
     restFallbackTranscribe,
     setPillState,
     resumeTranscribingOrHide,
+    isTranscriptionIdle,
   ]);
 
   // ---- Cancel ----
@@ -949,7 +959,13 @@ export default function AppPage(): React.JSX.Element {
       removeUp();
       removeCancel();
     };
-  }, [startRecording, commitRecording, cancelRecording, hidePill]);
+  }, [
+    startRecording,
+    commitRecording,
+    cancelRecording,
+    hidePill,
+    isTranscriptionIdle,
+  ]);
 
   // ---- Cleanup on unmount ----
   const mountedRef = useRef(true);

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -4,6 +4,10 @@ import { getApiBase, getClient, refreshApiBase } from "@renderer/lib/api";
 import { Recorder } from "@renderer/lib/recorder";
 import { Streamer } from "@renderer/lib/streamer";
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type AudioPlaybackMode,
+  normalizeAudioPlaybackMode,
+} from "../../../shared/audio-playback";
 
 const BARS = 14;
 const RISE = 0.55;
@@ -21,6 +25,7 @@ type BarMode = "connecting" | "listening" | "speaking";
 
 let _soundEnabled = true;
 let _outputMode = "paste";
+let _audioPlaybackMode: AudioPlaybackMode = "off";
 let _toneCtx: AudioContext | null = null;
 
 function getToneCtx(): AudioContext {
@@ -572,12 +577,18 @@ export default function AppPage(): React.JSX.Element {
       startBarAnimation("connecting");
 
       try {
+        if (_audioPlaybackMode !== "off") {
+          await window.api
+            ?.prepareSystemAudio(_audioPlaybackMode)
+            .catch(() => {});
+        }
         sessionStreamingRef.current = useStreamingRef.current;
         const stream = await recorderRef.current.acquireStream();
 
         if (!wantsMicRef.current) {
           recorderRef.current.cancel();
           recorderRef.current.releaseStream();
+          window.api?.restoreSystemAudio().catch(() => {});
           if (forReRecord) {
             resumeTranscribingOrHide();
           }
@@ -589,6 +600,7 @@ export default function AppPage(): React.JSX.Element {
           recorderRef.current.cancel();
           recorderRef.current.releaseStream();
           streamerRef.current?.cancel();
+          window.api?.restoreSystemAudio().catch(() => {});
           if (forReRecord) {
             resumeTranscribingOrHide();
           } else {
@@ -613,6 +625,7 @@ export default function AppPage(): React.JSX.Element {
       } catch (err) {
         pendingCommitRef.current = false;
         recorderRef.current.releaseStream();
+        window.api?.restoreSystemAudio().catch(() => {});
         hidePill();
         window.api.showErrorDialog(
           "Recording Failed",
@@ -634,6 +647,7 @@ export default function AppPage(): React.JSX.Element {
   const commitRecording = useCallback(async () => {
     wantsMicRef.current = false;
     recordingActiveRef.current = false;
+    window.api?.restoreSystemAudio().catch(() => {});
     playTone("stop");
 
     clearInterval(timerRef.current);
@@ -796,6 +810,7 @@ export default function AppPage(): React.JSX.Element {
       streamResolverRef.current = null;
       resolver({ raw: "", cleaned: "" });
     }
+    window.api?.restoreSystemAudio().catch(() => {});
     streamerRef.current?.cancel();
     recorderRef.current.cancel();
     recorderRef.current.releaseStream();
@@ -818,6 +833,39 @@ export default function AppPage(): React.JSX.Element {
         if (data?.value === "false") _soundEnabled = false;
       })
       .catch(() => {});
+    void (async () => {
+      try {
+        const modeResponse = await getClient().api.settings[":key"].$get({
+          param: { key: "audio_playback_mode" },
+        });
+        const modeData = modeResponse.ok ? await modeResponse.json() : null;
+        if (modeData?.value) {
+          _audioPlaybackMode = normalizeAudioPlaybackMode(modeData.value);
+          return;
+        }
+
+        const legacyPauseResponse = await getClient().api.settings[":key"].$get(
+          {
+            param: { key: "pause_playback_while_recording" },
+          },
+        );
+        const legacyPauseData = legacyPauseResponse.ok
+          ? await legacyPauseResponse.json()
+          : null;
+        if (legacyPauseData?.value === "true") {
+          _audioPlaybackMode = "pause";
+          return;
+        }
+
+        const legacyDuckResponse = await getClient().api.settings[":key"].$get({
+          param: { key: "audio_ducking_enabled" },
+        });
+        const legacyDuckData = legacyDuckResponse.ok
+          ? await legacyDuckResponse.json()
+          : null;
+        _audioPlaybackMode = legacyDuckData?.value === "true" ? "duck" : "off";
+      } catch {}
+    })();
     getClient()
       .api.settings[":key"].$get({ param: { key: "output_mode" } })
       .then((r) => (r.ok ? r.json() : null))
@@ -835,9 +883,19 @@ export default function AppPage(): React.JSX.Element {
     const removeOutputMode = window.api?.onOutputModeChanged((mode) => {
       _outputMode = mode;
     });
+    const removeAudioDucking = window.api?.onAudioDuckingChanged((enabled) => {
+      _audioPlaybackMode = enabled ? "duck" : "off";
+    });
+    const removeAudioPlaybackMode = window.api?.onAudioPlaybackModeChanged(
+      (mode) => {
+        _audioPlaybackMode = normalizeAudioPlaybackMode(mode);
+      },
+    );
     return () => {
       removePillPos?.();
       removeOutputMode?.();
+      removeAudioDucking?.();
+      removeAudioPlaybackMode?.();
     };
   }, [applyPillPosition]);
 

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -18,6 +18,7 @@ import {
   Mic,
   Monitor,
   Moon,
+  Pause,
   Sun,
   Trash2,
   Volume2,
@@ -25,6 +26,10 @@ import {
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type AudioPlaybackMode,
+  normalizeAudioPlaybackMode,
+} from "../../../shared/audio-playback";
 import { getDefaultHotkey } from "../../../shared/hotkey-defaults";
 
 // ---------------------------------------------------------------------------
@@ -35,6 +40,12 @@ const themeOptions = [
   { value: "light", label: "Light", icon: Sun },
   { value: "dark", label: "Dark", icon: Moon },
   { value: "system", label: "System", icon: Monitor },
+] as const;
+
+const audioPlaybackOptions = [
+  { id: "off", label: "Off", icon: VolumeOff },
+  { id: "duck", label: "Duck", icon: Volume2 },
+  { id: "pause", label: "Pause", icon: Pause },
 ] as const;
 
 interface AudioDevice {
@@ -62,6 +73,8 @@ export default function SettingsPage(): React.JSX.Element {
   const [outputMode, setOutputMode] = useState("paste");
   const [pillPosition, setPillPosition] = useState("bottom-center");
   const [soundEnabled, setSoundEnabled] = useState(true);
+  const [audioPlaybackMode, setAudioPlaybackMode] =
+    useState<AudioPlaybackMode>("off");
   const [transcriptionPrompt, setTranscriptionPrompt] = useState("");
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null);
   const [updateDownloaded, setUpdateDownloaded] = useState(false);
@@ -87,6 +100,8 @@ export default function SettingsPage(): React.JSX.Element {
     null,
   );
   const isMac = navigator.userAgent.includes("Mac");
+  const isLinux = window.api?.platform === "linux";
+  const supportsBackgroundAudio = isMac || isLinux;
   // macOS and Windows can deep-link to the OS mic privacy settings.
   const canOpenMicSettings = isMac || window.api?.platform === "win32";
 
@@ -248,6 +263,39 @@ export default function SettingsPage(): React.JSX.Element {
         if (data?.value === "false") setSoundEnabled(false);
       })
       .catch(() => {});
+    void (async () => {
+      try {
+        const modeResponse = await getClient().api.settings[":key"].$get({
+          param: { key: "audio_playback_mode" },
+        });
+        const modeData = modeResponse.ok ? await modeResponse.json() : null;
+        if (modeData?.value) {
+          setAudioPlaybackMode(normalizeAudioPlaybackMode(modeData.value));
+          return;
+        }
+
+        const legacyPauseResponse = await getClient().api.settings[":key"].$get(
+          {
+            param: { key: "pause_playback_while_recording" },
+          },
+        );
+        const legacyPauseData = legacyPauseResponse.ok
+          ? await legacyPauseResponse.json()
+          : null;
+        if (legacyPauseData?.value === "true") {
+          setAudioPlaybackMode("pause");
+          return;
+        }
+
+        const legacyDuckResponse = await getClient().api.settings[":key"].$get({
+          param: { key: "audio_ducking_enabled" },
+        });
+        const legacyDuckData = legacyDuckResponse.ok
+          ? await legacyDuckResponse.json()
+          : null;
+        setAudioPlaybackMode(legacyDuckData?.value === "true" ? "duck" : "off");
+      } catch {}
+    })();
     getClient()
       .api.settings[":key"].$get({ param: { key: "transcription_prompt" } })
       .then((r) => (r.ok ? r.json() : null))
@@ -401,6 +449,18 @@ export default function SettingsPage(): React.JSX.Element {
       .api.settings[":key"].$put({
         param: { key: "sound_enabled" },
         json: { value: String(enabled) },
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleAudioPlaybackModeChange = useCallback((value: string) => {
+    const mode = normalizeAudioPlaybackMode(value);
+    setAudioPlaybackMode(mode);
+    window.api?.sendAudioPlaybackModeChanged(mode);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "audio_playback_mode" },
+        json: { value: mode },
       })
       .catch(() => {});
   }, []);
@@ -677,10 +737,29 @@ export default function SettingsPage(): React.JSX.Element {
             />
           </Row>
 
+          {supportsBackgroundAudio ? (
+            <Row
+              label="Background audio"
+              desc={
+                isLinux
+                  ? "Duck lowers system volume. Pause pauses MPRIS media and lowers volume."
+                  : "Duck lowers volume. Pause pauses current media and lowers volume."
+              }
+              last
+            >
+              <Segment
+                compact
+                options={audioPlaybackOptions}
+                active={audioPlaybackMode}
+                onSelect={handleAudioPlaybackModeChange}
+              />
+            </Row>
+          ) : null}
+
           <Row
             label="Sound feedback"
             desc="Soft chimes at the start and end of recording."
-            last
+            last={!supportsBackgroundAudio}
           >
             <div className="flex items-center gap-2.5">
               {soundEnabled ? (

--- a/apps/electron/src/shared/audio-playback.ts
+++ b/apps/electron/src/shared/audio-playback.ts
@@ -1,0 +1,14 @@
+export type AudioPlaybackMode = "off" | "duck" | "pause";
+export type ActiveAudioPlaybackMode = Exclude<AudioPlaybackMode, "off">;
+
+export function normalizeAudioPlaybackMode(
+  value: string | null | undefined,
+): AudioPlaybackMode {
+  return value === "duck" || value === "pause" ? value : "off";
+}
+
+export function isActiveAudioPlaybackMode(
+  value: unknown,
+): value is ActiveAudioPlaybackMode {
+  return value === "duck" || value === "pause";
+}

--- a/apps/server/scripts/benchmark-post-process.ts
+++ b/apps/server/scripts/benchmark-post-process.ts
@@ -2,10 +2,7 @@ import { generateText } from "ai";
 import { maxOutputTokensForCleanup } from "../src/lib/editor/max-output-tokens.ts";
 import { sanitizeTranscriptText } from "../src/lib/editor/model-hints.ts";
 import { buildRewritePrompt } from "../src/lib/editor/prompts.ts";
-import {
-  getGroqChatModel,
-  normalizeGroqModelId,
-} from "../src/lib/groq-http.ts";
+import { getGroqChatModel } from "../src/lib/groq-http.ts";
 import { groqCleanupProviderOptions } from "../src/lib/post-process.ts";
 import {
   type BenchmarkCase,


### PR DESCRIPTION
## Summary
- Adds a Linux-only **Pause media while recording** toggle under Settings → Recording.
- Pauses MPRIS media players via D-Bus (`busctl`) while dictating, then resumes on stop/cancel.
- Falls back to muting the default audio sink via `wpctl` (PipeWire) or `pactl` when pause is unavailable.
- Optional `playerctl` support when installed.

## Test plan
- [x] YouTube in Chrome: pause on hotkey hold, resume on release
- [ ] Spotify desktop pause/resume
- [x] Toggle hotkey mode (start/stop)
- [x] Cancel recording restores playback
- [x] Setting off leaves media playing during recording
- [x] Non-MPRIS audio falls back to speaker mute

Closes #195

Made with [Cursor](https://cursor.com)