### PR TITLE
Add SenseVoice Small as a Local MLX ASR model

### DIFF
--- a/apps/server/src/lib/mlx-asr/constants.ts
+++ b/apps/server/src/lib/mlx-asr/constants.ts
@@ -54,6 +54,17 @@ export const MLX_ASR_MODELS: MlxAsrModelDef[] = [
     quantized: true,
   },
   {
+    id: "sensevoice-small",
+    hfId: "mlx-community/SenseVoiceSmall",
+    family: "sensevoice",
+    displayName: "SenseVoice",
+    sizeBytes: 936_000_000,
+    ramRequired: "~1.5 GB",
+    speed: "Fast",
+    quality: "High",
+    quantized: false,
+  },
+  {
     id: "parakeet-tdt-0.6b-v3",
     hfId: "mlx-community/parakeet-tdt-0.6b-v3",
     family: "parakeet",

--- a/apps/server/tests/mlx-models.test.ts
+++ b/apps/server/tests/mlx-models.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { MLX_ASR_MODELS } from "../src/lib/mlx-asr/constants.js";
+
+describe("MLX ASR model catalog", () => {
+  it("includes SenseVoice Small as a local MLX transcription model", () => {
+    const model = MLX_ASR_MODELS.find((m) => m.id === "sensevoice-small");
+
+    expect(model).toMatchObject({
+      hfId: "mlx-community/SenseVoiceSmall",
+      family: "sensevoice",
+      displayName: "SenseVoice",
+      quantized: false,
+    });
+  });
+});

--- a/scripts/mlx_asr_server.py
+++ b/scripts/mlx_asr_server.py
@@ -203,8 +203,25 @@ def _strip_prompt_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
 
 
 def _text_from_result(result: Any) -> str:
-    text = getattr(result, "text", result)
-    return "" if text is None else str(text)
+    if result is None:
+        return ""
+    if isinstance(result, str):
+        return result
+    if isinstance(result, list):
+        for item in result:
+            text = _text_from_result(item)
+            if text:
+                return text
+        return ""
+    if isinstance(result, dict):
+        for key in ("text", "transcription", "result"):
+            if key in result:
+                return _text_from_result(result[key])
+        return ""
+    text = getattr(result, "text", None)
+    if text is not None:
+        return _text_from_result(text)
+    return str(result)
 
 
 def _transcribe_kwargs(

--- a/scripts/test_mlx_asr_server.py
+++ b/scripts/test_mlx_asr_server.py
@@ -113,5 +113,19 @@ class PcmToWavTests(unittest.TestCase):
                 self.assertEqual(wf.getnframes(), 1600)
 
 
+class TextFromResultTests(unittest.TestCase):
+    def test_extracts_text_from_dict_result(self) -> None:
+        self.assertEqual(
+            mlx_asr_server._text_from_result({"text": "hello"}),
+            "hello",
+        )
+
+    def test_extracts_text_from_list_result(self) -> None:
+        self.assertEqual(
+            mlx_asr_server._text_from_result([{"text": "hello"}]),
+            "hello",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds SenseVoice Small as a Local MLX ASR option and makes the MLX worker more tolerant of result shapes returned by different MLX audio STT models.

Changes:
- add `sensevoice-small` to the Local MLX ASR catalog, backed by `mlx-community/SenseVoiceSmall`
- add a catalog test so the model remains registered
- make `scripts/mlx_asr_server.py` extract text from object, dict, and list result shapes
- add worker tests for dict/list text extraction

This keeps the default provider behavior unchanged; users only see an additional downloadable Local MLX model.

Refs #138.

## Verification

- `python3 scripts/test_mlx_asr_server.py` passed
- `pnpm --filter @freestyle/server test -- apps/server/tests/mlx-models.test.ts` not run locally because this server image has no `node`, `npm`, `pnpm`, or `corepack` on PATH. CI should cover this test.
