### PR TITLE
feat: live partial preview in the recording pill

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1573,12 +1573,14 @@ app.whenReady().then(async () => {
   ipcMain.on("hotkey:reload", () => {
     hotkeyActivationMode = loadHotkeyModeFromDB();
     registerHotkey(currentHotkeyAccel ?? undefined);
+    broadcastHotkeyMode(hotkeyActivationMode);
   });
 
   ipcMain.on("hotkey:set-mode", (_event, mode: string) => {
     hotkeyActivationMode = mode === "toggle" ? "toggle" : "hold";
     hotkeyPressed = false;
     registerHotkey(currentHotkeyAccel ?? undefined);
+    broadcastHotkeyMode(hotkeyActivationMode);
   });
 });
 
@@ -1662,6 +1664,11 @@ function loadHotkeyModeFromDB(): "hold" | "toggle" {
     // Ignore errors
   }
   return "hold";
+}
+
+function broadcastHotkeyMode(mode: "hold" | "toggle"): void {
+  mainWindow?.webContents.send("hotkey:mode-changed", mode);
+  settingsWindow?.webContents.send("hotkey:mode-changed", mode);
 }
 
 function sendHotkeyDown(): void {

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -9,6 +9,9 @@ declare global {
       updateHotkey: (hotkey: string) => void;
       reloadHotkey: () => void;
       setHotkeyMode: (mode: "hold" | "toggle") => void;
+      onHotkeyModeChanged: (
+        callback: (mode: "hold" | "toggle") => void,
+      ) => () => void;
       hidePill: () => void;
       showErrorDialog: (title: string, message: string) => Promise<void>;
       getServerPort: () => Promise<number>;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -12,6 +12,14 @@ const api = {
   reloadHotkey: (): void => ipcRenderer.send("hotkey:reload"),
   setHotkeyMode: (mode: "hold" | "toggle"): void =>
     ipcRenderer.send("hotkey:set-mode", mode),
+  onHotkeyModeChanged: (
+    callback: (mode: "hold" | "toggle") => void,
+  ): (() => void) => {
+    const handler = (_: unknown, mode: "hold" | "toggle"): void =>
+      callback(mode);
+    ipcRenderer.on("hotkey:mode-changed", handler);
+    return () => ipcRenderer.removeListener("hotkey:mode-changed", handler);
+  },
   hidePill: (): void => ipcRenderer.send("pill:hide"),
   showErrorDialog: (title: string, message: string): Promise<void> =>
     ipcRenderer.invoke("dialog:show-error", title, message),

--- a/apps/electron/src/renderer/src/lib/hotkey-mode.ts
+++ b/apps/electron/src/renderer/src/lib/hotkey-mode.ts
@@ -1,0 +1,21 @@
+export type HotkeyActivationMode = "hold" | "toggle";
+
+export function parseHotkeyMode(value: unknown): HotkeyActivationMode {
+  return value === "toggle" ? "toggle" : "hold";
+}
+
+export function hotkeyModeDescription(mode: HotkeyActivationMode): string {
+  return mode === "toggle"
+    ? "Press your shortcut once to start, press again to stop — hands-free for long dictations."
+    : "Hold your shortcut while you speak, release to transcribe.";
+}
+
+export function hotkeyModeHotkeyHint(mode: HotkeyActivationMode): string {
+  return mode === "toggle"
+    ? "Press the shortcut once to start, press again to stop."
+    : "Hold the shortcut to record, release to transcribe.";
+}
+
+export function showsLivePartialPreview(mode: HotkeyActivationMode): boolean {
+  return mode === "toggle";
+}

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -1,6 +1,11 @@
 import { Orb } from "@renderer/components/ui/orb";
 import { capture } from "@renderer/lib/analytics";
 import { getApiBase, getClient, refreshApiBase } from "@renderer/lib/api";
+import {
+  type HotkeyActivationMode,
+  parseHotkeyMode,
+  showsLivePartialPreview,
+} from "@renderer/lib/hotkey-mode";
 import { Recorder } from "@renderer/lib/recorder";
 import { Streamer } from "@renderer/lib/streamer";
 import {
@@ -145,6 +150,8 @@ export default function AppPage(): React.JSX.Element {
   const [isReRecording, setIsReRecording] = useState(false);
   const isReRecordingRef = useRef(false);
   const [pendingCount, setPendingCount] = useState(0);
+  const [hotkeyMode, setHotkeyMode] = useState<HotkeyActivationMode>("hold");
+  const hotkeyModeRef = useRef<HotkeyActivationMode>("hold");
   const [livePartial, setLivePartial] = useState("");
   const livePartialRef = useRef("");
   const partialScrollRef = useRef<HTMLDivElement>(null);
@@ -156,11 +163,23 @@ export default function AppPage(): React.JSX.Element {
   }, []);
 
   const updateLivePartial = useCallback((text: string) => {
+    if (!showsLivePartialPreview(hotkeyModeRef.current)) return;
     const display = text.trim();
     if (!display || display === livePartialRef.current) return;
     livePartialRef.current = display;
     setLivePartial(display);
   }, []);
+
+  const applyHotkeyMode = useCallback(
+    (mode: HotkeyActivationMode) => {
+      hotkeyModeRef.current = mode;
+      setHotkeyMode(mode);
+      if (!showsLivePartialPreview(mode)) {
+        clearLivePartial();
+      }
+    },
+    [clearLivePartial],
+  );
 
   updateLivePartialRef.current = updateLivePartial;
 
@@ -832,6 +851,13 @@ export default function AppPage(): React.JSX.Element {
         if (data?.value) _outputMode = data.value;
       })
       .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "hotkey_mode" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value) applyHotkeyMode(parseHotkeyMode(data.value));
+      })
+      .catch(() => {});
     window.api
       ?.getPillPosition()
       .then(applyPillPosition)
