### PR TITLE
Update platform default push-to-talk hotkeys

### DIFF
--- a/apps/electron/src/renderer/src/components/tutorial-demo.tsx
+++ b/apps/electron/src/renderer/src/components/tutorial-demo.tsx
@@ -2,6 +2,7 @@ import { formatAcceleratorKeys } from "@renderer/hooks/use-hotkey-recorder";
 import { getClient } from "@renderer/lib/api";
 import { cn } from "@renderer/lib/utils";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getDefaultHotkey } from "../../../shared/hotkey-defaults";
 
 // ---------------------------------------------------------------------------
 // Tutorial — animated 3-phase loop:
@@ -26,7 +27,7 @@ const PHASE_STEPS: ReadonlyArray<readonly [DemoPhase, number]> = [
 const SAMPLE_TRANSCRIPT = "Pushing the meeting to tomorrow at ten.";
 
 // Platform-aware default, mirrored from the main process via the preload.
-const DEFAULT_HOTKEY = window.api?.defaultHotkey ?? "Alt+Space";
+const DEFAULT_HOTKEY = window.api?.defaultHotkey ?? getDefaultHotkey();
 
 export function TutorialDemo({
   hotkey,

--- a/apps/electron/src/renderer/src/onboarding.tsx
+++ b/apps/electron/src/renderer/src/onboarding.tsx
@@ -41,6 +41,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
+import { getDefaultHotkey } from "../../shared/hotkey-defaults";
 
 type Step = "permissions" | "language" | "tutorial";
 
@@ -54,7 +55,8 @@ const IS_WINDOWS = PLATFORM === "win32";
 const IS_LINUX = PLATFORM === "linux";
 
 const DEFAULT_HOTKEY =
-  (typeof window !== "undefined" && window.api?.defaultHotkey) || "Alt+Space";
+  (typeof window !== "undefined" && window.api?.defaultHotkey) ||
+  getDefaultHotkey();
 
 // Linux system-setup state reported by the main process (input-group access
 // for the hotkey listener, xdotool/wtype for the paste fallback).

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getDefaultHotkey } from "../../../shared/hotkey-defaults";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -53,7 +54,7 @@ export default function SettingsPage(): React.JSX.Element {
   const [devices, setDevices] = useState<AudioDevice[]>([]);
   const [selectedDevice, setSelectedDevice] = useState<string>("");
   const [hotkey, setHotkey] = useState(
-    window.api?.defaultHotkey ?? "Alt+Space",
+    window.api?.defaultHotkey ?? getDefaultHotkey(),
   );
   const [hotkeyMode, setHotkeyMode] = useState<"hold" | "toggle">("hold");
   const [language, setLanguage] = useState("auto");

--- a/apps/electron/src/shared/hotkey-defaults.ts
+++ b/apps/electron/src/shared/hotkey-defaults.ts
@@ -1,12 +1,22 @@
 /**
  * Single source of truth for the default push-to-talk hotkey.
  *
- * Alt+Space opens the window system menu on Windows and the window menu on
- * many Linux window managers, so it is only a safe default on macOS.
+ * - macOS: Fn (Globe) — dedicated dictation key, no modifier conflicts
+ * - Windows: Control+Super — avoids Alt+Space window menu and common shortcuts
+ * - Linux: Alt+Super — common dictation combo (e.g. pepper-x), avoids WM launcher binds
  *
  * Imported by both the main process and the preload script (which exposes it
  * to the renderer as `window.api.defaultHotkey`).
  */
 export function getDefaultHotkey(platform: string = process.platform): string {
-  return platform === "darwin" ? "Alt+Space" : "Control+Alt+Space";
+  switch (platform) {
+    case "darwin":
+      return "Fn";
+    case "win32":
+      return "Control+Super";
+    case "linux":
+      return "Alt+Super";
+    default:
+      return "Control+Super";
+  }
 }

--- a/apps/electron/tsconfig.web.json
+++ b/apps/electron/tsconfig.web.json
@@ -5,6 +5,7 @@
     "src/renderer/src/**/*",
     "src/renderer/src/**/*.tsx",
     "src/preload/*.d.ts",
+    "src/shared/**/*",
     "../../packages/validations/src/**/*"
   ],
   "compilerOptions": {


### PR DESCRIPTION
## Summary
- Set macOS default hotkey to `Fn` (Globe key)
- Set Windows default hotkey to `Control+Super` (Ctrl + Win)
- Set Linux default hotkey to `Alt+Super` (common dictation combo, avoids WM launcher binds)
- Update renderer fallbacks to use the shared `getDefaultHotkey()` helper

## Test plan
- [ ] Fresh install / cleared hotkey setting on macOS defaults to Fn
- [ ] Fresh install on Windows defaults to Control+Super
- [ ] Fresh install on Linux defaults to Alt+Super
- [ ] Settings and onboarding show the correct default before a custom hotkey is saved
- [ ] Existing users with a saved hotkey setting are unchanged