### PR TITLE
fix(linux): use persistent uinput helper for Wayland paste

### DIFF
--- a/apps/electron/native/linux-fast-paste.c
+++ b/apps/electron/native/linux-fast-paste.c
@@ -11,6 +11,7 @@
  * Usage:
  *   linux-fast-paste                 # XTest mode (X11)
  *   linux-fast-paste --uinput        # uinput mode (Wayland)
+ *   linux-fast-paste --uinput-server # persistent uinput mode over stdin/stdout
  *   linux-fast-paste --portal        # D-Bus RemoteDesktop portal
  *   linux-fast-paste --terminal      # Force Ctrl+Shift+V
  *   linux-fast-paste --window <id>   # Target a specific X window
@@ -445,11 +446,11 @@ static void emit_input(int fd, int type, int code, int val) {
     if (write(fd, &ie, sizeof(ie)) < 0) { /* best-effort */ }
 }
 
-static int paste_via_uinput(int use_shift) {
+static int create_uinput_keyboard(void) {
     int fd = open("/dev/uinput", O_WRONLY | O_NONBLOCK);
     if (fd < 0) {
         fprintf(stderr, "Cannot open /dev/uinput: %s\n", strerror(errno));
-        return 3;
+        return -3;
     }
 
     if (ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0 ||
@@ -457,7 +458,7 @@ static int paste_via_uinput(int use_shift) {
         ioctl(fd, UI_SET_KEYBIT, KEY_LEFTSHIFT) < 0 ||
         ioctl(fd, UI_SET_KEYBIT, KEY_V) < 0) {
         close(fd);
-        return 4;
+        return -4;
     }
 
     struct uinput_setup usetup;
@@ -470,11 +471,15 @@ static int paste_via_uinput(int use_shift) {
     if (ioctl(fd, UI_DEV_SETUP, &usetup) < 0 ||
         ioctl(fd, UI_DEV_CREATE) < 0) {
         close(fd);
-        return 4;
+        return -4;
     }
 
-    usleep(50000);
+    /* Compositors attach newly-created uinput devices asynchronously. */
+    usleep(100000);
+    return fd;
+}
 
+static void send_uinput_paste(int fd, int use_shift) {
     emit_input(fd, EV_KEY, KEY_LEFTCTRL, 1);
     emit_input(fd, EV_SYN, SYN_REPORT, 0);
 
@@ -501,11 +506,49 @@ static int paste_via_uinput(int use_shift) {
 
     emit_input(fd, EV_KEY, KEY_LEFTCTRL, 0);
     emit_input(fd, EV_SYN, SYN_REPORT, 0);
+}
 
-    usleep(20000);
-
+static void destroy_uinput_keyboard(int fd) {
     ioctl(fd, UI_DEV_DESTROY);
     close(fd);
+}
+
+static int paste_via_uinput(int use_shift) {
+    int fd = create_uinput_keyboard();
+    if (fd < 0) return -fd;
+
+    send_uinput_paste(fd, use_shift);
+    /* Keep a one-shot device alive until the compositor consumes releases. */
+    usleep(100000);
+    destroy_uinput_keyboard(fd);
+    return 0;
+}
+
+static int run_uinput_server(void) {
+    int fd = create_uinput_keyboard();
+    if (fd < 0) return -fd;
+
+    setvbuf(stdout, NULL, _IOLBF, 0);
+    printf("READY\n");
+
+    char command[64];
+    while (fgets(command, sizeof(command), stdin)) {
+        command[strcspn(command, "\r\n")] = '\0';
+
+        if (strcmp(command, "PASTE") == 0) {
+            send_uinput_paste(fd, 0);
+            printf("OK\n");
+        } else if (strcmp(command, "PASTE_TERMINAL") == 0) {
+            send_uinput_paste(fd, 1);
+            printf("OK\n");
+        } else if (strcmp(command, "QUIT") == 0) {
+            break;
+        } else {
+            printf("ERROR unknown command\n");
+        }
+    }
+
+    destroy_uinput_keyboard(fd);
     return 0;
 }
 #endif
@@ -513,6 +556,7 @@ static int paste_via_uinput(int use_shift) {
 int main(int argc, char *argv[]) {
     int force_terminal = 0;
     int use_uinput = 0;
+    int use_uinput_server = 0;
     int use_portal = 0;
     const char *restore_token = NULL;
     Window target_window = None;
@@ -522,6 +566,8 @@ int main(int argc, char *argv[]) {
             force_terminal = 1;
         } else if (strcmp(argv[i], "--uinput") == 0) {
             use_uinput = 1;
+        } else if (strcmp(argv[i], "--uinput-server") == 0) {
+            use_uinput_server = 1;
         } else if (strcmp(argv[i], "--portal") == 0) {
             use_portal = 1;
         } else if (strcmp(argv[i], "--restore-token") == 0 && i + 1 < argc) {
@@ -529,6 +575,15 @@ int main(int argc, char *argv[]) {
         } else if (strcmp(argv[i], "--window") == 0 && i + 1 < argc) {
             target_window = (Window)strtoul(argv[++i], NULL, 0);
         }
+    }
+
+    if (use_uinput_server) {
+#ifdef HAVE_UINPUT
+        return run_uinput_server();
+#else
+        fprintf(stderr, "uinput support not compiled in\n");
+        return 3;
+#endif
     }
 
     if (use_portal) {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -82,7 +82,12 @@ import { NativeKeyListener } from "./key-listener";
 import * as linuxAutostart from "./linux-autostart";
 import { checkLinuxSetup } from "./linux-setup";
 import { MicListener } from "./mic-listener";
-import { isWaylandSession, pasteIntoFocusedApp } from "./paste";
+import {
+  isWaylandSession,
+  pasteIntoFocusedApp,
+  startLinuxPasteHelper,
+  stopLinuxPasteHelper,
+} from "./paste";
 
 const log = createAppLogger("electron");
 const hotkeyLog = createAppLogger("hotkey");
@@ -1078,6 +1083,8 @@ app.on("second-instance", () => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(async () => {
+  void startLinuxPasteHelper();
+
   // Set app user model id for windows
   electronApp.setAppUserModelId("com.freestyle.app");
 
@@ -1933,6 +1940,7 @@ async function registerHotkey(hotkey?: string): Promise<void> {
 
 // Clean up key listener and mic listener on quit
 app.on("will-quit", () => {
+  stopLinuxPasteHelper();
   if (keyListener) {
     keyListener.stop();
     keyListener = null;
@@ -1965,6 +1973,7 @@ let isQuitting = false;
 let updateDownloadState: "idle" | "downloading" | "downloaded" = "idle";
 
 function cleanupBeforeQuit(): void {
+  stopLinuxPasteHelper();
   stopWhisperServer().catch(() => {});
   stopMlxServer().catch(() => {});
   if (keyListener) {

--- a/apps/electron/src/main/paste.ts
+++ b/apps/electron/src/main/paste.ts
@@ -1,4 +1,9 @@
-import { exec, execFile } from "node:child_process";
+import {
+  type ChildProcessWithoutNullStreams,
+  exec,
+  execFile,
+  spawn,
+} from "node:child_process";
 import { createAppLogger } from "@freestyle/utils";
 import { clipboard } from "electron";
 import { isLinuxTerminalFocused } from "./linux-terminal-focus";
@@ -93,10 +98,176 @@ async function pasteWindows(): Promise<"native" | "legacy"> {
 
 type PasteMethod = "native" | "legacy";
 
-function linuxPasteArgs(wayland: boolean, isTerminal: boolean): string[] {
-  if (wayland) {
-    return isTerminal ? ["--uinput", "--terminal"] : ["--uinput"];
+let linuxUinputHelper: ChildProcessWithoutNullStreams | null = null;
+let linuxUinputReady = false;
+let linuxUinputStarting: Promise<boolean> | null = null;
+let linuxUinputLineBuffer = "";
+let linuxUinputPendingResponse: ((success: boolean) => void) | null = null;
+let linuxUinputCommandChain: Promise<unknown> = Promise.resolve();
+
+function settleLinuxUinputResponse(success: boolean): void {
+  const resolve = linuxUinputPendingResponse;
+  linuxUinputPendingResponse = null;
+  resolve?.(success);
+}
+
+function clearLinuxUinputHelper(helper: ChildProcessWithoutNullStreams): void {
+  if (linuxUinputHelper !== helper) return;
+  linuxUinputHelper = null;
+  linuxUinputReady = false;
+  linuxUinputStarting = null;
+  linuxUinputLineBuffer = "";
+  settleLinuxUinputResponse(false);
+}
+
+function handleLinuxUinputLine(line: string): void {
+  if (line === "READY") {
+    linuxUinputReady = true;
+    return;
   }
+  if (line === "OK") {
+    settleLinuxUinputResponse(true);
+    return;
+  }
+  if (line.startsWith("ERROR")) {
+    log.warn(`Persistent uinput helper: ${line}`);
+    settleLinuxUinputResponse(false);
+  }
+}
+
+export function startLinuxPasteHelper(): Promise<boolean> {
+  if (process.platform !== "linux" || !isWaylandSession()) {
+    return Promise.resolve(false);
+  }
+  if (linuxUinputHelper && linuxUinputReady) {
+    return Promise.resolve(true);
+  }
+  if (linuxUinputStarting) return linuxUinputStarting;
+
+  const binaryPath = getNativeBinaryPath("linux-fast-paste");
+  if (!binaryPath) return Promise.resolve(false);
+
+  linuxUinputStarting = new Promise<boolean>((resolve) => {
+    const helper = spawn(binaryPath, ["--uinput-server"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    linuxUinputHelper = helper;
+    let settled = false;
+    let stderr = "";
+
+    const settleStart = (success: boolean): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(success);
+    };
+
+    const timeout = setTimeout(() => {
+      log.warn("Persistent uinput helper timed out during startup");
+      settleStart(false);
+      helper.kill("SIGTERM");
+    }, 2_000);
+
+    helper.stdout.on("data", (data: Buffer) => {
+      linuxUinputLineBuffer += data.toString();
+      const lines = linuxUinputLineBuffer.split("\n");
+      linuxUinputLineBuffer = lines.pop() ?? "";
+      for (const rawLine of lines) {
+        const line = rawLine.trim();
+        handleLinuxUinputLine(line);
+        if (line === "READY") {
+          log.debug("Persistent uinput paste helper ready");
+          settleStart(true);
+        }
+      }
+    });
+
+    helper.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    helper.on("error", (err) => {
+      log.warn(`Persistent uinput helper error: ${err.message}`);
+      settleStart(false);
+      clearLinuxUinputHelper(helper);
+    });
+
+    helper.on("close", (code) => {
+      if (stderr.trim()) {
+        log.warn(`Persistent uinput helper failed: ${stderr.trim()}`);
+      } else if (linuxUinputReady && code !== 0) {
+        log.warn(`Persistent uinput helper exited with code ${code}`);
+      }
+      settleStart(false);
+      clearLinuxUinputHelper(helper);
+    });
+  });
+
+  return linuxUinputStarting;
+}
+
+export function stopLinuxPasteHelper(): void {
+  const helper = linuxUinputHelper;
+  if (!helper) return;
+  clearLinuxUinputHelper(helper);
+  if (!helper.stdin.writable) {
+    helper.kill("SIGTERM");
+    return;
+  }
+
+  helper.stdin.end("QUIT\n");
+  const forceKill = setTimeout(() => helper.kill("SIGTERM"), 250);
+  forceKill.unref();
+  helper.once("close", () => clearTimeout(forceKill));
+}
+
+async function sendPersistentUinputPaste(
+  isTerminal: boolean,
+): Promise<boolean> {
+  const run = async (): Promise<boolean> => {
+    if (!(await startLinuxPasteHelper())) return false;
+    const helper = linuxUinputHelper;
+    if (!helper?.stdin.writable) return false;
+
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const settle = (success: boolean): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        if (linuxUinputPendingResponse === settle) {
+          linuxUinputPendingResponse = null;
+        }
+        resolve(success);
+      };
+      const timeout = setTimeout(() => {
+        log.warn("Persistent uinput helper timed out while pasting");
+        settle(false);
+        clearLinuxUinputHelper(helper);
+        helper.kill("SIGTERM");
+      }, 1_000);
+
+      linuxUinputPendingResponse = settle;
+      const command = isTerminal ? "PASTE_TERMINAL\n" : "PASTE\n";
+      helper.stdin.write(command, (err) => {
+        if (err) {
+          settle(false);
+          clearLinuxUinputHelper(helper);
+          helper.kill("SIGTERM");
+        }
+      });
+    });
+  };
+
+  const result = linuxUinputCommandChain.then(run, run);
+  linuxUinputCommandChain = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+function linuxPasteArgs(isTerminal: boolean): string[] {
   return isTerminal ? ["--terminal"] : [];
 }
 
@@ -105,13 +276,13 @@ async function pasteLinux(isTerminal: boolean): Promise<PasteMethod> {
   const wayland = isWaylandSession();
 
   if (wayland) {
-    return pasteLinuxWayland(binaryPath, isTerminal);
+    return pasteLinuxWayland(isTerminal);
   }
 
   if (binaryPath) {
     const exitCode = await execFileAsync(
       binaryPath,
-      linuxPasteArgs(false, isTerminal),
+      linuxPasteArgs(isTerminal),
     );
     if (exitCode !== 0) {
       log.warn(
@@ -126,23 +297,12 @@ async function pasteLinux(isTerminal: boolean): Promise<PasteMethod> {
   return "legacy";
 }
 
-async function pasteLinuxWayland(
-  binaryPath: string | null,
-  isTerminal: boolean,
-): Promise<PasteMethod> {
-  if (binaryPath) {
-    const exitCode = await execFileAsync(
-      binaryPath,
-      linuxPasteArgs(true, isTerminal),
-    );
-    if (exitCode === 0) {
-      return "legacy";
-    }
-    log.warn(
-      `Native uinput paste failed (exit ${exitCode}), falling back to wtype`,
-    );
+async function pasteLinuxWayland(isTerminal: boolean): Promise<PasteMethod> {
+  if (await sendPersistentUinputPaste(isTerminal)) {
+    return "native";
   }
 
+  log.warn("Persistent uinput paste failed, falling back to wtype");
   await pasteLinuxLegacy(true, isTerminal);
   return "legacy";
 }


### PR DESCRIPTION
## Summary

- This fixes #266 
- Add a persistent Linux Wayland `uinput` paste helper.
- Create the virtual keyboard once at startup and reuse it for paste commands.
- Support normal and terminal paste shortcuts.
- Fall back to `wtype` when `uinput` is unavailable or fails.
- Handle helper timeouts, crashes, serialized commands, and graceful shutdown.
- Preserve existing macOS, Windows, and Linux X11 behavior.

## Verification

- Verified repeated normal and terminal pastes on Hyprland.
- Verified one-shot `uinput` compatibility.
- Passed Biome checks, TypeScript checks, and production build.