### PR TITLE
Cross platform stability fixes

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -75,12 +75,14 @@ import { autoUpdater } from "electron-updater";
 import { WebSocketServer } from "ws";
 import icon from "../../resources/icon.png?asset";
 import trayIconPath from "../../resources/tray/logoTemplate.png?asset";
+import { getDefaultHotkey } from "../shared/hotkey-defaults";
 import { HotkeyRecorder } from "./hotkey-recorder";
 import { normalizeAccelerator } from "./hotkey-utils";
 import { NativeKeyListener } from "./key-listener";
 import * as linuxAutostart from "./linux-autostart";
+import { checkLinuxSetup } from "./linux-setup";
 import { MicListener } from "./mic-listener";
-import { pasteIntoFocusedApp } from "./paste";
+import { isWaylandSession, pasteIntoFocusedApp } from "./paste";
 
 const log = createAppLogger("electron");
 const hotkeyLog = createAppLogger("hotkey");
@@ -1091,10 +1093,17 @@ app.whenReady().then(async () => {
 
   // IPC: paste text at cursor
   ipcMain.handle("paste:text", async (_event, text: string) => {
-    await pasteIntoFocusedApp(text, async () => {
-      hidePill();
-      await wait(0);
-    });
+    try {
+      await pasteIntoFocusedApp(text, async () => {
+        hidePill();
+        await wait(0);
+      });
+    } catch (err) {
+      // pasteIntoFocusedApp left the transcript on the clipboard — tell the
+      // user instead of letting the dictation silently vanish.
+      notifyPasteFailed();
+      throw err;
+    }
   });
 
   // IPC: copy text to clipboard
@@ -1144,11 +1153,14 @@ app.whenReady().then(async () => {
 
   // IPC: permission checks
   ipcMain.handle("permissions:check-mic", async () => {
-    if (process.platform === "darwin") {
-      const { systemPreferences } = await import("electron");
-      return systemPreferences.getMediaAccessStatus("microphone");
+    if (process.platform === "linux") {
+      // Linux has no OS-level mic permission API; the renderer resolves the
+      // real state with a getUserMedia probe (see lib/permissions.ts).
+      return "unknown";
     }
-    return "granted"; // Windows/Linux don't have this API
+    // macOS and Windows both report the real privacy-settings state here.
+    const { systemPreferences } = await import("electron");
+    return systemPreferences.getMediaAccessStatus("microphone");
   });
 
   ipcMain.handle("permissions:request-mic", async () => {
@@ -1157,7 +1169,13 @@ app.whenReady().then(async () => {
       const granted = await systemPreferences.askForMediaAccess("microphone");
       return granted ? "granted" : "denied";
     }
-    return "granted";
+    if (process.platform === "win32") {
+      // Windows has no programmatic prompt; report the privacy-settings
+      // state so the UI can send the user to Settings when it's denied.
+      const { systemPreferences } = await import("electron");
+      return systemPreferences.getMediaAccessStatus("microphone");
+    }
+    return "unknown"; // Linux: renderer probes getUserMedia instead
   });
 
   ipcMain.handle("permissions:check-accessibility", async () => {
@@ -1187,7 +1205,16 @@ app.whenReady().then(async () => {
       shell.openExternal(
         "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Microphone",
       );
+    } else if (process.platform === "win32") {
+      shell.openExternal("ms-settings:privacy-microphone");
     }
+  });
+
+  // IPC: Linux system setup (input-group access for the hotkey listener and
+  // the xdotool/wtype paste fallback). Returns null on other platforms.
+  ipcMain.handle("permissions:check-linux-setup", async () => {
+    if (process.platform !== "linux") return null;
+    return checkLinuxSetup();
   });
 
   ipcMain.handle("onboarding:complete", () => {
@@ -1582,7 +1609,7 @@ app.whenReady().then(async () => {
   });
 });
 
-const DEFAULT_HOTKEY = "Alt+Space";
+const DEFAULT_HOTKEY = getDefaultHotkey();
 const HOTKEY_MODIFIER_PARTS = new Set([
   "alt",
   "option",
@@ -1617,13 +1644,19 @@ function isValidAccelerator(accel: string): boolean {
   if (accel.endsWith("+")) return false;
   const parts = accel.split("+");
   if (parts.some((p) => !p.trim())) return false;
-  return parts.some((part) => {
-    const normalized = part.trim().toLowerCase();
-    return (
-      HOTKEY_MODIFIER_PARTS.has(normalized) ||
-      HOTKEY_MACRO_MOUSE_PARTS.has(normalized)
-    );
-  });
+  const lowered = parts.map((p) => p.trim().toLowerCase());
+  // Fn/Globe is only observable by the macOS native listener; on other
+  // platforms a hotkey containing it would silently never fire.
+  if (
+    process.platform !== "darwin" &&
+    lowered.some((p) => p === "fn" || p === "globe")
+  ) {
+    return false;
+  }
+  return lowered.some(
+    (part) =>
+      HOTKEY_MODIFIER_PARTS.has(part) || HOTKEY_MACRO_MOUSE_PARTS.has(part),
+  );
 }
 
 function loadHotkeyFromDB(): string | undefined {
@@ -1718,6 +1751,49 @@ function handleNativeHotkeyUp(): void {
   }
 }
 
+// Notify once per session when hold-to-talk degrades to toggle mode, so the
+// user isn't left wondering why holding the hotkey stopped working.
+let hotkeyDegradedNotified = false;
+function notifyHotkeyDegraded(accel: string, nativeError: string): void {
+  if (hotkeyDegradedNotified || hotkeyActivationMode !== "hold") return;
+  hotkeyDegradedNotified = true;
+  let fix = "";
+  if (
+    process.platform === "linux" &&
+    nativeError.includes("No accessible input devices")
+  ) {
+    fix =
+      " To enable hold-to-talk, run: sudo usermod -aG input $USER — then log out and back in.";
+  }
+  const body = `Hold-to-talk isn't available, so "${accel}" now toggles recording on and off.${fix}`;
+  hotkeyLog.warn(body);
+  if (Notification.isSupported()) {
+    new Notification({ title: "Freestyle is in toggle mode", body }).show();
+  }
+}
+
+// Rate-limited so a broken paste backend doesn't fire a notification per
+// dictation.
+const PASTE_FAILED_NOTIFY_INTERVAL_MS = 30_000;
+let lastPasteFailedNotifyAt = 0;
+function notifyPasteFailed(): void {
+  const now = Date.now();
+  if (now - lastPasteFailedNotifyAt < PASTE_FAILED_NOTIFY_INTERVAL_MS) return;
+  lastPasteFailedNotifyAt = now;
+  const shortcut = process.platform === "darwin" ? "Cmd+V" : "Ctrl+V";
+  let hint = "";
+  if (process.platform === "linux") {
+    const tool = isWaylandSession() ? "wtype" : "xdotool";
+    hint = ` Installing ${tool} may fix this (e.g. sudo apt install ${tool}).`;
+  }
+  if (Notification.isSupported()) {
+    new Notification({
+      title: "Freestyle couldn't paste",
+      body: `Your transcript is on the clipboard — press ${shortcut} to paste it.${hint}`,
+    }).show();
+  }
+}
+
 async function registerHotkey(hotkey?: string): Promise<void> {
   // Tear down previous listener
   if (keyListener) {
@@ -1789,6 +1865,7 @@ async function registerHotkey(hotkey?: string): Promise<void> {
       // "grant Accessibility" prompt during onboarding, and leave paste
       // silently broken in the notarized prod build. Only the native key
       // listener starting (above) is real proof of Accessibility.
+      notifyHotkeyDegraded(accel, nativeError);
     } else {
       let message = `Could not register hotkey "${accel}". Try a different key combination in Settings.`;
       if (

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -501,6 +501,7 @@ export class NativeKeyListener {
     this.macModState.clear();
     this.macFlagState.clear();
     this.macHotkeyActive = false;
+    this.macFnDown = false;
     this.restartAttempts = 0;
     this.start();
   }

--- a/apps/electron/src/main/linux-autostart.ts
+++ b/apps/electron/src/main/linux-autostart.ts
@@ -28,12 +28,19 @@ function getDesktopFilePath(): string {
   return join(getAutostartDir(), DESKTOP_FILENAME);
 }
 
+function getStableExecPath(): string {
+  // Under AppImage, process.execPath points into the transient mount at
+  // /tmp/.mount_* which changes every launch; the AppImage file itself is
+  // the stable path to put in the .desktop entry.
+  return process.env.APPIMAGE || process.execPath;
+}
+
 function buildDesktopEntry(): string {
   return [
     "[Desktop Entry]",
     "Type=Application",
     "Name=Freestyle",
-    `Exec="${process.execPath}"`,
+    `Exec="${getStableExecPath()}"`,
     "X-GNOME-Autostart-enabled=true",
     "",
   ].join("\n");

--- a/apps/electron/src/main/linux-setup.ts
+++ b/apps/electron/src/main/linux-setup.ts
@@ -1,0 +1,59 @@
+/**
+ * Linux system-setup checks surfaced during onboarding.
+ *
+ * Linux has no permission prompts like macOS — instead, the global hotkey
+ * listener needs read access to /dev/input (the `input` group), and the
+ * legacy paste fallback needs xdotool (X11) or wtype (Wayland). These checks
+ * let the UI explain missing pieces up front instead of failing silently
+ * mid-dictation.
+ */
+import { exec } from "node:child_process";
+import { accessSync, constants, readdirSync } from "node:fs";
+import { isWaylandSession } from "./paste";
+
+export interface LinuxSetupStatus {
+  wayland: boolean;
+  /** Can read at least one /dev/input/event* device (global hotkey listener). */
+  inputAccess: boolean;
+  /** The paste fallback tool this session needs (xdotool or wtype). */
+  pasteToolRequired: string;
+  /** Same as pasteToolRequired when installed, null when missing. */
+  pasteTool: string | null;
+}
+
+function hasCommand(cmd: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    exec(`command -v ${cmd}`, (err) => resolve(!err));
+  });
+}
+
+function hasInputAccess(): boolean {
+  try {
+    return readdirSync("/dev/input")
+      .filter((name) => name.startsWith("event"))
+      .some((name) => {
+        try {
+          accessSync(`/dev/input/${name}`, constants.R_OK);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+  } catch {
+    return false;
+  }
+}
+
+export async function checkLinuxSetup(): Promise<LinuxSetupStatus> {
+  const wayland = isWaylandSession();
+  const pasteToolRequired = wayland ? "wtype" : "xdotool";
+  const pasteTool = (await hasCommand(pasteToolRequired))
+    ? pasteToolRequired
+    : null;
+  return {
+    wayland,
+    inputAccess: hasInputAccess(),
+    pasteToolRequired,
+    pasteTool,
+  };
+}

--- a/apps/electron/src/main/paste.ts
+++ b/apps/electron/src/main/paste.ts
@@ -45,7 +45,7 @@ function execFileAsync(path: string, args: string[] = []): Promise<number> {
   });
 }
 
-function isWaylandSession(): boolean {
+export function isWaylandSession(): boolean {
   return (
     process.env.XDG_SESSION_TYPE?.toLowerCase() === "wayland" ||
     Boolean(process.env.WAYLAND_DISPLAY)
@@ -172,6 +172,7 @@ export async function pasteIntoFocusedApp(
   const prior = clipboard.readText();
   clipboard.writeText(text);
 
+  let pasted = false;
   try {
     await beforePaste?.();
 
@@ -187,12 +188,22 @@ export async function pasteIntoFocusedApp(
         method = await pasteLinux();
         break;
     }
+    pasted = true;
 
     const settleTable =
       method === "native" ? PASTE_SETTLE_MS : PASTE_SETTLE_LEGACY_MS;
     const settleMs = settleTable[process.platform] ?? 500;
     await new Promise((r) => setTimeout(r, settleMs));
   } finally {
-    clipboard.writeText(prior);
+    // When every paste backend failed, the clipboard is the only copy of the
+    // transcript the user still has — leave it there instead of restoring.
+    if (pasted) {
+      try {
+        clipboard.writeText(prior);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn(`Failed to restore clipboard: ${message}`);
+      }
+    }
   }
 }

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -4,6 +4,8 @@ declare global {
   interface Window {
     electron: ElectronAPI;
     api: {
+      platform: string;
+      defaultHotkey: string;
       pasteText: (text: string) => Promise<void>;
       copyText: (text: string) => Promise<void>;
       updateHotkey: (hotkey: string) => void;
@@ -18,6 +20,12 @@ declare global {
       checkMicPermission: () => Promise<string>;
       requestMicPermission: () => Promise<string>;
       checkAccessibilityPermission: () => Promise<boolean>;
+      checkLinuxSetup: () => Promise<{
+        wayland: boolean;
+        inputAccess: boolean;
+        pasteToolRequired: string;
+        pasteTool: string | null;
+      } | null>;
       openAccessibilitySettings: () => void;
       openMicSettings: () => void;
       getOnboardingComplete: () => Promise<boolean>;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -1,8 +1,13 @@
 import { electronAPI } from "@electron-toolkit/preload";
 import { contextBridge, ipcRenderer } from "electron";
+import { getDefaultHotkey } from "../shared/hotkey-defaults";
 
 // Custom APIs for renderer
 const api = {
+  // The renderer can't reach process.platform reliably (navigator.platform
+  // is deprecated); expose it once here so all platform checks agree.
+  platform: process.platform as string,
+  defaultHotkey: getDefaultHotkey(),
   pasteText: (text: string): Promise<void> =>
     ipcRenderer.invoke("paste:text", text),
   copyText: (text: string): Promise<void> =>
@@ -37,6 +42,12 @@ const api = {
     ipcRenderer.invoke("permissions:request-mic"),
   checkAccessibilityPermission: (): Promise<boolean> =>
     ipcRenderer.invoke("permissions:check-accessibility"),
+  checkLinuxSetup: (): Promise<{
+    wayland: boolean;
+    inputAccess: boolean;
+    pasteToolRequired: string;
+    pasteTool: string | null;
+  } | null> => ipcRenderer.invoke("permissions:check-linux-setup"),
   openAccessibilitySettings: (): void =>
     ipcRenderer.send("permissions:open-accessibility"),
   openMicSettings: (): void =>

--- a/apps/electron/src/renderer/src/components/tutorial-demo.tsx
+++ b/apps/electron/src/renderer/src/components/tutorial-demo.tsx
@@ -25,6 +25,9 @@ const PHASE_STEPS: ReadonlyArray<readonly [DemoPhase, number]> = [
 
 const SAMPLE_TRANSCRIPT = "Pushing the meeting to tomorrow at ten.";
 
+// Platform-aware default, mirrored from the main process via the preload.
+const DEFAULT_HOTKEY = window.api?.defaultHotkey ?? "Alt+Space";
+
 export function TutorialDemo({
   hotkey,
   interactive = false,
@@ -42,7 +45,7 @@ export function TutorialDemo({
 }): React.JSX.Element {
   const [phase, setPhase] = useState<DemoPhase>("idle");
   const [hotkeyTokens, setHotkeyTokens] = useState<string[]>(() =>
-    formatAcceleratorKeys(hotkey ?? "Alt+Space"),
+    formatAcceleratorKeys(hotkey ?? DEFAULT_HOTKEY),
   );
   const stepRef = useRef(0);
   const timeoutRef = useRef<number | null>(null);
@@ -96,12 +99,12 @@ export function TutorialDemo({
       .api.settings[":key"].$get({ param: { key: "hotkey" } })
       .then((r) => (r.ok ? r.json() : null))
       .then((data: { value?: string } | null) => {
-        const val = data?.value || "Alt+Space";
+        const val = data?.value || DEFAULT_HOTKEY;
         const tokens = formatAcceleratorKeys(val);
         if (tokens.length > 0) setHotkeyTokens(tokens);
       })
       .catch(() => {
-        const tokens = formatAcceleratorKeys("Alt+Space");
+        const tokens = formatAcceleratorKeys(DEFAULT_HOTKEY);
         if (tokens.length > 0) setHotkeyTokens(tokens);
       });
   }, [hotkey]);

--- a/apps/electron/src/renderer/src/lib/permissions.ts
+++ b/apps/electron/src/renderer/src/lib/permissions.ts
@@ -1,0 +1,28 @@
+/**
+ * Mic permission resolution that works on every platform.
+ *
+ * macOS and Windows report a real status from the OS privacy settings via
+ * the main process. Linux has no such API, so the main process returns
+ * "unknown" and we resolve the real state by briefly opening a capture
+ * stream.
+ */
+
+async function probeMicAccess(): Promise<"granted" | "denied"> {
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    for (const track of stream.getTracks()) track.stop();
+    return "granted";
+  } catch {
+    return "denied";
+  }
+}
+
+export async function resolveMicStatus(): Promise<string> {
+  const status = (await window.api?.checkMicPermission()) ?? "unknown";
+  return status === "unknown" ? probeMicAccess() : status;
+}
+
+export async function requestMicAccess(): Promise<string> {
+  const status = (await window.api?.requestMicPermission()) ?? "unknown";
+  return status === "unknown" ? probeMicAccess() : status;
+}

--- a/apps/electron/src/renderer/src/onboarding.tsx
+++ b/apps/electron/src/renderer/src/onboarding.tsx
@@ -21,11 +21,13 @@ import {
   type VoiceItem,
   type WhisperStatus,
 } from "@renderer/lib/models";
+import { requestMicAccess, resolveMicStatus } from "@renderer/lib/permissions";
 import { cn, ON_DEVICE_PHRASE } from "@renderer/lib/utils";
 import {
   ArrowRight,
   Check,
   ChevronLeft,
+  ClipboardPaste,
   Eye,
   EyeOff,
   HardDrive,
@@ -42,8 +44,26 @@ import { useNavigate } from "react-router";
 
 type Step = "permissions" | "language" | "tutorial";
 
-const IS_MAC =
-  typeof navigator !== "undefined" && navigator.userAgent.includes("Mac");
+const PLATFORM =
+  (typeof window !== "undefined" && window.api?.platform) ||
+  (typeof navigator !== "undefined" && navigator.userAgent.includes("Mac")
+    ? "darwin"
+    : "unknown");
+const IS_MAC = PLATFORM === "darwin";
+const IS_WINDOWS = PLATFORM === "win32";
+const IS_LINUX = PLATFORM === "linux";
+
+const DEFAULT_HOTKEY =
+  (typeof window !== "undefined" && window.api?.defaultHotkey) || "Alt+Space";
+
+// Linux system-setup state reported by the main process (input-group access
+// for the hotkey listener, xdotool/wtype for the paste fallback).
+type LinuxSetup = {
+  wayland: boolean;
+  inputAccess: boolean;
+  pasteToolRequired: string;
+  pasteTool: string | null;
+};
 
 // The opinionated on-device pick, in order of preference. Qwen3 ASR (MLX)
 // is the hero when the machine can run it; whisper.cpp's Balanced model is
@@ -84,6 +104,7 @@ export default function OnboardingPage(): React.JSX.Element {
   // Permissions state
   const [micStatus, setMicStatus] = useState<string>("unknown");
   const [accessibilityStatus, setAccessibilityStatus] = useState(false);
+  const [linuxSetup, setLinuxSetup] = useState<LinuxSetup | null>(null);
 
   // Voice model state
   const [available, setAvailable] = useState<AvailableModel[]>([]);
@@ -119,7 +140,7 @@ export default function OnboardingPage(): React.JSX.Element {
   const [showKey, setShowKey] = useState(false);
 
   // Hotkey recorder state (tutorial step)
-  const [hotkey, setHotkey] = useState("Alt+Space");
+  const [hotkey, setHotkey] = useState(DEFAULT_HOTKEY);
 
   const handleHotkeyRecorded = useCallback((accelerator: string) => {
     setHotkey(accelerator);
@@ -152,14 +173,19 @@ export default function OnboardingPage(): React.JSX.Element {
 
   // Load permissions + saved hotkey
   useEffect(() => {
-    window.api
-      ?.checkMicPermission()
+    resolveMicStatus()
       .then(setMicStatus)
       .catch(() => {});
     window.api
       ?.checkAccessibilityPermission()
       .then(setAccessibilityStatus)
       .catch(() => {});
+    if (IS_LINUX) {
+      window.api
+        ?.checkLinuxSetup()
+        .then((setup) => setup && setLinuxSetup(setup))
+        .catch(() => {});
+    }
     getClient()
       .api.settings[":key"].$get({ param: { key: "hotkey" } })
       .then((r) => (r.ok ? r.json() : null))
@@ -179,7 +205,7 @@ export default function OnboardingPage(): React.JSX.Element {
     if (!started.current) {
       started.current = true;
       capture("onboarding_started", {
-        platform: IS_MAC ? "mac" : "other",
+        platform: PLATFORM,
       });
     }
     capture("onboarding_step_viewed", { step });
@@ -273,8 +299,14 @@ export default function OnboardingPage(): React.JSX.Element {
 
   const requestMic = useCallback(async () => {
     capture("onboarding_mic_permission_clicked", { action: "allow" });
-    const status = await window.api?.requestMicPermission();
+    const status = await requestMicAccess();
     if (status) setMicStatus(status);
+  }, []);
+
+  const recheckLinuxSetup = useCallback(async () => {
+    capture("onboarding_linux_setup_rechecked");
+    const setup = await window.api?.checkLinuxSetup();
+    if (setup) setLinuxSetup(setup);
   }, []);
 
   const openMicSettings = useCallback(() => {
@@ -605,9 +637,11 @@ export default function OnboardingPage(): React.JSX.Element {
           <PermissionsStep
             micStatus={micStatus}
             accessibilityStatus={accessibilityStatus}
+            linuxSetup={linuxSetup}
             onRequestMic={requestMic}
             onOpenMicSettings={openMicSettings}
             onOpenAccessibility={openAccessibility}
+            onRecheckLinuxSetup={recheckLinuxSetup}
             onContinue={() => {
               capture("onboarding_permissions_completed");
               setStep("language");
@@ -704,21 +738,32 @@ export default function OnboardingPage(): React.JSX.Element {
 function PermissionsStep({
   micStatus,
   accessibilityStatus,
+  linuxSetup,
   onRequestMic,
   onOpenMicSettings,
   onOpenAccessibility,
+  onRecheckLinuxSetup,
   onContinue,
 }: {
   micStatus: string;
   accessibilityStatus: boolean;
+  linuxSetup: LinuxSetup | null;
   onRequestMic: () => void;
   onOpenMicSettings: () => void;
   onOpenAccessibility: () => void;
+  onRecheckLinuxSetup: () => void;
   onContinue: () => void;
 }): React.JSX.Element {
   const micGranted = micStatus === "granted";
+  // On Wayland there is no hotkey fallback without /dev/input access, so
+  // missing input access blocks. On X11 the Electron globalShortcut still
+  // works (toggle mode), so the card only warns.
+  const linuxBlocked = !!linuxSetup?.wayland && !linuxSetup.inputAccess;
   // Accessibility is macOS-only; elsewhere the mic alone unblocks.
-  const allGranted = micGranted && (!IS_MAC || accessibilityStatus);
+  const allGranted =
+    micGranted && (!IS_MAC || accessibilityStatus) && !linuxBlocked;
+  // macOS and Windows can deep-link to the OS mic privacy settings.
+  const canOpenMicSettings = IS_MAC || IS_WINDOWS;
 
   return (
     <div className="w-full max-w-[440px]">
@@ -729,7 +774,7 @@ function PermissionsStep({
           desc="To hear what you say."
           granted={micGranted}
           action={
-            micStatus === "denied" && IS_MAC ? (
+            micStatus === "denied" && canOpenMicSettings ? (
               <PermButton onClick={onOpenMicSettings}>Open Settings</PermButton>
             ) : (
               <PermButton onClick={onRequestMic}>Allow</PermButton>
@@ -747,6 +792,52 @@ function PermissionsStep({
               <PermButton onClick={onOpenAccessibility}>
                 Open Settings
               </PermButton>
+            }
+          />
+        )}
+
+        {IS_LINUX && linuxSetup && (
+          <PermCard
+            icon={Keyboard}
+            title="Keyboard access"
+            desc={
+              linuxSetup.inputAccess ? (
+                "To detect your hotkey in any app."
+              ) : (
+                <>
+                  To detect your hotkey in any app, run{" "}
+                  <code className="text-foreground">
+                    sudo usermod -aG input $USER
+                  </code>{" "}
+                  in a terminal, then log out and back in.
+                  {!linuxSetup.wayland &&
+                    " Until then, the hotkey only works in toggle mode."}
+                </>
+              )
+            }
+            granted={linuxSetup.inputAccess}
+            action={
+              <PermButton onClick={onRecheckLinuxSetup}>Re-check</PermButton>
+            }
+          />
+        )}
+
+        {IS_LINUX && linuxSetup && !linuxSetup.pasteTool && (
+          <PermCard
+            icon={ClipboardPaste}
+            title="Paste tool"
+            desc={
+              <>
+                To paste into other apps, install {linuxSetup.pasteToolRequired}
+                :{" "}
+                <code className="text-foreground">
+                  sudo apt install {linuxSetup.pasteToolRequired}
+                </code>
+              </>
+            }
+            granted={false}
+            action={
+              <PermButton onClick={onRecheckLinuxSetup}>Re-check</PermButton>
             }
           />
         )}
@@ -786,7 +877,7 @@ function PermCard({
 }: {
   icon: typeof Mic;
   title: string;
-  desc: string;
+  desc: React.ReactNode;
   granted: boolean;
   action: React.ReactNode;
 }): React.JSX.Element {

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -6,6 +6,7 @@ import {
   useHotkeyRecorder,
 } from "@renderer/hooks/use-hotkey-recorder";
 import { getClient } from "@renderer/lib/api";
+import { requestMicAccess, resolveMicStatus } from "@renderer/lib/permissions";
 import { cn } from "@renderer/lib/utils";
 import {
   Check,
@@ -51,7 +52,9 @@ export default function SettingsPage(): React.JSX.Element {
   const { theme, setTheme } = useTheme();
   const [devices, setDevices] = useState<AudioDevice[]>([]);
   const [selectedDevice, setSelectedDevice] = useState<string>("");
-  const [hotkey, setHotkey] = useState("Alt+Space");
+  const [hotkey, setHotkey] = useState(
+    window.api?.defaultHotkey ?? "Alt+Space",
+  );
   const [hotkeyMode, setHotkeyMode] = useState<"hold" | "toggle">("hold");
   const [language, setLanguage] = useState("auto");
   const [outputMode, setOutputMode] = useState("paste");
@@ -82,10 +85,12 @@ export default function SettingsPage(): React.JSX.Element {
     null,
   );
   const isMac = navigator.userAgent.includes("Mac");
+  // macOS and Windows can deep-link to the OS mic privacy settings.
+  const canOpenMicSettings = isMac || window.api?.platform === "win32";
 
   const checkPermissions = useCallback(async () => {
     try {
-      const mic = await window.api?.checkMicPermission();
+      const mic = await resolveMicStatus();
       if (mic) setMicStatus(mic as MicStatus);
     } catch {}
     try {
@@ -95,7 +100,7 @@ export default function SettingsPage(): React.JSX.Element {
   }, []);
 
   const requestMic = useCallback(async () => {
-    const status = await window.api?.requestMicPermission();
+    const status = await requestMicAccess();
     if (status) setMicStatus(status as MicStatus);
   }, []);
 
@@ -736,17 +741,19 @@ export default function SettingsPage(): React.JSX.Element {
               granted={micStatus === "granted"}
               checking={micStatus === "unknown"}
               actionLabel={
-                micStatus === "denied" && isMac
+                micStatus === "denied" && canOpenMicSettings
                   ? "Open Settings"
                   : micStatus === "granted"
                     ? null
                     : "Allow"
               }
-              external={micStatus === "denied" && isMac}
+              external={micStatus === "denied" && canOpenMicSettings}
               onAction={
-                micStatus === "denied" && isMac ? openMicSettings : requestMic
+                micStatus === "denied" && canOpenMicSettings
+                  ? openMicSettings
+                  : requestMic
               }
-              onManage={isMac ? openMicSettings : undefined}
+              onManage={canOpenMicSettings ? openMicSettings : undefined}
             />
           </Row>
           <Row

--- a/apps/electron/src/shared/hotkey-defaults.ts
+++ b/apps/electron/src/shared/hotkey-defaults.ts
@@ -1,0 +1,12 @@
+/**
+ * Single source of truth for the default push-to-talk hotkey.
+ *
+ * Alt+Space opens the window system menu on Windows and the window menu on
+ * many Linux window managers, so it is only a safe default on macOS.
+ *
+ * Imported by both the main process and the preload script (which exposes it
+ * to the renderer as `window.api.defaultHotkey`).
+ */
+export function getDefaultHotkey(platform: string = process.platform): string {
+  return platform === "darwin" ? "Alt+Space" : "Control+Alt+Space";
+}

--- a/apps/electron/tsconfig.node.json
+++ b/apps/electron/tsconfig.node.json
@@ -1,6 +1,11 @@
 {
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
-  "include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*"],
+  "include": [
+    "electron.vite.config.*",
+    "src/main/**/*",
+    "src/preload/**/*",
+    "src/shared/**/*"
+  ],
   "compilerOptions": {
     "composite": true,
     "types": ["electron-vite/node"]


### PR DESCRIPTION
# Overview

1. Platform-aware default hotkey — New src/shared/hotkey-defaults.ts is the
  single source of truth: Alt+Space on macOS, Control+Alt+Space on Windows/Linux
  (avoiding the window-system-menu conflict). The main process uses it for
  DEFAULT_HOTKEY, and the preload now exposes window.api.defaultHotkey +
  window.api.platform, which replaced the hardcoded "Alt+Space" literals in
  onboarding.tsx, settings.tsx, and tutorial-demo.tsx.

  2. Real onboarding gating on Windows/Linux —
  - permissions:check-mic / request-mic now return the real Windows
  privacy-settings state via getMediaAccessStatus, and return "unknown" on Linux,
  where the new renderer helper lib/permissions.ts resolves it with a brief
  getUserMedia probe. Both onboarding and the Settings page use it.
  - "Open Settings" for a denied mic now also works on Windows (deep-links to
  ms-settings:privacy-microphone).
  - New main/linux-setup.ts + permissions:check-linux-setup IPC checks /dev/input
  readability and xdotool/wtype presence. Onboarding on Linux shows two new cards:
  Keyboard access (with the sudo usermod -aG input $USER command and a Re-check
  button — blocking on Wayland where there's no fallback, warning-only on X11) and
  Paste tool (install command, non-blocking, only shown when missing).

  3. Degradation & paste-failure notifications — When the native key listener
  fails and the app falls back to globalShortcut, a one-time OS notification
  explains that the hotkey is now toggle-only, with the Linux input-group fix when
  that's the cause (only fires if the user's mode is hold-to-talk).
  pasteIntoFocusedApp no longer restores the old clipboard when the paste backend
  fails — the transcript stays on the clipboard as the user's only copy — and a
  rate-limited notification says "press Ctrl+V/Cmd+V to paste it," with an
  xdotool/wtype install hint on Linux.

  4. AppImage autostart fix — linux-autostart.ts writes $APPIMAGE (the stable file
  path) instead of process.execPath (the transient /tmp/.mount_* path) into the
  .desktop entry.

  5. Hotkey state/validation fixes — macFnDown is now reset in updateHotkey(), and
  isValidAccelerator() rejects Fn/Globe hotkeys on non-mac platforms (so a
  synced/stale config falls back to the platform default instead of silently never
  firing).