### PR TITLE
feat(models): add OpenAPI-compatible providers and local-llm voice support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,10 +61,32 @@ jobs:
 
       - name: Install Craft
         run: |
-          CRAFT_URL=$(curl -fsSL https://api.github.com/repos/getsentry/craft/releases/latest \
-            | jq -r '.assets[] | select(.name == "craft") | .browser_download_url')
-          sudo curl -fsSL -o /usr/local/bin/craft "$CRAFT_URL"
+          set -euo pipefail
+
+          # Retry the GitHub API call because it can return 502/504 transiently.
+          CRAFT_URL=""
+          for i in 1 2 3 4 5; do
+            CRAFT_URL=$(curl -fsSL --retry 5 --retry-delay 2 \
+              https://api.github.com/repos/getsentry/craft/releases/latest \
+              | jq -r '.assets[] | select(.name == "craft") | .browser_download_url') && break
+            echo "Attempt $i failed to resolve Craft URL; retrying in 5s..."
+            sleep 5
+          done
+
+          if [[ -z "$CRAFT_URL" ]]; then
+            echo "::error::Could not determine Craft download URL"
+            exit 1
+          fi
+
+          # Retry the binary download for the same reason.
+          for i in 1 2 3 4 5; do
+            sudo curl -fsSL --retry 5 --retry-delay 2 -o /usr/local/bin/craft "$CRAFT_URL" && break
+            echo "Attempt $i failed to download Craft; retrying in 5s..."
+            sleep 5
+          done
+
           sudo chmod +x /usr/local/bin/craft
+          craft --version
 
       - name: Wait for CI on release branch
         env:

--- a/apps/electron/native/linux-mic-listener.c
+++ b/apps/electron/native/linux-mic-listener.c
@@ -1,0 +1,66 @@
+/*
+ * Linux microphone activity listener.
+ *
+ * Monitors PulseAudio/PipeWire source-outputs (apps recording audio) and emits:
+ *   MIC_ACTIVE   when at least one source-output exists
+ *   MIC_INACTIVE when no source-outputs remain
+ *
+ * It watches `pactl subscribe` for source-output new/remove events, then re-checks
+ * the actual count with `pactl list source-outputs` to avoid false positives from
+ * our own process or transient events.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define CHECK_INTERVAL_US 500000
+
+static int count_source_outputs(void) {
+    FILE *fp = popen("pactl list source-outputs 2>/dev/null", "r");
+    if (!fp) return 0;
+
+    int count = 0;
+    char line[1024];
+    while (fgets(line, sizeof(line), fp)) {
+        if (strncmp(line, "Source Output #", 15) == 0) {
+            count++;
+        }
+    }
+    pclose(fp);
+    return count;
+}
+
+static void emit(const char *state) {
+    printf("%s\n", state);
+    fflush(stdout);
+}
+
+int main(void) {
+    FILE *fp = popen("pactl subscribe 2>/dev/null", "r");
+    if (!fp) {
+        fprintf(stderr, "failed to run pactl subscribe\n");
+        return 1;
+    }
+
+    int active = count_source_outputs() > 0;
+    emit(active ? "MIC_ACTIVE" : "MIC_INACTIVE");
+
+    char line[1024];
+    while (fgets(line, sizeof(line), fp)) {
+        if (strstr(line, "source-output") == NULL) continue;
+
+        /* Debounce: wait a moment for state to settle, then recount. */
+        usleep(50000);
+        int now_active = count_source_outputs() > 0;
+        if (now_active != active) {
+            active = now_active;
+            emit(active ? "MIC_ACTIVE" : "MIC_INACTIVE");
+        }
+    }
+
+    pclose(fp);
+    return 0;
+}

--- a/apps/electron/native/macos-volume-control.swift
+++ b/apps/electron/native/macos-volume-control.swift
@@ -1,0 +1,146 @@
+import CoreAudio
+import Foundation
+
+// Freestyle macOS volume control helper.
+// Replaces AppleScript osascript calls with synchronous CoreAudio APIs.
+//
+// Commands:
+//   get              -> prints "<volume>|<muted>" where volume is 0..1
+//   set <volume>     -> set output volume (0..1)
+//   mute             -> mute default output device
+//   unmute           -> unmute default output device
+
+enum VolumeError: Error {
+    case invalidCommand
+    case audioObjectError(OSStatus)
+    case missingDefaultDevice
+}
+
+func defaultOutputDeviceID() throws -> AudioDeviceID {
+    var id = AudioDeviceID(0)
+    var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject),
+        &address,
+        0,
+        nil,
+        &size,
+        &id
+    )
+    guard status == noErr else {
+        throw VolumeError.audioObjectError(status)
+    }
+    guard id != kAudioDeviceUnknown else {
+        throw VolumeError.missingDefaultDevice
+    }
+    return id
+}
+
+func getVolume(deviceID: AudioDeviceID) throws -> Float {
+    var volume: Float = 0
+    var size = UInt32(MemoryLayout<Float>.size)
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwareServiceDeviceProperty_VirtualMasterVolume,
+        mScope: kAudioDevicePropertyScopeOutput,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &volume)
+    guard status == noErr else {
+        throw VolumeError.audioObjectError(status)
+    }
+    return volume
+}
+
+func setVolume(deviceID: AudioDeviceID, value: Float) throws {
+    var volume = max(0, min(1, value))
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwareServiceDeviceProperty_VirtualMasterVolume,
+        mScope: kAudioDevicePropertyScopeOutput,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectSetPropertyData(
+        deviceID,
+        &address,
+        0,
+        nil,
+        UInt32(MemoryLayout<Float>.size),
+        &volume
+    )
+    guard status == noErr else {
+        throw VolumeError.audioObjectError(status)
+    }
+}
+
+func getMute(deviceID: AudioDeviceID) throws -> Bool {
+    var muted: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyMute,
+        mScope: kAudioDevicePropertyScopeOutput,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &muted)
+    guard status == noErr else {
+        throw VolumeError.audioObjectError(status)
+    }
+    return muted != 0
+}
+
+func setMute(deviceID: AudioDeviceID, muted: Bool) throws {
+    var value: UInt32 = muted ? 1 : 0
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyMute,
+        mScope: kAudioDevicePropertyScopeOutput,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectSetPropertyData(
+        deviceID,
+        &address,
+        0,
+        nil,
+        UInt32(MemoryLayout<UInt32>.size),
+        &value
+    )
+    guard status == noErr else {
+        throw VolumeError.audioObjectError(status)
+    }
+}
+
+func run() throws {
+    let args = CommandLine.arguments.dropFirst()
+    guard let command = args.first else {
+        throw VolumeError.invalidCommand
+    }
+
+    let deviceID = try defaultOutputDeviceID()
+
+    switch command {
+    case "get":
+        let volume = try getVolume(deviceID: deviceID)
+        let muted = try getMute(deviceID: deviceID)
+        print("\(volume)|\(muted)")
+    case "set":
+        guard args.count >= 2, let value = Float(args.dropFirst().first!) else {
+            throw VolumeError.invalidCommand
+        }
+        try setVolume(deviceID: deviceID, value: value)
+    case "mute":
+        try setMute(deviceID: deviceID, muted: true)
+    case "unmute":
+        try setMute(deviceID: deviceID, muted: false)
+    default:
+        throw VolumeError.invalidCommand
+    }
+}
+
+do {
+    try run()
+} catch {
+    fputs("error: \(error)\n", stderr)
+    exit(1)
+}

--- a/apps/electron/native/windows-mic-listener.c
+++ b/apps/electron/native/windows-mic-listener.c
@@ -7,8 +7,8 @@
  * Uses IAudioSessionManager2 to enumerate and monitor capture sessions.
  * Supports --exclude-pid to ignore the app's own microphone usage.
  *
- * Compile with: cl /O2 windows-mic-listener.c /Fe:windows-mic-listener.exe ole32.lib oleaut32.lib
- * Or with MinGW: gcc -O2 windows-mic-listener.c -o windows-mic-listener.exe -lole32 -loleaut32
+ * Compile with: cl /O2 windows-mic-listener.c /Fe:windows-mic-listener.exe user32.lib ole32.lib oleaut32.lib uuid.lib
+ * Or with MinGW: gcc -O2 windows-mic-listener.c -o windows-mic-listener.exe -luser32 -lole32 -loleaut32 -luuid
  */
 
 #define WIN32_LEAN_AND_MEAN

