### PR TITLE
fix: move toLowerCase() outside loop in post-process and formats

### DIFF
--- a/apps/server/src/lib/post-process.ts
+++ b/apps/server/src/lib/post-process.ts
@@ -40,6 +40,7 @@ function getContextHint(
 
   const matchStr = buildMatchContext(rawContext);
   if (!matchStr) return "";
+  const matchStrLower = matchStr.toLowerCase();
 
   try {
     const rows = db
@@ -51,7 +52,7 @@ function getContextHint(
     for (const row of rows) {
       const patterns = row.app_pattern.split("|").map((p) => p.trim());
       for (const pattern of patterns) {
-        if (pattern && matchStr.toLowerCase().includes(pattern.toLowerCase())) {
+        if (pattern && matchStrLower.includes(pattern.toLowerCase())) {
           return row.instructions;
         }
       }

--- a/apps/server/src/routes/formats.ts
+++ b/apps/server/src/routes/formats.ts
@@ -73,6 +73,7 @@ const formats = new Hono()
     const db = getDb();
     const context = c.req.query("context") ?? "";
     if (!context) return c.json(null);
+    const contextLower = context.toLowerCase();
 
     const rows = db
       .prepare("SELECT * FROM format_rules ORDER BY is_default ASC, id DESC")
@@ -82,7 +83,7 @@ const formats = new Hono()
     for (const row of rows) {
       const patterns = row.app_pattern.split("|").map((p) => p.trim());
       for (const pattern of patterns) {
-        if (pattern && context.toLowerCase().includes(pattern.toLowerCase())) {
+        if (pattern && contextLower.includes(pattern.toLowerCase())) {
           return c.json(row);
         }
       }


### PR DESCRIPTION
 Fixes [#253](https://github.com/freestyle-voice/freestyle/issues/253)
  
  What changed

  Moved toLowerCase() calls outside of loops in two places to avoid creating unnecessary strings on every iteration.

  - apps/server/src/lib/post-process.ts (getContextHint): extracted matchStr.toLowerCase() into const matchStrLower before the loop
  - apps/server/src/routes/formats.ts (/match endpoint): extracted context.toLowerCase() into const contextLower before the loop