@@ -842,11 +868,15 @@ export default function AppPage(): React.JSX.Element {
     const removeOutputMode = window.api?.onOutputModeChanged((mode) => {
       _outputMode = mode;
     });
+    const removeHotkeyMode = window.api?.onHotkeyModeChanged((mode) => {
+      applyHotkeyMode(mode);
+    });
     return () => {
       removePillPos?.();
       removeOutputMode?.();
+      removeHotkeyMode?.();
     };
-  }, [applyPillPosition]);
+  }, [applyPillPosition, applyHotkeyMode]);
 
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -922,6 +952,7 @@ export default function AppPage(): React.JSX.Element {
           : "glow-idle";
 
   const showPartialPreview =
+    showsLivePartialPreview(hotkeyMode) &&
     livePartial.length > 0 &&
     (state === "recording" || state === "transcribing");
 

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -3,7 +3,13 @@ import { capture } from "@renderer/lib/analytics";
 import { getApiBase, getClient, refreshApiBase } from "@renderer/lib/api";
 import { Recorder } from "@renderer/lib/recorder";
 import { Streamer } from "@renderer/lib/streamer";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 const BARS = 14;
 const RISE = 0.55;
@@ -95,6 +101,18 @@ const pillTextStyle: React.CSSProperties = {
   paddingRight: 7,
 };
 
+/** Scrollable slot so long partials stay pinned to the newest words. */
+const pillPartialScrollStyle: React.CSSProperties = {
+  color: "var(--muted-foreground)",
+  fontSize: 12,
+  flex: "1 1 0%",
+  minWidth: 0,
+  overflow: "hidden",
+  whiteSpace: "nowrap",
+  paddingRight: 7,
+  WebkitAppRegion: "no-drag",
+} as React.CSSProperties;
+
 interface TranscribeResult {
   raw: string;
   cleaned: string;
@@ -127,6 +145,31 @@ export default function AppPage(): React.JSX.Element {
   const [isReRecording, setIsReRecording] = useState(false);
   const isReRecordingRef = useRef(false);
   const [pendingCount, setPendingCount] = useState(0);
+  const [livePartial, setLivePartial] = useState("");
+  const livePartialRef = useRef("");
+  const partialScrollRef = useRef<HTMLDivElement>(null);
+  const updateLivePartialRef = useRef<(text: string) => void>(() => {});
+
+  const clearLivePartial = useCallback(() => {
+    livePartialRef.current = "";
+    setLivePartial("");
+  }, []);
+
+  const updateLivePartial = useCallback((text: string) => {
+    const display = text.trim();
+    if (!display || display === livePartialRef.current) return;
+    livePartialRef.current = display;
+    setLivePartial(display);
+  }, []);
+
+  updateLivePartialRef.current = updateLivePartial;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-pin scroll when partial text grows
+  useLayoutEffect(() => {
+    const el = partialScrollRef.current;
+    if (!el) return;
+    el.scrollLeft = Math.max(0, el.scrollWidth - el.clientWidth);
+  }, [livePartial]);
 
   const recorderRef = useRef(new Recorder());
   const streamerRef = useRef<Streamer | null>(null);
@@ -296,8 +339,11 @@ export default function AppPage(): React.JSX.Element {
           }
         },
         onReady: () => {},
-        onPartial: () => {},
+        onPartial: (text) => {
+          updateLivePartialRef.current(text);
+        },
         onFinal: (text) => {
+          if (text.trim()) updateLivePartialRef.current(text);
           const resolver = streamResolverRef.current;
           if (!resolver) return;
           streamResolverRef.current = null;
@@ -505,9 +551,10 @@ export default function AppPage(): React.JSX.Element {
     drainAgainRef.current = false;
     recordingActiveRef.current = false;
     streamResolverRef.current = null;
+    clearLivePartial();
     stopVisualization();
     window.api.hidePill();
-  }, [stopVisualization]);
+  }, [stopVisualization, clearLivePartial]);
 
   // ---- Start recording ----
   const startRecording = useCallback(
@@ -552,6 +599,7 @@ export default function AppPage(): React.JSX.Element {
         setState("initializing");
         startBarAnimation("connecting");
       }
+      clearLivePartial();
 
       try {
         sessionStreamingRef.current = useStreamingRef.current;
@@ -594,7 +642,13 @@ export default function AppPage(): React.JSX.Element {
         );
       }
     },