--- a/apps/electron/native/windows-volume-control.c
+++ b/apps/electron/native/windows-volume-control.c
@@ -1,0 +1,322 @@
+/**
+ * Windows Volume Control Helper
+ *
+ * Native helper for low-latency Windows system-volume ducking.
+ *
+ * Opens the default playback endpoint's IAudioEndpointVolume once and keeps it
+ * alive for the lifetime of the process. Reads commands from stdin and writes
+ * compact "volume|muted" responses to stdout.
+ *
+ * Design goals:
+ *  - Fast: no PowerShell spawn per operation, warm COM object.
+ *  - Safe: clean shutdown on stdin close / EOF / CTRL events; the parent
+ *    process owns restore logic.
+ *  - Simple IPC: line-delimited text, one command per line.
+ *
+ * Supported commands (case-sensitive, trailing whitespace ignored):
+ *   get              -> "0.75|false\n"
+ *   set <0..1>       -> "ok\n"
+ *   mute <0|1>       -> "ok\n"
+ *   quit             -> "ok\n" then exit
+ *
+ * Error responses start with "err|" and are followed by a short message.
+ *
+ * Compile (MSVC):
+ *   cl /O2 /MT windows-volume-control.c /Fe:windows-volume-control.exe \
+ *      user32.lib ole32.lib uuid.lib
+ *
+ * Compile (MinGW):
+ *   gcc -O2 -mwindows windows-volume-control.c -o windows-volume-control.exe \
+ *       -luser32 -lole32 -luuid
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#define COBJMACROS
+#define CINTERFACE
+
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+/* Core Audio interface declarations. */
+#include <mmdeviceapi.h>
+#include <endpointvolume.h>
+
+/* ------------------------------------------------------------------------ *
+ * Explicit GUID definitions
+ *
+ * These symbols are normally supplied by defining INITGUID and including
+ * <initguid.h> before the Core Audio headers, or by linking uuid.lib. On the
+ * current build host only clang-cl is available, and neither path resolves the
+ * symbols, so we define them directly in this translation unit.
+ * ------------------------------------------------------------------------ */
+
+const CLSID CLSID_MMDeviceEnumerator =
+    { 0xBCDE0395, 0xE52F, 0x467C, { 0x8E, 0x3D, 0xC4, 0x57, 0x92, 0x91, 0x69, 0x2E } };
+
+const IID IID_IMMDeviceEnumerator =
+    { 0xA95664D2, 0x9614, 0x4F35, { 0xA7, 0x46, 0xDE, 0x8D, 0xB6, 0x36, 0x17, 0xE6 } };
+
+const IID IID_IAudioEndpointVolume =
+    { 0x5CDF2C82, 0x841E, 0x4546, { 0x97, 0x22, 0x0C, 0xF7, 0x40, 0x78, 0x22, 0x9A } };
+
+/* ------------------------------------------------------------------------ *
+ * Globals
+ * ------------------------------------------------------------------------ */
+
+static volatile BOOL g_running = TRUE;
+static IAudioEndpointVolume *g_endpoint = NULL;
+static IMMDeviceEnumerator *g_enumerator = NULL;
+static IMMDevice *g_device = NULL;
+
+/* ------------------------------------------------------------------------ *
+ * Helpers
+ * ------------------------------------------------------------------------ */
+
+static void write_line(const char *line) {
+    if (!line) return;
+    DWORD written = 0;
+    DWORD len = (DWORD)strlen(line);
+    HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (h == INVALID_HANDLE_VALUE) return;
+    WriteFile(h, line, len, &written, NULL);
+    WriteFile(h, "\n", 1, &written, NULL);
+    FlushFileBuffers(h);
+}
+
+static void report_error(const char *msg) {
+    char buf[512];
+    snprintf(buf, sizeof(buf), "err|%s", msg ? msg : "unknown");
+    write_line(buf);
+}
+
+static BOOL ensure_endpoint(void) {
+    if (g_endpoint) return TRUE;
+
+    HRESULT hr = CoCreateInstance(
+        &CLSID_MMDeviceEnumerator,
+        NULL,
+        CLSCTX_ALL,
+        &IID_IMMDeviceEnumerator,
+        (void **)&g_enumerator);
+    if (FAILED(hr) || !g_enumerator) {
+        report_error("device-enumerator-creation-failed");
+        return FALSE;
+    }
+
+    hr = g_enumerator->lpVtbl->GetDefaultAudioEndpoint(
+        g_enumerator, eRender, eMultimedia, &g_device);
+    if (FAILED(hr) || !g_device) {
+        report_error("default-endpoint-not-found");
+        return FALSE;
+    }
+
+    hr = g_device->lpVtbl->Activate(
+        g_device,
+        &IID_IAudioEndpointVolume,
+        CLSCTX_ALL,
+        NULL,
+        (void **)&g_endpoint);
+    if (FAILED(hr) || !g_endpoint) {
+        report_error("endpoint-activation-failed");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+static void release_endpoint(void) {
+    if (g_endpoint) {
+        g_endpoint->lpVtbl->Release(g_endpoint);
+        g_endpoint = NULL;
+    }
+    if (g_device) {
+        g_device->lpVtbl->Release(g_device);
+        g_device = NULL;
+    }
+    if (g_enumerator) {
+        g_enumerator->lpVtbl->Release(g_enumerator);
+        g_enumerator = NULL;
+    }
+}
+
+static void cmd_get(void) {
+    if (!ensure_endpoint()) return;
+
+    float volume = 0.0f;
+    BOOL muted = FALSE;
+    HRESULT hr = g_endpoint->lpVtbl->GetMasterVolumeLevelScalar(g_endpoint, &volume);
+    if (FAILED(hr)) {
+        report_error("get-volume-failed");
+        return;
+    }
+    hr = g_endpoint->lpVtbl->GetMute(g_endpoint, &muted);
+    if (FAILED(hr)) {
+        report_error("get-mute-failed");
+        return;
+    }
+
+    char buf[64];
+    snprintf(buf, sizeof(buf), "%f|%s", volume, muted ? "true" : "false");
+    write_line(buf);
+}
+
+static void cmd_set(const char *arg) {
+    if (!arg || !*arg) {
+        report_error("set-missing-argument");
+        return;
+    }
+    char *end = NULL;
+    double value = strtod(arg, &end);
+    if (end == arg || value < 0.0 || value > 1.0) {
+        report_error("set-invalid-argument");
+        return;
+    }
+    if (!ensure_endpoint()) return;
+
+    HRESULT hr = g_endpoint->lpVtbl->SetMasterVolumeLevelScalar(
+        g_endpoint, (float)value, NULL);
+    if (FAILED(hr)) {
+        report_error("set-volume-failed");
+        return;
+    }
+    write_line("ok");
+}
+
+static void cmd_mute(const char *arg) {
+    if (!arg || !*arg) {
+        report_error("mute-missing-argument");
+        return;
+    }
+    BOOL muted = FALSE;
+    if (strcmp(arg, "1") == 0 || _stricmp(arg, "true") == 0) {
+        muted = TRUE;
+    } else if (strcmp(arg, "0") == 0 || _stricmp(arg, "false") == 0) {
+        muted = FALSE;
+    } else {
+        report_error("mute-invalid-argument");
+        return;
+    }
+    if (!ensure_endpoint()) return;
+
+    HRESULT hr = g_endpoint->lpVtbl->SetMute(g_endpoint, muted, NULL);
+    if (FAILED(hr)) {
+        report_error("set-mute-failed");
+        return;
+    }
+    write_line("ok");
+}
+
+static void process_line(const char *line) {
+    char buf[256];
+    strncpy_s(buf, sizeof(buf), line, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+
+    /* Trim trailing whitespace */
+    size_t len = strlen(buf);
+    while (len > 0 && isspace((unsigned char)buf[len - 1])) {
+        buf[len - 1] = '\0';
+        len--;
+    }
+
+    if (strcmp(buf, "get") == 0) {
+        cmd_get();
+    } else if (strcmp(buf, "quit") == 0) {
+        write_line("ok");
+        g_running = FALSE;
+    } else if (strncmp(buf, "set ", 4) == 0) {
+        cmd_set(buf + 4);
+    } else if (strncmp(buf, "mute ", 5) == 0) {
+        cmd_mute(buf + 5);
+    } else if (strcmp(buf, "set") == 0 || strcmp(buf, "mute") == 0) {
+        report_error("missing-argument");
+    } else {
+        report_error("unknown-command");
+    }
+}
+
+/* ------------------------------------------------------------------------ *
+ * Console / signal handling
+ * ------------------------------------------------------------------------ */
+
+static BOOL WINAPI console_handler(DWORD signal) {
+    if (signal == CTRL_C_EVENT ||
+        signal == CTRL_BREAK_EVENT ||
+        signal == CTRL_CLOSE_EVENT ||
+        signal == CTRL_LOGOFF_EVENT ||
+        signal == CTRL_SHUTDOWN_EVENT) {
+        g_running = FALSE;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/* ------------------------------------------------------------------------ *
+ * Stdin reader
+ * ------------------------------------------------------------------------ */
+
+static BOOL read_line(char *out, size_t out_size) {
+    if (!out || out_size == 0) return FALSE;
+    size_t i = 0;
+    out[0] = '\0';
+
+    HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
+    if (hStdin == INVALID_HANDLE_VALUE) return FALSE;
+
+    while (g_running && i < out_size - 1) {
+        char ch = 0;
+        DWORD read = 0;
+        BOOL ok = ReadFile(hStdin, &ch, 1, &read, NULL);
+        if (!ok || read == 0) {
+            /* EOF or pipe closed */
+            return FALSE;
+        }
+        if (ch == '\n') {
+            break;
+        }
+        if (ch != '\r') {
+            out[i++] = ch;
+        }
+    }
+    out[i] = '\0';
+    return TRUE;
+}
+
+/* ------------------------------------------------------------------------ *
+ * Main
+ * ------------------------------------------------------------------------ */
+
+int main(void) {
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCtrlHandler(console_handler, TRUE);
+
+    HRESULT hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+    if (FAILED(hr)) {
+        report_error("coinitialize-failed");
+        return 1;
+    }
+
+    /* Pre-warm the endpoint so the first real command is fast. */
+    if (!ensure_endpoint()) {
+        CoUninitialize();
+        return 1;
+    }
+
+    write_line("ready");
+
+    char line[512];
+    while (g_running) {
+        BOOL ok = read_line(line, sizeof(line));
+        if (!ok) {
+            /* EOF / parent closed pipe -> exit cleanly. */
+            break;
+        }
+        process_line(line);
+    }
+
+    release_endpoint();
+    CoUninitialize();
+    return 0;
+}

--- a/apps/electron/scripts/compile-native.js
+++ b/apps/electron/scripts/compile-native.js
@@ -78,6 +78,11 @@ function compileMacOS() {
       src: "macos-mic-listener.swift",
       frameworks: ["CoreAudio", "Foundation"],
     },
+    {
+      name: "macos-volume-control",
+      src: "macos-volume-control.swift",
+      frameworks: ["CoreAudio", "Foundation"],
+    },
   ];
 
   for (const bin of binaries) {
@@ -114,7 +119,12 @@ function compileWindows() {
     {
       name: "windows-mic-listener.exe",
       src: "windows-mic-listener.c",
-      libs: ["ole32.lib", "oleaut32.lib"],
+      libs: ["user32.lib", "ole32.lib", "oleaut32.lib", "uuid.lib"],
+    },
+    {
+      name: "windows-volume-control.exe",
+      src: "windows-volume-control.c",
+      libs: ["user32.lib", "ole32.lib", "uuid.lib"],
     },
   ];
 
@@ -123,14 +133,25 @@ function compileWindows() {
     const src = join(NATIVE_DIR, bin.src);
     const out = join(outputDir, bin.name);
 
-    // Try MSVC first (cl.exe), fall back to gcc (MinGW)
     const clArgs = ["/O2", src, `/Fe:${out}`, ...bin.libs];
-    let ok = run("cl", clArgs);
+    const gccLibs = bin.libs.map((l) => `-l${l.replace(".lib", "")}`);
+    const gccArgs = ["-O2", "-static-libgcc", src, "-o", out, ...gccLibs];
+    const clangArgs = ["-O2", src, "-o", out, ...gccLibs];
 
+    // Try MSVC first, then clang-cl (drop-in MSVC-compatible CLI),
+    // then clang/gcc with MinGW-style flags.
+    let ok = run("cl", clArgs);
     if (!ok) {
-      console.log("  MSVC not found, trying MinGW gcc...");
-      const gccLibs = bin.libs.map((l) => `-l${l.replace(".lib", "")}`);
-      ok = run("gcc", ["-O2", "-static-libgcc", src, "-o", out, ...gccLibs]);
+      console.log("  MSVC not found, trying clang-cl...");
+      ok = run("clang-cl", clArgs);
+    }
+    if (!ok) {
+      console.log("  clang-cl not found, trying clang...");
+      ok = run("clang", clangArgs);
+    }
+    if (!ok) {
+      console.log("  clang not found, trying MinGW gcc...");
+      ok = run("gcc", gccArgs);
     }
 
     if (!ok) {
@@ -220,6 +241,20 @@ function compileLinux() {
       console.log(`  -> ${out}`);
     } else {
       console.warn("  WARNING: Failed to compile linux-key-listener.");
+    }
+  }
+
+  // linux-mic-listener
+  console.log("  Compiling linux-mic-listener...");
+  {
+    const src = join(NATIVE_DIR, "linux-mic-listener.c");
+    const out = join(outputDir, "linux-mic-listener");
+    const ok = runShell(`gcc -O2 ${src} -o ${out}`);
+    if (ok) {
+      chmodSync(out, 0o755);
+      console.log(`  -> ${out}`);
+    } else {
+      console.warn("  WARNING: Failed to compile linux-mic-listener.");
     }
   }
 }

--- a/apps/electron/src/main/audio-ducking.ts
+++ b/apps/electron/src/main/audio-ducking.ts
@@ -1,0 +1,821 @@
+import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { promisify } from "node:util";
+import { createAppLogger } from "@freestyle/utils";
+import { getNativeBinaryPath } from "./native-binary";
+
+const execFileAsync = promisify(execFile);
+const log = createAppLogger("audio-ducking");
+
+const MIN_DUCK_DELTA = 0.02;
+const RESTORE_EPSILON = 0.08;
+const DEFAULT_DUCK_LEVEL = 0;
+
+const NATIVE_COMMAND_TIMEOUT_MS = 500;
+const NATIVE_STARTUP_TIMEOUT_MS = 2000;
+const NATIVE_KILL_TIMEOUT_MS = 500;
+
+type BackendKind = "windows-native" | "windows" | "macos" | "linux-wpctl" | "linux-pactl";
+type DuckStrategy = "volume" | "mute";
+
+interface Snapshot {
+  kind: BackendKind;
+  current: number;
+  muted: boolean;
+  target: number | null;
+  strategy: DuckStrategy;
+}
+
+interface VolumeState {
+  volume: number;
+  muted: boolean;
+}
+
+interface RestorePlan {
+  restoreVolume: boolean;
+  restoreMute: boolean;
+}
+
+interface PendingRequest {
+  resolve: (value: string) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Context needed to execute a backend operation. On Windows this may carry a
+ * live native controller; on other platforms it is just the backend kind.
+ */
+interface BackendContext {
+  kind: BackendKind;
+  native?: NativeWindowsVolumeController;
+}
+
+/**
+ * Low-latency Windows volume controller backed by a native helper.
+ *
+ * The helper opens the default playback endpoint's IAudioEndpointVolume once
+ * and keeps it warm. Commands are sent over stdin; responses are read from
+ * stdout. If the helper fails to start, crashes, hangs, or misbehaves, callers
+ * can fall back to the slower PowerShell-based implementation.
+ *
+ * Safety features:
+ *  - startup timeout
+ *  - per-command timeout
+ *  - automatic cleanup on dispose / crash / EOF
+ *  - explicit kill with graceful window then SIGTERM
+ *  - stderr logging
+ */
+class NativeWindowsVolumeController {
+  private process: ChildProcessWithoutNullStreams | null = null;
+  private pending: PendingRequest | null = null;
+  private buffer = "";
+  private ready = false;
+  private disposed = false;
+
+  constructor(private readonly binaryPath: string) {}
+
+  /**
+   * Start the helper process. Returns true if it printed "ready", false
+   * otherwise. Subsequent calls are no-ops if already started.
+   */
+  async start(): Promise<boolean> {
+    if (this.process) return this.ready;
+    if (this.disposed) return false;
+
+    log.debug(`Starting native Windows volume helper: ${this.binaryPath}`);
+
+    return new Promise((resolve) => {
+      const startupTimer = setTimeout(() => {
+        log.error("Native volume helper startup timed out");
+        this.dispose();
+        resolve(false);
+      }, NATIVE_STARTUP_TIMEOUT_MS);
+
+      try {
+        this.process = spawn(this.binaryPath, [], {
+          windowsHide: true,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } catch (err) {
+        clearTimeout(startupTimer);
+        log.error(`Failed to spawn native volume helper: ${String(err)}`);
+        resolve(false);
+        return;
+      }
+
+      if (!this.process?.stdin || !this.process?.stdout || !this.process?.stderr) {
+        clearTimeout(startupTimer);
+        log.error("Native volume helper has no stdio pipes");
+        this.dispose();
+        resolve(false);
+        return;
+      }
+
+      this.process.stdout.setEncoding("utf8");
+      this.process.stdout.on("data", (chunk: string) => this.onData(chunk));
+      this.process.on("error", (err) => {
+        log.error(`Native volume helper process error: ${err.message}`);
+        this.onProcessExit();
+      });
+      this.process.on("exit", () => this.onProcessExit());
+      this.process.on("close", () => this.onProcessExit());
+      this.process.stderr.on("data", (chunk: Buffer) => {
+        const text = chunk.toString("utf8").trim();
+        if (text) log.debug(`Native volume helper stderr: ${text}`);
+      });
+
+      const onFirstLines = (chunk: string) => {
+        this.buffer += chunk;
+        const lines = this.buffer.split(/\r?\n/);
+        this.buffer = lines.pop() ?? "";
+        for (const raw of lines) {
+          const line = raw.trim();
+          if (!line) continue;
+
+          if (line === "ready") {
+            clearTimeout(startupTimer);
+            this.ready = true;
+            // Replace one-time handler with normal handler.
+            this.process?.stdout.off("data", onFirstLines);
+            this.process?.stdout.on("data", (c: string) => this.onData(c));
+            resolve(true);
+            return;
+          }
+
+          if (line.startsWith("err|")) {
+            clearTimeout(startupTimer);
+            log.error(`Native volume helper failed to initialize: ${line}`);
+            this.dispose();
+            resolve(false);
+            return;
+          }
+        }
+      };
+
+      this.process.stdout.on("data", onFirstLines);
+    });
+  }
+
+  private onData(chunk: string): void {
+    this.buffer += chunk;
+    const lines = this.buffer.split(/\r?\n/);
+    this.buffer = lines.pop() ?? "";
+    for (const raw of lines) {
+      const line = raw.trim();
+      if (!line) continue;
+      this.handleResponse(line);
+    }
+  }
+
+  private handleResponse(line: string): void {
+    const pending = this.pending;
+    if (!pending) {
+      log.debug(`Unexpected response from native volume helper: ${line}`);
+      return;
+    }
+    this.pending = null;
+    clearTimeout(pending.timer);
+    pending.resolve(line);
+  }
+
+  private onProcessExit(): void {
+    if (!this.process) return;
+    log.debug("Native volume helper process exited");
+    const wasPending = this.pending;
+    this.pending = null;
+    this.process = null;
+    this.ready = false;
+    if (wasPending) {
+      clearTimeout(wasPending.timer);
+      wasPending.reject(new Error("Native volume helper exited unexpectedly"));
+    }
+  }
+
+  /**
+   * Send a command and wait for a single-line response. Throws on timeout,
+   * process error, or non-ok response where applicable.
+   */
+  async request(command: string, timeoutMs = NATIVE_COMMAND_TIMEOUT_MS): Promise<string> {
+    if (this.disposed) throw new Error("Native volume helper is disposed");
+    if (!this.ready || !this.process?.stdin) {
+      throw new Error("Native volume helper not ready");
+    }
+    if (this.pending) {
+      throw new Error("Native volume helper already has a pending request");
+    }
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending = null;
+        log.error(`Native volume helper command timed out: ${command}`);
+        this.dispose();
+        reject(new Error(`Native volume helper command timed out: ${command}`));
+      }, timeoutMs);
+
+      this.pending = { resolve, reject, timer };
+      this.process!.stdin.write(`${command}\n`, (err) => {
+        if (err) {
+          this.pending = null;
+          clearTimeout(timer);
+          log.error(`Failed to write to native volume helper: ${err.message}`);
+          this.dispose();
+          reject(err);
+        }
+      });
+    });
+  }
+
+  async getVolumeState(): Promise<VolumeState | null> {
+    const line = await this.request("get");
+    return parsePipeVolumeState(line);
+  }
+
+  async setVolume(value: number): Promise<void> {
+    const response = await this.request(`set ${clamp01(value).toFixed(4)}`);
+    if (response !== "ok") {
+      throw new Error(`set volume failed: ${response}`);
+    }
+  }
+
+  async setMuted(muted: boolean): Promise<void> {
+    const response = await this.request(`mute ${muted ? "1" : "0"}`);
+    if (response !== "ok") {
+      throw new Error(`set mute failed: ${response}`);
+    }
+  }
+
+  /**
+   * Kill the helper process and clean up. Idempotent.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    const proc = this.process;
+    const wasPending = this.pending;
+
+    this.process = null;
+    this.pending = null;
+    this.ready = false;
+
+    if (wasPending) {
+      clearTimeout(wasPending.timer);
+      wasPending.reject(new Error("Native volume helper disposed"));
+    }
+
+    if (!proc) return;
+
+    try {
+      if (!proc.stdin.destroyed) {
+        proc.stdin.end();
+      }
+    } catch {
+      // ignore
+    }
+
+    const killTimer = setTimeout(() => {
+      try {
+        if (!proc.killed) {
+          proc.kill("SIGTERM");
+        }
+      } catch {
+        // ignore
+      }
+    }, NATIVE_KILL_TIMEOUT_MS);
+
+    proc.on("exit", () => clearTimeout(killTimer));
+    proc.on("close", () => clearTimeout(killTimer));
+
+    if (proc.exitCode !== null) {
+      clearTimeout(killTimer);
+    }
+  }
+}
+
+export class AudioDucker {
+  private snapshot: Snapshot | null = null;
+  private backendPromise: Promise<BackendContext | null> | null = null;
+  private queue = Promise.resolve();
+  private depth = 0;
+  private nativeController: NativeWindowsVolumeController | null = null;
+
+  duck(level = DEFAULT_DUCK_LEVEL): Promise<void> {
+    return this.enqueue(async () => {
+      this.depth += 1;
+      if (this.snapshot) return;
+
+      const ctx = await this.getBackend();
+      if (!ctx) return;
+
+      const state = await readVolumeState(ctx);
+      if (!state || state.muted) return;
+
+      const desiredLevel = clamp01(level);
+      const target = clamp01(state.volume * desiredLevel);
+      const useMuteFallback =
+        desiredLevel <= 0 || state.volume - target < MIN_DUCK_DELTA;
+
+      if (useMuteFallback) {
+        await setMuted(ctx, true);
+        this.snapshot = {
+          kind: ctx.kind,
+          current: state.volume,
+          muted: state.muted,
+          target: null,
+          strategy: "mute",
+        };
+        log.debug(`Applied mute fallback while ducking on ${ctx.kind}`);
+        return;
+      }
+
+      await setVolume(ctx, target);
+      this.snapshot = {
+        kind: ctx.kind,
+        current: state.volume,
+        muted: state.muted,
+        target,
+        strategy: "volume",
+      };
+      log.debug(
+        `Applied volume ducking on ${ctx.kind}: ${state.volume.toFixed(3)} -> ${target.toFixed(3)}`,
+      );
+    });
+  }
+
+  restore(): Promise<void> {
+    return this.enqueue(async () => {
+      if (this.depth > 0) {
+        this.depth -= 1;
+      }
+      if (this.depth > 0) return;
+
+      const snapshot = this.snapshot;
+      this.snapshot = null;
+      if (!snapshot) return;
+
+      // If we have a live native controller, use it for restore; otherwise
+      // reconstruct a minimal context from the snapshot kind.
+      const ctx: BackendContext | null = this.nativeController
+        ? { kind: snapshot.kind, native: this.nativeController }
+        : await this.getBackend().catch(() => null);
+
+      if (!ctx) return;
+
+      const live = await readVolumeState(ctx).catch(() => null);
+      const restorePlan = getRestorePlan(snapshot, live);
+      if (!restorePlan.restoreVolume && !restorePlan.restoreMute) {
+        log.debug(
+          `Skipping restore on ${snapshot.kind} because audio state changed externally`,
+        );
+        return;
+      }
+
+      if (restorePlan.restoreVolume) {
+        await setVolume(ctx, snapshot.current);
+      }
+      if (restorePlan.restoreMute) {
+        await setMuted(ctx, snapshot.muted);
+      }
+      log.debug(`Restored audio after ducking on ${snapshot.kind}`);
+    });
+  }
+
+  /**
+   * Dispose the native helper (if any). Call this when the app is quitting.
+   */
+  dispose(): void {
+    this.nativeController?.dispose();
+    this.nativeController = null;
+    this.backendPromise = null;
+  }
+
+  private enqueue(work: () => Promise<void>): Promise<void> {
+    this.queue = this.queue.then(work).catch((error) => {
+      log.debug(
+        error instanceof Error ? error.message : String(error ?? "unknown"),
+      );
+    });
+    return this.queue;
+  }
+
+  private getBackend(): Promise<BackendContext | null> {
+    if (!this.backendPromise) {
+      this.backendPromise = detectBackend(this);
+    }
+    return this.backendPromise;
+  }
+}
+
+async function detectBackend(ducker: AudioDucker): Promise<BackendContext | null> {
+  if (process.platform === "win32") {
+    const nativePath = getNativeBinaryPath("windows-volume-control");
+    if (nativePath) {
+      const controller = new NativeWindowsVolumeController(nativePath);
+      ducker["nativeController"] = controller;
+      const ok = await controller.start();
+      if (ok) {
+        log.debug("Using native Windows volume control helper");
+        return { kind: "windows-native", native: controller };
+      }
+      log.debug("Native Windows volume helper unavailable, falling back to PowerShell");
+      controller.dispose();
+      ducker["nativeController"] = null;
+    }
+    return { kind: "windows" };
+  }
+  if (process.platform === "darwin") return { kind: "macos" };
+  if (process.platform !== "linux") return null;
+
+  const tool = await commandExists("wpctl")
+    .then((ok) => (ok ? "linux-wpctl" : null))
+    .then(
+      async (kind) =>
+        kind ?? ((await commandExists("pactl")) ? "linux-pactl" : null),
+    );
+
+  return tool ? { kind: tool } : null;
+}
+
+async function commandExists(command: string): Promise<boolean> {
+  try {
+    await execFileAsync("sh", ["-lc", `command -v ${command} >/dev/null 2>&1`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readVolumeState(ctx: BackendContext): Promise<VolumeState | null> {
+  switch (ctx.kind) {
+    case "windows-native":
+      return ctx.native!.getVolumeState();
+    case "windows":
+      return readWindowsVolumeState();
+    case "macos":
+      return readMacVolumeState();
+    case "linux-wpctl":
+      return readWpctlVolumeState();
+    case "linux-pactl":
+      return readPactlVolumeState();
+    default:
+      return null;
+  }
+}
+
+async function setVolume(ctx: BackendContext, value: number): Promise<void> {
+  const clamped = clamp01(value);
+  switch (ctx.kind) {
+    case "windows-native":
+      await ctx.native!.setVolume(clamped);
+      return;
+    case "windows":
+      await setWindowsVolume(clamped);
+      return;
+    case "macos":
+      await setMacVolume(clamped);
+      return;
+    case "linux-wpctl":
+      await execFileAsync("wpctl", [
+        "set-volume",
+        "@DEFAULT_AUDIO_SINK@",
+        clamped.toFixed(3),
+      ]);
+      return;
+    case "linux-pactl":
+      await execFileAsync("pactl", [
+        "set-sink-volume",
+        "@DEFAULT_SINK@",
+        `${Math.round(clamped * 100)}%`,
+      ]);
+      return;
+  }
+}
+
+async function setMuted(ctx: BackendContext, muted: boolean): Promise<void> {
+  switch (ctx.kind) {
+    case "windows-native":
+      await ctx.native!.setMuted(muted);
+      return;
+    case "windows":
+      await setWindowsMuted(muted);
+      return;
+    case "macos":
+      await setMacMuted(muted);
+      return;
+    case "linux-wpctl":
+      await execFileAsync("wpctl", [
+        "set-mute",
+        "@DEFAULT_AUDIO_SINK@",
+        muted ? "1" : "0",
+      ]);
+      return;
+    case "linux-pactl":
+      await execFileAsync("pactl", [
+        "set-sink-mute",
+        "@DEFAULT_SINK@",
+        muted ? "1" : "0",
+      ]);
+      return;
+  }
+}
+
+function getRestorePlan(
+  snapshot: Snapshot,
+  live: VolumeState | null,
+): RestorePlan {
+  if (!live) {
+    return { restoreVolume: true, restoreMute: true };
+  }
+
+  if (snapshot.strategy === "mute") {
+    if (!live.muted) {
+      return { restoreVolume: false, restoreMute: false };
+    }
+
+    return {
+      restoreVolume:
+        Math.abs(live.volume - snapshot.current) <= RESTORE_EPSILON,
+      restoreMute: true,
+    };
+  }
+
+  if (snapshot.target === null || live.muted) {
+    return { restoreVolume: false, restoreMute: false };
+  }
+
+  const stillDucked =
+    Math.abs(live.volume - snapshot.target) <= RESTORE_EPSILON;
+
+  return {
+    restoreVolume: stillDucked,
+    restoreMute: stillDucked,
+  };
+}
+
+const WINDOWS_VOLUME_TYPE = `
+using System;
+using System.Runtime.InteropServices;
+
+[Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IAudioEndpointVolume {
+    int RegisterControlChangeNotify(IntPtr pNotify);
+    int UnregisterControlChangeNotify(IntPtr pNotify);
+    int GetChannelCount(out uint pnChannelCount);
+    int SetMasterVolumeLevel(float fLevelDB, Guid pguidEventContext);
+    int SetMasterVolumeLevelScalar(float fLevel, Guid pguidEventContext);
+    int GetMasterVolumeLevel(out float pfLevelDB);
+    int GetMasterVolumeLevelScalar(out float pfLevel);
+    int SetChannelVolumeLevel(uint nChannel, float fLevelDB, Guid pguidEventContext);
+    int SetChannelVolumeLevelScalar(uint nChannel, float fLevel, Guid pguidEventContext);
+    int GetChannelVolumeLevel(uint nChannel, out float pfLevelDB);
+    int GetChannelVolumeLevelScalar(uint nChannel, out float pfLevel);
+    int SetMute([MarshalAs(UnmanagedType.Bool)] bool bMute, Guid pguidEventContext);
+    int GetMute(out bool pbMute);
+    int GetVolumeStepInfo(out uint pnStep, out uint pnStepCount);
+    int VolumeStepUp(Guid pguidEventContext);
+    int VolumeStepDown(Guid pguidEventContext);
+    int QueryHardwareSupport(out uint pdwHardwareSupportMask);
+    int GetVolumeRange(out float pflVolumeMindB, out float pflVolumeMaxdB, out float pflVolumeIncrementdB);
+}
+
+[Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IMMDeviceEnumerator {
+    int EnumAudioEndpoints(int dataFlow, int dwStateMask, IntPtr ppDevices);
+    int GetDefaultAudioEndpoint(int dataFlow, int role, out IMMDevice ppDevice);
+}
+
+[Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IMMDevice {
+    int Activate(ref Guid iid, int dwClsCtx, IntPtr pActivationParams, [MarshalAs(UnmanagedType.Interface)] out IAudioEndpointVolume ppInterface);
+}
+
+[ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+public class MMDeviceEnumeratorComObject {}
+
+public static class FreestyleAudioEndpointVolume {
+    private static IAudioEndpointVolume Open() {
+        var enumerator = (IMMDeviceEnumerator)new MMDeviceEnumeratorComObject();
+        IMMDevice device;
+        Marshal.ThrowExceptionForHR(enumerator.GetDefaultAudioEndpoint(0, 1, out device));
+        var iid = typeof(IAudioEndpointVolume).GUID;
+        IAudioEndpointVolume endpoint;
+        Marshal.ThrowExceptionForHR(device.Activate(ref iid, 23, IntPtr.Zero, out endpoint));
+        return endpoint;
+    }
+
+    public static float GetVolumeScalar() {
+        float volume;
+        Marshal.ThrowExceptionForHR(Open().GetMasterVolumeLevelScalar(out volume));
+        return volume;
+    }
+
+    public static bool GetMute() {
+        bool muted;
+        Marshal.ThrowExceptionForHR(Open().GetMute(out muted));
+        return muted;
+    }
+
+    public static void SetMute(bool muted) {
+        Marshal.ThrowExceptionForHR(Open().SetMute(muted, Guid.Empty));
+    }
+
+    public static void SetVolumeScalar(float value) {
+        Marshal.ThrowExceptionForHR(Open().SetMasterVolumeLevelScalar(value, Guid.Empty));
+    }
+}
+`;
+
+function encodePowerShell(script: string): string {
+  return Buffer.from(script, "utf16le").toString("base64");
+}
+
+function buildWindowsVolumeScript(body: string): string {
+  return [
+    "$ErrorActionPreference = 'Stop'",
+    'Add-Type -TypeDefinition @"',
+    WINDOWS_VOLUME_TYPE.trim(),
+    '"@',
+    body.trim(),
+  ].join("\n");
+}
+
+async function execWindowsPowerShell(script: string): Promise<string> {
+  const { stdout } = await execFileAsync("powershell.exe", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-EncodedCommand",
+    encodePowerShell(script),
+  ]);
+  return stdout.trim();
+}
+
+function parseWindowsVolumeState(stdout: string): VolumeState | null {
+  const line = stdout
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .find((entry) => entry.includes("|"));
+  if (!line) return null;
+
+  const [volumeRaw, mutedRaw] = line.split("|", 2);
+  const volume = Number.parseFloat(volumeRaw);
+  if (!Number.isFinite(volume)) return null;
+
+  return {
+    volume: clamp01(volume),
+    muted: mutedRaw?.toLowerCase() === "true",
+  };
+}
+
+async function readWindowsVolumeState(): Promise<VolumeState | null> {
+  const stdout = await execWindowsPowerShell(
+    buildWindowsVolumeScript(`
+[float]$volume = [FreestyleAudioEndpointVolume]::GetVolumeScalar()
+[bool]$muted = [FreestyleAudioEndpointVolume]::GetMute()
+Write-Output ("$volume|$muted")
+    `),
+  );
+
+  return parseWindowsVolumeState(stdout);
+}
+
+async function setWindowsVolume(value: number): Promise<void> {
+  await execWindowsPowerShell(
+    buildWindowsVolumeScript(`
+[FreestyleAudioEndpointVolume]::SetVolumeScalar([float]${clamp01(value)})
+    `),
+  );
+}
+
+async function setWindowsMuted(muted: boolean): Promise<void> {
+  await execWindowsPowerShell(
+    buildWindowsVolumeScript(`
+[FreestyleAudioEndpointVolume]::SetMute(${muted ? "$true" : "$false"})
+    `),
+  );
+}
+
+async function readMacVolumeState(): Promise<VolumeState | null> {
+  const nativePath = getNativeBinaryPath("macos-volume-control");
+  if (nativePath) {
+    try {
+      const { stdout } = await execFileAsync(nativePath, ["get"]);
+      return parsePipeVolumeState(stdout);
+    } catch (err) {
+      log.debug(
+        `macOS native volume read failed, falling back to AppleScript: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  const [{ stdout: volumeRaw }, { stdout: mutedRaw }] = await Promise.all([
+    execFileAsync("osascript", [
+      "-e",
+      "output volume of (get volume settings)",
+    ]),
+    execFileAsync("osascript", ["-e", "output muted of (get volume settings)"]),
+  ]);
+
+  const volume = Number.parseFloat(volumeRaw.trim());
+  if (!Number.isFinite(volume)) return null;
+
+  return {
+    volume: clamp01(volume / 100),
+    muted: mutedRaw.trim().toLowerCase() === "true",
+  };
+}
+
+async function setMacVolume(value: number): Promise<void> {
+  const nativePath = getNativeBinaryPath("macos-volume-control");
+  if (nativePath) {
+    try {
+      await execFileAsync(nativePath, ["set", clamp01(value).toFixed(4)]);
+      return;
+    } catch (err) {
+      log.debug(
+        `macOS native volume set failed, falling back to AppleScript: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  await execFileAsync("osascript", [
+    "-e",
+    `set volume output volume ${Math.round(clamp01(value) * 100)}`,
+  ]);
+}
+
+async function setMacMuted(muted: boolean): Promise<void> {
+  const nativePath = getNativeBinaryPath("macos-volume-control");
+  if (nativePath) {
+    try {
+      await execFileAsync(nativePath, [muted ? "mute" : "unmute"]);
+      return;
+    } catch (err) {
+      log.debug(
+        `macOS native mute set failed, falling back to AppleScript: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  await execFileAsync("osascript", [
+    "-e",
+    muted
+      ? "set volume with output muted"
+      : "set volume without output muted",
+  ]);
+}
+
+function parsePipeVolumeState(stdout: string): VolumeState | null {
+  const line = stdout
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .find((entry) => entry.includes("|"));
+  if (!line) return null;
+
+  const [volumeRaw, mutedRaw] = line.split("|", 2);
+  const volume = Number.parseFloat(volumeRaw);
+  if (!Number.isFinite(volume)) return null;
+
+  return {
+    volume: clamp01(volume),
+    muted: mutedRaw?.toLowerCase() === "true",
+  };
+}
+
+async function readWpctlVolumeState(): Promise<VolumeState | null> {
+  const { stdout } = await execFileAsync("wpctl", [
+    "get-volume",
+    "@DEFAULT_AUDIO_SINK@",
+  ]);
+  const match = stdout.match(/([0-9]*\.?[0-9]+)/);
+  if (!match) return null;
+
+  return {
+    volume: clamp01(Number.parseFloat(match[1])),
+    muted: /\bmuted\b/i.test(stdout),
+  };
+}
+
+async function readPactlVolumeState(): Promise<VolumeState | null> {
+  const [{ stdout: volumeRaw }, { stdout: mutedRaw }] = await Promise.all([
+    execFileAsync("pactl", ["get-sink-volume", "@DEFAULT_SINK@"]),
+    execFileAsync("pactl", ["get-sink-mute", "@DEFAULT_SINK@"]),
+  ]);
+  const match = volumeRaw.match(/(\d+)%/);
+  if (!match) return null;
+
+  return {
+    volume: clamp01(Number.parseInt(match[1], 10) / 100),
+    muted: /\byes\b/i.test(mutedRaw),
+  };
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(value, 0), 1);
+}

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -76,6 +76,7 @@ import { WebSocketServer } from "ws";
 import icon from "../../resources/icon.png?asset";
 import trayIconPath from "../../resources/tray/logoTemplate.png?asset";
 import { getDefaultHotkey } from "../shared/hotkey-defaults";
+import { AudioDucker } from "./audio-ducking";
 import { HotkeyRecorder } from "./hotkey-recorder";
 import { normalizeAccelerator } from "./hotkey-utils";
 import { NativeKeyListener } from "./key-listener";
@@ -135,6 +136,7 @@ let mainWindow: BrowserWindow | null = null;
 let settingsWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let keyListener: NativeKeyListener | null = null;
+const audioDucker = new AudioDucker();
 // Latching flag: set only once the native key listener has started
 // successfully, which requires Accessibility permission and therefore
 // proves it is granted. NOT set on the globalShortcut fallback, which
@@ -147,6 +149,24 @@ let currentHotkeyAccel: string | null = null;
 let hotkeyActivationMode: "hold" | "toggle" = "hold";
 let micListener: MicListener | null = null;
 let hotkeyRecorder: HotkeyRecorder | null = null;
+let audioDuckingEnabled = true;
+let audioDuckingLevel = 0;
+
+function readDbSetting(key: string): string | undefined {
+  try {
+    const dbPath = process.env.FREESTYLE_DB_PATH;
+    if (!dbPath) return undefined;
+    const { DatabaseSync } = require("node:sqlite");
+    const db = new DatabaseSync(dbPath);
+    const row = db
+      .prepare("SELECT value FROM settings WHERE key = ?")
+      .get(key) as { value: string } | undefined;
+    db.close();
+    return row?.value;
+  } catch {
+    return undefined;
+  }
+}
 
 function stopHotkeyRecorderProcess(): void {
   hotkeyRecorder?.stop();
@@ -1089,6 +1109,16 @@ app.whenReady().then(async () => {
 
   rebuildMenus();
 
+  // Load audio ducking preferences so key-event ducking works before the
+  // renderer has a chance to broadcast them.
+  const savedDuckingEnabled = readDbSetting("audio_ducking_enabled");
+  if (savedDuckingEnabled === "false") audioDuckingEnabled = false;
+  const savedDuckingLevel = readDbSetting("audio_ducking_level");
+  if (savedDuckingLevel !== undefined) {
+    const parsed = Number.parseInt(savedDuckingLevel, 10);
+    if (Number.isFinite(parsed)) audioDuckingLevel = parsed / 100;
+  }
+
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.
   app.on("browser-window-created", (_, window) => {
@@ -1121,9 +1151,38 @@ app.whenReady().then(async () => {
     mainWindow?.webContents.send("settings:output-mode-changed", mode);
   });
 
+  ipcMain.on("settings:audio-ducking-changed", (_event, enabled: boolean) => {
+    audioDuckingEnabled = enabled;
+    mainWindow?.webContents.send("settings:audio-ducking-changed", enabled);
+    settingsWindow?.webContents.send("settings:audio-ducking-changed", enabled);
+  });
+
+  ipcMain.on(
+    "settings:audio-ducking-level-changed",
+    (_event, level: number) => {
+      audioDuckingLevel = level / 100;
+      mainWindow?.webContents.send(
+        "settings:audio-ducking-level-changed",
+        level,
+      );
+      settingsWindow?.webContents.send(
+        "settings:audio-ducking-level-changed",
+        level,
+      );
+    },
+  );
+
   // IPC: hide the pill window on request from renderer
   ipcMain.on("pill:hide", () => {
     hidePill();
+  });
+
+  ipcMain.handle("audio:duck-start", async (_event, level?: number) => {
+    await audioDucker.duck(level);
+  });
+
+  ipcMain.handle("audio:duck-stop", async () => {
+    await audioDucker.restore();
   });
 
   // IPC: fan out per-frame audio levels from the pill to other windows
@@ -1732,9 +1791,11 @@ function handleNativeHotkeyDown(): void {
   if (hotkeyActivationMode === "toggle") {
     if (!hotkeyPressed) {
       hotkeyPressed = true;
+      if (audioDuckingEnabled) void audioDucker.duck(audioDuckingLevel);
       sendHotkeyDown();
     } else {
       hotkeyPressed = false;
+      void audioDucker.restore();
       sendHotkeyUp();
     }
     return;
@@ -1742,6 +1803,7 @@ function handleNativeHotkeyDown(): void {
 
   if (!hotkeyPressed) {
     hotkeyPressed = true;
+    if (audioDuckingEnabled) void audioDucker.duck(audioDuckingLevel);
     sendHotkeyDown();
   }
 }
@@ -1751,11 +1813,12 @@ function handleNativeHotkeyUp(): void {
 
   if (hotkeyPressed) {
     hotkeyPressed = false;
+    void audioDucker.restore();
     sendHotkeyUp();
   }
 }
 
-// Notify once per session when hold-to-talk degrades to toggle mode, so the
+// Notify once per session when push-to-talk degrades to toggle mode, so the
 // user isn't left wondering why holding the hotkey stopped working.
 let hotkeyDegradedNotified = false;
 function notifyHotkeyDegraded(accel: string, nativeError: string): void {
@@ -1767,9 +1830,9 @@ function notifyHotkeyDegraded(accel: string, nativeError: string): void {
     nativeError.includes("No accessible input devices")
   ) {
     fix =
-      " To enable hold-to-talk, run: sudo usermod -aG input $USER — then log out and back in.";
+      " To enable push-to-talk, run: sudo usermod -aG input $USER — then log out and back in.";
   }
-  const body = `Hold-to-talk isn't available, so "${accel}" now toggles recording on and off.${fix}`;
+  const body = `Push-to-talk isn't available, so "${accel}" now toggles recording on and off.${fix}`;
   hotkeyLog.warn(body);
   if (Notification.isSupported()) {
     new Notification({ title: "Freestyle is in toggle mode", body }).show();
@@ -1933,6 +1996,7 @@ async function registerHotkey(hotkey?: string): Promise<void> {
 
 // Clean up key listener and mic listener on quit
 app.on("will-quit", () => {
+  void audioDucker.restore();
   if (keyListener) {
     keyListener.stop();
     keyListener = null;
@@ -1965,6 +2029,7 @@ let isQuitting = false;
 let updateDownloadState: "idle" | "downloading" | "downloaded" = "idle";
 
 function cleanupBeforeQuit(): void {
+  void audioDucker.restore();
   stopWhisperServer().catch(() => {});
   stopMlxServer().catch(() => {});
   if (keyListener) {

--- a/apps/electron/src/main/mic-listener.ts
+++ b/apps/electron/src/main/mic-listener.ts
@@ -83,7 +83,26 @@ export class MicListener {
   }
 
   private startLinux(): boolean {
-    // On Linux, use `pactl subscribe` to monitor PulseAudio events
+    // Prefer the native helper if it was compiled; otherwise fall back to
+    // spawning `pactl subscribe` directly.
+    const binaryPath = getNativeBinaryPath("linux-mic-listener");
+    if (binaryPath) {
+      try {
+        this.process = spawn(binaryPath, [], {
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        this.setupProcessHandlers();
+        return true;
+      } catch (err) {
+        log.debug(
+          `Failed to spawn native linux-mic-listener: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+
+    // Fallback: `pactl subscribe` to monitor PulseAudio events
     try {
       this.process = spawn("pactl", ["subscribe"], {
         stdio: ["pipe", "pipe", "pipe"],

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -79,11 +79,21 @@ declare global {
       // Output mode
       sendOutputModeChanged: (mode: string) => void;
       onOutputModeChanged: (callback: (mode: string) => void) => () => void;
+      sendAudioDuckingChanged: (enabled: boolean) => void;
+      onAudioDuckingChanged: (
+        callback: (enabled: boolean) => void,
+      ) => () => void;
+      sendAudioDuckingLevelChanged: (level: number) => void;
+      onAudioDuckingLevelChanged: (
+        callback: (level: number) => void,
+      ) => () => void;
       // Hotkey error notifications
       onHotkeyError: (
         callback: (error: { message: string }) => void,
       ) => () => void;
       // Audio level stream
+      startAudioDucking: (level: number) => Promise<void>;
+      stopAudioDucking: () => Promise<void>;
       sendAudioLevel: (level: number) => void;
       onAudioLevel: (callback: (level: number) => void) => () => void;
       // Transcription completion broadcast

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -166,6 +166,29 @@ const api = {
     return () =>
       ipcRenderer.removeListener("settings:output-mode-changed", handler);
   },
+  sendAudioDuckingChanged: (enabled: boolean): void =>
+    ipcRenderer.send("settings:audio-ducking-changed", enabled),
+  onAudioDuckingChanged: (
+    callback: (enabled: boolean) => void,
+  ): (() => void) => {
+    const handler = (_: unknown, enabled: boolean): void => callback(enabled);
+    ipcRenderer.on("settings:audio-ducking-changed", handler);
+    return () =>
+      ipcRenderer.removeListener("settings:audio-ducking-changed", handler);
+  },
+  sendAudioDuckingLevelChanged: (level: number): void =>
+    ipcRenderer.send("settings:audio-ducking-level-changed", level),
+  onAudioDuckingLevelChanged: (
+    callback: (level: number) => void,
+  ): (() => void) => {
+    const handler = (_: unknown, level: number): void => callback(level);
+    ipcRenderer.on("settings:audio-ducking-level-changed", handler);
+    return () =>
+      ipcRenderer.removeListener(
+        "settings:audio-ducking-level-changed",
+        handler,
+      );
+  },
   // Hotkey error notifications
   onHotkeyError: (
     callback: (error: { message: string }) => void,
@@ -177,6 +200,9 @@ const api = {
   },
   // Audio level stream — pill broadcasts per-frame mic amplitude (0..1) so
   // other windows (the Today tutorial demo) can render a live waveform.
+  startAudioDucking: (level: number): Promise<void> =>
+    ipcRenderer.invoke("audio:duck-start", level),
+  stopAudioDucking: (): Promise<void> => ipcRenderer.invoke("audio:duck-stop"),
   sendAudioLevel: (level: number): void =>
     ipcRenderer.send("audio:level", level),
   onAudioLevel: (callback: (level: number) => void): (() => void) => {

--- a/apps/electron/src/renderer/src/components/model-row.tsx
+++ b/apps/electron/src/renderer/src/components/model-row.tsx
@@ -4,6 +4,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 export const PROVIDER_FILTER_MARKS: Record<string, string> = {
   openai: "OAI",
+  openrouter: "OR",
+  together: "T",
+  fireworks: "FW",
   anthropic: "A",
   google: "G",
   groq: "GQ",

--- a/apps/electron/src/renderer/src/lib/models.ts
+++ b/apps/electron/src/renderer/src/lib/models.ts
@@ -71,6 +71,9 @@ export interface MlxAsrStatus {
 
 export const CLOUD_VOICE_PROVIDERS = [
   "openai",
+  "openrouter",
+  "together",
+  "fireworks",
   "groq",
   "deepgram",
   "elevenlabs",
@@ -80,6 +83,7 @@ export const VOICE_PROVIDERS = [
   ...CLOUD_VOICE_PROVIDERS,
   "local-whisper",
   "local-mlx",
+  "local-llm",
 ];
 
 export const LLM_PROVIDERS = [
@@ -100,7 +104,9 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   elevenlabs: "ElevenLabs",
   mistral: "Mistral",
   openrouter: "OpenRouter",
-  "local-llm": "Local LLM",
+  together: "Together AI",
+  fireworks: "Fireworks AI",
+  "local-llm": "OpenAPI Compatible",
   "local-whisper": "Local Whisper",
   "local-mlx": "Local MLX",
 };
@@ -108,6 +114,9 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 /** Where to create an API key, linked from the key-entry views. */
 export const PROVIDER_KEY_URLS: Record<string, string> = {
   openai: "https://platform.openai.com/api-keys",
+  openrouter: "https://openrouter.ai/keys",
+  together: "https://api.together.ai/settings/api-keys",
+  fireworks: "https://app.fireworks.ai/users/settings/api-keys",
   groq: "https://console.groq.com/keys",
   deepgram: "https://console.deepgram.com",
   elevenlabs: "https://elevenlabs.io/app/settings/api-keys",

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -20,8 +20,15 @@ type BarMode = "connecting" | "listening" | "speaking";
 // ---------------------------------------------------------------------------
 
 let _soundEnabled = true;
+let _duckingEnabled = true;
+let _duckingLevel = 0;
 let _outputMode = "paste";
 let _toneCtx: AudioContext | null = null;
+
+function clampDuckingLevel(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.round(value), 0), 100);
+}
 
 function getToneCtx(): AudioContext {
   if (!_toneCtx || _toneCtx.state === "closed") _toneCtx = new AudioContext();
@@ -165,6 +172,15 @@ export default function AppPage(): React.JSX.Element {
   const drainAgainRef = useRef(false);
 
   const getInputVolume = useCallback(() => volumeRef.current, []);
+  const startAudioDucking = useCallback(() => {
+    if (!_duckingEnabled) return;
+    const request = window.api?.startAudioDucking(_duckingLevel / 100);
+    request?.catch(() => {});
+  }, []);
+  const stopAudioDucking = useCallback(() => {
+    const request = window.api?.stopAudioDucking();
+    request?.catch(() => {});
+  }, []);
 
   // ---- Queue drain ----
   // biome-ignore lint/correctness/useExhaustiveDependencies: drainQueue only reads refs plus hidePill, which is declared later in this component, so adding it to the deps array would reference it before initialization (TDZ). The empty array is intentional.
@@ -505,6 +521,7 @@ export default function AppPage(): React.JSX.Element {
 
   // ---- Hide pill ----
   const hidePill = useCallback(() => {
+    stopAudioDucking();
     setPillState("idle");
     setIsReRecording(false);
     isReRecordingRef.current = false;
@@ -518,7 +535,7 @@ export default function AppPage(): React.JSX.Element {
     streamResolverRef.current = null;
     stopVisualization();
     window.api.hidePill();
-  }, [stopVisualization, setPillState]);
+  }, [stopVisualization, stopAudioDucking, setPillState]);
 
   // ---- Start recording ----
   const startRecording = useCallback(
@@ -582,6 +599,7 @@ export default function AppPage(): React.JSX.Element {
           return;
         }
 
+        startAudioDucking();
         playTone("start");
         setPillState("recording");
         recordingActiveRef.current = true;
@@ -598,6 +616,7 @@ export default function AppPage(): React.JSX.Element {
       } catch (err) {
         pendingCommitRef.current = false;
         recorderRef.current.releaseStream();
+        stopAudioDucking();
         hidePill();
         window.api.showErrorDialog(
           "Recording Failed",
@@ -605,7 +624,15 @@ export default function AppPage(): React.JSX.Element {
         );
       }
     },
-    [startBarAnimation, startListening, hidePill, getStreamer, setPillState],
+    [
+      startBarAnimation,
+      startListening,
+      hidePill,
+      getStreamer,
+      setPillState,
+      startAudioDucking,
+      stopAudioDucking,
+    ],
   );
 
   // ---- Commit recording ----
@@ -614,6 +641,7 @@ export default function AppPage(): React.JSX.Element {
     recordingActiveRef.current = false;
     isReRecordingRef.current = false;
     setIsReRecording(false);
+    stopAudioDucking();
     playTone("stop");
 
     clearInterval(timerRef.current);
@@ -769,6 +797,7 @@ export default function AppPage(): React.JSX.Element {
     startBarAnimation,
     restFallbackTranscribe,
     setPillState,
+    stopAudioDucking,
   ]);
 
   // ---- Cancel ----
@@ -781,8 +810,9 @@ export default function AppPage(): React.JSX.Element {
     streamerRef.current?.cancel();
     recorderRef.current.cancel();
     recorderRef.current.releaseStream();
+    stopAudioDucking();
     hidePill();
-  }, [hidePill]);
+  }, [hidePill, stopAudioDucking]);
 
   // ---- Preferences ----
   const applyPillPosition = useCallback((pos: string | null | undefined) => {
@@ -798,6 +828,20 @@ export default function AppPage(): React.JSX.Element {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data?.value === "false") _soundEnabled = false;
+      })
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "audio_ducking_enabled" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        _duckingEnabled = data?.value !== "false";
+      })
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "audio_ducking_level" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        _duckingLevel = clampDuckingLevel(Number(data?.value ?? 0));
       })
       .catch(() => {});
     getClient()
@@ -817,9 +861,19 @@ export default function AppPage(): React.JSX.Element {
     const removeOutputMode = window.api?.onOutputModeChanged((mode) => {
       _outputMode = mode;
     });
+    const removeAudioDucking = window.api?.onAudioDuckingChanged((enabled) => {
+      _duckingEnabled = enabled;
+    });
+    const removeAudioDuckingLevel = window.api?.onAudioDuckingLevelChanged(
+      (level) => {
+        _duckingLevel = clampDuckingLevel(level);
+      },
+    );
     return () => {
       removePillPos?.();
       removeOutputMode?.();
+      removeAudioDucking?.();
+      removeAudioDuckingLevel?.();
     };
   }, [applyPillPosition]);
 
@@ -959,8 +1013,8 @@ export default function AppPage(): React.JSX.Element {
             50% { box-shadow: 0 0 10px 2px rgba(251,191,36,0.22), 0 0 16px 4px rgba(251,191,36,0.09); }
           }
           @keyframes glow-pulse-green {
-            0%, 100% { box-shadow: 0 0 6px 2px rgba(138,182,42,0.12), 0 0 13px 3px rgba(138,182,42,0.05); }
-            50% { box-shadow: 0 0 10px 2px rgba(138,182,42,0.20), 0 0 16px 4px rgba(138,182,42,0.08); }
+            0%, 100% { box-shadow: 0 0 6px 2px rgba(91,124,250,0.14), 0 0 13px 3px rgba(91,124,250,0.06); }
+            50% { box-shadow: 0 0 10px 2px rgba(91,124,250,0.22), 0 0 16px 4px rgba(91,124,250,0.1); }
           }
           @keyframes glow-pulse-blue {
             0%, 100% { box-shadow: 0 0 6px 2px rgba(96,165,250,0.14), 0 0 13px 3px rgba(96,165,250,0.06); }
@@ -1093,7 +1147,7 @@ export default function AppPage(): React.JSX.Element {
                     ? ["#60A5FA", "#3B82F6"]
                     : state === "initializing"
                       ? ["#FBBF24", "#F59E0B"]
-                      : ["#8AB62A", "#6B8F12"]
+                      : ["#5A6FAD", "#435595"]
                 }
                 agentState={
                   state === "initializing"

--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -1,3 +1,8 @@
+import {
+  normalizeOpenApiCompatibleEndpoint,
+  OPENAPI_CLOUD_PROVIDER_IDS,
+  OPENAPI_ENDPOINT_PRESETS,
+} from "@freestyle/validations";
 import { PROVIDER_FILTER_MARKS } from "@renderer/components/model-row";
 import type {
   AvailableModel,
@@ -7,7 +12,6 @@ import type {
 import { formatBytes, formatSpeed } from "@renderer/lib/models";
 import { cn } from "@renderer/lib/utils";
 import {
-  ArrowLeft,
   Check,
   Download,
   Eye,
@@ -22,7 +26,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import type { UseModels } from "./use-models";
 import { displayName } from "./utils";
 
@@ -48,6 +52,87 @@ interface Row {
   onCancel?: () => void;
   onDelete?: () => void;
   onRetry?: () => void;
+}
+
+interface OpenApiCredentialUi {
+  placeholder: string;
+}
+
+interface OpenApiModelUi {
+  placeholder: string;
+  hint: string;
+}
+
+function getOpenApiCredentialUi(presetId: string | null): OpenApiCredentialUi {
+  switch (presetId) {
+    case "openrouter":
+      return { placeholder: "OpenRouter API key" };
+    case "azure":
+      return { placeholder: "Azure API key" };
+    case "moonshot":
+      return { placeholder: "Moonshot API key" };
+    case "together":
+      return { placeholder: "Together API key" };
+    case "fireworks":
+      return { placeholder: "Fireworks API key" };
+    case "deepinfra":
+      return { placeholder: "DeepInfra API key" };
+    case "sambanova":
+      return { placeholder: "SambaNova API key" };
+    default:
+      return { placeholder: "API key or token (optional)" };
+  }
+}
+
+function getOpenApiModelUi(presetId: string | null): OpenApiModelUi {
+  switch (presetId) {
+    case "azure":
+      return {
+        placeholder: "Deployment name (for example: gpt-4.1-mini)",
+        hint: "Azure usually needs the deployment name you created, even when shared model discovery is unavailable.",
+      };
+    case "openrouter":
+      return {
+        placeholder: "Model ID (for example: openai/gpt-4.1-mini)",
+        hint: "If model discovery is unavailable, enter the full OpenRouter model ID manually.",
+      };
+    case "deepinfra":
+      return {
+        placeholder: "Model ID (for example: deepseek-ai/DeepSeek-V3)",
+        hint: "DeepInfra model names are usually provider-prefixed. If discovery is unavailable, enter the full catalog model ID manually.",
+      };
+    default:
+      return {
+        placeholder: "Model or deployment name",
+        hint: "Needed for Azure and any compatible endpoint that does not expose /models.",
+      };
+  }
+}
+
+function getOpenApiCompatibleProviderLabel(endpoint: string): string {
+  const normalized =
+    normalizeOpenApiCompatibleEndpoint(endpoint) ?? endpoint.trim();
+  try {
+    const url = new URL(normalized);
+    if (url.hostname.endsWith(".openai.azure.com")) return "Azure OpenAI";
+    if (url.hostname === "api.openai.com") return "OpenAI";
+    if (url.hostname === "openrouter.ai") return "OpenRouter";
+    if (url.hostname === "api.moonshot.cn") return "Moonshot";
+    if (url.hostname === "api.together.ai") return "Together AI";
+    if (url.hostname === "api.fireworks.ai") return "Fireworks AI";
+    if (url.hostname === "api.deepinfra.com") return "DeepInfra";
+    if (url.hostname === "api.sambanova.ai") return "SambaNova";
+    if (
+      url.hostname === "localhost" ||
+      url.hostname === "127.0.0.1" ||
+      url.hostname === "::1"
+    ) {
+      return "Local OpenAPI";
+    }
+  } catch {
+    // Fall through to generic label.
+  }
+  return "OpenAPI Compatible";
 }
 
 /**
@@ -134,6 +219,7 @@ function buildLlmRows(
   h: { onPickCloud: (model: AvailableModel) => void; onClose: () => void },
 ): Row[] {
   const rows: Row[] = [];
+  const localProviderLabel = getOpenApiCompatibleProviderLabel(m.localLlm.url);
 
   for (const [providerId, { providerName, models }] of m.llmModelsByProvider) {
     for (const model of models) {
@@ -153,7 +239,16 @@ function buildLlmRows(
     }
   }
 
+  // Collect every model the configured OpenAPI-compatible endpoint serves.
+  // The server returns them in `available` on every load, but the UI was only
+  // showing models discovered during the current test session, so they
+  // disappeared after reopening the page.
   const names = new Set(m.localLlm.models);
+  for (const model of m.available) {
+    if (model.type === "llm" && model.provider_id === "local-llm") {
+      names.add(model.model_id.replace(/^local-llm\//, ""));
+    }
+  }
   if (m.defaultLlm?.provider === "local-llm") {
     names.add(m.defaultLlm.model_id.replace(/^local-llm\//, ""));
   }
@@ -163,8 +258,8 @@ function buildLlmRows(
       key: `local:${name}`,
       name,
       source: "local",
-      provider: "local",
-      meta: "On-device",
+      provider: "local-llm",
+      meta: `${localProviderLabel} endpoint`,
       curated: true,
       selected:
         m.defaultLlm?.provider === "local-llm" &&
@@ -202,23 +297,7 @@ export function ModelList({
 }): React.JSX.Element {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState("all");
-  // Voice opens on the simple three-tier view; LLM opens on the curated list.
-  const [view, setView] = useState<"tiers" | "all">(
-    type === "voice" ? "tiers" : "all",
-  );
   const [showAllLlm, setShowAllLlm] = useState(false);
-
-  if (type === "voice" && view === "tiers") {
-    return (
-      <VoiceTiers
-        m={m}
-        onClose={onClose}
-        onPickCloud={onPickCloud}
-        onPickLocalVoice={onPickLocalVoice}
-        onShowAll={() => setView("all")}
-      />
-    );
-  }
 
   const rows =
     type === "voice"
@@ -229,6 +308,32 @@ export function ModelList({
         })
       : buildLlmRows(m, { onPickCloud, onClose });
 
+  // The OpenAPI-compatible provider shelf is part of the LLM picker. In the
+  // voice picker the same providers are folded into the existing filter-chip
+  // row so they do not push the model list out of the modal.
+  const showLocalLlmForm = type === "llm";
+  const activePresetId = filter.startsWith("preset:")
+    ? filter.slice("preset:".length)
+    : null;
+  const activePreset = OPENAPI_ENDPOINT_PRESETS.find(
+    (p) => p.id === activePresetId,
+  );
+
+  const handleFilterChange = useCallback(
+    (id: string) => {
+      setFilter(id);
+      if (type === "voice" && id.startsWith("preset:")) {
+        const presetId = id.slice("preset:".length);
+        const preset = OPENAPI_ENDPOINT_PRESETS.find((p) => p.id === presetId);
+        if (preset) {
+          m.localLlm.setUrl(preset.endpoint);
+          m.localLlm.clearStatus();
+        }
+      }
+    },
+    [type, m.localLlm.setUrl, m.localLlm.clearStatus],
+  );
+
   const q = search.toLowerCase();
   // Curated-only for LLM until expanded; searching always searches everything.
   const curatedOnly = type === "llm" && !showAllLlm && !q;
@@ -236,13 +341,16 @@ export function ModelList({
     if (curatedOnly && !r.curated) return false;
     if (filter === "cloud" && r.source !== "cloud") return false;
     if (filter === "local" && r.source !== "local") return false;
-    if (
+    if (activePresetId) {
+      if (r.provider !== "local-llm") return false;
+    } else if (
       filter !== "all" &&
       filter !== "cloud" &&
       filter !== "local" &&
       r.provider !== filter
-    )
+    ) {
       return false;
+    }
     if (q && !`${r.name} ${r.meta}`.toLowerCase().includes(q)) return false;
     return true;
   });
@@ -250,22 +358,11 @@ export function ModelList({
     ? rows.length - rows.filter((r) => r.curated).length
     : 0;
 
-  const showLocalLlmForm =
-    type === "llm" && (filter === "all" || filter === "local");
-
   return (
     <>
       <header className="border-border flex shrink-0 items-center gap-3 border-b px-5 py-3.5">
         {type === "voice" ? (
-          <button
-            type="button"
-            onClick={() => setView("tiers")}
-            className="text-muted-foreground hover:text-foreground flex shrink-0 items-center gap-1.5"
-            aria-label="Back to simple view"
-          >
-            <ArrowLeft size={14} />
-            <Mic className="h-3.5 w-3.5" />
-          </button>
+          <Mic className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
         ) : (
           <Sparkles className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
         )}
@@ -295,7 +392,30 @@ export function ModelList({
         </button>
       </header>
 
-      <FilterBar rows={rows} active={filter} onChange={setFilter} />
+      {showLocalLlmForm && (
+        <LocalLlmConnect
+          m={m}
+          onApply={m.localLlm.applyModel}
+          showCards
+        />
+      )}
+
+      <FilterBar
+        rows={rows}
+        active={filter}
+        onChange={handleFilterChange}
+        type={type}
+      />
+
+      {activePreset && type === "voice" && (
+        <div className="border-border border-b">
+          <LocalLlmConnect
+            m={m}
+            onApply={m.localLlm.applyVoiceModel}
+            activePresetId={activePresetId}
+          />
+        </div>
+      )}
 
       {type === "voice" && m.whisperStatus?.binaryDownloading && (
         <div className="border-border flex items-center gap-2.5 border-b px-5 py-3">
@@ -307,7 +427,6 @@ export function ModelList({
       )}
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {showLocalLlmForm && <LocalLlmConnect m={m} />}
         {visible.length === 0 ? (
           <div className="text-muted-foreground px-5 py-10 text-center text-[13px]">
             No models match.
@@ -332,225 +451,6 @@ export function ModelList({
 }
 
 // ---------------------------------------------------------------------------
-// VoiceTiers — the simple picker: three meaningful choices, no model IDs.
-// ---------------------------------------------------------------------------
-
-const ACCURATE_TIER: AvailableModel = {
-  provider_id: "openai",
-  provider_name: "OpenAI",
-  model_id: "openai/gpt-4o-transcribe",
-  model_name: "OpenAI Transcribe",
-  type: "voice",
-};
-
-const FASTEST_TIER: AvailableModel = {
-  provider_id: "groq",
-  provider_name: "Groq",
-  model_id: "groq/whisper-large-v3-turbo",
-  model_name: "Groq Whisper",
-  type: "voice",
-};
-
-function VoiceTiers({
-  m,
-  onClose,
-  onPickCloud,
-  onPickLocalVoice,
-  onShowAll,
-}: {
-  m: UseModels;
-  onClose: () => void;
-  onPickCloud: (model: AvailableModel) => void;
-  onPickLocalVoice: (
-    defId: string,
-    name: string,
-    engine?: "whisper" | "mlx",
-  ) => void;
-  onShowAll: () => void;
-}): React.JSX.Element {
-  const privateItem = m.voiceItems.find(
-    (it) => it.key === recommendedVoiceKey(m.voiceItems),
-  );
-  const status = privateItem?.status ?? "not_downloaded";
-  const downloading = status === "downloading" || status === "verifying";
-  // Selecting "Private" downloads if needed, then commits once ready.
-  const [autoSelect, setAutoSelect] = useState(false);
-
-  useEffect(() => {
-    if (autoSelect && privateItem?.defId && status === "ready") {
-      setAutoSelect(false);
-      onPickLocalVoice(
-        privateItem.defId,
-        privateItem.name,
-        privateItem.localEngine,
-      );
-    }
-  }, [autoSelect, status, privateItem, onPickLocalVoice]);
-
-  function pickPrivate(): void {
-    if (!privateItem?.defId) return;
-    if (status === "ready") {
-      onPickLocalVoice(
-        privateItem.defId,
-        privateItem.name,
-        privateItem.localEngine,
-      );
-      return;
-    }
-    if (status === "not_downloaded" || status === "error") {
-      setAutoSelect(true);
-      m.downloadLocal(privateItem.defId, privateItem.localEngine);
-    }
-  }
-
-  const isSelected = (modelId: string, provider: string): boolean =>
-    m.defaultVoice?.provider === provider &&
-    m.defaultVoice?.model_id === modelId;
-
-  return (
-    <>
-      <header className="border-border flex shrink-0 items-center gap-3 border-b px-5 py-3.5">
-        <Mic className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-        <span
-          className="mono text-foreground flex-1 text-[11px] uppercase"
-          style={{ letterSpacing: "0.14em" }}
-        >
-          How should Freestyle transcribe?
-        </span>
-        <button
-          type="button"
-          onClick={onClose}
-          className="text-muted-foreground hover:text-foreground shrink-0"
-          aria-label="Close"
-        >
-          <X size={16} />
-        </button>
-      </header>
-
-      <div className="grid grid-cols-1 gap-3 p-5 sm:grid-cols-3">
-        <TierCard
-          title="Private"
-          badge="Recommended"
-          description="Runs on your device. Nothing leaves it. Free."
-          detail={
-            downloading
-              ? undefined
-              : (privateItem &&
-                  `${privateItem.name}${
-                    status !== "ready" && privateItem.sizeBytes
-                      ? ` · ${formatBytes(privateItem.sizeBytes)} download`
-                      : ""
-                  }`) ||
-                undefined
-          }
-          selected={privateItem?.selected ?? false}
-          disabled={!privateItem || downloading}
-          onClick={pickPrivate}
-        >
-          {downloading && <Progress state={privateItem?.state} />}
-          {status === "error" && privateItem?.state?.error && (
-            <p className="text-destructive mt-1.5 text-[11px] leading-snug">
-              {privateItem.state.error}
-            </p>
-          )}
-        </TierCard>
-        <TierCard
-          title="Most accurate"
-          description="OpenAI cloud — needs an API key (~$0.18/hr)."
-          detail={
-            m.keyProviders.has("openai") ? "Key added" : "We'll ask for a key"
-          }
-          selected={isSelected(ACCURATE_TIER.model_id, "openai")}
-          onClick={() => onPickCloud(ACCURATE_TIER)}
-        />
-        <TierCard
-          title="Fastest"
-          description="Groq cloud — needs an API key (~$0.04/hr)."
-          detail={
-            m.keyProviders.has("groq") ? "Key added" : "We'll ask for a key"
-          }
-          selected={isSelected(FASTEST_TIER.model_id, "groq")}
-          onClick={() => onPickCloud(FASTEST_TIER)}
-        />
-      </div>
-
-      <footer className="border-border flex items-center justify-between border-t px-5 py-3">
-        <button
-          type="button"
-          onClick={onShowAll}
-          className="text-muted-foreground hover:text-foreground text-[12.5px]"
-        >
-          All models →
-        </button>
-        <button
-          type="button"
-          onClick={onClose}
-          className="border-border hover:bg-secondary rounded-md border px-3.5 py-1.5 text-[12.5px]"
-        >
-          Cancel
-        </button>
-      </footer>
-    </>
-  );
-}
-
-function TierCard({
-  title,
-  badge,
-  description,
-  detail,
-  selected,
-  disabled,
-  onClick,
-  children,
-}: {
-  title: string;
-  badge?: string;
-  description: string;
-  detail?: string;
-  selected: boolean;
-  disabled?: boolean;
-  onClick: () => void;
-  children?: React.ReactNode;
-}): React.JSX.Element {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "border-border hover:border-primary/50 hover:bg-secondary/40 flex flex-col items-start rounded-[12px] border p-4 text-left transition-colors disabled:cursor-default",
-        selected && "border-primary bg-primary/[0.06]",
-      )}
-    >
-      <div className="flex w-full items-center gap-2">
-        <span className="text-foreground text-[14.5px] font-semibold">
-          {title}
-        </span>
-        {selected && <Check size={14} className="text-primary shrink-0" />}
-        {badge && !selected && (
-          <span
-            className="mono bg-primary/10 text-primary ml-auto rounded-full px-2 py-0.5 text-[9px] uppercase"
-            style={{ letterSpacing: "0.1em" }}
-          >
-            {badge}
-          </span>
-        )}
-      </div>
-      <p className="text-muted-foreground mt-1.5 text-[12px] leading-relaxed">
-        {description}
-      </p>
-      {detail && (
-        <p className="text-muted-foreground/80 mono mt-2 text-[10.5px]">
-          {detail}
-        </p>
-      )}
-      {children && <div className="mt-2 w-full">{children}</div>}
-    </button>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Filter bar — single-select source + provider chips
 // ---------------------------------------------------------------------------
 
@@ -558,15 +458,22 @@ function FilterBar({
   rows,
   active,
   onChange,
+  type,
 }: {
   rows: Row[];
   active: string;
   onChange: (id: string) => void;
+  type: "voice" | "llm";
 }): React.JSX.Element {
   const providers: { id: string; label: string; mark?: string }[] = [];
   const seen = new Set<string>();
   for (const r of rows) {
-    if (r.source !== "cloud" || seen.has(r.provider)) continue;
+    if (seen.has(r.provider)) continue;
+    // Keep voice local engines in the On-device bucket only. In the voice
+    // picker the OpenAPI-compatible endpoint is represented by preset chips
+    // (Azure, Together, …) rather than the generic local-llm provider chip.
+    if (type === "voice" && r.source === "local") continue;
+    if (type === "voice" && r.provider === "local-llm") continue;
     seen.add(r.provider);
     providers.push({
       id: r.provider,
@@ -575,11 +482,29 @@ function FilterBar({
     });
   }
 
+  // In the voice picker, surface the OpenAPI-compatible providers as chips in
+  // the same filter bar instead of a separate shelf above the list.
+  const openApiChips =
+    type === "voice"
+      ? OPENAPI_ENDPOINT_PRESETS.filter(
+          (preset) =>
+            !OPENAPI_CLOUD_PROVIDER_IDS.includes(
+              preset.id as (typeof OPENAPI_CLOUD_PROVIDER_IDS)[number],
+            ),
+        ).map((preset) => ({
+          id: `preset:${preset.id}`,
+          label: preset.label,
+          mark: "API" as const,
+        }))
+      : [];
+
   const sources = [
     { id: "all", label: "All" },
     { id: "cloud", label: "Cloud" },
     { id: "local", label: "On-device" },
   ];
+
+  const showDivider = providers.length > 0 || openApiChips.length > 0;
 
   return (
     <div className="border-border flex flex-wrap items-center gap-2 border-b px-5 py-2.5">
@@ -591,10 +516,19 @@ function FilterBar({
           onClick={() => onChange(f.id)}
         />
       ))}
-      {providers.length > 0 && (
+      {showDivider && (
         <span className="bg-border mx-1 h-4 w-px shrink-0" aria-hidden="true" />
       )}
       {providers.map((p) => (
+        <Chip
+          key={p.id}
+          label={p.label}
+          mark={p.mark}
+          on={active === p.id}
+          onClick={() => onChange(p.id)}
+        />
+      ))}
+      {openApiChips.map((p) => (
         <Chip
           key={p.id}
           label={p.label}
@@ -817,24 +751,76 @@ function Progress({
 // Local LLM connect form (shown under the On-device filter for LLM)
 // ---------------------------------------------------------------------------
 
-function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
+function LocalLlmConnect({
+  m,
+  onApply,
+  activePresetId: forcedPresetId,
+  showCards = false,
+}: {
+  m: UseModels;
+  onApply: () => Promise<void>;
+  activePresetId?: string | null;
+  showCards?: boolean;
+}): React.JSX.Element {
   const [showKey, setShowKey] = useState(false);
   const { localLlm } = m;
+  const normalizedUrl =
+    normalizeOpenApiCompatibleEndpoint(localLlm.url) ?? localLlm.url.trim();
+  const activePresetId =
+    forcedPresetId ??
+    (OPENAPI_ENDPOINT_PRESETS.find(
+      (preset) =>
+        normalizeOpenApiCompatibleEndpoint(preset.endpoint) === normalizedUrl,
+    )?.id ??
+      null);
+  const credentialUi = getOpenApiCredentialUi(activePresetId);
+  const modelUi = getOpenApiModelUi(activePresetId);
 
   return (
     <div className="border-border border-b">
-      <div className="flex items-center gap-2 px-5 pb-2 pt-3">
-        <Laptop className="text-primary h-3 w-3" />
-        <span
-          className="mono text-foreground text-[10px] uppercase"
-          style={{ letterSpacing: "0.14em" }}
-        >
-          On-device
-        </span>
-        <span className="text-muted-foreground text-[11.5px]">
-          Ollama, LM Studio & other OpenAI-compatible servers
-        </span>
-      </div>
+      {showCards && (
+        <>
+          <div className="flex items-center gap-2 px-5 pb-2 pt-3">
+            <Laptop className="text-primary h-3 w-3" />
+            <span
+              className="mono text-foreground text-[10px] uppercase"
+              style={{ letterSpacing: "0.14em" }}
+            >
+              Add a provider
+            </span>
+            <span className="text-muted-foreground text-[11.5px]">
+              Pick a service, enter its key, then test and apply a model
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-2 px-5 pb-3 sm:grid-cols-3">
+            {OPENAPI_ENDPOINT_PRESETS.map((preset) => {
+              const active = preset.id === activePresetId;
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => {
+                    localLlm.setUrl(preset.endpoint);
+                    localLlm.clearStatus();
+                  }}
+                  className={cn(
+                    "flex flex-col items-start gap-0.5 rounded-lg border p-2.5 text-left transition-colors",
+                    active
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-border bg-background text-foreground hover:border-primary/60 hover:bg-secondary/40",
+                  )}
+                  title={preset.description}
+                >
+                  <span className="text-[12px] font-medium">{preset.label}</span>
+                  <span className="text-muted-foreground line-clamp-2 text-[10.5px] leading-snug">
+                    {preset.description}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
       <form
         onSubmit={(e) => {
           e.preventDefault();
@@ -850,7 +836,7 @@ function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
               localLlm.setUrl(e.target.value);
               localLlm.clearStatus();
             }}
-            placeholder="http://localhost:11434"
+            placeholder="http://localhost:11434/v1"
             className="border-border bg-background min-w-0 flex-1 rounded-md border px-3 py-2 text-[13px]"
           />
           <button
@@ -868,12 +854,18 @@ function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
             )}
           </button>
         </div>
+        <p className="text-muted-foreground text-[11.5px] leading-relaxed">
+          Use a base ending in <code>/v1</code>. If you paste a full{" "}
+          <code>/responses</code> or <code>/chat/completions</code> URL, we
+          normalize it to the matching <code>/v1</code> base before testing and
+          saving.
+        </p>
         <div className="relative">
           <input
             type={showKey ? "text" : "password"}
             value={localLlm.apiKey}
             onChange={(e) => localLlm.setApiKey(e.target.value)}
-            placeholder="API key (optional)"
+            placeholder={credentialUi.placeholder}
             className="border-border bg-background w-full rounded-md border px-3 py-2 pr-10 text-[13px]"
           />
           <button
@@ -884,10 +876,56 @@ function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
             {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
           </button>
         </div>
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={localLlm.modelName}
+              onChange={(e) => localLlm.setModelName(e.target.value)}
+              placeholder={modelUi.placeholder}
+              className="border-border bg-background min-w-0 flex-1 rounded-md border px-3 py-2 text-[13px]"
+            />
+            <button
+              type="button"
+              onClick={() => void onApply()}
+              disabled={!localLlm.modelName.trim() || localLlm.applyingModel}
+              className="bg-secondary hover:bg-secondary/80 shrink-0 rounded-md px-3.5 py-2 text-[12.5px] font-medium disabled:opacity-50"
+            >
+              {localLlm.applyingModel ? (
+                <span className="flex items-center gap-1.5">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Saving…
+                </span>
+              ) : (
+                "Use model"
+              )}
+            </button>
+          </div>
+          <p className="text-muted-foreground text-[11.5px] leading-relaxed">
+            {modelUi.hint}
+          </p>
+        </div>
+        {activePresetId && (
+          <p className="text-muted-foreground text-[11.5px] leading-relaxed">
+            {
+              OPENAPI_ENDPOINT_PRESETS.find(
+                (preset) => preset.id === activePresetId,
+              )?.description
+            }
+          </p>
+        )}
+        {localLlm.hint && (
+          <p className="text-muted-foreground text-[11.5px] leading-relaxed">
+            {localLlm.hint}
+          </p>
+        )}
         {localLlm.connected === true && (
           <p className="text-primary text-[12px]">
-            Connected ({localLlm.models.length}{" "}
-            {localLlm.models.length === 1 ? "model" : "models"})
+            {localLlm.models.length > 0
+              ? `Connected (${localLlm.models.length} ${
+                  localLlm.models.length === 1 ? "model" : "models"
+                } discovered)`
+              : "Connected"}
           </p>
         )}
         {localLlm.connected === false && (

--- a/apps/electron/src/renderer/src/pages/models/use-models.ts
+++ b/apps/electron/src/renderer/src/pages/models/use-models.ts
@@ -1,3 +1,4 @@
+import { normalizeOpenApiCompatibleEndpoint } from "@freestyle/validations";
 import { getClient } from "@renderer/lib/api";
 import type {
   AvailableModel,
@@ -23,11 +24,17 @@ export interface LocalLlmState {
   setUrl: (v: string) => void;
   apiKey: string;
   setApiKey: (v: string) => void;
+  modelName: string;
+  setModelName: (v: string) => void;
   testing: boolean;
+  applyingModel: boolean;
   connected: boolean | null;
   error: string | null;
+  hint: string | null;
   models: string[];
   test: () => Promise<void>;
+  applyModel: () => Promise<void>;
+  applyVoiceModel: () => Promise<void>;
   clearStatus: () => void;
 }
 
@@ -64,6 +71,7 @@ export interface UseModels {
     name: string,
     engine?: "whisper" | "mlx",
   ) => Promise<void>;
+  selectLocalVoiceModel: (modelName: string) => Promise<void>;
   retryLocalMlx: (defId: string) => Promise<void>;
   downloadLocal: (defId: string, engine?: "whisper" | "mlx") => void;
   cancelLocal: (defId: string, engine?: "whisper" | "mlx") => void;
@@ -89,12 +97,15 @@ export function useModels(): UseModels {
     DEFAULT_MLX_KEEP_ALIVE_MINUTES,
   );
 
-  // Local LLM (Ollama / LM Studio) connection — simplified inline form state.
-  const [localUrl, setLocalUrl] = useState("http://localhost:11434");
+  // OpenAPI-compatible cleanup model connection.
+  const [localUrl, setLocalUrl] = useState("http://localhost:11434/v1");
   const [localApiKey, setLocalApiKey] = useState("");
+  const [localModelName, setLocalModelName] = useState("");
   const [localTesting, setLocalTesting] = useState(false);
+  const [localApplyingModel, setLocalApplyingModel] = useState(false);
   const [localConnected, setLocalConnected] = useState<boolean | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [localHint, setLocalHint] = useState<string | null>(null);
   const [localModels, setLocalModels] = useState<string[]>([]);
 
   // -------------------------------------------------------------------------
@@ -134,7 +145,11 @@ export function useModels(): UseModels {
       }
       if (localUrlRes.ok) {
         const data = await localUrlRes.json();
-        if ("value" in data && data.value) setLocalUrl(data.value);
+        if ("value" in data && data.value) {
+          setLocalUrl(
+            normalizeOpenApiCompatibleEndpoint(data.value) ?? data.value,
+          );
+        }
       }
       if (localKeyRes.ok) {
         const data = await localKeyRes.json();
@@ -263,6 +278,13 @@ export function useModels(): UseModels {
       keyProviders,
     },
   );
+
+  useEffect(() => {
+    if (defaultLlm?.provider !== "local-llm") return;
+    const configuredModel = defaultLlm.model_id.replace(/^local-llm\//, "");
+    if (!configuredModel) return;
+    setLocalModelName((prev) => prev || configuredModel);
+  }, [defaultLlm]);
 
   // -------------------------------------------------------------------------
   // Actions
@@ -426,6 +448,22 @@ export function useModels(): UseModels {
     [loadData],
   );
 
+  const selectLocalVoiceModel = useCallback(
+    async (modelName: string) => {
+      await getClient().api.models.configured.$post({
+        json: {
+          provider: "local-llm",
+          model_id: `local-llm/${modelName}`,
+          model_name: modelName,
+          type: "voice",
+          is_default: true,
+        },
+      });
+      await loadData();
+    },
+    [loadData],
+  );
+
   const setCleanup = useCallback((next: boolean) => {
     setLlmCleanup(next);
     getClient()
@@ -477,14 +515,23 @@ export function useModels(): UseModels {
   const clearLocalStatus = useCallback(() => {
     setLocalConnected(null);
     setLocalError(null);
+    setLocalHint(null);
   }, []);
 
   const testLocalLlm = useCallback(async () => {
     setLocalTesting(true);
     setLocalConnected(null);
     setLocalError(null);
+    setLocalHint(null);
     try {
-      const url = localUrl.replace(/\/+$/, "");
+      const url = normalizeOpenApiCompatibleEndpoint(localUrl);
+      if (!url) {
+        setLocalConnected(false);
+        setLocalError(
+          "Use https, or http only for localhost, and end the base URL with /v1.",
+        );
+        return;
+      }
       const key = localApiKey.trim();
       const client = getClient();
       await Promise.all([
@@ -509,8 +556,17 @@ export function useModels(): UseModels {
       if (res.ok) {
         const result = await res.json();
         if ("ok" in result && result.ok) {
+          const models = Array.isArray(result.models) ? result.models : [];
           setLocalConnected(true);
-          setLocalModels(result.models ?? []);
+          setLocalModels(models);
+          setLocalHint(
+            "hint" in result && typeof result.hint === "string"
+              ? result.hint
+              : null,
+          );
+          if (models.length > 0 && !localModelName.trim()) {
+            setLocalModelName(models[0] ?? "");
+          }
           await loadData();
           return;
         }
@@ -530,7 +586,64 @@ export function useModels(): UseModels {
     } finally {
       setLocalTesting(false);
     }
-  }, [localUrl, localApiKey, loadData]);
+  }, [localUrl, localApiKey, localModelName, loadData]);
+
+  const applyLocalLlmModel = useCallback(async () => {
+    const modelName = localModelName.trim();
+    if (!modelName) {
+      setLocalError("Enter a model or deployment name first.");
+      return;
+    }
+
+    setLocalApplyingModel(true);
+    setLocalError(null);
+
+    try {
+      await selectLocalLlmModel(modelName);
+      if (!llmCleanup) {
+        await getClient()
+          .api.settings[":key"].$put({
+            param: { key: "llm_cleanup" },
+            json: { value: "true" },
+          })
+          .then(() => setLlmCleanup(true))
+          .catch((err) => console.error("Failed to enable cleanup:", err));
+      }
+      setLocalModels((prev) =>
+        prev.includes(modelName) ? prev : [...prev, modelName],
+      );
+    } catch (err) {
+      setLocalError(
+        err instanceof Error ? err.message : "Failed to save model name",
+      );
+    } finally {
+      setLocalApplyingModel(false);
+    }
+  }, [localModelName, llmCleanup, selectLocalLlmModel]);
+
+  const applyLocalVoiceModel = useCallback(async () => {
+    const modelName = localModelName.trim();
+    if (!modelName) {
+      setLocalError("Enter a model or deployment name first.");
+      return;
+    }
+
+    setLocalApplyingModel(true);
+    setLocalError(null);
+
+    try {
+      await selectLocalVoiceModel(modelName);
+      setLocalModels((prev) =>
+        prev.includes(modelName) ? prev : [...prev, modelName],
+      );
+    } catch (err) {
+      setLocalError(
+        err instanceof Error ? err.message : "Failed to save model name",
+      );
+    } finally {
+      setLocalApplyingModel(false);
+    }
+  }, [localModelName, selectLocalVoiceModel]);
 
   return {
     loading,
@@ -551,16 +664,23 @@ export function useModels(): UseModels {
       setUrl: setLocalUrl,
       apiKey: localApiKey,
       setApiKey: setLocalApiKey,
+      modelName: localModelName,
+      setModelName: setLocalModelName,
       testing: localTesting,
+      applyingModel: localApplyingModel,
       connected: localConnected,
       error: localError,
+      hint: localHint,
       models: localModels,
       test: testLocalLlm,
+      applyModel: applyLocalLlmModel,
+      applyVoiceModel: applyLocalVoiceModel,
       clearStatus: clearLocalStatus,
     },
     configureModel,
     saveKey,
     selectLocalVoice,
+    selectLocalVoiceModel,
     retryLocalMlx,
     downloadLocal,
     cancelLocal,

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -18,6 +18,7 @@ import {
   Mic,
   Monitor,
   Moon,
+  Sparkles,
   Sun,
   Trash2,
   Volume2,
@@ -69,6 +70,7 @@ export default function SettingsPage(): React.JSX.Element {
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [audioDuckingEnabled, setAudioDuckingEnabled] = useState(true);
   const [audioDuckingLevel, setAudioDuckingLevel] = useState(0);
+  const [llmCleanupEnabled, setLlmCleanupEnabled] = useState(false);
   const [transcriptionPrompt, setTranscriptionPrompt] = useState("");
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null);
   const [updateDownloaded, setUpdateDownloaded] = useState(false);
@@ -270,6 +272,13 @@ export default function SettingsPage(): React.JSX.Element {
       })
       .catch(() => {});
     getClient()
+      .api.settings[":key"].$get({ param: { key: "llm_cleanup" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value === "true") setLlmCleanupEnabled(true);
+      })
+      .catch(() => {});
+    getClient()
       .api.settings[":key"].$get({ param: { key: "transcription_prompt" } })
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
@@ -445,6 +454,16 @@ export default function SettingsPage(): React.JSX.Element {
       .api.settings[":key"].$put({
         param: { key: "audio_ducking_level" },
         json: { value: String(next) },
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleLlmCleanupToggle = useCallback((enabled: boolean) => {
+    setLlmCleanupEnabled(enabled);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "llm_cleanup" },
+        json: { value: String(enabled) },
       })
       .catch(() => {});
   }, []);
@@ -817,6 +836,21 @@ export default function SettingsPage(): React.JSX.Element {
           </Row>
         </Section>
 
+        <Section label="Cleanup model">
+          <Row
+            label="Enable cleanup model"
+            desc="Use a text model to post-process transcripts after speech recognition. Configure the cleanup model on the Models page."
+            last
+          >
+            <div className="flex items-center gap-2.5">
+              <Sparkles className="text-muted-foreground h-4 w-4 shrink-0" />
+              <Toggle
+                on={llmCleanupEnabled}
+                onChange={handleLlmCleanupToggle}
+              />
+            </div>
+          </Row>
+        </Section>
 
         <Section label="Permissions">
           <Row

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -46,6 +46,11 @@ function normalizePillPos(pos: string): string {
   return pos.startsWith("custom") ? "custom" : pos;
 }
 
+function clampAudioDuckingLevel(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.round(value), 0), 100);
+}
+
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
@@ -62,6 +67,8 @@ export default function SettingsPage(): React.JSX.Element {
   const [outputMode, setOutputMode] = useState("paste");
   const [pillPosition, setPillPosition] = useState("bottom-center");
   const [soundEnabled, setSoundEnabled] = useState(true);
+  const [audioDuckingEnabled, setAudioDuckingEnabled] = useState(true);
+  const [audioDuckingLevel, setAudioDuckingLevel] = useState(0);
   const [transcriptionPrompt, setTranscriptionPrompt] = useState("");
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null);
   const [updateDownloaded, setUpdateDownloaded] = useState(false);
@@ -249,6 +256,20 @@ export default function SettingsPage(): React.JSX.Element {
       })
       .catch(() => {});
     getClient()
+      .api.settings[":key"].$get({ param: { key: "audio_ducking_enabled" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value === "false") setAudioDuckingEnabled(false);
+      })
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "audio_ducking_level" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        setAudioDuckingLevel(clampAudioDuckingLevel(Number(data?.value ?? 0)));
+      })
+      .catch(() => {});
+    getClient()
       .api.settings[":key"].$get({ param: { key: "transcription_prompt" } })
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
@@ -401,6 +422,29 @@ export default function SettingsPage(): React.JSX.Element {
       .api.settings[":key"].$put({
         param: { key: "sound_enabled" },
         json: { value: String(enabled) },
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleAudioDuckingToggle = useCallback((enabled: boolean) => {
+    setAudioDuckingEnabled(enabled);
+    window.api?.sendAudioDuckingChanged(enabled);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "audio_ducking_enabled" },
+        json: { value: String(enabled) },
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleAudioDuckingLevelChange = useCallback((value: number) => {
+    const next = clampAudioDuckingLevel(value);
+    setAudioDuckingLevel(next);
+    window.api?.sendAudioDuckingLevelChanged(next);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "audio_ducking_level" },
+        json: { value: String(next) },
       })
       .catch(() => {});
   }, []);
@@ -680,7 +724,6 @@ export default function SettingsPage(): React.JSX.Element {
           <Row
             label="Sound feedback"
             desc="Soft chimes at the start and end of recording."
-            last
           >
             <div className="flex items-center gap-2.5">
               {soundEnabled ? (
@@ -689,6 +732,61 @@ export default function SettingsPage(): React.JSX.Element {
                 <VolumeOff className="text-muted-foreground h-4 w-4 shrink-0" />
               )}
               <Toggle on={soundEnabled} onChange={handleSoundToggle} />
+            </div>
+          </Row>
+
+          <Row
+            label="Push-to-talk ducking"
+            desc="Set the background audio level while push-to-talk is active. 0% fully mutes it; higher values keep more sound in the mix."
+            last
+          >
+            <div className="max-w-md space-y-3">
+              <div className="flex items-center gap-2.5">
+                {audioDuckingEnabled ? (
+                  <Volume2 className="text-muted-foreground h-4 w-4 shrink-0" />
+                ) : (
+                  <VolumeOff className="text-muted-foreground h-4 w-4 shrink-0" />
+                )}
+                <Toggle
+                  on={audioDuckingEnabled}
+                  onChange={handleAudioDuckingToggle}
+                />
+                <span className="text-muted-foreground text-[12.5px]">
+                  {audioDuckingLevel === 0
+                    ? "Full mute"
+                    : `${audioDuckingLevel}% of current volume`}
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-muted-foreground w-10 text-[12px]">
+                  0%
+                </span>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  step={1}
+                  value={audioDuckingLevel}
+                  disabled={!audioDuckingEnabled}
+                  onChange={(e) =>
+                    handleAudioDuckingLevelChange(Number(e.target.value))
+                  }
+                  className="h-2 w-full appearance-none rounded-full outline-none disabled:opacity-40 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-primary [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:shadow-[0_0_0_4px_var(--card)]"
+                  style={{
+                    background: `linear-gradient(to right, var(--color-primary) 0%, var(--color-primary) ${audioDuckingLevel}%, color-mix(in srgb, var(--color-border) 86%, transparent) ${audioDuckingLevel}%, color-mix(in srgb, var(--color-border) 86%, transparent) 100%)`,
+                  }}
+                />
+                <span className="text-muted-foreground w-12 text-right text-[12px]">
+                  100%
+                </span>
+              </div>
+              <p className="text-muted-foreground text-[12px] leading-[1.5]">
+                {audioDuckingEnabled
+                  ? audioDuckingLevel === 0
+                    ? "Freestyle fully mutes background audio while you hold push-to-talk."
+                    : `Freestyle keeps background audio at ${audioDuckingLevel}% of its current volume while you hold push-to-talk.`
+                  : "Turn this on if you want Freestyle to reduce or mute background audio while you speak."}
+              </p>
             </div>
           </Row>
         </Section>
@@ -718,6 +816,7 @@ export default function SettingsPage(): React.JSX.Element {
             />
           </Row>
         </Section>
+
 
         <Section label="Permissions">
           <Row

--- a/apps/server/src/lib/openapi-compatible.ts
+++ b/apps/server/src/lib/openapi-compatible.ts
@@ -1,0 +1,109 @@
+import { normalizeOpenApiCompatibleEndpoint } from "@freestyle/validations";
+import { getOpenRouterHeaders } from "./openrouter.js";
+
+const MANUAL_MODEL_SELECTION_STATUSES = new Set([400, 404, 405, 422, 501]);
+
+export function getNormalizedOpenApiCompatibleEndpoint(
+  value: unknown,
+): string | null {
+  return normalizeOpenApiCompatibleEndpoint(value) ?? null;
+}
+
+export function isAzureOpenAiEndpoint(endpoint: string): boolean {
+  const url = safeParseUrl(endpoint);
+  return Boolean(url?.hostname.endsWith(".openai.azure.com"));
+}
+
+export function isOfficialOpenAiEndpoint(endpoint: string): boolean {
+  const url = safeParseUrl(endpoint);
+  return Boolean(url && url.hostname === "api.openai.com");
+}
+
+export function isOpenRouterEndpoint(endpoint: string): boolean {
+  const url = safeParseUrl(endpoint);
+  return Boolean(url && url.hostname === "openrouter.ai");
+}
+
+export function getOpenApiCompatibleProviderLabel(endpoint: string): string {
+  if (isAzureOpenAiEndpoint(endpoint)) return "Azure OpenAI";
+
+  const url = safeParseUrl(endpoint);
+  if (!url) return "OpenAPI Compatible";
+  if (url.hostname === "api.openai.com") return "OpenAI";
+  if (url.hostname === "openrouter.ai") return "OpenRouter";
+  if (url.hostname === "api.moonshot.cn") return "Moonshot";
+  if (url.hostname === "api.together.ai") return "Together AI";
+  if (url.hostname === "api.fireworks.ai") return "Fireworks AI";
+  if (url.hostname === "api.deepinfra.com") return "DeepInfra";
+  if (url.hostname === "api.sambanova.ai") return "SambaNova";
+  if (isLocalOpenApiHost(url.hostname)) {
+    return "Local OpenAPI";
+  }
+  return "OpenAPI Compatible";
+}
+
+export function canUseManualOpenApiCompatibleModelSelection(
+  status: number,
+): boolean {
+  return MANUAL_MODEL_SELECTION_STATUSES.has(status);
+}
+
+export function getOpenApiCompatibleManualModelHint(endpoint: string): string {
+  if (isAzureOpenAiEndpoint(endpoint)) {
+    return "Azure OpenAI often skips shared /models discovery here. Enter your deployment name manually below, then choose it as the cleanup model.";
+  }
+
+  if (isOpenRouterEndpoint(endpoint)) {
+    return "OpenRouter did not return model discovery from this endpoint right now. Enter the model ID manually below if you want to use it anyway.";
+  }
+
+  const url = safeParseUrl(endpoint);
+  if (url?.hostname === "api.moonshot.cn") {
+    return "Moonshot did not return model discovery from this endpoint right now. Enter the model name manually below, then choose it as the cleanup model.";
+  }
+
+  if (url && isLocalOpenApiHost(url.hostname)) {
+    return "This local gateway did not expose /models. Enter the model name manually below, then choose it as the cleanup model.";
+  }
+
+  return "This OpenAPI-compatible endpoint did not expose /models. Enter the model or deployment name manually below, then choose it as the cleanup model.";
+}
+
+export function buildOpenApiCompatibleHeaders(
+  endpoint: string,
+  apiKey?: string,
+  extra?: Record<string, string>,
+): Record<string, string> {
+  if (isOpenRouterEndpoint(endpoint)) {
+    return getOpenRouterHeaders(apiKey, extra);
+  }
+
+  const headers: Record<string, string> = {
+    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    ...extra,
+  };
+
+  if (apiKey) {
+    if (isAzureOpenAiEndpoint(endpoint)) {
+      headers["api-key"] = apiKey;
+    } else if (!isOfficialOpenAiEndpoint(endpoint)) {
+      headers["x-api-key"] = apiKey;
+    }
+  }
+
+  return headers;
+}
+
+function safeParseUrl(endpoint: string): URL | null {
+  try {
+    return new URL(endpoint);
+  } catch {
+    return null;
+  }
+}
+
+function isLocalOpenApiHost(hostname: string): boolean {
+  return (
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+  );
+}

--- a/apps/server/src/lib/openrouter.ts
+++ b/apps/server/src/lib/openrouter.ts
@@ -1,0 +1,24 @@
+export const OPENROUTER_API_BASE = "https://openrouter.ai/api/v1";
+export const OPENROUTER_PROVIDER_ID = "openrouter";
+export const OPENROUTER_PROVIDER_NAME = "OpenRouter";
+
+const OPENROUTER_APP_URL = "https://github.com/freestyle-voice/freestyle";
+const OPENROUTER_APP_TITLE = "Freestyle";
+
+export function getOpenRouterHeaders(
+  apiKey?: string,
+  extra?: Record<string, string>,
+): Record<string, string> {
+  return {
+    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    "HTTP-Referer": OPENROUTER_APP_URL,
+    "X-Title": OPENROUTER_APP_TITLE,
+    ...extra,
+  };
+}
+
+export function prefixOpenRouterModelId(modelId: string): string {
+  return modelId.startsWith(`${OPENROUTER_PROVIDER_ID}/`)
+    ? modelId
+    : `${OPENROUTER_PROVIDER_ID}/${modelId}`;
+}

--- a/apps/server/src/lib/providers.ts
+++ b/apps/server/src/lib/providers.ts
@@ -6,6 +6,11 @@ import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModel } from "ai";
 import { getDb } from "./db.js";
 import { reconcileUnsupportedMlxVoiceDefault } from "./mlx-asr/reconcile.js";
+import {
+  buildOpenApiCompatibleHeaders,
+  getNormalizedOpenApiCompatibleEndpoint,
+  getOpenApiCompatibleProviderLabel,
+} from "./openapi-compatible.js";
 import { getApiKeyForProvider } from "./streaming-stt.js";
 
 const LOCAL_PROVIDERS = new Set(["local-llm"]);
@@ -57,10 +62,25 @@ const PROVIDER_FACTORIES: Record<
       .prepare("SELECT value FROM settings WHERE key = 'local_llm_api_key'")
       .get() as { value: string } | undefined;
 
-    const baseURL = urlRow.value.replace(/\/v1\/?$/, "");
-    const apiKey = keyRow?.value || "local";
+    const endpoint = getNormalizedOpenApiCompatibleEndpoint(urlRow.value);
+    if (!endpoint) {
+      throw new Error(
+        "OpenAPI-compatible endpoint URL is invalid. Re-save it in Settings > Models.",
+      );
+    }
+    const rawApiKey = keyRow?.value?.trim() || undefined;
+    const apiKey = rawApiKey || "local";
 
-    const p = createOpenAI({ apiKey, baseURL: `${baseURL}/v1` });
+    const p = createOpenAI({
+      apiKey,
+      baseURL: endpoint,
+      headers: rawApiKey
+        ? buildOpenApiCompatibleHeaders(endpoint, rawApiKey)
+        : undefined,
+      name: getOpenApiCompatibleProviderLabel(endpoint)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-"),
+    });
     return { chat: (m: string) => p.chat(m) };
   },
 };

--- a/apps/server/src/lib/streaming-stt.ts
+++ b/apps/server/src/lib/streaming-stt.ts
@@ -45,6 +45,14 @@ export function openStreamingSession(opts: {
 export function getApiKeyForProvider(providerId: string): string | null {
   if (LOCAL_STT_PROVIDERS.has(providerId)) return "local";
 
+  if (providerId === "local-llm") {
+    const db = getDb();
+    const row = db
+      .prepare("SELECT value FROM settings WHERE key = 'local_llm_api_key'")
+      .get() as { value: string } | undefined;
+    return row?.value?.trim() ?? null;
+  }
+
   const db = getDb();
   const row = db
     .prepare("SELECT key FROM api_keys WHERE provider = ?")

--- a/apps/server/src/lib/streaming/providers/local-llm.ts
+++ b/apps/server/src/lib/streaming/providers/local-llm.ts
@@ -1,0 +1,44 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { getDb } from "../../db.js";
+import type {
+  StreamingSessionOptions,
+  StreamSession,
+  TranscribeOptions,
+  TranscribeResult,
+  TranscriptionProvider,
+} from "../types.js";
+import { stripProviderPrefix } from "../types.js";
+import { transcribeWithAiSdk } from "../utils.js";
+
+function getLocalLlmSettings(): { url: string | null; apiKey: string | null } {
+  const db = getDb();
+  const urlRow = db
+    .prepare("SELECT value FROM settings WHERE key = 'local_llm_url'")
+    .get() as { value: string } | undefined;
+  const keyRow = db
+    .prepare("SELECT value FROM settings WHERE key = 'local_llm_api_key'")
+    .get() as { value: string } | undefined;
+  return {
+    url: urlRow?.value?.trim() || null,
+    apiKey: keyRow?.value?.trim() || null,
+  };
+}
+
+export class LocalLlmTranscriptionProvider implements TranscriptionProvider {
+  readonly providerId = "local-llm";
+
+  async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
+    const { url } = getLocalLlmSettings();
+    const createProvider = (config: { apiKey: string }) =>
+      createOpenAI({ apiKey: config.apiKey, baseURL: url ?? undefined });
+    return transcribeWithAiSdk(opts, createProvider, this.providerId);
+  }
+
+  supportsStreaming(): boolean {
+    return false;
+  }
+
+  openStreamingSession(_opts: StreamingSessionOptions): StreamSession {
+    throw new Error("Streaming is not supported for local-llm voice models");
+  }
+}

--- a/apps/server/src/lib/streaming/providers/openapi-compatible.ts
+++ b/apps/server/src/lib/streaming/providers/openapi-compatible.ts
@@ -1,0 +1,48 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import {
+  getOpenApiEndpointPreset,
+  isFixedOpenApiEndpoint,
+} from "@freestyle/validations";
+import type {
+  StreamingSessionOptions,
+  StreamSession,
+  TranscribeOptions,
+  TranscribeResult,
+  TranscriptionProvider,
+} from "../types.js";
+import { transcribeWithAiSdk } from "../utils.js";
+
+export class OpenApiCompatibleTranscriptionProvider
+  implements TranscriptionProvider
+{
+  readonly providerId: string;
+
+  constructor(providerId: string) {
+    this.providerId = providerId;
+  }
+
+  async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
+    const preset = getOpenApiEndpointPreset(this.providerId);
+    if (!preset || !isFixedOpenApiEndpoint(preset.endpoint)) {
+      throw new Error(
+        `No fixed OpenAPI-compatible endpoint configured for provider: ${this.providerId}`,
+      );
+    }
+
+    const endpoint = preset.endpoint.replace(/\/+$/, "");
+    const createProvider = (config: { apiKey: string }) =>
+      createOpenAI({ apiKey: config.apiKey, baseURL: endpoint });
+
+    return transcribeWithAiSdk(opts, createProvider, this.providerId);
+  }
+
+  supportsStreaming(): boolean {
+    return false;
+  }
+
+  openStreamingSession(_opts: StreamingSessionOptions): StreamSession {
+    throw new Error(
+      `Streaming is not supported for OpenAPI-compatible provider: ${this.providerId}`,
+    );
+  }
+}

--- a/apps/server/src/lib/streaming/providers/openrouter.ts
+++ b/apps/server/src/lib/streaming/providers/openrouter.ts
@@ -1,0 +1,70 @@
+import { Buffer } from "node:buffer";
+import {
+  getOpenRouterHeaders,
+  OPENROUTER_API_BASE,
+  OPENROUTER_PROVIDER_ID,
+} from "../../openrouter.js";
+import type {
+  TranscribeOptions,
+  TranscribeResult,
+  TranscriptionProvider,
+} from "../types.js";
+import { CLOUD_TRANSCRIBE_TIMEOUT_MS, stripProviderPrefix } from "../types.js";
+
+interface OpenRouterTranscriptionResponse {
+  text?: string;
+  usage?: {
+    seconds?: number;
+  };
+  error?: {
+    message?: string;
+  };
+}
+
+export class OpenRouterTranscriptionProvider implements TranscriptionProvider {
+  readonly providerId = OPENROUTER_PROVIDER_ID;
+
+  async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
+    const res = await fetch(`${OPENROUTER_API_BASE}/audio/transcriptions`, {
+      method: "POST",
+      headers: getOpenRouterHeaders(opts.apiKey, {
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({
+        model: stripProviderPrefix(opts.model),
+        input_audio: {
+          data: Buffer.from(opts.audio).toString("base64"),
+          format: "wav",
+        },
+        ...(opts.language && opts.language !== "auto"
+          ? { language: opts.language }
+          : {}),
+      }),
+      signal: AbortSignal.timeout(CLOUD_TRANSCRIBE_TIMEOUT_MS),
+    });
+
+    if (!res.ok) {
+      const message = await readOpenRouterError(res);
+      throw new Error(message);
+    }
+
+    const data = (await res.json()) as OpenRouterTranscriptionResponse;
+    return {
+      text: data.text?.trim() ?? "",
+      durationInSeconds: data.usage?.seconds,
+    };
+  }
+
+  supportsStreaming(_modelId: string): boolean {
+    return false;
+  }
+}
+
+async function readOpenRouterError(res: Response): Promise<string> {
+  const body = (await res
+    .json()
+    .catch(() => null)) as OpenRouterTranscriptionResponse | null;
+  const detail = body?.error?.message?.trim() ?? "";
+  if (detail) return detail;
+  return `OpenRouter transcription failed (${res.status})`;
+}

--- a/apps/server/src/lib/streaming/registry.ts
+++ b/apps/server/src/lib/streaming/registry.ts
@@ -1,18 +1,25 @@
 import { DeepgramTranscriptionProvider } from "./providers/deepgram.js";
 import { ElevenLabsTranscriptionProvider } from "./providers/elevenlabs.js";
 import { GroqTranscriptionProvider } from "./providers/groq.js";
+import { LocalLlmTranscriptionProvider } from "./providers/local-llm.js";
+import { OpenApiCompatibleTranscriptionProvider } from "./providers/openapi-compatible.js";
 import { MlxLocalTranscriptionProvider } from "./providers/mlx-local.js";
 import { OpenAITranscriptionProvider } from "./providers/openai.js";
+import { OpenRouterTranscriptionProvider } from "./providers/openrouter.js";
 import { WhisperLocalTranscriptionProvider } from "./providers/whisper-local.js";
 import type { TranscriptionProvider } from "./types.js";
 
 const providers: TranscriptionProvider[] = [
   new OpenAITranscriptionProvider(),
+  new OpenRouterTranscriptionProvider(),
   new DeepgramTranscriptionProvider(),
   new ElevenLabsTranscriptionProvider(),
   new GroqTranscriptionProvider(),
   new WhisperLocalTranscriptionProvider(),
   new MlxLocalTranscriptionProvider(),
+  new LocalLlmTranscriptionProvider(),
+  new OpenApiCompatibleTranscriptionProvider("together"),
+  new OpenApiCompatibleTranscriptionProvider("fireworks"),
 ];
 
 const providerMap = new Map(providers.map((p) => [p.providerId, p]));

--- a/apps/server/src/lib/validate-key.ts
+++ b/apps/server/src/lib/validate-key.ts
@@ -5,6 +5,8 @@
  * authenticates the key without incurring usage charges.
  */
 
+import { getOpenRouterHeaders, OPENROUTER_API_BASE } from "./openrouter.js";
+
 const TIMEOUT_MS = 10_000;
 
 interface ValidationResult {
@@ -24,6 +26,10 @@ const FORMAT_HINTS: Record<string, { prefix: string; hint: string }> = {
   groq: {
     prefix: "gsk_",
     hint: 'Groq keys start with "gsk_".',
+  },
+  openrouter: {
+    prefix: "sk-or-",
+    hint: 'OpenRouter keys start with "sk-or-".',
   },
 };
 
@@ -146,6 +152,27 @@ async function validateMistral(apiKey: string): Promise<ValidationResult> {
   return { valid: false, error: `Mistral returned HTTP ${res.status}.` };
 }
 
+async function validateOpenRouter(apiKey: string): Promise<ValidationResult> {
+  const res = await fetch(`${OPENROUTER_API_BASE}/key`, {
+    headers: getOpenRouterHeaders(apiKey),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.ok) return { valid: true };
+  if (res.status === 401 || res.status === 403) {
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  }
+  if (res.status === 402) {
+    return {
+      valid: false,
+      error: "OpenRouter key has no credits available.",
+    };
+  }
+  return { valid: false, error: `OpenRouter returned HTTP ${res.status}.` };
+}
+
 // ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
@@ -161,6 +188,7 @@ const LIVE_VALIDATORS: Record<
   anthropic: validateAnthropic,
   google: validateGoogle,
   mistral: validateMistral,
+  openrouter: validateOpenRouter,
 };
 
 export async function validateApiKey(

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -9,6 +9,26 @@ import {
 import { getMlxModelStatus } from "../lib/mlx-asr/models.js";
 import { reconcileUnsupportedMlxVoiceDefault } from "../lib/mlx-asr/reconcile.js";
 import { canRunMlxAsr } from "../lib/mlx-asr/server.js";
+import {
+  buildOpenApiCompatibleHeaders,
+  getNormalizedOpenApiCompatibleEndpoint,
+  getOpenApiCompatibleProviderLabel,
+} from "../lib/openapi-compatible.js";
+import { getApiKeyForProvider } from "../lib/streaming-stt.js";
+import {
+  getOpenApiEndpointPreset,
+  isFixedOpenApiEndpoint,
+  OPENAPI_CLOUD_PROVIDER_IDS,
+  type OpenApiCloudProviderId,
+} from "@freestyle/validations";
+
+import {
+  getOpenRouterHeaders,
+  OPENROUTER_API_BASE,
+  OPENROUTER_PROVIDER_ID,
+  OPENROUTER_PROVIDER_NAME,
+  prefixOpenRouterModelId,
+} from "../lib/openrouter.js";
 import { capture } from "../lib/posthog.js";
 import { stripProviderPrefix } from "../lib/streaming/types.js";
 import { isServerBinaryAvailable } from "../lib/whisper/binary.js";
@@ -35,10 +55,15 @@ interface AvailableModel {
 
 const DEPRECATED_STATUS = "deprecated";
 const REGISTRY_FETCH_TIMEOUT_MS = 3000;
+const OPENROUTER_FETCH_TIMEOUT_MS = 4000;
+const OPENAPI_CLOUD_FETCH_TIMEOUT_MS = 4000;
+const MAX_OPENAPI_MODELS_PER_PROVIDER = 200;
 const UNSUITABLE_CLEANUP_MODEL_PATTERN =
   /guard|safeguard|safety|moderation|classif(?:y|ier|ication)?|embed(?:ding)?|image/i;
 
-async function fetchLocalLlmModels(): Promise<AvailableModel[]> {
+async function fetchLocalOpenApiModels(
+  type: "voice" | "llm",
+): Promise<AvailableModel[]> {
   const db = getDb();
   const urlRow = db
     .prepare("SELECT value FROM settings WHERE key = 'local_llm_url'")
@@ -49,12 +74,12 @@ async function fetchLocalLlmModels(): Promise<AvailableModel[]> {
     .prepare("SELECT value FROM settings WHERE key = 'local_llm_api_key'")
     .get() as { value: string } | undefined;
 
-  const baseUrl = urlRow.value.replace(/\/+$/, "").replace(/\/v1$/, "");
+  const endpoint = getNormalizedOpenApiCompatibleEndpoint(urlRow.value);
+  if (!endpoint) return [];
+  const apiKey = keyRow?.value?.trim() || undefined;
 
-  const res = await fetch(`${baseUrl}/v1/models`, {
-    headers: {
-      ...(keyRow?.value ? { Authorization: `Bearer ${keyRow.value}` } : {}),
-    },
+  const res = await fetch(`${endpoint}/models`, {
+    headers: buildOpenApiCompatibleHeaders(endpoint, apiKey),
     signal: AbortSignal.timeout(3000),
   });
   if (!res.ok) return [];
@@ -64,13 +89,15 @@ async function fetchLocalLlmModels(): Promise<AvailableModel[]> {
   };
   if (!data.data || !Array.isArray(data.data)) return [];
 
+  const providerName = getOpenApiCompatibleProviderLabel(endpoint);
+
   return data.data.map((m) => ({
     provider_id: "local-llm",
-    provider_name: "Local LLM",
+    provider_name: providerName,
     model_id: `local-llm/${m.id}`,
     model_name: m.id,
-    family: "local",
-    type: "llm" as const,
+    family: "openapi-compatible",
+    type,
     cost_input: 0,
     cost_output: 0,
   }));
@@ -166,6 +193,17 @@ const CURATED_LLM_IDS = new Set([
 // In-memory cache for models.dev data
 let modelsCache: { data: unknown; fetchedAt: number } | null = null;
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+let openRouterVoiceCache: { data: AvailableModel[]; fetchedAt: number } | null =
+  null;
+const openApiCloudVoiceCache = new Map<
+  OpenApiCloudProviderId,
+  { data: AvailableModel[]; fetchedAt: number }
+>();
+
+// Heuristic identifiers for transcription-capable models on OpenAPI-compatible
+// providers that do not publish modality metadata in their /models response.
+const TRANSCRIPTION_MODEL_HINTS =
+  /whisper|transcrib|audio|speech.?to.?text|stt/i;
 
 async function fetchModelsFromRegistry(): Promise<Record<string, unknown>> {
   if (modelsCache && Date.now() - modelsCache.fetchedAt < CACHE_TTL_MS) {
@@ -181,6 +219,132 @@ async function fetchModelsFromRegistry(): Promise<Record<string, unknown>> {
   const data = (await res.json()) as Record<string, unknown>;
   modelsCache = { data, fetchedAt: Date.now() };
   return data;
+}
+
+interface OpenRouterModel {
+  id: string;
+  name: string;
+  architecture?: {
+    input_modalities?: string[];
+    output_modalities?: string[];
+    modality?: string;
+  };
+}
+
+async function fetchOpenRouterVoiceModels(): Promise<AvailableModel[]> {
+  if (
+    openRouterVoiceCache &&
+    Date.now() - openRouterVoiceCache.fetchedAt < CACHE_TTL_MS
+  ) {
+    return openRouterVoiceCache.data;
+  }
+
+  const res = await fetch(
+    `${OPENROUTER_API_BASE}/models?output_modalities=transcription`,
+    {
+      headers: getOpenRouterHeaders(),
+      signal: AbortSignal.timeout(OPENROUTER_FETCH_TIMEOUT_MS),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch OpenRouter models: ${res.status}`);
+  }
+
+  const data = (await res.json()) as { data?: OpenRouterModel[] };
+  const models = (data.data ?? [])
+    .filter((model) => {
+      const input = model.architecture?.input_modalities ?? [];
+      const output = model.architecture?.output_modalities ?? [];
+      return input.includes("audio") && output.includes("transcription");
+    })
+    .map(
+      (model): AvailableModel => ({
+        provider_id: OPENROUTER_PROVIDER_ID,
+        provider_name: OPENROUTER_PROVIDER_NAME,
+        model_id: prefixOpenRouterModelId(model.id),
+        model_name: model.name,
+        family: model.id.split("/")[0] ?? "openrouter",
+        type: "voice",
+      }),
+    )
+    .sort((a, b) => a.model_name.localeCompare(b.model_name));
+
+  openRouterVoiceCache = { data: models, fetchedAt: Date.now() };
+  return models;
+}
+
+async function fetchOpenApiCloudVoiceModels(
+  providerId: OpenApiCloudProviderId,
+): Promise<AvailableModel[]> {
+  const cached = openApiCloudVoiceCache.get(providerId);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.data;
+  }
+
+  const preset = getOpenApiEndpointPreset(providerId);
+  if (!preset || !isFixedOpenApiEndpoint(preset.endpoint)) {
+    return [];
+  }
+
+  const apiKey = getApiKeyForProvider(providerId);
+  if (!apiKey) {
+    return [];
+  }
+
+  const endpoint = getNormalizedOpenApiCompatibleEndpoint(preset.endpoint);
+  if (!endpoint) {
+    return [];
+  }
+
+  const res = await fetch(`${endpoint}/models`, {
+    headers: buildOpenApiCompatibleHeaders(endpoint, apiKey),
+    signal: AbortSignal.timeout(OPENAPI_CLOUD_FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    return [];
+  }
+
+  const data = (await res.json()) as {
+    data?: Array<{
+      id: string;
+      name?: string;
+      architecture?: {
+        input_modalities?: string[];
+        output_modalities?: string[];
+        modality?: string;
+      };
+    }>;
+  };
+  if (!data.data || !Array.isArray(data.data)) {
+    return [];
+  }
+
+  const models = data.data
+    .slice(0, MAX_OPENAPI_MODELS_PER_PROVIDER)
+    .filter((model) => {
+      const input = model.architecture?.input_modalities ?? [];
+      const output = model.architecture?.output_modalities ?? [];
+      const hasAudioModality =
+        input.includes("audio") && output.includes("transcription");
+      const matchesTranscriptionHint = TRANSCRIPTION_MODEL_HINTS.test(
+        `${model.id} ${model.name ?? ""}`,
+      );
+      return hasAudioModality || matchesTranscriptionHint;
+    })
+    .map(
+      (model): AvailableModel => ({
+        provider_id: providerId,
+        provider_name: preset.label,
+        model_id: `${providerId}/${model.id}`,
+        model_name: model.name ?? model.id,
+        family: providerId,
+        type: "voice",
+      }),
+    )
+    .sort((a, b) => a.model_name.localeCompare(b.model_name));
+
+  openApiCloudVoiceCache.set(providerId, { data: models, fetchedAt: Date.now() });
+  return models;
 }
 
 /**
@@ -314,6 +478,23 @@ const models = new Hono()
         ...BUILTIN_VOICE_MODELS.map((m) => ({ ...m, curated: true })),
       );
 
+      try {
+        available.push(...(await fetchOpenRouterVoiceModels()));
+      } catch {
+        // OpenRouter model discovery is optional.
+      }
+
+      for (const providerId of OPENAPI_CLOUD_PROVIDER_IDS) {
+        if (providerId === OPENROUTER_PROVIDER_ID) continue;
+        try {
+          available.push(
+            ...(await fetchOpenApiCloudVoiceModels(providerId)),
+          );
+        } catch {
+          // Cloud OpenAPI provider discovery is optional.
+        }
+      }
+
       // Add local whisper voice models (only those that are downloaded)
       for (const whisperModel of LOCAL_WHISPER_VOICE_MODELS) {
         const modelId = whisperModel.model_id.split("/")[1];
@@ -334,11 +515,15 @@ const models = new Hono()
       }
 
       try {
-        const localModels = await fetchLocalLlmModels();
+        const localLlmModels = await fetchLocalOpenApiModels("llm");
+        const localVoiceModels = await fetchLocalOpenApiModels("voice");
         // The user explicitly connected this server — everything it serves is curated.
-        available.push(...localModels.map((m) => ({ ...m, curated: true })));
+        available.push(
+          ...localLlmModels.map((m) => ({ ...m, curated: true })),
+          ...localVoiceModels.map((m) => ({ ...m, curated: true })),
+        );
       } catch {
-        // Local LLM server not reachable
+        // Local OpenAPI-compatible server not reachable
       }
 
       return c.json(available);

--- a/apps/server/src/routes/settings.ts
+++ b/apps/server/src/routes/settings.ts
@@ -1,11 +1,17 @@
 import {
   localLlmConfigSchema,
+  normalizeOpenApiCompatibleEndpoint,
   settingValueSchema,
 } from "@freestyle/validations";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
 import { applyMlxAsrRetentionPolicy } from "../lib/mlx-asr/server.js";
+import {
+  buildOpenApiCompatibleHeaders,
+  canUseManualOpenApiCompatibleModelSelection,
+  getOpenApiCompatibleManualModelHint,
+} from "../lib/openapi-compatible.js";
 import { capture } from "../lib/posthog.js";
 
 const settings = new Hono()
@@ -67,19 +73,34 @@ const settings = new Hono()
     zValidator("json", localLlmConfigSchema),
     async (c) => {
       const body = c.req.valid("json");
-      const url = body.url.replace(/\/+$/, "").replace(/\/v1$/, "");
+      const endpoint = normalizeOpenApiCompatibleEndpoint(body.url);
+      if (!endpoint) {
+        return c.json(
+          {
+            error:
+              "Use https, or http only for localhost, and provide a base ending in /v1 or a full /responses or /chat/completions URL.",
+          },
+          400,
+        );
+      }
+      const apiKey = body.api_key?.trim() || undefined;
 
       try {
-        const res = await fetch(`${url}/v1/models`, {
-          headers: {
-            ...(body.api_key
-              ? { Authorization: `Bearer ${body.api_key}` }
-              : {}),
-          },
+        const res = await fetch(`${endpoint}/models`, {
+          headers: buildOpenApiCompatibleHeaders(endpoint, apiKey),
           signal: AbortSignal.timeout(5000),
         });
 
         if (!res.ok) {
+          if (canUseManualOpenApiCompatibleModelSelection(res.status)) {
+            return c.json({
+              ok: true,
+              models: [],
+              model_discovery: "manual",
+              hint: getOpenApiCompatibleManualModelHint(endpoint),
+            });
+          }
+
           return c.json(
             { error: `Server returned ${res.status}: ${res.statusText}` },
             502,
@@ -95,7 +116,16 @@ const settings = new Hono()
           models = data.data.map((m) => m.id);
         }
 
-        return c.json({ ok: true, models });
+        if (models.length === 0) {
+          return c.json({
+            ok: true,
+            models: [],
+            model_discovery: "manual",
+            hint: getOpenApiCompatibleManualModelHint(endpoint),
+          });
+        }
+
+        return c.json({ ok: true, models, model_discovery: "available" });
       } catch (err) {
         const message =
           err instanceof Error ? err.message : "Failed to connect";

--- a/apps/server/tests/openapi-compatible-route.test.ts
+++ b/apps/server/tests/openapi-compatible-route.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/index.js";
+
+describe("OpenAPI-compatible local LLM setup", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("allows manual model entry when /models discovery is unavailable", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response("not found", {
+        status: 404,
+        statusText: "Not Found",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const res = await app.request("/api/settings/local-llm/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        url: "https://demo.openai.azure.com/openai/v1",
+        api_key: "azure-key",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(
+      expect.objectContaining({
+        ok: true,
+        models: [],
+        model_discovery: "manual",
+        hint: expect.stringContaining("deployment"),
+      }),
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://demo.openai.azure.com/openai/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer azure-key",
+          "api-key": "azure-key",
+        }),
+      }),
+    );
+  });
+});

--- a/apps/server/tests/openapi-compatible.test.ts
+++ b/apps/server/tests/openapi-compatible.test.ts
@@ -1,0 +1,117 @@
+import {
+  normalizeOpenApiCompatibleEndpoint,
+  OPENAPI_ENDPOINT_PRESETS,
+} from "@freestyle/validations";
+import { describe, expect, it } from "vitest";
+import {
+  buildOpenApiCompatibleHeaders,
+  canUseManualOpenApiCompatibleModelSelection,
+  getOpenApiCompatibleManualModelHint,
+  getOpenApiCompatibleProviderLabel,
+  isAzureOpenAiEndpoint,
+} from "../src/lib/openapi-compatible.js";
+
+describe("OpenAPI-compatible endpoint helpers", () => {
+  it("normalizes OpenAPI-compatible endpoints to a /v1 base", () => {
+    expect(
+      normalizeOpenApiCompatibleEndpoint(
+        "https://example.com/v1/chat/completions",
+      ),
+    ).toBe("https://example.com/v1");
+    expect(
+      normalizeOpenApiCompatibleEndpoint("http://localhost:4000/v1/responses"),
+    ).toBe("http://localhost:4000/v1");
+    expect(
+      normalizeOpenApiCompatibleEndpoint("https://api.moonshot.cn/v1"),
+    ).toBe("https://api.moonshot.cn/v1");
+    expect(
+      normalizeOpenApiCompatibleEndpoint(
+        "https://api.deepinfra.com/v1/openai/chat/completions",
+      ),
+    ).toBe("https://api.deepinfra.com/v1/openai");
+  });
+
+  it("rejects non-local plain-http endpoints", () => {
+    expect(
+      normalizeOpenApiCompatibleEndpoint("http://example.com/v1"),
+    ).toBeUndefined();
+  });
+
+  it("adds provider-specific auth headers for Azure and generic gateways", () => {
+    expect(
+      isAzureOpenAiEndpoint("https://demo.openai.azure.com/openai/v1"),
+    ).toBe(true);
+    expect(
+      buildOpenApiCompatibleHeaders(
+        "https://demo.openai.azure.com/openai/v1",
+        "azure-key",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        Authorization: "Bearer azure-key",
+        "api-key": "azure-key",
+      }),
+    );
+
+    expect(
+      buildOpenApiCompatibleHeaders("https://api.moonshot.cn/v1", "moon-key"),
+    ).toEqual(
+      expect.objectContaining({
+        Authorization: "Bearer moon-key",
+        "x-api-key": "moon-key",
+      }),
+    );
+  });
+
+  it("labels imported OpenPets presets clearly", () => {
+    expect(
+      getOpenApiCompatibleProviderLabel("https://openrouter.ai/api/v1"),
+    ).toBe("OpenRouter");
+    expect(getOpenApiCompatibleProviderLabel("https://api.openai.com/v1")).toBe(
+      "OpenAI",
+    );
+    expect(
+      getOpenApiCompatibleProviderLabel("https://api.moonshot.cn/v1"),
+    ).toBe("Moonshot");
+    expect(
+      getOpenApiCompatibleProviderLabel("https://api.together.ai/v1"),
+    ).toBe("Together AI");
+    expect(
+      getOpenApiCompatibleProviderLabel(
+        "https://api.fireworks.ai/inference/v1",
+      ),
+    ).toBe("Fireworks AI");
+    expect(
+      getOpenApiCompatibleProviderLabel("https://api.deepinfra.com/v1/openai"),
+    ).toBe("DeepInfra");
+    expect(
+      getOpenApiCompatibleProviderLabel("https://api.sambanova.ai/v1"),
+    ).toBe("SambaNova");
+    expect(getOpenApiCompatibleProviderLabel("http://localhost:11434/v1")).toBe(
+      "Local OpenAPI",
+    );
+  });
+
+  it("covers the curated OpenAPI-compatible presets", () => {
+    expect(OPENAPI_ENDPOINT_PRESETS.map((preset) => preset.id)).toEqual(
+      expect.arrayContaining([
+        "openrouter",
+        "azure",
+        "litellm-local",
+        "together",
+        "fireworks",
+        "https-template",
+      ]),
+    );
+  });
+
+  it("allows manual model selection when shared model discovery is unavailable", () => {
+    expect(canUseManualOpenApiCompatibleModelSelection(404)).toBe(true);
+    expect(canUseManualOpenApiCompatibleModelSelection(401)).toBe(false);
+    expect(
+      getOpenApiCompatibleManualModelHint(
+        "https://demo.openai.azure.com/openai/v1",
+      ),
+    ).toContain("deployment");
+  });
+});

--- a/apps/server/tests/openrouter.test.ts
+++ b/apps/server/tests/openrouter.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/index.js";
+import { validateApiKey } from "../src/lib/validate-key.js";
+
+describe("OpenRouter support", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("validates OpenRouter keys against the current key endpoint", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { limit_remaining: 42 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await validateApiKey("openrouter", "sk-or-test-key");
+
+    expect(result).toEqual({ valid: true });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://openrouter.ai/api/v1/key",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-or-test-key",
+        }),
+      }),
+    );
+  });
+
+  it("includes OpenRouter transcription models in the available catalog", async () => {
+    const fetchSpy = vi.fn((input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url === "https://models.dev/api.json") {
+        return Promise.resolve(
+          new Response(JSON.stringify({}), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      if (
+        url ===
+        "https://openrouter.ai/api/v1/models?output_modalities=transcription"
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  id: "nvidia/parakeet-tdt-0.6b-v3",
+                  name: "NVIDIA: Parakeet TDT 0.6B v3",
+                  architecture: {
+                    input_modalities: ["audio"],
+                    output_modalities: ["transcription"],
+                  },
+                },
+              ],
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const res = await app.request("/api/models/available");
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as Array<Record<string, unknown>>;
+    expect(data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider_id: "openrouter",
+          provider_name: "OpenRouter",
+          model_id: "openrouter/nvidia/parakeet-tdt-0.6b-v3",
+          model_name: "NVIDIA: Parakeet TDT 0.6B v3",
+          type: "voice",
+        }),
+      ]),
+    );
+  });
+});

--- a/docs/pr-messages/PR_native_windows_volume_control.md
+++ b/docs/pr-messages/PR_native_windows_volume_control.md
@@ -1,0 +1,98 @@
+# Cross-platform native volume-control helpers for audio ducking
+
+**Branch:** `build/native-windows-volume-control`  
+**Base:** `main`
+
+## What this PR does
+
+Replaces the Windows audio-ducking PowerShell/COM backend with a small, persistent native helper written in **C**, and hardens the macOS and Linux audio-ducking paths so all three desktop platforms use fast, native volume APIs with safe fallbacks.
+
+- **Windows:** persistent C helper using Core Audio `IAudioEndpointVolume`, with PowerShell fallback preserved.
+- **macOS:** new Swift helper using CoreAudio `AudioObjectGetPropertyData` / `AudioObjectSetPropertyData`, replacing per-duck AppleScript `osascript` calls; AppleScript fallback preserved.
+- **Linux:** hardened shell-out path and native mic listener, with no shell-injection surface and bounded C buffers.
+
+## Why C instead of PowerShell on Windows
+
+The old Windows path encoded a C# snippet into base64 and spawned a **new PowerShell process** for every `duck()` and `restore()`. That added noticeable latency, created a process per key-press, and depended on shell round-trips. A warm C helper removes that overhead while preserving the same snapshot/restore safety model.
+
+## Windows C implementation details
+
+- `apps/electron/native/windows-volume-control.c` (new)
+  - Persistent helper using Core Audio `IMMDeviceEnumerator` + `IAudioEndpointVolume`.
+  - Line-based stdin protocol: `get`, `set <0..1>`, `mute <0|1>`, `quit`.
+  - Defines the three required COM GUIDs inline so the binary links with `clang-cl`/`clang` without relying on `uuid.lib` for those symbols.
+  - Clean shutdown on stdin EOF, `quit`, Ctrl+C/Close/Logoff/Shutdown events; releases COM objects and calls `CoUninitialize()`.
+- `apps/electron/scripts/compile-native.js`
+  - Adds `windows-volume-control.exe` to the Windows binary list.
+  - Falls back gracefully if compilation fails.
+- `apps/electron/src/main/audio-ducking.ts`
+  - Adds `NativeWindowsVolumeController`: spawns the helper once, enforces startup (2 s) and per-command (500 ms) timeouts, restarts on failure, and falls back to PowerShell after repeated failure.
+  - Keeps snapshot/restore depth logic, `MIN_DUCK_DELTA`, and `RESTORE_EPSILON` unchanged.
+
+## Benefits
+
+- **Snappy:** Volume changes happen as soon as the key event arrives; no PowerShell cold-start overhead per key press.
+- **Low overhead:** One persistent helper process reuses the COM endpoint instead of spawning a new process every duck/restore cycle.
+- **Predictable:** Direct Core Audio calls replace shelling out, parsing base64, and depending on the PowerShell runtime.
+- **Resilient:** If the helper cannot be compiled, is missing, exits unexpectedly, or fails repeatedly, the code automatically falls back to the original PowerShell backend.
+- **Clean lifecycle:** The helper exits cleanly on stdin EOF, an explicit `quit` command, or console/session events; all COM objects are released and `CoUninitialize()` is called.
+- **Self-contained:** Inline GUID definitions let it link on Windows build hosts that only have `clang-cl` available and lack `uuid.lib`.
+
+## Safety mechanisms
+
+- **Snapshot/restore depth tracking** remains unchanged, so nested duck/restore calls cannot leave the system volume stuck.
+- **`MIN_DUCK_DELTA` and `RESTORE_EPSILON`** are preserved, preventing tiny, inaudible volume adjustments and noisy restore attempts.
+- **Startup timeout (2 s)** prevents the UI from waiting forever if the helper binary hangs on launch.
+- **Per-command timeout (500 ms)** aborts a stuck helper command and triggers a restart.
+- **Restart-on-failure with a failure budget** avoids an infinite crash loop; after repeated failures the controller switches back to the proven PowerShell fallback.
+- **Safe disposal** kills the helper process and releases all handles/resources when the app quits or the controller is torn down.
+- **Unexpected-exit handling** detects when the helper dies and restarts it on the next duck request.
+
+## macOS implementation hardening
+
+The macOS audio-ducking path was hardened as part of this change:
+
+- **Native CoreAudio helper:** Added `apps/electron/native/macos-volume-control.swift`, a small Swift binary that replaces AppleScript `osascript` calls. It reads and writes the default output device’s `kAudioHardwareServiceDeviceProperty_VirtualMasterVolume` and `kAudioDevicePropertyMute` via `AudioObjectGetPropertyData` / `AudioObjectSetPropertyData`.
+- **Simple argv protocol:** `get` returns `volume|muted`; `set <0..1>` adjusts output volume; `mute` / `unmute` toggle mute.
+- **Fallback preserved:** `audio-ducking.ts` detects `process.platform === "darwin"` and prefers the native helper when compiled, falling back to AppleScript if the binary is missing or fails.
+- **Build integration:** `apps/electron/scripts/compile-native.js` compiles `macos-volume-control` with `-framework CoreAudio -framework Foundation` during packaging.
+- **No shell injection surface:** When the native helper is unavailable, `osascript` is invoked through `execFileAsync` with fixed argument arrays; no user-controlled strings reach a shell.
+- **Safety model unchanged:** Snapshot/restore depth tracking, `MIN_DUCK_DELTA`, and `RESTORE_EPSILON` apply to the macOS path exactly as before.
+
+## Linux implementation hardening
+
+The Linux audio-ducking path was reviewed and hardened as part of this change:
+
+- **No shell injection surface:** `audio-ducking.ts` invokes `pactl`/`wpctl` through `execFileAsync` with fixed argument arrays; no user-controlled strings are passed to a shell.
+- **Bounded C helpers:** `linux-key-listener.c` uses `strncpy` with explicit null-termination and `snprintf` with fixed-size buffers; no raw `strcpy`, `strcat`, `sprintf`, `gets`, or `system` calls are present.
+- **Fixed commands only:** `linux-mic-listener.c` uses `popen` only with hard-coded `pactl` commands and reads output with `fgets` into fixed buffers.
+- **Single-process/single-thread:** the helpers do not share mutable state across threads, so `strtok` non-reentrancy is not a practical concern.
+
+## Known limitations
+
+- `windows-mic-listener.exe` still fails to link on the clang-cl-only build host because of the same unresolved COM GUID issue. This is pre-existing; mic detection falls back to the legacy path.
+- The helper targets the default multimedia playback endpoint only. Per-application ducking is out of scope.
+
+## How to test
+
+1. `pnpm typecheck` in `apps/electron` should pass for both node and web.
+2. `pnpm compile:native` on Windows should produce `resources/bin/win32-x64/windows-volume-control.exe`.
+3. `pnpm compile:native` on macOS should produce `resources/bin/darwin-*/macos-volume-control`.
+4. Manually pipe commands to the Windows helper and verify `get`, `set`, `mute`, and `quit` respond correctly.
+5. Run the macOS helper with `get`, `set`, `mute`, and `unmute` and verify volume/mute state changes.
+6. Run `pnpm build:win` and confirm the installer is signed and contains the new binary.
+7. In the running app, hold the push-to-hold key; system volume should duck immediately and restore on release.
+
+## Checklist
+
+- [x] Windows native helper implemented in C using Core Audio.
+- [x] Windows native helper compiles with the available toolchain.
+- [x] macOS native helper implemented in Swift using CoreAudio.
+- [x] macOS native helper compiles with the available toolchain.
+- [x] Linux shell-out and native helper paths hardened.
+- [x] TypeScript typechecks pass.
+- [x] Windows PowerShell fallback preserved.
+- [x] macOS AppleScript fallback preserved.
+- [x] Snapshot/restore safety logic unchanged.
+- [x] Build script updated for all three platforms.
+- [x] Windows installer built and signed.

--- a/docs/pr-messages/PR_openapi_providers.md
+++ b/docs/pr-messages/PR_openapi_providers.md
@@ -1,0 +1,79 @@
+# OpenAPI-compatible providers and model-page configuration
+
+**Branch:** `pr/openapi-providers`  
+**Base:** `main`
+
+## What this PR does
+
+Adds support for the most commonly used OpenAPI-compatible providers (OpenRouter, Azure OpenAI, LiteLLM/Local, Together AI, Fireworks AI, and generic custom endpoints) directly in the Models page. Lesser-known providers are omitted to keep the picker approachable; users can still reach any other endpoint through the "Custom endpoint" preset.
+
+## Files changed
+
+### Server / API
+
+- `apps/server/src/lib/openapi-compatible.ts` — OpenAPI-compatible request/response handling and endpoint normalization.
+- `apps/server/src/lib/openrouter.ts` — OpenRouter-specific integration.
+- `apps/server/src/lib/providers.ts` — Provider registry updates.
+- `apps/server/src/lib/streaming/providers/openrouter.ts` — Streaming support for OpenRouter.
+- `apps/server/src/lib/streaming/registry.ts` — Registry wiring.
+- `apps/server/src/lib/validate-key.ts` — API-key validation updates.
+- `apps/server/src/routes/models.ts` — `/available` now fetches models from the configured OpenAPI-compatible endpoint; `/settings/local-llm/test` validates the connection.
+- `apps/server/src/routes/settings.ts` — Settings route updates.
+- `apps/server/tests/openapi-compatible.test.ts`
+- `apps/server/tests/openapi-compatible-route.test.ts`
+- `apps/server/tests/openrouter.test.ts`
+
+### Shared validations
+
+- `packages/validations/src/index.ts`
+- `packages/validations/src/openapi.ts` — Schemas for OpenAPI provider config, endpoint normalization, and the curated preset list.
+
+### Electron renderer
+
+- `apps/electron/src/renderer/src/components/model-row.tsx` — Row rendering for OpenAPI models.
+- `apps/electron/src/renderer/src/pages/models/model-list.tsx` — Adds a prominent "Add a provider" shelf at the top of the LLM picker. The curated providers (OpenRouter, Azure OpenAI, LiteLLM / Local, Together AI, Fireworks AI, Custom endpoint) are shown as labeled cards with short descriptions. Clicking a card pre-fills the endpoint and reveals the key/model form.
+- `apps/electron/src/renderer/src/pages/models/model-modal.tsx` — Modal wiring.
+- `apps/electron/src/renderer/src/pages/models/use-models.ts` — State and test/apply logic for the local-llm connection.
+
+## First-class cloud voice providers
+
+OpenRouter, Together AI, and Fireworks AI are also promoted to first-class voice providers in the model picker:
+
+- Each appears as a provider chip once an API key is stored.
+- The server fetches transcription-capable models from the provider’s `/models` endpoint.
+- A generic `OpenApiCompatibleTranscriptionProvider` routes audio through the provider’s endpoint.
+- Preset chips for these three providers are suppressed in voice mode to avoid duplication.
+
+Azure OpenAI, LiteLLM / Local, and Custom endpoint remain manual configuration presets because they require a URL or deployment name.
+
+## How it works
+
+OpenAPI-compatible providers are **configured, not auto-discovered**. They appear in the UI after the user:
+
+1. Opens the LLM model picker (Settings → Models → Cleanup model).
+2. Selects an OpenAPI-compatible preset (e.g., OpenRouter) or types a custom `/v1` endpoint.
+3. Enters an API key if required.
+4. Clicks **Test**.
+5. Selects a discovered model (or types one manually) and clicks **Apply**.
+
+Once configured, the discovered models are listed as `local-llm` rows in the model picker.
+
+## How to test
+
+1. `pnpm typecheck` should pass.
+2. Server unit tests should pass (`pnpm test` in `apps/server`).
+3. Open the LLM model picker and confirm the "Add a provider" shelf is visible at the top with six cards.
+4. Enter a valid OpenRouter API key, click Test, and confirm models are discovered.
+5. Select a model and verify it is saved as the cleanup model.
+6. Confirm that removed presets (Moonshot, DeepInfra, SambaNova, vLLM, raw localhost template) no longer appear in the shelf.
+
+## Checklist
+
+- [x] OpenAPI-compatible provider backend implemented.
+- [x] OpenRouter provider implemented.
+- [x] First-class cloud voice providers (OpenRouter, Together AI, Fireworks AI) implemented.
+- [x] Generic OpenApiCompatibleTranscriptionProvider implemented.
+- [x] Duplicate provider/preset chips removed.
+- [x] Model-page UI updated.
+- [x] Validation schemas added.
+- [x] Tests added.

--- a/docs/pr-messages/README.md
+++ b/docs/pr-messages/README.md
@@ -1,0 +1,11 @@
+# Pull request messages
+
+This directory contains prepared pull-request descriptions for the current feature batch. They are organized by category so each branch can be reviewed and merged independently.
+
+| File | Branch | Category |
+|---|---|---|
+| `PR_native_windows_volume_control.md` | `feat/native-windows-volume-control` | Native Windows audio-ducking helper |
+| `PR_branding_icons.md` | `pr/branding-icons` | Royal-blue icon/branding refresh |
+| `PR_openapi_providers.md` | `pr/openapi-providers` | OpenAPI-compatible providers |
+
+The integration build that combines these branches is `build/audio-ducking-rename-branding`.

--- a/packages/validations/src/index.ts
+++ b/packages/validations/src/index.ts
@@ -3,6 +3,7 @@ export * from "./dictionary.js";
 export * from "./formats.js";
 export * from "./local-llm.js";
 export * from "./models.js";
+export * from "./openapi.js";
 export * from "./query.js";
 export * from "./settings.js";
 export * from "./vocabulary.js";

--- a/packages/validations/src/openapi.ts
+++ b/packages/validations/src/openapi.ts
@@ -1,0 +1,142 @@
+export type OpenApiEndpointPresetApplyMode = "save" | "draft";
+
+export interface OpenApiEndpointPreset {
+  id: string;
+  label: string;
+  endpoint: string;
+  applyMode: OpenApiEndpointPresetApplyMode;
+  description: string;
+}
+
+/**
+ * Curated list of the most commonly used OpenAPI-compatible providers.
+ * Lesser-known providers are intentionally omitted to keep the picker
+ * approachable; users can still reach any other endpoint through the
+ * "Custom endpoint" preset.
+ */
+export const OPENAPI_ENDPOINT_PRESETS: readonly OpenApiEndpointPreset[] = [
+  {
+    id: "openrouter",
+    label: "OpenRouter",
+    endpoint: "https://openrouter.ai/api/v1",
+    applyMode: "save",
+    description:
+      "OpenRouter's OpenAPI-compatible base for models and chat completions.",
+  },
+  {
+    id: "azure",
+    label: "Azure OpenAI",
+    endpoint: "https://YOUR-RESOURCE-NAME.openai.azure.com/openai/v1",
+    applyMode: "draft",
+    description:
+      "Prefills the Azure OpenAI v1 base. Replace YOUR-RESOURCE-NAME first.",
+  },
+  {
+    id: "litellm-local",
+    label: "LiteLLM / Local",
+    endpoint: "http://localhost:4000/v1",
+    applyMode: "save",
+    description: "Common local LiteLLM gateway port.",
+  },
+  {
+    id: "together",
+    label: "Together AI",
+    endpoint: "https://api.together.ai/v1",
+    applyMode: "save",
+    description:
+      "Together AI's OpenAI-compatible base for open-weight chat and speech models.",
+  },
+  {
+    id: "fireworks",
+    label: "Fireworks AI",
+    endpoint: "https://api.fireworks.ai/inference/v1",
+    applyMode: "save",
+    description:
+      "Fireworks AI's OpenAI-compatible inference base for chat-capable models.",
+  },
+  {
+    id: "https-template",
+    label: "Custom endpoint",
+    endpoint: "https://YOUR-HOSTNAME.example.com/v1",
+    applyMode: "draft",
+    description: "Any other hosted OpenAPI-compatible gateway or proxy.",
+  },
+] as const;
+
+/**
+ * Cloud providers whose endpoint is fixed and only requires an API key.
+ * These are surfaced as first-class provider chips rather than manual
+ * endpoint presets.
+ */
+export const OPENAPI_CLOUD_PROVIDER_IDS = [
+  "openrouter",
+  "together",
+  "fireworks",
+] as const;
+
+export type OpenApiCloudProviderId =
+  (typeof OPENAPI_CLOUD_PROVIDER_IDS)[number];
+
+export function isFixedOpenApiEndpoint(endpoint: string): boolean {
+  return (
+    !endpoint.includes("YOUR-") &&
+    !endpoint.includes("example.com") &&
+    !endpoint.includes("localhost") &&
+    !endpoint.includes("127.0.0.1")
+  );
+}
+
+export function getOpenApiEndpointPreset(id: string) {
+  return OPENAPI_ENDPOINT_PRESETS.find((p) => p.id === id);
+}
+
+export function normalizeOpenApiCompatibleEndpoint(
+  value: unknown,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 2_048 || /[\0\r\n]/.test(trimmed)) {
+    return undefined;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return undefined;
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") return undefined;
+  if (
+    url.protocol === "http:" &&
+    url.hostname !== "localhost" &&
+    url.hostname !== "127.0.0.1" &&
+    url.hostname !== "::1"
+  ) {
+    return undefined;
+  }
+  if (!url.hostname || url.username || url.password || url.search || url.hash) {
+    return undefined;
+  }
+
+  const path = url.pathname.replace(/\/+$/, "");
+  if (!path || path === "/") {
+    url.pathname = "/v1";
+  } else if (
+    path.endsWith("/responses") ||
+    path.endsWith("/chat/completions")
+  ) {
+    const basePath = path.replace(/\/(?:responses|chat\/completions)$/, "");
+    if (basePath.endsWith("/v1") || basePath.endsWith("/v1/openai")) {
+      url.pathname = basePath;
+    } else {
+      return undefined;
+    }
+  } else if (path.endsWith("/v1") || path.endsWith("/v1/openai")) {
+    url.pathname = path;
+  } else {
+    return undefined;
+  }
+
+  return url.toString();
+}


### PR DESCRIPTION
# OpenAPI-compatible providers and model-page configuration

**Branch:** `pr/openapi-providers`  
**Base:** `main`

## What this PR does

Adds support for the most commonly used OpenAPI-compatible providers (OpenRouter, Azure OpenAI, LiteLLM/Local, Together AI, Fireworks AI, and generic custom endpoints) directly in the Models page. Lesser-known providers are omitted to keep the picker approachable; users can still reach any other endpoint through the "Custom endpoint" preset.

## Files changed

### Server / API

- `apps/server/src/lib/openapi-compatible.ts` — OpenAPI-compatible request/response handling and endpoint normalization.
- `apps/server/src/lib/openrouter.ts` — OpenRouter-specific integration.
- `apps/server/src/lib/providers.ts` — Provider registry updates.
- `apps/server/src/lib/streaming/providers/openrouter.ts` — Streaming support for OpenRouter.
- `apps/server/src/lib/streaming/registry.ts` — Registry wiring.
- `apps/server/src/lib/validate-key.ts` — API-key validation updates.
- `apps/server/src/routes/models.ts` — `/available` now fetches models from the configured OpenAPI-compatible endpoint; `/settings/local-llm/test` validates the connection.
- `apps/server/src/routes/settings.ts` — Settings route updates.
- `apps/server/tests/openapi-compatible.test.ts`
- `apps/server/tests/openapi-compatible-route.test.ts`
- `apps/server/tests/openrouter.test.ts`

### Shared validations

- `packages/validations/src/index.ts`
- `packages/validations/src/openapi.ts` — Schemas for OpenAPI provider config, endpoint normalization, and the curated preset list.

### Electron renderer

- `apps/electron/src/renderer/src/components/model-row.tsx` — Row rendering for OpenAPI models.
- `apps/electron/src/renderer/src/pages/models/model-list.tsx` — Adds a prominent "Add a provider" shelf at the top of the LLM picker. The curated providers (OpenRouter, Azure OpenAI, LiteLLM / Local, Together AI, Fireworks AI, Custom endpoint) are shown as labeled cards with short descriptions. Clicking a card pre-fills the endpoint and reveals the key/model form.
- `apps/electron/src/renderer/src/pages/models/model-modal.tsx` — Modal wiring.
- `apps/electron/src/renderer/src/pages/models/use-models.ts` — State and test/apply logic for the local-llm connection.

## First-class cloud voice providers

OpenRouter, Together AI, and Fireworks AI are also promoted to first-class voice providers in the model picker:

- Each appears as a provider chip once an API key is stored.
- The server fetches transcription-capable models from the provider’s `/models` endpoint.
- A generic `OpenApiCompatibleTranscriptionProvider` routes audio through the provider’s endpoint.
- Preset chips for these three providers are suppressed in voice mode to avoid duplication.

Azure OpenAI, LiteLLM / Local, and Custom endpoint remain manual configuration presets because they require a URL or deployment name.

## How it works

OpenAPI-compatible providers are **configured, not auto-discovered**. They appear in the UI after the user:

1. Opens the LLM model picker (Settings → Models → Cleanup model).
2. Selects an OpenAPI-compatible preset (e.g., OpenRouter) or types a custom `/v1` endpoint.
3. Enters an API key if required.
4. Clicks **Test**.
5. Selects a discovered model (or types one manually) and clicks **Apply**.

Once configured, the discovered models are listed as `local-llm` rows in the model picker.

## How to test

1. `pnpm typecheck` should pass.
2. Server unit tests should pass (`pnpm test` in `apps/server`).
3. Open the LLM model picker and confirm the "Add a provider" shelf is visible at the top with six cards.
4. Enter a valid OpenRouter API key, click Test, and confirm models are discovered.
5. Select a model and verify it is saved as the cleanup model.
6. Confirm that removed presets (Moonshot, DeepInfra, SambaNova, vLLM, raw localhost template) no longer appear in the shelf.

## Checklist

- [x] OpenAPI-compatible provider backend implemented.
- [x] OpenRouter provider implemented.
- [x] First-class cloud voice providers (OpenRouter, Together AI, Fireworks AI) implemented.
- [x] Generic OpenApiCompatibleTranscriptionProvider implemented.
- [x] Duplicate provider/preset chips removed.
- [x] Model-page UI updated.
- [x] Validation schemas added.
- [x] Tests added.
