### PR TITLE
Add OpenAPI-compatible providers and move configuration to Models page

### DIFF
--- a/apps/electron/src/renderer/src/lib/models.ts
+++ b/apps/electron/src/renderer/src/lib/models.ts
@@ -71,6 +71,7 @@ export interface MlxAsrStatus {
 
 export const CLOUD_VOICE_PROVIDERS = [
   "openai",
+  "openrouter",
   "groq",
   "deepgram",
   "elevenlabs",
@@ -100,7 +101,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   elevenlabs: "ElevenLabs",
   mistral: "Mistral",
   openrouter: "OpenRouter",
-  "local-llm": "Local LLM",
+  "local-llm": "OpenAPI Compatible",
   "local-whisper": "Local Whisper",
   "local-mlx": "Local MLX",
 };
@@ -108,6 +109,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 /** Where to create an API key, linked from the key-entry views. */
 export const PROVIDER_KEY_URLS: Record<string, string> = {
   openai: "https://platform.openai.com/api-keys",
+  openrouter: "https://openrouter.ai/keys",
   groq: "https://console.groq.com/keys",
   deepgram: "https://console.deepgram.com",
   elevenlabs: "https://elevenlabs.io/app/settings/api-keys",

--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -1,3 +1,7 @@
+import {
+  normalizeOpenApiCompatibleEndpoint,
+  OPENAPI_ENDPOINT_PRESETS,
+} from "@freestyle/validations";
 import { PROVIDER_FILTER_MARKS } from "@renderer/components/model-row";
 import type {
   AvailableModel,
@@ -7,7 +11,6 @@ import type {
 import { formatBytes, formatSpeed } from "@renderer/lib/models";
 import { cn } from "@renderer/lib/utils";
 import {
-  ArrowLeft,
   Check,
   Download,
   Eye,
@@ -22,7 +25,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { UseModels } from "./use-models";
 import { displayName } from "./utils";
 
@@ -48,6 +51,87 @@ interface Row {
   onCancel?: () => void;
   onDelete?: () => void;
   onRetry?: () => void;
+}
+
+interface OpenApiCredentialUi {
+  placeholder: string;
+}
+
+interface OpenApiModelUi {
+  placeholder: string;
+  hint: string;
+}
+
+function getOpenApiCredentialUi(presetId: string | null): OpenApiCredentialUi {
+  switch (presetId) {
+    case "openrouter":
+      return { placeholder: "OpenRouter API key" };
+    case "azure":
+      return { placeholder: "Azure API key" };
+    case "moonshot":
+      return { placeholder: "Moonshot API key" };
+    case "together":
+      return { placeholder: "Together API key" };
+    case "fireworks":
+      return { placeholder: "Fireworks API key" };
+    case "deepinfra":
+      return { placeholder: "DeepInfra API key" };
+    case "sambanova":
+      return { placeholder: "SambaNova API key" };
+    default:
+      return { placeholder: "API key or token (optional)" };
+  }
+}
+
+function getOpenApiModelUi(presetId: string | null): OpenApiModelUi {
+  switch (presetId) {
+    case "azure":
+      return {
+        placeholder: "Deployment name (for example: gpt-4.1-mini)",
+        hint: "Azure usually needs the deployment name you created, even when shared model discovery is unavailable.",
+      };
+    case "openrouter":
+      return {
+        placeholder: "Model ID (for example: openai/gpt-4.1-mini)",
+        hint: "If model discovery is unavailable, enter the full OpenRouter model ID manually.",
+      };
+    case "deepinfra":
+      return {
+        placeholder: "Model ID (for example: deepseek-ai/DeepSeek-V3)",
+        hint: "DeepInfra model names are usually provider-prefixed. If discovery is unavailable, enter the full catalog model ID manually.",
+      };
+    default:
+      return {
+        placeholder: "Model or deployment name",
+        hint: "Needed for Azure and any compatible endpoint that does not expose /models.",
+      };
+  }
+}
+
+function getOpenApiCompatibleProviderLabel(endpoint: string): string {
+  const normalized =
+    normalizeOpenApiCompatibleEndpoint(endpoint) ?? endpoint.trim();
+  try {
+    const url = new URL(normalized);
+    if (url.hostname.endsWith(".openai.azure.com")) return "Azure OpenAI";
+    if (url.hostname === "api.openai.com") return "OpenAI";
+    if (url.hostname === "openrouter.ai") return "OpenRouter";
+    if (url.hostname === "api.moonshot.cn") return "Moonshot";
+    if (url.hostname === "api.together.ai") return "Together AI";
+    if (url.hostname === "api.fireworks.ai") return "Fireworks AI";
+    if (url.hostname === "api.deepinfra.com") return "DeepInfra";
+    if (url.hostname === "api.sambanova.ai") return "SambaNova";
+    if (
+      url.hostname === "localhost" ||
+      url.hostname === "127.0.0.1" ||
+      url.hostname === "::1"
+    ) {
+      return "Local OpenAPI";
+    }
+  } catch {
+    // Fall through to generic label.
+  }
+  return "OpenAPI Compatible";
 }
 
 /**
@@ -134,6 +218,7 @@ function buildLlmRows(
   h: { onPickCloud: (model: AvailableModel) => void; onClose: () => void },
 ): Row[] {
   const rows: Row[] = [];
+  const localProviderLabel = getOpenApiCompatibleProviderLabel(m.localLlm.url);
 
   for (const [providerId, { providerName, models }] of m.llmModelsByProvider) {
     for (const model of models) {
@@ -164,7 +249,7 @@ function buildLlmRows(
       name,
       source: "local",
       provider: "local",
-      meta: "On-device",
+      meta: `${localProviderLabel} endpoint`,
       curated: true,
       selected:
         m.defaultLlm?.provider === "local-llm" &&
@@ -202,23 +287,7 @@ export function ModelList({
 }): React.JSX.Element {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState("all");
-  // Voice opens on the simple three-tier view; LLM opens on the curated list.
-  const [view, setView] = useState<"tiers" | "all">(
-    type === "voice" ? "tiers" : "all",
-  );
   const [showAllLlm, setShowAllLlm] = useState(false);
-
-  if (type === "voice" && view === "tiers") {
-    return (
-      <VoiceTiers
-        m={m}
-        onClose={onClose}
-        onPickCloud={onPickCloud}
-        onPickLocalVoice={onPickLocalVoice}
-        onShowAll={() => setView("all")}
-      />
-    );
-  }
 
   const rows =
     type === "voice"
@@ -257,15 +326,7 @@ export function ModelList({
     <>
       <header className="border-border flex shrink-0 items-center gap-3 border-b px-5 py-3.5">
         {type === "voice" ? (
-          <button
-            type="button"
-            onClick={() => setView("tiers")}
-            className="text-muted-foreground hover:text-foreground flex shrink-0 items-center gap-1.5"
-            aria-label="Back to simple view"
-          >
-            <ArrowLeft size={14} />
-            <Mic className="h-3.5 w-3.5" />
-          </button>
+          <Mic className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
         ) : (
           <Sparkles className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
         )}
@@ -328,225 +389,6 @@ export function ModelList({
         )}
       </div>
     </>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// VoiceTiers — the simple picker: three meaningful choices, no model IDs.
-// ---------------------------------------------------------------------------
-
-const ACCURATE_TIER: AvailableModel = {
-  provider_id: "openai",
-  provider_name: "OpenAI",
-  model_id: "openai/gpt-4o-transcribe",
-  model_name: "OpenAI Transcribe",
-  type: "voice",
-};
-
-const FASTEST_TIER: AvailableModel = {
-  provider_id: "groq",
-  provider_name: "Groq",
-  model_id: "groq/whisper-large-v3-turbo",
-  model_name: "Groq Whisper",
-  type: "voice",
-};
-
-function VoiceTiers({
-  m,
-  onClose,
-  onPickCloud,
-  onPickLocalVoice,
-  onShowAll,
-}: {
-  m: UseModels;
-  onClose: () => void;
-  onPickCloud: (model: AvailableModel) => void;
-  onPickLocalVoice: (
-    defId: string,
-    name: string,
-    engine?: "whisper" | "mlx",
-  ) => void;
-  onShowAll: () => void;
-}): React.JSX.Element {
-  const privateItem = m.voiceItems.find(
-    (it) => it.key === recommendedVoiceKey(m.voiceItems),
-  );
-  const status = privateItem?.status ?? "not_downloaded";
-  const downloading = status === "downloading" || status === "verifying";
-  // Selecting "Private" downloads if needed, then commits once ready.
-  const [autoSelect, setAutoSelect] = useState(false);
-
-  useEffect(() => {
-    if (autoSelect && privateItem?.defId && status === "ready") {
-      setAutoSelect(false);
-      onPickLocalVoice(
-        privateItem.defId,
-        privateItem.name,
-        privateItem.localEngine,
-      );
-    }
-  }, [autoSelect, status, privateItem, onPickLocalVoice]);
-
-  function pickPrivate(): void {
-    if (!privateItem?.defId) return;
-    if (status === "ready") {
-      onPickLocalVoice(
-        privateItem.defId,
-        privateItem.name,
-        privateItem.localEngine,
-      );
-      return;
-    }
-    if (status === "not_downloaded" || status === "error") {
-      setAutoSelect(true);
-      m.downloadLocal(privateItem.defId, privateItem.localEngine);
-    }
-  }
-
-  const isSelected = (modelId: string, provider: string): boolean =>
-    m.defaultVoice?.provider === provider &&
-    m.defaultVoice?.model_id === modelId;
-
-  return (
-    <>
-      <header className="border-border flex shrink-0 items-center gap-3 border-b px-5 py-3.5">
-        <Mic className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-        <span
-          className="mono text-foreground flex-1 text-[11px] uppercase"
-          style={{ letterSpacing: "0.14em" }}
-        >
-          How should Freestyle transcribe?
-        </span>
-        <button
-          type="button"
-          onClick={onClose}
-          className="text-muted-foreground hover:text-foreground shrink-0"
-          aria-label="Close"
-        >
-          <X size={16} />
-        </button>
-      </header>
-
-      <div className="grid grid-cols-1 gap-3 p-5 sm:grid-cols-3">
-        <TierCard
-          title="Private"
-          badge="Recommended"
-          description="Runs on your device. Nothing leaves it. Free."
-          detail={
-            downloading
-              ? undefined
-              : (privateItem &&
-                  `${privateItem.name}${
-                    status !== "ready" && privateItem.sizeBytes
-                      ? ` · ${formatBytes(privateItem.sizeBytes)} download`
-                      : ""
-                  }`) ||
-                undefined
-          }
-          selected={privateItem?.selected ?? false}
-          disabled={!privateItem || downloading}
-          onClick={pickPrivate}
-        >
-          {downloading && <Progress state={privateItem?.state} />}
-          {status === "error" && privateItem?.state?.error && (
-            <p className="text-destructive mt-1.5 text-[11px] leading-snug">
-              {privateItem.state.error}
-            </p>
-          )}
-        </TierCard>
-        <TierCard
-          title="Most accurate"
-          description="OpenAI cloud — needs an API key (~$0.18/hr)."
-          detail={
-            m.keyProviders.has("openai") ? "Key added" : "We'll ask for a key"
-          }
-          selected={isSelected(ACCURATE_TIER.model_id, "openai")}
-          onClick={() => onPickCloud(ACCURATE_TIER)}
-        />
-        <TierCard
-          title="Fastest"
-          description="Groq cloud — needs an API key (~$0.04/hr)."
-          detail={
-            m.keyProviders.has("groq") ? "Key added" : "We'll ask for a key"
-          }
-          selected={isSelected(FASTEST_TIER.model_id, "groq")}
-          onClick={() => onPickCloud(FASTEST_TIER)}
-        />
-      </div>
-
-      <footer className="border-border flex items-center justify-between border-t px-5 py-3">
-        <button
-          type="button"
-          onClick={onShowAll}
-          className="text-muted-foreground hover:text-foreground text-[12.5px]"
-        >
-          All models →
-        </button>
-        <button
-          type="button"
-          onClick={onClose}
-          className="border-border hover:bg-secondary rounded-md border px-3.5 py-1.5 text-[12.5px]"
-        >
-          Cancel
-        </button>
-      </footer>
-    </>
-  );
-}
-
-function TierCard({
-  title,
-  badge,
-  description,
-  detail,
-  selected,
-  disabled,
-  onClick,
-  children,
-}: {
-  title: string;
-  badge?: string;
-  description: string;
-  detail?: string;
-  selected: boolean;
-  disabled?: boolean;
-  onClick: () => void;
-  children?: React.ReactNode;
-}): React.JSX.Element {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "border-border hover:border-primary/50 hover:bg-secondary/40 flex flex-col items-start rounded-[12px] border p-4 text-left transition-colors disabled:cursor-default",
-        selected && "border-primary bg-primary/[0.06]",
-      )}
-    >
-      <div className="flex w-full items-center gap-2">
-        <span className="text-foreground text-[14.5px] font-semibold">
-          {title}
-        </span>
-        {selected && <Check size={14} className="text-primary shrink-0" />}
-        {badge && !selected && (
-          <span
-            className="mono bg-primary/10 text-primary ml-auto rounded-full px-2 py-0.5 text-[9px] uppercase"
-            style={{ letterSpacing: "0.1em" }}
-          >
-            {badge}
-          </span>
-        )}
-      </div>
-      <p className="text-muted-foreground mt-1.5 text-[12px] leading-relaxed">
-        {description}
-      </p>
-      {detail && (
-        <p className="text-muted-foreground/80 mono mt-2 text-[10.5px]">
-          {detail}
-        </p>
-      )}
-      {children && <div className="mt-2 w-full">{children}</div>}
-    </button>
   );
 }
 
@@ -820,6 +662,15 @@ function Progress({
 function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
   const [showKey, setShowKey] = useState(false);
   const { localLlm } = m;
+  const normalizedUrl =
+    normalizeOpenApiCompatibleEndpoint(localLlm.url) ?? localLlm.url.trim();
+  const activePresetId =
+    OPENAPI_ENDPOINT_PRESETS.find(
+      (preset) =>
+        normalizeOpenApiCompatibleEndpoint(preset.endpoint) === normalizedUrl,
+    )?.id ?? null;
+  const credentialUi = getOpenApiCredentialUi(activePresetId);
+  const modelUi = getOpenApiModelUi(activePresetId);
 
   return (
     <div className="border-border border-b">
@@ -829,11 +680,35 @@ function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
           className="mono text-foreground text-[10px] uppercase"
           style={{ letterSpacing: "0.14em" }}
         >
-          On-device
+          OpenAPI Compatible
         </span>
         <span className="text-muted-foreground text-[11.5px]">
-          Ollama, LM Studio & other OpenAI-compatible servers
+          Azure, OpenRouter, Together, Fireworks, DeepInfra, local gateways &
+          more
         </span>
+      </div>
+      <div className="flex flex-wrap gap-2 px-5 pb-3">
+        {OPENAPI_ENDPOINT_PRESETS.map((preset) => {
+          const active = preset.id === activePresetId;
+          return (
+            <button
+              key={preset.id}
+              type="button"
+              onClick={() => {
+                localLlm.setUrl(preset.endpoint);
+                localLlm.clearStatus();
+              }}
+              className={cn(
+                "rounded-full border px-3 py-1 text-[11.5px] transition-colors",
+                active
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border bg-background text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {preset.label}
+            </button>
+          );
+        })}
       </div>
       <form
         onSubmit={(e) => {
@@ -850,7 +725,7 @@ function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
               localLlm.setUrl(e.target.value);
               localLlm.clearStatus();
             }}
-            placeholder="http://localhost:11434"
+            placeholder="http://localhost:11434/v1"
             className="border-border bg-background min-w-0 flex-1 rounded-md border px-3 py-2 text-[13px]"
           />
           <button
@@ -868,12 +743,18 @@ function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
             )}
           </button>
         </div>
+        <p className="text-muted-foreground text-[11.5px] leading-relaxed">
+          Use a base ending in <code>/v1</code>. If you paste a full{" "}
+          <code>/responses</code> or <code>/chat/completions</code> URL, we
+          normalize it to the matching <code>/v1</code> base before testing and
+          saving.
+        </p>
         <div className="relative">
           <input
             type={showKey ? "text" : "password"}
             value={localLlm.apiKey}
             onChange={(e) => localLlm.setApiKey(e.target.value)}
-            placeholder="API key (optional)"
+            placeholder={credentialUi.placeholder}
             className="border-border bg-background w-full rounded-md border px-3 py-2 pr-10 text-[13px]"
           />
           <button
@@ -884,10 +765,56 @@ function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
             {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
           </button>
         </div>
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={localLlm.modelName}
+              onChange={(e) => localLlm.setModelName(e.target.value)}
+              placeholder={modelUi.placeholder}
+              className="border-border bg-background min-w-0 flex-1 rounded-md border px-3 py-2 text-[13px]"
+            />
+            <button
+              type="button"
+              onClick={() => void localLlm.applyModel()}
+              disabled={!localLlm.modelName.trim() || localLlm.applyingModel}
+              className="bg-secondary hover:bg-secondary/80 shrink-0 rounded-md px-3.5 py-2 text-[12.5px] font-medium disabled:opacity-50"
+            >
+              {localLlm.applyingModel ? (
+                <span className="flex items-center gap-1.5">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Saving…
+                </span>
+              ) : (
+                "Use model"
+              )}
+            </button>
+          </div>
+          <p className="text-muted-foreground text-[11.5px] leading-relaxed">
+            {modelUi.hint}
+          </p>
+        </div>
+        {activePresetId && (
+          <p className="text-muted-foreground text-[11.5px] leading-relaxed">
+            {
+              OPENAPI_ENDPOINT_PRESETS.find(
+                (preset) => preset.id === activePresetId,
+              )?.description
+            }
+          </p>
+        )}
+        {localLlm.hint && (
+          <p className="text-muted-foreground text-[11.5px] leading-relaxed">
+            {localLlm.hint}
+          </p>
+        )}
         {localLlm.connected === true && (
           <p className="text-primary text-[12px]">
-            Connected ({localLlm.models.length}{" "}
-            {localLlm.models.length === 1 ? "model" : "models"})
+            {localLlm.models.length > 0
+              ? `Connected (${localLlm.models.length} ${
+                  localLlm.models.length === 1 ? "model" : "models"
+                } discovered)`
+              : "Connected"}
           </p>
         )}
         {localLlm.connected === false && (

--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -238,7 +238,16 @@ function buildLlmRows(
     }
   }
 
+  // Collect every model the configured OpenAPI-compatible endpoint serves.
+  // The server returns them in `available` on every load, but the UI was only
+  // showing models discovered during the current test session, so they
+  // disappeared after reopening the page.
   const names = new Set(m.localLlm.models);
+  for (const model of m.available) {
+    if (model.type === "llm" && model.provider_id === "local-llm") {
+      names.add(model.model_id.replace(/^local-llm\//, ""));
+    }
+  }
   if (m.defaultLlm?.provider === "local-llm") {
     names.add(m.defaultLlm.model_id.replace(/^local-llm\//, ""));
   }
@@ -248,7 +257,7 @@ function buildLlmRows(
       key: `local:${name}`,
       name,
       source: "local",
-      provider: "local",
+      provider: "local-llm",
       meta: `${localProviderLabel} endpoint`,
       curated: true,
       selected:
@@ -359,7 +368,7 @@ export function ModelList({
         </button>
       </header>
 
-      <FilterBar rows={rows} active={filter} onChange={setFilter} />
+      <FilterBar rows={rows} active={filter} onChange={setFilter} type={type} />
 
       {type === "voice" && m.whisperStatus?.binaryDownloading && (
         <div className="border-border flex items-center gap-2.5 border-b px-5 py-3">
@@ -403,15 +412,20 @@ function FilterBar({
   rows,
   active,
   onChange,
+  type,
 }: {
   rows: Row[];
   active: string;
   onChange: (id: string) => void;
+  type: "voice" | "llm";
 }): React.JSX.Element {
   const providers: { id: string; label: string; mark?: string }[] = [];
   const seen = new Set<string>();
   for (const r of rows) {
-    if (r.source !== "cloud" || seen.has(r.provider)) continue;
+    if (seen.has(r.provider)) continue;
+    // Keep voice local engines in the On-device bucket only; surface the
+    // OpenAPI-compatible provider as a first-class filter for LLM.
+    if (type === "voice" && r.source === "local") continue;
     seen.add(r.provider);
     providers.push({
       id: r.provider,

--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -319,8 +319,11 @@ export function ModelList({
     ? rows.length - rows.filter((r) => r.curated).length
     : 0;
 
-  const showLocalLlmForm =
-    type === "llm" && (filter === "all" || filter === "local");
+  // The OpenAPI-compatible connector is part of the LLM picker itself, not a
+  // row filter, so keep it visible regardless of which source/provider chip is
+  // active. Otherwise the form disappears as soon as the user clicks a cloud
+  // provider filter and looks like it was removed from the page.
+  const showLocalLlmForm = type === "llm";
 
   return (
     <>

--- a/apps/electron/src/renderer/src/pages/models/use-models.ts
+++ b/apps/electron/src/renderer/src/pages/models/use-models.ts
@@ -1,3 +1,4 @@
+import { normalizeOpenApiCompatibleEndpoint } from "@freestyle/validations";
 import { getClient } from "@renderer/lib/api";
 import type {
   AvailableModel,
@@ -23,11 +24,16 @@ export interface LocalLlmState {
   setUrl: (v: string) => void;
   apiKey: string;
   setApiKey: (v: string) => void;
+  modelName: string;
+  setModelName: (v: string) => void;
   testing: boolean;
+  applyingModel: boolean;
   connected: boolean | null;
   error: string | null;
+  hint: string | null;
   models: string[];
   test: () => Promise<void>;
+  applyModel: () => Promise<void>;
   clearStatus: () => void;
 }
 
@@ -89,12 +95,15 @@ export function useModels(): UseModels {
     DEFAULT_MLX_KEEP_ALIVE_MINUTES,
   );
 
-  // Local LLM (Ollama / LM Studio) connection — simplified inline form state.
-  const [localUrl, setLocalUrl] = useState("http://localhost:11434");
+  // OpenAPI-compatible cleanup model connection.
+  const [localUrl, setLocalUrl] = useState("http://localhost:11434/v1");
   const [localApiKey, setLocalApiKey] = useState("");
+  const [localModelName, setLocalModelName] = useState("");
   const [localTesting, setLocalTesting] = useState(false);
+  const [localApplyingModel, setLocalApplyingModel] = useState(false);
   const [localConnected, setLocalConnected] = useState<boolean | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [localHint, setLocalHint] = useState<string | null>(null);
   const [localModels, setLocalModels] = useState<string[]>([]);
 
   // -------------------------------------------------------------------------
@@ -134,7 +143,11 @@ export function useModels(): UseModels {
       }
       if (localUrlRes.ok) {
         const data = await localUrlRes.json();
-        if ("value" in data && data.value) setLocalUrl(data.value);
+        if ("value" in data && data.value) {
+          setLocalUrl(
+            normalizeOpenApiCompatibleEndpoint(data.value) ?? data.value,
+          );
+        }
       }
       if (localKeyRes.ok) {
         const data = await localKeyRes.json();
@@ -263,6 +276,13 @@ export function useModels(): UseModels {
       keyProviders,
     },
   );
+
+  useEffect(() => {
+    if (defaultLlm?.provider !== "local-llm") return;
+    const configuredModel = defaultLlm.model_id.replace(/^local-llm\//, "");
+    if (!configuredModel) return;
+    setLocalModelName((prev) => prev || configuredModel);
+  }, [defaultLlm]);
 
   // -------------------------------------------------------------------------
   // Actions
@@ -477,14 +497,23 @@ export function useModels(): UseModels {
   const clearLocalStatus = useCallback(() => {
     setLocalConnected(null);
     setLocalError(null);
+    setLocalHint(null);
   }, []);
 
   const testLocalLlm = useCallback(async () => {
     setLocalTesting(true);
     setLocalConnected(null);
     setLocalError(null);
+    setLocalHint(null);
     try {
-      const url = localUrl.replace(/\/+$/, "");
+      const url = normalizeOpenApiCompatibleEndpoint(localUrl);
+      if (!url) {
+        setLocalConnected(false);
+        setLocalError(
+          "Use https, or http only for localhost, and end the base URL with /v1.",
+        );
+        return;
+      }
       const key = localApiKey.trim();
       const client = getClient();
       await Promise.all([
@@ -509,8 +538,17 @@ export function useModels(): UseModels {
       if (res.ok) {
         const result = await res.json();
         if ("ok" in result && result.ok) {
+          const models = Array.isArray(result.models) ? result.models : [];
           setLocalConnected(true);
-          setLocalModels(result.models ?? []);
+          setLocalModels(models);
+          setLocalHint(
+            "hint" in result && typeof result.hint === "string"
+              ? result.hint
+              : null,
+          );
+          if (models.length > 0 && !localModelName.trim()) {
+            setLocalModelName(models[0] ?? "");
+          }
           await loadData();
           return;
         }
@@ -530,7 +568,40 @@ export function useModels(): UseModels {
     } finally {
       setLocalTesting(false);
     }
-  }, [localUrl, localApiKey, loadData]);
+  }, [localUrl, localApiKey, localModelName, loadData]);
+
+  const applyLocalLlmModel = useCallback(async () => {
+    const modelName = localModelName.trim();
+    if (!modelName) {
+      setLocalError("Enter a model or deployment name first.");
+      return;
+    }
+
+    setLocalApplyingModel(true);
+    setLocalError(null);
+
+    try {
+      await selectLocalLlmModel(modelName);
+      if (!llmCleanup) {
+        await getClient()
+          .api.settings[":key"].$put({
+            param: { key: "llm_cleanup" },
+            json: { value: "true" },
+          })
+          .then(() => setLlmCleanup(true))
+          .catch((err) => console.error("Failed to enable cleanup:", err));
+      }
+      setLocalModels((prev) =>
+        prev.includes(modelName) ? prev : [...prev, modelName],
+      );
+    } catch (err) {
+      setLocalError(
+        err instanceof Error ? err.message : "Failed to save model name",
+      );
+    } finally {
+      setLocalApplyingModel(false);
+    }
+  }, [localModelName, llmCleanup, selectLocalLlmModel]);
 
   return {
     loading,
@@ -551,11 +622,16 @@ export function useModels(): UseModels {
       setUrl: setLocalUrl,
       apiKey: localApiKey,
       setApiKey: setLocalApiKey,
+      modelName: localModelName,
+      setModelName: setLocalModelName,
       testing: localTesting,
+      applyingModel: localApplyingModel,
       connected: localConnected,
       error: localError,
+      hint: localHint,
       models: localModels,
       test: testLocalLlm,
+      applyModel: applyLocalLlmModel,
       clearStatus: clearLocalStatus,
     },
     configureModel,

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -18,6 +18,7 @@ import {
   Mic,
   Monitor,
   Moon,
+  Sparkles,
   Sun,
   Trash2,
   Volume2,
@@ -46,6 +47,11 @@ function normalizePillPos(pos: string): string {
   return pos.startsWith("custom") ? "custom" : pos;
 }
 
+function clampAudioDuckingLevel(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.round(value), 0), 100);
+}
+
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
@@ -62,6 +68,9 @@ export default function SettingsPage(): React.JSX.Element {
   const [outputMode, setOutputMode] = useState("paste");
   const [pillPosition, setPillPosition] = useState("bottom-center");
   const [soundEnabled, setSoundEnabled] = useState(true);
+  const [audioDuckingEnabled, setAudioDuckingEnabled] = useState(true);
+  const [audioDuckingLevel, setAudioDuckingLevel] = useState(0);
+  const [llmCleanupEnabled, setLlmCleanupEnabled] = useState(false);
   const [transcriptionPrompt, setTranscriptionPrompt] = useState("");
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null);
   const [updateDownloaded, setUpdateDownloaded] = useState(false);
@@ -249,6 +258,39 @@ export default function SettingsPage(): React.JSX.Element {
       })
       .catch(() => {});
     getClient()
+      .api.settings[":key"].$get({ param: { key: "audio_ducking_enabled" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value === "false") setAudioDuckingEnabled(false);
+      })
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "audio_ducking_level" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        setAudioDuckingLevel(clampAudioDuckingLevel(Number(data?.value ?? 0)));
+      })
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "llm_cleanup" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value === "true") setLlmCleanupEnabled(true);
+      })
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "theme" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (
+          data?.value &&
+          ["light", "dark", "system"].includes(data.value as string)
+        ) {
+          setTheme(data.value as string);
+        }
+      })
+      .catch(() => {});
+    getClient()
       .api.settings[":key"].$get({ param: { key: "transcription_prompt" } })
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
@@ -321,7 +363,7 @@ export default function SettingsPage(): React.JSX.Element {
       if (accessibilityPollRef.current)
         clearInterval(accessibilityPollRef.current);
     };
-  }, [checkPermissions]);
+  }, [checkPermissions, setTheme]);
 
   const handleDeviceChange = useCallback((deviceId: string) => {
     setSelectedDevice(deviceId);
@@ -400,6 +442,39 @@ export default function SettingsPage(): React.JSX.Element {
     getClient()
       .api.settings[":key"].$put({
         param: { key: "sound_enabled" },
+        json: { value: String(enabled) },
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleAudioDuckingToggle = useCallback((enabled: boolean) => {
+    setAudioDuckingEnabled(enabled);
+    window.api?.sendAudioDuckingChanged(enabled);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "audio_ducking_enabled" },
+        json: { value: String(enabled) },
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleAudioDuckingLevelChange = useCallback((value: number) => {
+    const next = clampAudioDuckingLevel(value);
+    setAudioDuckingLevel(next);
+    window.api?.sendAudioDuckingLevelChanged(next);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "audio_ducking_level" },
+        json: { value: String(next) },
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleLlmCleanupToggle = useCallback((enabled: boolean) => {
+    setLlmCleanupEnabled(enabled);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "llm_cleanup" },
         json: { value: String(enabled) },
       })
       .catch(() => {});
@@ -513,7 +588,7 @@ export default function SettingsPage(): React.JSX.Element {
             desc={
               hotkeyMode === "toggle"
                 ? "Press the shortcut once to start, press again to stop."
-                : "Hold the shortcut to record, release to transcribe."
+                : "Push-to-talk while the shortcut is held; release to transcribe."
             }
           >
             {recorderState === "idle" ? (
@@ -585,7 +660,7 @@ export default function SettingsPage(): React.JSX.Element {
                     : "text-muted-foreground hover:text-foreground",
                 )}
               >
-                Hold
+                Push-to-talk
               </button>
               <button
                 type="button"
@@ -680,7 +755,6 @@ export default function SettingsPage(): React.JSX.Element {
           <Row
             label="Sound feedback"
             desc="Soft chimes at the start and end of recording."
-            last
           >
             <div className="flex items-center gap-2.5">
               {soundEnabled ? (
@@ -689,6 +763,61 @@ export default function SettingsPage(): React.JSX.Element {
                 <VolumeOff className="text-muted-foreground h-4 w-4 shrink-0" />
               )}
               <Toggle on={soundEnabled} onChange={handleSoundToggle} />
+            </div>
+          </Row>
+
+          <Row
+            label="Push-to-talk ducking"
+            desc="Set the background audio level while push-to-talk is active. 0% fully mutes it; higher values keep more sound in the mix."
+            last
+          >
+            <div className="max-w-md space-y-3">
+              <div className="flex items-center gap-2.5">
+                {audioDuckingEnabled ? (
+                  <Volume2 className="text-muted-foreground h-4 w-4 shrink-0" />
+                ) : (
+                  <VolumeOff className="text-muted-foreground h-4 w-4 shrink-0" />
+                )}
+                <Toggle
+                  on={audioDuckingEnabled}
+                  onChange={handleAudioDuckingToggle}
+                />
+                <span className="text-muted-foreground text-[12.5px]">
+                  {audioDuckingLevel === 0
+                    ? "Full mute"
+                    : `${audioDuckingLevel}% of current volume`}
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-muted-foreground w-10 text-[12px]">
+                  0%
+                </span>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  step={1}
+                  value={audioDuckingLevel}
+                  disabled={!audioDuckingEnabled}
+                  onChange={(e) =>
+                    handleAudioDuckingLevelChange(Number(e.target.value))
+                  }
+                  className="h-2 w-full appearance-none rounded-full outline-none disabled:opacity-40 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-primary [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:shadow-[0_0_0_4px_var(--card)]"
+                  style={{
+                    background: `linear-gradient(to right, var(--color-primary) 0%, var(--color-primary) ${audioDuckingLevel}%, color-mix(in srgb, var(--color-border) 86%, transparent) ${audioDuckingLevel}%, color-mix(in srgb, var(--color-border) 86%, transparent) 100%)`,
+                  }}
+                />
+                <span className="text-muted-foreground w-12 text-right text-[12px]">
+                  100%
+                </span>
+              </div>
+              <p className="text-muted-foreground text-[12px] leading-[1.5]">
+                {audioDuckingEnabled
+                  ? audioDuckingLevel === 0
+                    ? "Freestyle fully mutes background audio while you hold push-to-talk."
+                    : `Freestyle keeps background audio at ${audioDuckingLevel}% of its current volume while you hold push-to-talk.`
+                  : "Turn this on if you want Freestyle to reduce or mute background audio while you speak."}
+              </p>
             </div>
           </Row>
         </Section>
@@ -716,6 +845,22 @@ export default function SettingsPage(): React.JSX.Element {
               active={pillPosition}
               onSelect={handlePillPositionChange}
             />
+          </Row>
+        </Section>
+
+        <Section label="Cleanup model">
+          <Row
+            label="Enable cleanup model"
+            desc="Use a text model to post-process transcripts after speech recognition. Configure the cleanup model on the Models page."
+            last
+          >
+            <div className="flex items-center gap-2.5">
+              <Sparkles className="text-muted-foreground h-4 w-4 shrink-0" />
+              <Toggle
+                on={llmCleanupEnabled}
+                onChange={handleLlmCleanupToggle}
+              />
+            </div>
           </Row>
         </Section>
 
@@ -912,7 +1057,7 @@ function Segment({
                 ? "px-2.5 py-[4px] text-[12px]"
                 : "px-3 py-[6px] text-[12.5px]",
               isOn
-                ? "bg-card border-border text-foreground border font-medium shadow-[0_1px_2px_rgba(20,12,4,0.04)]"
+                ? "bg-card border-border text-foreground border font-medium shadow-[0_1px_2px_rgba(0,0,0,0.04)]"
                 : "text-muted-foreground hover:text-foreground border border-transparent",
             )}
           >

--- a/apps/server/src/lib/openapi-compatible.ts
+++ b/apps/server/src/lib/openapi-compatible.ts
@@ -1,0 +1,109 @@
+import { normalizeOpenApiCompatibleEndpoint } from "@freestyle/validations";
+import { getOpenRouterHeaders } from "./openrouter.js";
+
+const MANUAL_MODEL_SELECTION_STATUSES = new Set([400, 404, 405, 422, 501]);
+
+export function getNormalizedOpenApiCompatibleEndpoint(
+  value: unknown,
+): string | null {
+  return normalizeOpenApiCompatibleEndpoint(value) ?? null;
+}
+
+export function isAzureOpenAiEndpoint(endpoint: string): boolean {
+  const url = safeParseUrl(endpoint);
+  return Boolean(url?.hostname.endsWith(".openai.azure.com"));
+}
+
+export function isOfficialOpenAiEndpoint(endpoint: string): boolean {
+  const url = safeParseUrl(endpoint);
+  return Boolean(url && url.hostname === "api.openai.com");
+}
+
+export function isOpenRouterEndpoint(endpoint: string): boolean {
+  const url = safeParseUrl(endpoint);
+  return Boolean(url && url.hostname === "openrouter.ai");
+}
+
+export function getOpenApiCompatibleProviderLabel(endpoint: string): string {
+  if (isAzureOpenAiEndpoint(endpoint)) return "Azure OpenAI";
+
+  const url = safeParseUrl(endpoint);
+  if (!url) return "OpenAPI Compatible";
+  if (url.hostname === "api.openai.com") return "OpenAI";
+  if (url.hostname === "openrouter.ai") return "OpenRouter";
+  if (url.hostname === "api.moonshot.cn") return "Moonshot";
+  if (url.hostname === "api.together.ai") return "Together AI";
+  if (url.hostname === "api.fireworks.ai") return "Fireworks AI";
+  if (url.hostname === "api.deepinfra.com") return "DeepInfra";
+  if (url.hostname === "api.sambanova.ai") return "SambaNova";
+  if (isLocalOpenApiHost(url.hostname)) {
+    return "Local OpenAPI";
+  }
+  return "OpenAPI Compatible";
+}
+
+export function canUseManualOpenApiCompatibleModelSelection(
+  status: number,
+): boolean {
+  return MANUAL_MODEL_SELECTION_STATUSES.has(status);
+}
+
+export function getOpenApiCompatibleManualModelHint(endpoint: string): string {
+  if (isAzureOpenAiEndpoint(endpoint)) {
+    return "Azure OpenAI often skips shared /models discovery here. Enter your deployment name manually below, then choose it as the cleanup model.";
+  }
+
+  if (isOpenRouterEndpoint(endpoint)) {
+    return "OpenRouter did not return model discovery from this endpoint right now. Enter the model ID manually below if you want to use it anyway.";
+  }
+
+  const url = safeParseUrl(endpoint);
+  if (url?.hostname === "api.moonshot.cn") {
+    return "Moonshot did not return model discovery from this endpoint right now. Enter the model name manually below, then choose it as the cleanup model.";
+  }
+
+  if (url && isLocalOpenApiHost(url.hostname)) {
+    return "This local gateway did not expose /models. Enter the model name manually below, then choose it as the cleanup model.";
+  }
+
+  return "This OpenAPI-compatible endpoint did not expose /models. Enter the model or deployment name manually below, then choose it as the cleanup model.";
+}
+
+export function buildOpenApiCompatibleHeaders(
+  endpoint: string,
+  apiKey?: string,
+  extra?: Record<string, string>,
+): Record<string, string> {
+  if (isOpenRouterEndpoint(endpoint)) {
+    return getOpenRouterHeaders(apiKey, extra);
+  }
+
+  const headers: Record<string, string> = {
+    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    ...extra,
+  };
+
+  if (apiKey) {
+    if (isAzureOpenAiEndpoint(endpoint)) {
+      headers["api-key"] = apiKey;
+    } else if (!isOfficialOpenAiEndpoint(endpoint)) {
+      headers["x-api-key"] = apiKey;
+    }
+  }
+
+  return headers;
+}
+
+function safeParseUrl(endpoint: string): URL | null {
+  try {
+    return new URL(endpoint);
+  } catch {
+    return null;
+  }
+}
+
+function isLocalOpenApiHost(hostname: string): boolean {
+  return (
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+  );
+}

--- a/apps/server/src/lib/openrouter.ts
+++ b/apps/server/src/lib/openrouter.ts
@@ -1,0 +1,24 @@
+export const OPENROUTER_API_BASE = "https://openrouter.ai/api/v1";
+export const OPENROUTER_PROVIDER_ID = "openrouter";
+export const OPENROUTER_PROVIDER_NAME = "OpenRouter";
+
+const OPENROUTER_APP_URL = "https://github.com/freestyle-voice/freestyle";
+const OPENROUTER_APP_TITLE = "Freestyle";
+
+export function getOpenRouterHeaders(
+  apiKey?: string,
+  extra?: Record<string, string>,
+): Record<string, string> {
+  return {
+    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    "HTTP-Referer": OPENROUTER_APP_URL,
+    "X-Title": OPENROUTER_APP_TITLE,
+    ...extra,
+  };
+}
+
+export function prefixOpenRouterModelId(modelId: string): string {
+  return modelId.startsWith(`${OPENROUTER_PROVIDER_ID}/`)
+    ? modelId
+    : `${OPENROUTER_PROVIDER_ID}/${modelId}`;
+}

--- a/apps/server/src/lib/providers.ts
+++ b/apps/server/src/lib/providers.ts
@@ -6,6 +6,11 @@ import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModel } from "ai";
 import { getDb } from "./db.js";
 import { reconcileUnsupportedMlxVoiceDefault } from "./mlx-asr/reconcile.js";
+import {
+  buildOpenApiCompatibleHeaders,
+  getNormalizedOpenApiCompatibleEndpoint,
+  getOpenApiCompatibleProviderLabel,
+} from "./openapi-compatible.js";
 import { getApiKeyForProvider } from "./streaming-stt.js";
 
 const LOCAL_PROVIDERS = new Set(["local-llm"]);
@@ -57,10 +62,25 @@ const PROVIDER_FACTORIES: Record<
       .prepare("SELECT value FROM settings WHERE key = 'local_llm_api_key'")
       .get() as { value: string } | undefined;
 
-    const baseURL = urlRow.value.replace(/\/v1\/?$/, "");
-    const apiKey = keyRow?.value || "local";
+    const endpoint = getNormalizedOpenApiCompatibleEndpoint(urlRow.value);
+    if (!endpoint) {
+      throw new Error(
+        "OpenAPI-compatible endpoint URL is invalid. Re-save it in Settings > Models.",
+      );
+    }
+    const rawApiKey = keyRow?.value?.trim() || undefined;
+    const apiKey = rawApiKey || "local";
 
-    const p = createOpenAI({ apiKey, baseURL: `${baseURL}/v1` });
+    const p = createOpenAI({
+      apiKey,
+      baseURL: endpoint,
+      headers: rawApiKey
+        ? buildOpenApiCompatibleHeaders(endpoint, rawApiKey)
+        : undefined,
+      name: getOpenApiCompatibleProviderLabel(endpoint)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-"),
+    });
     return { chat: (m: string) => p.chat(m) };
   },
 };

--- a/apps/server/src/lib/streaming/providers/openrouter.ts
+++ b/apps/server/src/lib/streaming/providers/openrouter.ts
@@ -1,0 +1,70 @@
+import { Buffer } from "node:buffer";
+import {
+  getOpenRouterHeaders,
+  OPENROUTER_API_BASE,
+  OPENROUTER_PROVIDER_ID,
+} from "../../openrouter.js";
+import type {
+  TranscribeOptions,
+  TranscribeResult,
+  TranscriptionProvider,
+} from "../types.js";
+import { CLOUD_TRANSCRIBE_TIMEOUT_MS, stripProviderPrefix } from "../types.js";
+
+interface OpenRouterTranscriptionResponse {
+  text?: string;
+  usage?: {
+    seconds?: number;
+  };
+  error?: {
+    message?: string;
+  };
+}
+
+export class OpenRouterTranscriptionProvider implements TranscriptionProvider {
+  readonly providerId = OPENROUTER_PROVIDER_ID;
+
+  async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
+    const res = await fetch(`${OPENROUTER_API_BASE}/audio/transcriptions`, {
+      method: "POST",
+      headers: getOpenRouterHeaders(opts.apiKey, {
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({
+        model: stripProviderPrefix(opts.model),
+        input_audio: {
+          data: Buffer.from(opts.audio).toString("base64"),
+          format: "wav",
+        },
+        ...(opts.language && opts.language !== "auto"
+          ? { language: opts.language }
+          : {}),
+      }),
+      signal: AbortSignal.timeout(CLOUD_TRANSCRIBE_TIMEOUT_MS),
+    });
+
+    if (!res.ok) {
+      const message = await readOpenRouterError(res);
+      throw new Error(message);
+    }
+
+    const data = (await res.json()) as OpenRouterTranscriptionResponse;
+    return {
+      text: data.text?.trim() ?? "",
+      durationInSeconds: data.usage?.seconds,
+    };
+  }
+
+  supportsStreaming(_modelId: string): boolean {
+    return false;
+  }
+}
+
+async function readOpenRouterError(res: Response): Promise<string> {
+  const body = (await res
+    .json()
+    .catch(() => null)) as OpenRouterTranscriptionResponse | null;
+  const detail = body?.error?.message?.trim() ?? "";
+  if (detail) return detail;
+  return `OpenRouter transcription failed (${res.status})`;
+}

--- a/apps/server/src/lib/streaming/registry.ts
+++ b/apps/server/src/lib/streaming/registry.ts
@@ -3,11 +3,13 @@ import { ElevenLabsTranscriptionProvider } from "./providers/elevenlabs.js";
 import { GroqTranscriptionProvider } from "./providers/groq.js";
 import { MlxLocalTranscriptionProvider } from "./providers/mlx-local.js";
 import { OpenAITranscriptionProvider } from "./providers/openai.js";
+import { OpenRouterTranscriptionProvider } from "./providers/openrouter.js";
 import { WhisperLocalTranscriptionProvider } from "./providers/whisper-local.js";
 import type { TranscriptionProvider } from "./types.js";
 
 const providers: TranscriptionProvider[] = [
   new OpenAITranscriptionProvider(),
+  new OpenRouterTranscriptionProvider(),
   new DeepgramTranscriptionProvider(),
   new ElevenLabsTranscriptionProvider(),
   new GroqTranscriptionProvider(),

--- a/apps/server/src/lib/validate-key.ts
+++ b/apps/server/src/lib/validate-key.ts
@@ -5,6 +5,8 @@
  * authenticates the key without incurring usage charges.
  */
 
+import { getOpenRouterHeaders, OPENROUTER_API_BASE } from "./openrouter.js";
+
 const TIMEOUT_MS = 10_000;
 
 interface ValidationResult {
@@ -24,6 +26,10 @@ const FORMAT_HINTS: Record<string, { prefix: string; hint: string }> = {
   groq: {
     prefix: "gsk_",
     hint: 'Groq keys start with "gsk_".',
+  },
+  openrouter: {
+    prefix: "sk-or-",
+    hint: 'OpenRouter keys start with "sk-or-".',
   },
 };
 
@@ -146,6 +152,27 @@ async function validateMistral(apiKey: string): Promise<ValidationResult> {
   return { valid: false, error: `Mistral returned HTTP ${res.status}.` };
 }
 
+async function validateOpenRouter(apiKey: string): Promise<ValidationResult> {
+  const res = await fetch(`${OPENROUTER_API_BASE}/key`, {
+    headers: getOpenRouterHeaders(apiKey),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.ok) return { valid: true };
+  if (res.status === 401 || res.status === 403) {
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  }
+  if (res.status === 402) {
+    return {
+      valid: false,
+      error: "OpenRouter key has no credits available.",
+    };
+  }
+  return { valid: false, error: `OpenRouter returned HTTP ${res.status}.` };
+}
+
 // ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
@@ -161,6 +188,7 @@ const LIVE_VALIDATORS: Record<
   anthropic: validateAnthropic,
   google: validateGoogle,
   mistral: validateMistral,
+  openrouter: validateOpenRouter,
 };
 
 export async function validateApiKey(

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -9,6 +9,18 @@ import {
 import { getMlxModelStatus } from "../lib/mlx-asr/models.js";
 import { reconcileUnsupportedMlxVoiceDefault } from "../lib/mlx-asr/reconcile.js";
 import { canRunMlxAsr } from "../lib/mlx-asr/server.js";
+import {
+  buildOpenApiCompatibleHeaders,
+  getNormalizedOpenApiCompatibleEndpoint,
+  getOpenApiCompatibleProviderLabel,
+} from "../lib/openapi-compatible.js";
+import {
+  getOpenRouterHeaders,
+  OPENROUTER_API_BASE,
+  OPENROUTER_PROVIDER_ID,
+  OPENROUTER_PROVIDER_NAME,
+  prefixOpenRouterModelId,
+} from "../lib/openrouter.js";
 import { capture } from "../lib/posthog.js";
 import { stripProviderPrefix } from "../lib/streaming/types.js";
 import { isServerBinaryAvailable } from "../lib/whisper/binary.js";
@@ -35,6 +47,7 @@ interface AvailableModel {
 
 const DEPRECATED_STATUS = "deprecated";
 const REGISTRY_FETCH_TIMEOUT_MS = 3000;
+const OPENROUTER_FETCH_TIMEOUT_MS = 4000;
 const UNSUITABLE_CLEANUP_MODEL_PATTERN =
   /guard|safeguard|safety|moderation|classif(?:y|ier|ication)?|embed(?:ding)?|image/i;
 
@@ -49,12 +62,12 @@ async function fetchLocalLlmModels(): Promise<AvailableModel[]> {
     .prepare("SELECT value FROM settings WHERE key = 'local_llm_api_key'")
     .get() as { value: string } | undefined;
 
-  const baseUrl = urlRow.value.replace(/\/+$/, "").replace(/\/v1$/, "");
+  const endpoint = getNormalizedOpenApiCompatibleEndpoint(urlRow.value);
+  if (!endpoint) return [];
+  const apiKey = keyRow?.value?.trim() || undefined;
 
-  const res = await fetch(`${baseUrl}/v1/models`, {
-    headers: {
-      ...(keyRow?.value ? { Authorization: `Bearer ${keyRow.value}` } : {}),
-    },
+  const res = await fetch(`${endpoint}/models`, {
+    headers: buildOpenApiCompatibleHeaders(endpoint, apiKey),
     signal: AbortSignal.timeout(3000),
   });
   if (!res.ok) return [];
@@ -64,12 +77,14 @@ async function fetchLocalLlmModels(): Promise<AvailableModel[]> {
   };
   if (!data.data || !Array.isArray(data.data)) return [];
 
+  const providerName = getOpenApiCompatibleProviderLabel(endpoint);
+
   return data.data.map((m) => ({
     provider_id: "local-llm",
-    provider_name: "Local LLM",
+    provider_name: providerName,
     model_id: `local-llm/${m.id}`,
     model_name: m.id,
-    family: "local",
+    family: "openapi-compatible",
     type: "llm" as const,
     cost_input: 0,
     cost_output: 0,
@@ -166,6 +181,8 @@ const CURATED_LLM_IDS = new Set([
 // In-memory cache for models.dev data
 let modelsCache: { data: unknown; fetchedAt: number } | null = null;
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+let openRouterVoiceCache: { data: AvailableModel[]; fetchedAt: number } | null =
+  null;
 
 async function fetchModelsFromRegistry(): Promise<Record<string, unknown>> {
   if (modelsCache && Date.now() - modelsCache.fetchedAt < CACHE_TTL_MS) {
@@ -181,6 +198,58 @@ async function fetchModelsFromRegistry(): Promise<Record<string, unknown>> {
   const data = (await res.json()) as Record<string, unknown>;
   modelsCache = { data, fetchedAt: Date.now() };
   return data;
+}
+
+interface OpenRouterModel {
+  id: string;
+  name: string;
+  architecture?: {
+    input_modalities?: string[];
+    output_modalities?: string[];
+    modality?: string;
+  };
+}
+
+async function fetchOpenRouterVoiceModels(): Promise<AvailableModel[]> {
+  if (
+    openRouterVoiceCache &&
+    Date.now() - openRouterVoiceCache.fetchedAt < CACHE_TTL_MS
+  ) {
+    return openRouterVoiceCache.data;
+  }
+
+  const res = await fetch(
+    `${OPENROUTER_API_BASE}/models?output_modalities=transcription`,
+    {
+      headers: getOpenRouterHeaders(),
+      signal: AbortSignal.timeout(OPENROUTER_FETCH_TIMEOUT_MS),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch OpenRouter models: ${res.status}`);
+  }
+
+  const data = (await res.json()) as { data?: OpenRouterModel[] };
+  const models = (data.data ?? [])
+    .filter((model) => {
+      const input = model.architecture?.input_modalities ?? [];
+      const output = model.architecture?.output_modalities ?? [];
+      return input.includes("audio") && output.includes("transcription");
+    })
+    .map(
+      (model): AvailableModel => ({
+        provider_id: OPENROUTER_PROVIDER_ID,
+        provider_name: OPENROUTER_PROVIDER_NAME,
+        model_id: prefixOpenRouterModelId(model.id),
+        model_name: model.name,
+        family: model.id.split("/")[0] ?? "openrouter",
+        type: "voice",
+      }),
+    )
+    .sort((a, b) => a.model_name.localeCompare(b.model_name));
+
+  openRouterVoiceCache = { data: models, fetchedAt: Date.now() };
+  return models;
 }
 
 /**
@@ -313,6 +382,12 @@ const models = new Hono()
       available.push(
         ...BUILTIN_VOICE_MODELS.map((m) => ({ ...m, curated: true })),
       );
+
+      try {
+        available.push(...(await fetchOpenRouterVoiceModels()));
+      } catch {
+        // OpenRouter model discovery is optional.
+      }
 
       // Add local whisper voice models (only those that are downloaded)
       for (const whisperModel of LOCAL_WHISPER_VOICE_MODELS) {

--- a/apps/server/src/routes/settings.ts
+++ b/apps/server/src/routes/settings.ts
@@ -1,11 +1,17 @@
 import {
   localLlmConfigSchema,
+  normalizeOpenApiCompatibleEndpoint,
   settingValueSchema,
 } from "@freestyle/validations";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
 import { applyMlxAsrRetentionPolicy } from "../lib/mlx-asr/server.js";
+import {
+  buildOpenApiCompatibleHeaders,
+  canUseManualOpenApiCompatibleModelSelection,
+  getOpenApiCompatibleManualModelHint,
+} from "../lib/openapi-compatible.js";
 import { capture } from "../lib/posthog.js";
 
 const settings = new Hono()
@@ -67,19 +73,34 @@ const settings = new Hono()
     zValidator("json", localLlmConfigSchema),
     async (c) => {
       const body = c.req.valid("json");
-      const url = body.url.replace(/\/+$/, "").replace(/\/v1$/, "");
+      const endpoint = normalizeOpenApiCompatibleEndpoint(body.url);
+      if (!endpoint) {
+        return c.json(
+          {
+            error:
+              "Use https, or http only for localhost, and provide a base ending in /v1 or a full /responses or /chat/completions URL.",
+          },
+          400,
+        );
+      }
+      const apiKey = body.api_key?.trim() || undefined;
 
       try {
-        const res = await fetch(`${url}/v1/models`, {
-          headers: {
-            ...(body.api_key
-              ? { Authorization: `Bearer ${body.api_key}` }
-              : {}),
-          },
+        const res = await fetch(`${endpoint}/models`, {
+          headers: buildOpenApiCompatibleHeaders(endpoint, apiKey),
           signal: AbortSignal.timeout(5000),
         });
 
         if (!res.ok) {
+          if (canUseManualOpenApiCompatibleModelSelection(res.status)) {
+            return c.json({
+              ok: true,
+              models: [],
+              model_discovery: "manual",
+              hint: getOpenApiCompatibleManualModelHint(endpoint),
+            });
+          }
+
           return c.json(
             { error: `Server returned ${res.status}: ${res.statusText}` },
             502,
@@ -95,7 +116,16 @@ const settings = new Hono()
           models = data.data.map((m) => m.id);
         }
 
-        return c.json({ ok: true, models });
+        if (models.length === 0) {
+          return c.json({
+            ok: true,
+            models: [],
+            model_discovery: "manual",
+            hint: getOpenApiCompatibleManualModelHint(endpoint),
+          });
+        }
+
+        return c.json({ ok: true, models, model_discovery: "available" });
       } catch (err) {
         const message =
           err instanceof Error ? err.message : "Failed to connect";

--- a/apps/server/tests/openapi-compatible-route.test.ts
+++ b/apps/server/tests/openapi-compatible-route.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/index.js";
+
+describe("OpenAPI-compatible local LLM setup", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("allows manual model entry when /models discovery is unavailable", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response("not found", {
+        status: 404,
+        statusText: "Not Found",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const res = await app.request("/api/settings/local-llm/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        url: "https://demo.openai.azure.com/openai/v1",
+        api_key: "azure-key",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(
+      expect.objectContaining({
+        ok: true,
+        models: [],
+        model_discovery: "manual",
+        hint: expect.stringContaining("deployment"),
+      }),
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://demo.openai.azure.com/openai/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer azure-key",
+          "api-key": "azure-key",
+        }),
+      }),
+    );
+  });
+});

--- a/apps/server/tests/openapi-compatible.test.ts
+++ b/apps/server/tests/openapi-compatible.test.ts
@@ -1,0 +1,122 @@
+import {
+  normalizeOpenApiCompatibleEndpoint,
+  OPENAPI_ENDPOINT_PRESETS,
+} from "@freestyle/validations";
+import { describe, expect, it } from "vitest";
+import {
+  buildOpenApiCompatibleHeaders,
+  canUseManualOpenApiCompatibleModelSelection,
+  getOpenApiCompatibleManualModelHint,
+  getOpenApiCompatibleProviderLabel,
+  isAzureOpenAiEndpoint,
+} from "../src/lib/openapi-compatible.js";
+
+describe("OpenAPI-compatible endpoint helpers", () => {
+  it("normalizes OpenAPI-compatible endpoints to a /v1 base", () => {
+    expect(
+      normalizeOpenApiCompatibleEndpoint(
+        "https://example.com/v1/chat/completions",
+      ),
+    ).toBe("https://example.com/v1");
+    expect(
+      normalizeOpenApiCompatibleEndpoint("http://localhost:4000/v1/responses"),
+    ).toBe("http://localhost:4000/v1");
+    expect(
+      normalizeOpenApiCompatibleEndpoint("https://api.moonshot.cn/v1"),
+    ).toBe("https://api.moonshot.cn/v1");
+    expect(
+      normalizeOpenApiCompatibleEndpoint(
+        "https://api.deepinfra.com/v1/openai/chat/completions",
+      ),
+    ).toBe("https://api.deepinfra.com/v1/openai");
+  });
+
+  it("rejects non-local plain-http endpoints", () => {
+    expect(
+      normalizeOpenApiCompatibleEndpoint("http://example.com/v1"),
+    ).toBeUndefined();
+  });
+
+  it("adds provider-specific auth headers for Azure and generic gateways", () => {
+    expect(
+      isAzureOpenAiEndpoint("https://demo.openai.azure.com/openai/v1"),
+    ).toBe(true);
+    expect(
+      buildOpenApiCompatibleHeaders(
+        "https://demo.openai.azure.com/openai/v1",
+        "azure-key",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        Authorization: "Bearer azure-key",
+        "api-key": "azure-key",
+      }),
+    );
+
+    expect(
+      buildOpenApiCompatibleHeaders("https://api.moonshot.cn/v1", "moon-key"),
+    ).toEqual(
+      expect.objectContaining({
+        Authorization: "Bearer moon-key",
+        "x-api-key": "moon-key",
+      }),
+    );
+  });
+
+  it("labels imported OpenPets presets clearly", () => {
+    expect(
+      getOpenApiCompatibleProviderLabel("https://openrouter.ai/api/v1"),
+    ).toBe("OpenRouter");
+    expect(getOpenApiCompatibleProviderLabel("https://api.openai.com/v1")).toBe(
+      "OpenAI",
+    );
+    expect(
+      getOpenApiCompatibleProviderLabel("https://api.moonshot.cn/v1"),
+    ).toBe("Moonshot");
+    expect(
+      getOpenApiCompatibleProviderLabel("https://api.together.ai/v1"),
+    ).toBe("Together AI");
+    expect(
+      getOpenApiCompatibleProviderLabel(
+        "https://api.fireworks.ai/inference/v1",
+      ),
+    ).toBe("Fireworks AI");
+    expect(
+      getOpenApiCompatibleProviderLabel("https://api.deepinfra.com/v1/openai"),
+    ).toBe("DeepInfra");
+    expect(
+      getOpenApiCompatibleProviderLabel("https://api.sambanova.ai/v1"),
+    ).toBe("SambaNova");
+    expect(getOpenApiCompatibleProviderLabel("http://localhost:11434/v1")).toBe(
+      "Local OpenAPI",
+    );
+  });
+
+  it("covers the non-OpenAI OpenPets-compatible presets", () => {
+    expect(OPENAPI_ENDPOINT_PRESETS.map((preset) => preset.id)).toEqual(
+      expect.arrayContaining([
+        "openrouter",
+        "azure",
+        "litellm-local",
+        "vllm-local",
+        "localhost-template",
+        "https-template",
+        "moonshot",
+        "together",
+        "fireworks",
+        "deepinfra",
+        "sambanova",
+      ]),
+    );
+  });
+
+  it("allows manual model selection when shared model discovery is unavailable", () => {
+    expect(canUseManualOpenApiCompatibleModelSelection(404)).toBe(true);
+    expect(canUseManualOpenApiCompatibleModelSelection(401)).toBe(false);
+    expect(
+      getOpenApiCompatibleManualModelHint(
+        "https://demo.openai.azure.com/openai/v1",
+      ),
+    ).toContain("deployment");
+  });
+});

--- a/apps/server/tests/openrouter.test.ts
+++ b/apps/server/tests/openrouter.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/index.js";
+import { validateApiKey } from "../src/lib/validate-key.js";
+
+describe("OpenRouter support", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("validates OpenRouter keys against the current key endpoint", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { limit_remaining: 42 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await validateApiKey("openrouter", "sk-or-test-key");
+
+    expect(result).toEqual({ valid: true });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://openrouter.ai/api/v1/key",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-or-test-key",
+        }),
+      }),
+    );
+  });
+
+  it("includes OpenRouter transcription models in the available catalog", async () => {
+    const fetchSpy = vi.fn((input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url === "https://models.dev/api.json") {
+        return Promise.resolve(
+          new Response(JSON.stringify({}), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      if (
+        url ===
+        "https://openrouter.ai/api/v1/models?output_modalities=transcription"
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  id: "nvidia/parakeet-tdt-0.6b-v3",
+                  name: "NVIDIA: Parakeet TDT 0.6B v3",
+                  architecture: {
+                    input_modalities: ["audio"],
+                    output_modalities: ["transcription"],
+                  },
+                },
+              ],
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const res = await app.request("/api/models/available");
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as Array<Record<string, unknown>>;
+    expect(data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider_id: "openrouter",
+          provider_name: "OpenRouter",
+          model_id: "openrouter/nvidia/parakeet-tdt-0.6b-v3",
+          model_name: "NVIDIA: Parakeet TDT 0.6B v3",
+          type: "voice",
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/validations/src/index.ts
+++ b/packages/validations/src/index.ts
@@ -3,6 +3,7 @@ export * from "./dictionary.js";
 export * from "./formats.js";
 export * from "./local-llm.js";
 export * from "./models.js";
+export * from "./openapi.js";
 export * from "./query.js";
 export * from "./settings.js";
 export * from "./vocabulary.js";

--- a/packages/validations/src/openapi.ts
+++ b/packages/validations/src/openapi.ts
@@ -1,0 +1,147 @@
+export type OpenApiEndpointPresetApplyMode = "save" | "draft";
+
+export interface OpenApiEndpointPreset {
+  id: string;
+  label: string;
+  endpoint: string;
+  applyMode: OpenApiEndpointPresetApplyMode;
+  description: string;
+}
+
+export const OPENAPI_ENDPOINT_PRESETS: readonly OpenApiEndpointPreset[] = [
+  {
+    id: "openrouter",
+    label: "OpenRouter",
+    endpoint: "https://openrouter.ai/api/v1",
+    applyMode: "save",
+    description:
+      "OpenRouter's OpenAPI-compatible base for models and chat completions.",
+  },
+  {
+    id: "azure",
+    label: "Azure Template",
+    endpoint: "https://YOUR-RESOURCE-NAME.openai.azure.com/openai/v1",
+    applyMode: "draft",
+    description:
+      "Prefills the Azure OpenAI v1 base. Replace YOUR-RESOURCE-NAME first.",
+  },
+  {
+    id: "litellm-local",
+    label: "LiteLLM Local",
+    endpoint: "http://localhost:4000/v1",
+    applyMode: "save",
+    description: "Common local LiteLLM gateway port.",
+  },
+  {
+    id: "vllm-local",
+    label: "vLLM Local",
+    endpoint: "http://localhost:8000/v1",
+    applyMode: "save",
+    description: "Common local vLLM server port.",
+  },
+  {
+    id: "localhost-template",
+    label: "Custom Local Template",
+    endpoint: "http://localhost:11434/v1",
+    applyMode: "draft",
+    description:
+      "Template for Ollama, LM Studio, or another localhost gateway.",
+  },
+  {
+    id: "https-template",
+    label: "Generic HTTPS Template",
+    endpoint: "https://YOUR-HOSTNAME.example.com/v1",
+    applyMode: "draft",
+    description: "Template for hosted OpenAPI-compatible gateways and proxies.",
+  },
+  {
+    id: "moonshot",
+    label: "Moonshot (Kimi)",
+    endpoint: "https://api.moonshot.cn/v1",
+    applyMode: "save",
+    description: "Moonshot AI's OpenAPI-compatible endpoint for Kimi models.",
+  },
+  {
+    id: "together",
+    label: "Together AI",
+    endpoint: "https://api.together.ai/v1",
+    applyMode: "save",
+    description:
+      "Together AI's OpenAI-compatible base for open-weight chat and speech models.",
+  },
+  {
+    id: "fireworks",
+    label: "Fireworks AI",
+    endpoint: "https://api.fireworks.ai/inference/v1",
+    applyMode: "save",
+    description:
+      "Fireworks AI's OpenAI-compatible inference base for chat-capable models.",
+  },
+  {
+    id: "deepinfra",
+    label: "DeepInfra",
+    endpoint: "https://api.deepinfra.com/v1/openai",
+    applyMode: "save",
+    description:
+      "DeepInfra's OpenAI-compatible base for chat-completions style model access.",
+  },
+  {
+    id: "sambanova",
+    label: "SambaNova",
+    endpoint: "https://api.sambanova.ai/v1",
+    applyMode: "save",
+    description:
+      "SambaNova's OpenAI-compatible base for SambaCloud model access.",
+  },
+] as const;
+
+export function normalizeOpenApiCompatibleEndpoint(
+  value: unknown,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 2_048 || /[\0\r\n]/.test(trimmed)) {
+    return undefined;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return undefined;
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") return undefined;
+  if (
+    url.protocol === "http:" &&
+    url.hostname !== "localhost" &&
+    url.hostname !== "127.0.0.1" &&
+    url.hostname !== "::1"
+  ) {
+    return undefined;
+  }
+  if (!url.hostname || url.username || url.password || url.search || url.hash) {
+    return undefined;
+  }
+
+  const path = url.pathname.replace(/\/+$/, "");
+  if (!path || path === "/") {
+    url.pathname = "/v1";
+  } else if (
+    path.endsWith("/responses") ||
+    path.endsWith("/chat/completions")
+  ) {
+    const basePath = path.replace(/\/(?:responses|chat\/completions)$/, "");
+    if (basePath.endsWith("/v1") || basePath.endsWith("/v1/openai")) {
+      url.pathname = basePath;
+    } else {
+      return undefined;
+    }
+  } else if (path.endsWith("/v1") || path.endsWith("/v1/openai")) {
+    url.pathname = path;
+  } else {
+    return undefined;
+  }
+
+  return url.toString();
+}


### PR DESCRIPTION
## Summary
This PR expands the old local-LLM lane into a full OpenAPI-compatible provider lane, adds first-class OpenRouter support, and moves the provider configuration UI from Settings to the Models page.

## What changed
### Server
- `apps/server/src/lib/openapi-compatible.ts` (new) — endpoint normalization and request building.
- `apps/server/src/lib/openrouter.ts` (new) — OpenRouter-specific helpers.
- `apps/server/src/lib/streaming/providers/openrouter.ts` (new) — OpenRouter streaming provider.
- `apps/server/src/lib/providers.ts` — wires OpenRouter and generic OpenAPI providers.
- `apps/server/src/lib/streaming/registry.ts` — registers OpenRouter streaming.
- `apps/server/src/lib/validate-key.ts` — provider-aware key validation.
- `apps/server/src/routes/models.ts` / `settings.ts` — OpenAPI model routes and local-LLM test settings.

### Validations
- `packages/validations/src/openapi.ts` (new) — presets, endpoint normalization, schemas.

### Client
- `apps/electron/src/renderer/src/pages/models/use-models.ts` — owns OpenAPI state, test/apply actions, auto-enables cleanup.
- `apps/electron/src/renderer/src/pages/models/model-list.tsx` — full OpenAPI provider UI in the LLM list.
- `apps/electron/src/renderer/src/lib/models.ts` — provider label helpers.
- `apps/electron/src/renderer/src/pages/settings.tsx` — removes OpenAPI form, keeps cleanup toggle and theme selector.

### Tests
- `apps/server/tests/openapi-compatible.test.ts`
- `apps/server/tests/openapi-compatible-route.test.ts`
- `apps/server/tests/openrouter.test.ts`

## Verification
- `pnpm --filter @freestyle/server test` — 109 passed.
- `pnpm --filter @freestyle/electron typecheck` passes.
- `pnpm exec biome check` on touched files passes.