-    [startBarAnimation, startListening, hidePill, getStreamer],
+    [
+      startBarAnimation,
+      startListening,
+      hidePill,
+      getStreamer,
+      clearLivePartial,
+    ],
   );
 
   // ---- Commit recording ----
@@ -867,6 +921,14 @@ export default function AppPage(): React.JSX.Element {
           ? "glow-transcribing"
           : "glow-idle";
 
+  const showPartialPreview =
+    livePartial.length > 0 &&
+    (state === "recording" || state === "transcribing");
+
+  const activePillInnerStyle: React.CSSProperties = showPartialPreview
+    ? { ...pillInnerStyle, width: 248 }
+    : pillInnerStyle;
+
   const badge =
     state === "recording"
       ? formatTimer(elapsed)
@@ -875,9 +937,10 @@ export default function AppPage(): React.JSX.Element {
         : null;
 
   const showBars =
-    state === "initializing" ||
-    state === "recording" ||
-    state === "transcribing";
+    (state === "initializing" ||
+      state === "recording" ||
+      state === "transcribing") &&
+    !showPartialPreview;
 
   const renderBars = (ref?: React.RefObject<SVGSVGElement | null>) => (
     <svg
@@ -1041,7 +1104,12 @@ export default function AppPage(): React.JSX.Element {
         >
           <div
             className="inline-flex items-center gap-2.5"
-            style={pillInnerStyle}
+            style={{
+              ...activePillInnerStyle,
+              display: showPartialPreview
+                ? "flex"
+                : activePillInnerStyle.display,
+            }}
           >
             <div
               style={
@@ -1080,7 +1148,19 @@ export default function AppPage(): React.JSX.Element {
               />
             </div>
 
-            {showBars && renderBars(barsSvgRef)}
+            {showPartialPreview ? (
+              <div
+                ref={partialScrollRef}
+                style={pillPartialScrollStyle}
+                title={livePartial}
+                aria-live="polite"
+                aria-atomic="true"
+              >
+                <span style={{ display: "inline-block" }}>{livePartial}</span>
+              </div>
+            ) : (
+              showBars && renderBars(barsSvgRef)
+            )}
 
             {badge && (
               <span

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -4,14 +4,22 @@ import {
   isServerBinaryAvailable,
 } from "../../whisper/binary.js";
 import { WHISPER_PROVIDER_ID } from "../../whisper/constants.js";
-import { ensureBinariesDownloaded } from "../../whisper/models.js";
 import {
+  ensureBinariesDownloaded,
+  getDownloadedModelPath,
+} from "../../whisper/models.js";
+import { encodePcmS16leToWav } from "../../whisper/pcm-wav.js";
+import {
+  ensureServerRunning,
   getServerPort,
   isServerRunning,
   startInBackground,
 } from "../../whisper/server.js";
 import { transcribeWithWhisper } from "../../whisper/transcribe.js";
 import type {
+  StreamCallbacks,
+  StreamingSessionOptions,
+  StreamSession,
   TranscribeOptions,
   TranscribeResult,
   TranscriptionProvider,
@@ -19,6 +27,9 @@ import type {
 import { stripProviderPrefix } from "../types.js";
 
 const log = createAppLogger("whisper");
+const STREAM_SAMPLE_RATE = 16_000;
+const PARTIAL_INTERVAL_MS = 2_000;
+const MIN_PARTIAL_AUDIO_MS = 1_000;
 
 export class WhisperLocalTranscriptionProvider
   implements TranscriptionProvider
@@ -79,8 +90,303 @@ export class WhisperLocalTranscriptionProvider
   }
 
   supportsStreaming(_modelId: string): boolean {
-    return false;
+    return true;
   }
+
+  openStreamingSession(opts: StreamingSessionOptions): StreamSession {
+    const modelId = stripProviderPrefix(opts.model);
+    return new WhisperLocalStreamingSession({
+      modelId,
+      language:
+        opts.language && opts.language !== "auto" ? opts.language : undefined,
+      callbacks: opts.callbacks,
+    });
+  }
+}
+
+class WhisperLocalStreamingSession implements StreamSession {
+  private chunks: Buffer[] = [];
+  private sampleCount = 0;
+  private closed = false;
+  private canceled = false;
+  private inFlight = false;
+  private dirty = false;
+  private commitRequested = false;
+  private partialTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastText = "";
+  private generation = 0;
+  private workerReadyPromise: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly opts: {
+      modelId: string;
+      language?: string;
+      callbacks: StreamCallbacks;
+    },
+  ) {
+    this.startWorkerLoad();
+  }
+
+  sendAudio(chunk: ArrayBuffer): void {
+    if (this.closed || this.canceled) return;
+    const buf = Buffer.from(chunk);
+    this.chunks.push(buf);
+    this.sampleCount += Math.floor(buf.byteLength / 2);
+
+    if (this.audioDurationMs() < MIN_PARTIAL_AUDIO_MS) return;
+    this.schedulePartial();
+  }
+
+  reset(): void {
+    this.clearTimer();
+    if (this.inFlight && this.commitRequested) {
+      this.opts.callbacks.onFinal(this.lastText);
+    }
+    this.chunks = [];
+    this.sampleCount = 0;
+    this.canceled = false;
+    this.inFlight = false;
+    this.dirty = false;
+    this.commitRequested = false;
+    this.lastText = "";
+    this.generation++;
+    this.startWorkerLoad();
+  }
+
+  waitUntilReady(): Promise<void> {
+    return this.workerReadyPromise;
+  }
+
+  commit(): void {
+    this.clearTimer();
+    this.commitRequested = true;
+    if (
+      !this.inFlight &&
+      !this.lastText &&
+      this.audioDurationMs() >= MIN_PARTIAL_AUDIO_MS
+    ) {
+      this.runInference(false);
+      return;
+    }
+    this.runInference(true);
+  }
+
+  cancel(): void {
+    this.canceled = true;
+    this.clearTimer();
+    this.chunks = [];
+    this.sampleCount = 0;
+    this.dirty = false;
+    this.commitRequested = false;
+    this.generation++;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.cancel();
+  }
+
+  private startWorkerLoad(): void {
+    if (!getDownloadedModelPath(this.opts.modelId)) {
+      this.workerReadyPromise = Promise.reject(
+        new Error(
+          `Whisper model "${this.opts.modelId}" is not downloaded. Download it from Settings > Models.`,
+        ),
+      );
+      this.workerReadyPromise.catch(() => undefined);
+      this.opts.callbacks.onError(
+        `Whisper model "${this.opts.modelId}" is not downloaded yet.`,
+      );
+      return;
+    }
+
+    const generation = this.generation;
+    this.workerReadyPromise = this.ensureWhisperReady().then(() => {
+      if (this.closed || this.canceled || generation !== this.generation) {
+        return;
+      }
+      this.opts.callbacks.onReady(this.opts.modelId);
+      this.runReadyPreview(generation);
+    });
+    this.workerReadyPromise.catch((err: Error) => {
+      if (this.closed || generation !== this.generation) return;
+      this.opts.callbacks.onError(err.message);
+    });
+  }
+
+  private async ensureWhisperReady(): Promise<void> {
+    if (
+      !isBinaryAvailable() &&
+      !isServerBinaryAvailable() &&
+      !isServerRunning()
+    ) {
+      await ensureBinariesDownloaded();
+    }
+    if (isServerBinaryAvailable() || isServerRunning()) {
+      await ensureServerRunning(this.opts.modelId);
+      return;
+    }
+    if (!isBinaryAvailable()) {
+      throw new Error(
+        "whisper.cpp binary not found. The build may have failed — check the logs above.",
+      );
+    }
+  }
+
+  private schedulePartial(): void {
+    if (this.closed || this.canceled || this.commitRequested) return;
+    if (this.partialTimer) return;
+    this.partialTimer = setTimeout(() => {
+      this.partialTimer = null;
+      this.runInference(false);
+    }, PARTIAL_INTERVAL_MS);
+  }
+
+  private runReadyPreview(generation: number): void {
+    if (
+      this.closed ||
+      this.canceled ||
+      this.inFlight ||
+      this.lastText ||
+      generation !== this.generation ||
+      this.audioDurationMs() < MIN_PARTIAL_AUDIO_MS
+    ) {
+      return;
+    }
+    this.clearTimer();
+    this.runInference(false);
+  }
+
+  private runInference(final: boolean): void {
+    if (this.closed || this.canceled) return;
+    if (this.inFlight) {
+      this.dirty = true;
+      if (final) this.commitRequested = true;
+      return;
+    }
+
+    if (this.sampleCount === 0) {
+      if (final) this.opts.callbacks.onFinal("");
+      return;
+    }
+
+    const generation = this.generation;
+    const pcm = Buffer.concat(this.chunks);
+    this.inFlight = true;
+    this.dirty = false;
+
+    void this.workerReadyPromise
+      .then(() => {
+        if (this.closed || this.canceled || generation !== this.generation) {
+          return;
+        }
+        return transcribeBufferedPcm({
+          pcm,
+          modelId: this.opts.modelId,
+          language: this.opts.language,
+        });
+      })
+      .then((text) => {
+        if (text === undefined) return;
+        if (this.closed || this.canceled || generation !== this.generation) {
+          return;
+        }
+        const cleanText = text.trim();
+        if (final) {
+          this.lastText = cleanText;
+          this.opts.callbacks.onFinal(cleanText);
+          return;
+        }
+        this.emitPartial(cleanText, generation);
+      })
+      .catch((err: Error) => {
+        if (this.closed || generation !== this.generation) return;
+        this.opts.callbacks.onError(err.message);
+      })
+      .finally(() => {
+        if (this.closed || this.canceled || generation !== this.generation) {
+          return;
+        }
+        this.inFlight = false;
+        if (this.commitRequested) {
+          this.commitRequested = false;
+          this.runInference(true);
+          return;
+        }
+        if (this.dirty) {
+          this.schedulePartial();
+        }
+      });
+  }
+
+  private emitPartial(text: string, generation: number): void {
+    const cleanText = text.trim();
+    if (
+      !cleanText ||
+      cleanText === this.lastText ||
+      this.closed ||
+      this.canceled ||
+      generation !== this.generation
+    ) {
+      return;
+    }
+    this.lastText = cleanText;
+    this.opts.callbacks.onPartial(cleanText);
+  }
+
+  private audioDurationMs(): number {
+    return Math.round((this.sampleCount / STREAM_SAMPLE_RATE) * 1000);
+  }
+
+  private clearTimer(): void {
+    if (!this.partialTimer) return;
+    clearTimeout(this.partialTimer);
+    this.partialTimer = null;
+  }
+}
+
+async function transcribeBufferedPcm(opts: {
+  pcm: Buffer;
+  modelId: string;
+  language?: string;
+}): Promise<string> {
+  const wav = encodePcmS16leToWav(opts.pcm);
+  const audio = new Uint8Array(wav);
+
+  if (isServerRunning()) {
+    try {
+      const result = await transcribeViaServer(audio, getServerPort());
+      return result.text;
+    } catch {
+      // fall through
+    }
+  }
+
+  if (isServerBinaryAvailable()) {
+    await ensureServerRunning(opts.modelId);
+    try {
+      const result = await transcribeViaServer(audio, getServerPort());
+      return result.text;
+    } catch {
+      // fall through
+    }
+  }
+
+  if (isBinaryAvailable()) {
+    const result = await transcribeWithWhisper({
+      audio,
+      modelId: opts.modelId,
+      language: opts.language,
+    });
+    if (isServerBinaryAvailable() && !isServerRunning()) {
+      startInBackground(opts.modelId);
+    }
+    return result.text;
+  }
+
+  throw new Error(
+    "whisper.cpp binary not found. The build may have failed — check the logs above.",
+  );
 }
 
 async function transcribeViaServer(

--- a/apps/server/src/lib/whisper/pcm-wav.ts
+++ b/apps/server/src/lib/whisper/pcm-wav.ts
@@ -1,0 +1,19 @@
+/** Encode mono PCM s16le at `sampleRate` Hz into a WAV buffer. */
+export function encodePcmS16leToWav(pcm: Buffer, sampleRate = 16_000): Buffer {
+  const dataSize = pcm.byteLength;
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0);
+  header.writeUInt32LE(36 + dataSize, 4);
+  header.write("WAVE", 8);
+  header.write("fmt ", 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(1, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(sampleRate * 2, 28);
+  header.writeUInt16LE(2, 32);
+  header.writeUInt16LE(16, 34);
+  header.write("data", 36);
+  header.writeUInt32LE(dataSize, 40);
+  return Buffer.concat([header, pcm]);
+}


### PR DESCRIPTION
Update: Live partial preview is now toggle (hands-free) mode only. Hold mode keeps the waveform bars.

Show streaming STT text in the pill while dictating, including local Whisper via incremental inference. Long partials scroll to keep the newest words visible.