### PR TITLE
feat(audio-ducking): cross-platform native volume control and hardening

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,10 +61,32 @@ jobs:
 
       - name: Install Craft
         run: |
-          CRAFT_URL=$(curl -fsSL https://api.github.com/repos/getsentry/craft/releases/latest \
-            | jq -r '.assets[] | select(.name == "craft") | .browser_download_url')
-          sudo curl -fsSL -o /usr/local/bin/craft "$CRAFT_URL"
+          set -euo pipefail
+
+          # Retry the GitHub API call because it can return 502/504 transiently.
+          CRAFT_URL=""
+          for i in 1 2 3 4 5; do
+            CRAFT_URL=$(curl -fsSL --retry 5 --retry-delay 2 \
+              https://api.github.com/repos/getsentry/craft/releases/latest \
+              | jq -r '.assets[] | select(.name == "craft") | .browser_download_url') && break
+            echo "Attempt $i failed to resolve Craft URL; retrying in 5s..."
+            sleep 5
+          done
+
+          if [[ -z "$CRAFT_URL" ]]; then
+            echo "::error::Could not determine Craft download URL"
+            exit 1
+          fi
+
+          # Retry the binary download for the same reason.
+          for i in 1 2 3 4 5; do
+            sudo curl -fsSL --retry 5 --retry-delay 2 -o /usr/local/bin/craft "$CRAFT_URL" && break
+            echo "Attempt $i failed to download Craft; retrying in 5s..."
+            sleep 5
+          done
+
           sudo chmod +x /usr/local/bin/craft
+          craft --version
 
       - name: Wait for CI on release branch
         env:

--- a/apps/electron/native/linux-mic-listener.c
+++ b/apps/electron/native/linux-mic-listener.c
@@ -1,0 +1,66 @@
+/*
+ * Linux microphone activity listener.
+ *
+ * Monitors PulseAudio/PipeWire source-outputs (apps recording audio) and emits:
+ *   MIC_ACTIVE   when at least one source-output exists
+ *   MIC_INACTIVE when no source-outputs remain
+ *
+ * It watches `pactl subscribe` for source-output new/remove events, then re-checks
+ * the actual count with `pactl list source-outputs` to avoid false positives from
+ * our own process or transient events.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define CHECK_INTERVAL_US 500000
+
+static int count_source_outputs(void) {
+    FILE *fp = popen("pactl list source-outputs 2>/dev/null", "r");
+    if (!fp) return 0;
+
+    int count = 0;
+    char line[1024];
+    while (fgets(line, sizeof(line), fp)) {
+        if (strncmp(line, "Source Output #", 15) == 0) {
+            count++;
+        }
+    }
+    pclose(fp);
+    return count;
+}
+
+static void emit(const char *state) {
+    printf("%s\n", state);
+    fflush(stdout);
+}
+
+int main(void) {
+    FILE *fp = popen("pactl subscribe 2>/dev/null", "r");
+    if (!fp) {
+        fprintf(stderr, "failed to run pactl subscribe\n");
+        return 1;
+    }
+
+    int active = count_source_outputs() > 0;
+    emit(active ? "MIC_ACTIVE" : "MIC_INACTIVE");
+
+    char line[1024];
+    while (fgets(line, sizeof(line), fp)) {
+        if (strstr(line, "source-output") == NULL) continue;
+
+        /* Debounce: wait a moment for state to settle, then recount. */
+        usleep(50000);
+        int now_active = count_source_outputs() > 0;
+        if (now_active != active) {
+            active = now_active;
+            emit(active ? "MIC_ACTIVE" : "MIC_INACTIVE");
+        }
+    }
+
+    pclose(fp);
+    return 0;
+}

--- a/apps/electron/native/macos-volume-control.swift
+++ b/apps/electron/native/macos-volume-control.swift
@@ -1,0 +1,146 @@
+import CoreAudio
+import Foundation
+
+// Freestyle macOS volume control helper.
+// Replaces AppleScript osascript calls with synchronous CoreAudio APIs.
+//
+// Commands:
+//   get              -> prints "<volume>|<muted>" where volume is 0..1
+//   set <volume>     -> set output volume (0..1)
+//   mute             -> mute default output device
+//   unmute           -> unmute default output device
+
+enum VolumeError: Error {
+    case invalidCommand
+    case audioObjectError(OSStatus)
+    case missingDefaultDevice
+}
+
+func defaultOutputDeviceID() throws -> AudioDeviceID {
+    var id = AudioDeviceID(0)
+    var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject),
+        &address,
+        0,
+        nil,
+        &size,
+        &id
+    )
+    guard status == noErr else {
+        throw VolumeError.audioObjectError(status)
+    }
+    guard id != kAudioDeviceUnknown else {
+        throw VolumeError.missingDefaultDevice
+    }
+    return id
+}
+
+func getVolume(deviceID: AudioDeviceID) throws -> Float {
+    var volume: Float = 0
+    var size = UInt32(MemoryLayout<Float>.size)
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwareServiceDeviceProperty_VirtualMasterVolume,
+        mScope: kAudioDevicePropertyScopeOutput,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &volume)
+    guard status == noErr else {
+        throw VolumeError.audioObjectError(status)
+    }
+    return volume
+}
+
+func setVolume(deviceID: AudioDeviceID, value: Float) throws {
+    var volume = max(0, min(1, value))
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwareServiceDeviceProperty_VirtualMasterVolume,
+        mScope: kAudioDevicePropertyScopeOutput,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectSetPropertyData(
+        deviceID,
+        &address,
+        0,
+        nil,
+        UInt32(MemoryLayout<Float>.size),
+        &volume
+    )
+    guard status == noErr else {
+        throw VolumeError.audioObjectError(status)
+    }
+}
+
+func getMute(deviceID: AudioDeviceID) throws -> Bool {
+    var muted: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyMute,
+        mScope: kAudioDevicePropertyScopeOutput,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &muted)
+    guard status == noErr else {
+        throw VolumeError.audioObjectError(status)
+    }
+    return muted != 0
+}
+
+func setMute(deviceID: AudioDeviceID, muted: Bool) throws {
+    var value: UInt32 = muted ? 1 : 0
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyMute,
+        mScope: kAudioDevicePropertyScopeOutput,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectSetPropertyData(
+        deviceID,
+        &address,
+        0,
+        nil,
+        UInt32(MemoryLayout<UInt32>.size),
+        &value
+    )
+    guard status == noErr else {
+        throw VolumeError.audioObjectError(status)
+    }
+}
+
+func run() throws {
+    let args = CommandLine.arguments.dropFirst()
+    guard let command = args.first else {
+        throw VolumeError.invalidCommand
+    }
+
+    let deviceID = try defaultOutputDeviceID()
+
+    switch command {
+    case "get":
+        let volume = try getVolume(deviceID: deviceID)
+        let muted = try getMute(deviceID: deviceID)
+        print("\(volume)|\(muted)")
+    case "set":
+        guard args.count >= 2, let value = Float(args.dropFirst().first!) else {
+            throw VolumeError.invalidCommand
+        }
+        try setVolume(deviceID: deviceID, value: value)
+    case "mute":
+        try setMute(deviceID: deviceID, muted: true)
+    case "unmute":
+        try setMute(deviceID: deviceID, muted: false)
+    default:
+        throw VolumeError.invalidCommand
+    }
+}
+
+do {
+    try run()
+} catch {
+    fputs("error: \(error)\n", stderr)
+    exit(1)
+}

--- a/apps/electron/native/windows-mic-listener.c
+++ b/apps/electron/native/windows-mic-listener.c
@@ -7,8 +7,8 @@
  * Uses IAudioSessionManager2 to enumerate and monitor capture sessions.
  * Supports --exclude-pid to ignore the app's own microphone usage.
  *
- * Compile with: cl /O2 windows-mic-listener.c /Fe:windows-mic-listener.exe ole32.lib oleaut32.lib
- * Or with MinGW: gcc -O2 windows-mic-listener.c -o windows-mic-listener.exe -lole32 -loleaut32
+ * Compile with: cl /O2 windows-mic-listener.c /Fe:windows-mic-listener.exe user32.lib ole32.lib oleaut32.lib uuid.lib
+ * Or with MinGW: gcc -O2 windows-mic-listener.c -o windows-mic-listener.exe -luser32 -lole32 -loleaut32 -luuid
  */
 
 #define WIN32_LEAN_AND_MEAN

--- a/apps/electron/native/windows-volume-control.c
+++ b/apps/electron/native/windows-volume-control.c
@@ -1,0 +1,322 @@
+/**
+ * Windows Volume Control Helper
+ *
+ * Native helper for low-latency Windows system-volume ducking.
+ *
+ * Opens the default playback endpoint's IAudioEndpointVolume once and keeps it
+ * alive for the lifetime of the process. Reads commands from stdin and writes
+ * compact "volume|muted" responses to stdout.
+ *
+ * Design goals:
+ *  - Fast: no PowerShell spawn per operation, warm COM object.
+ *  - Safe: clean shutdown on stdin close / EOF / CTRL events; the parent
+ *    process owns restore logic.
+ *  - Simple IPC: line-delimited text, one command per line.
+ *
+ * Supported commands (case-sensitive, trailing whitespace ignored):
+ *   get              -> "0.75|false\n"
+ *   set <0..1>       -> "ok\n"
+ *   mute <0|1>       -> "ok\n"
+ *   quit             -> "ok\n" then exit
+ *
+ * Error responses start with "err|" and are followed by a short message.
+ *
+ * Compile (MSVC):
+ *   cl /O2 /MT windows-volume-control.c /Fe:windows-volume-control.exe \
+ *      user32.lib ole32.lib uuid.lib
+ *
+ * Compile (MinGW):
+ *   gcc -O2 -mwindows windows-volume-control.c -o windows-volume-control.exe \
+ *       -luser32 -lole32 -luuid
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#define COBJMACROS
+#define CINTERFACE
+
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+/* Core Audio interface declarations. */
+#include <mmdeviceapi.h>
+#include <endpointvolume.h>
+
+/* ------------------------------------------------------------------------ *
+ * Explicit GUID definitions
+ *
+ * These symbols are normally supplied by defining INITGUID and including
+ * <initguid.h> before the Core Audio headers, or by linking uuid.lib. On the
+ * current build host only clang-cl is available, and neither path resolves the
+ * symbols, so we define them directly in this translation unit.
+ * ------------------------------------------------------------------------ */
+
+const CLSID CLSID_MMDeviceEnumerator =
+    { 0xBCDE0395, 0xE52F, 0x467C, { 0x8E, 0x3D, 0xC4, 0x57, 0x92, 0x91, 0x69, 0x2E } };
+
+const IID IID_IMMDeviceEnumerator =
+    { 0xA95664D2, 0x9614, 0x4F35, { 0xA7, 0x46, 0xDE, 0x8D, 0xB6, 0x36, 0x17, 0xE6 } };
+
+const IID IID_IAudioEndpointVolume =
+    { 0x5CDF2C82, 0x841E, 0x4546, { 0x97, 0x22, 0x0C, 0xF7, 0x40, 0x78, 0x22, 0x9A } };
+
+/* ------------------------------------------------------------------------ *
+ * Globals
+ * ------------------------------------------------------------------------ */
+
+static volatile BOOL g_running = TRUE;
+static IAudioEndpointVolume *g_endpoint = NULL;
+static IMMDeviceEnumerator *g_enumerator = NULL;
+static IMMDevice *g_device = NULL;
+
+/* ------------------------------------------------------------------------ *
+ * Helpers
+ * ------------------------------------------------------------------------ */
+
+static void write_line(const char *line) {
+    if (!line) return;
+    DWORD written = 0;
+    DWORD len = (DWORD)strlen(line);
+    HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (h == INVALID_HANDLE_VALUE) return;
+    WriteFile(h, line, len, &written, NULL);
+    WriteFile(h, "\n", 1, &written, NULL);
+    FlushFileBuffers(h);
+}
+
+static void report_error(const char *msg) {
+    char buf[512];
+    snprintf(buf, sizeof(buf), "err|%s", msg ? msg : "unknown");
+    write_line(buf);
+}
+
+static BOOL ensure_endpoint(void) {
+    if (g_endpoint) return TRUE;
+
+    HRESULT hr = CoCreateInstance(
+        &CLSID_MMDeviceEnumerator,
+        NULL,
+        CLSCTX_ALL,
+        &IID_IMMDeviceEnumerator,
+        (void **)&g_enumerator);
+    if (FAILED(hr) || !g_enumerator) {
+        report_error("device-enumerator-creation-failed");
+        return FALSE;
+    }
+
+    hr = g_enumerator->lpVtbl->GetDefaultAudioEndpoint(
+        g_enumerator, eRender, eMultimedia, &g_device);
+    if (FAILED(hr) || !g_device) {
+        report_error("default-endpoint-not-found");
+        return FALSE;
+    }
+
+    hr = g_device->lpVtbl->Activate(
+        g_device,
+        &IID_IAudioEndpointVolume,
+        CLSCTX_ALL,
+        NULL,
+        (void **)&g_endpoint);
+    if (FAILED(hr) || !g_endpoint) {
+        report_error("endpoint-activation-failed");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+static void release_endpoint(void) {
+    if (g_endpoint) {
+        g_endpoint->lpVtbl->Release(g_endpoint);
+        g_endpoint = NULL;
+    }
+    if (g_device) {
+        g_device->lpVtbl->Release(g_device);
+        g_device = NULL;
+    }
+    if (g_enumerator) {
+        g_enumerator->lpVtbl->Release(g_enumerator);
+        g_enumerator = NULL;
+    }
+}
+
+static void cmd_get(void) {
+    if (!ensure_endpoint()) return;
+
+    float volume = 0.0f;
+    BOOL muted = FALSE;
+    HRESULT hr = g_endpoint->lpVtbl->GetMasterVolumeLevelScalar(g_endpoint, &volume);
+    if (FAILED(hr)) {
+        report_error("get-volume-failed");
+        return;
+    }
+    hr = g_endpoint->lpVtbl->GetMute(g_endpoint, &muted);
+    if (FAILED(hr)) {
+        report_error("get-mute-failed");
+        return;
+    }
+
+    char buf[64];
+    snprintf(buf, sizeof(buf), "%f|%s", volume, muted ? "true" : "false");
+    write_line(buf);
+}
+
+static void cmd_set(const char *arg) {
+    if (!arg || !*arg) {
+        report_error("set-missing-argument");
+        return;
+    }
+    char *end = NULL;
+    double value = strtod(arg, &end);
+    if (end == arg || value < 0.0 || value > 1.0) {
+        report_error("set-invalid-argument");
+        return;
+    }
+    if (!ensure_endpoint()) return;
+
+    HRESULT hr = g_endpoint->lpVtbl->SetMasterVolumeLevelScalar(
+        g_endpoint, (float)value, NULL);
+    if (FAILED(hr)) {
+        report_error("set-volume-failed");
+        return;
+    }
+    write_line("ok");
+}
+
+static void cmd_mute(const char *arg) {
+    if (!arg || !*arg) {
+        report_error("mute-missing-argument");
+        return;
+    }
+    BOOL muted = FALSE;
+    if (strcmp(arg, "1") == 0 || _stricmp(arg, "true") == 0) {
+        muted = TRUE;
+    } else if (strcmp(arg, "0") == 0 || _stricmp(arg, "false") == 0) {
+        muted = FALSE;
+    } else {
+        report_error("mute-invalid-argument");
+        return;
+    }
+    if (!ensure_endpoint()) return;
+
+    HRESULT hr = g_endpoint->lpVtbl->SetMute(g_endpoint, muted, NULL);
+    if (FAILED(hr)) {
+        report_error("set-mute-failed");
+        return;
+    }
+    write_line("ok");
+}
+
+static void process_line(const char *line) {
+    char buf[256];
+    strncpy_s(buf, sizeof(buf), line, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+
+    /* Trim trailing whitespace */
+    size_t len = strlen(buf);
+    while (len > 0 && isspace((unsigned char)buf[len - 1])) {
+        buf[len - 1] = '\0';
+        len--;
+    }
+
+    if (strcmp(buf, "get") == 0) {
+        cmd_get();
+    } else if (strcmp(buf, "quit") == 0) {
+        write_line("ok");
+        g_running = FALSE;
+    } else if (strncmp(buf, "set ", 4) == 0) {
+        cmd_set(buf + 4);
+    } else if (strncmp(buf, "mute ", 5) == 0) {
+        cmd_mute(buf + 5);
+    } else if (strcmp(buf, "set") == 0 || strcmp(buf, "mute") == 0) {
+        report_error("missing-argument");
+    } else {
+        report_error("unknown-command");
+    }
+}
+
+/* ------------------------------------------------------------------------ *
+ * Console / signal handling
+ * ------------------------------------------------------------------------ */
+
+static BOOL WINAPI console_handler(DWORD signal) {
+    if (signal == CTRL_C_EVENT ||
+        signal == CTRL_BREAK_EVENT ||
+        signal == CTRL_CLOSE_EVENT ||
+        signal == CTRL_LOGOFF_EVENT ||
+        signal == CTRL_SHUTDOWN_EVENT) {
+        g_running = FALSE;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/* ------------------------------------------------------------------------ *
+ * Stdin reader
+ * ------------------------------------------------------------------------ */
+
+static BOOL read_line(char *out, size_t out_size) {
+    if (!out || out_size == 0) return FALSE;
+    size_t i = 0;
+    out[0] = '\0';
+
+    HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
+    if (hStdin == INVALID_HANDLE_VALUE) return FALSE;
+
+    while (g_running && i < out_size - 1) {
+        char ch = 0;
+        DWORD read = 0;
+        BOOL ok = ReadFile(hStdin, &ch, 1, &read, NULL);
+        if (!ok || read == 0) {
+            /* EOF or pipe closed */
+            return FALSE;
+        }
+        if (ch == '\n') {
+            break;
+        }
+        if (ch != '\r') {
+            out[i++] = ch;
+        }
+    }
+    out[i] = '\0';
+    return TRUE;
+}
+
+/* ------------------------------------------------------------------------ *
+ * Main
+ * ------------------------------------------------------------------------ */
+
+int main(void) {
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCtrlHandler(console_handler, TRUE);
+
+    HRESULT hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+    if (FAILED(hr)) {
+        report_error("coinitialize-failed");
+        return 1;
+    }
+
+    /* Pre-warm the endpoint so the first real command is fast. */
+    if (!ensure_endpoint()) {
+        CoUninitialize();
+        return 1;
+    }
+
+    write_line("ready");
+
+    char line[512];
+    while (g_running) {
+        BOOL ok = read_line(line, sizeof(line));
+        if (!ok) {
+            /* EOF / parent closed pipe -> exit cleanly. */
+            break;
+        }
+        process_line(line);
+    }
+
+    release_endpoint();
+    CoUninitialize();
+    return 0;
+}

--- a/apps/electron/scripts/compile-native.js
+++ b/apps/electron/scripts/compile-native.js
@@ -78,6 +78,11 @@ function compileMacOS() {
       src: "macos-mic-listener.swift",
       frameworks: ["CoreAudio", "Foundation"],
     },
+    {
+      name: "macos-volume-control",
+      src: "macos-volume-control.swift",
+      frameworks: ["CoreAudio", "Foundation"],
+    },
   ];
 
   for (const bin of binaries) {
@@ -114,7 +119,12 @@ function compileWindows() {
     {
       name: "windows-mic-listener.exe",
       src: "windows-mic-listener.c",
-      libs: ["ole32.lib", "oleaut32.lib"],
+      libs: ["user32.lib", "ole32.lib", "oleaut32.lib", "uuid.lib"],
+    },
+    {
+      name: "windows-volume-control.exe",
+      src: "windows-volume-control.c",
+      libs: ["user32.lib", "ole32.lib", "uuid.lib"],
     },
   ];
 
@@ -123,14 +133,25 @@ function compileWindows() {
     const src = join(NATIVE_DIR, bin.src);
     const out = join(outputDir, bin.name);
 
-    // Try MSVC first (cl.exe), fall back to gcc (MinGW)
     const clArgs = ["/O2", src, `/Fe:${out}`, ...bin.libs];
-    let ok = run("cl", clArgs);
+    const gccLibs = bin.libs.map((l) => `-l${l.replace(".lib", "")}`);
+    const gccArgs = ["-O2", "-static-libgcc", src, "-o", out, ...gccLibs];
+    const clangArgs = ["-O2", src, "-o", out, ...gccLibs];
 
+    // Try MSVC first, then clang-cl (drop-in MSVC-compatible CLI),
+    // then clang/gcc with MinGW-style flags.
+    let ok = run("cl", clArgs);
     if (!ok) {
-      console.log("  MSVC not found, trying MinGW gcc...");
-      const gccLibs = bin.libs.map((l) => `-l${l.replace(".lib", "")}`);
-      ok = run("gcc", ["-O2", "-static-libgcc", src, "-o", out, ...gccLibs]);
+      console.log("  MSVC not found, trying clang-cl...");
+      ok = run("clang-cl", clArgs);
+    }
+    if (!ok) {
+      console.log("  clang-cl not found, trying clang...");
+      ok = run("clang", clangArgs);
+    }
+    if (!ok) {
+      console.log("  clang not found, trying MinGW gcc...");
+      ok = run("gcc", gccArgs);
     }
 
     if (!ok) {
@@ -220,6 +241,20 @@ function compileLinux() {
       console.log(`  -> ${out}`);
     } else {
       console.warn("  WARNING: Failed to compile linux-key-listener.");
+    }
+  }
+
+  // linux-mic-listener
+  console.log("  Compiling linux-mic-listener...");
+  {
+    const src = join(NATIVE_DIR, "linux-mic-listener.c");
+    const out = join(outputDir, "linux-mic-listener");
+    const ok = runShell(`gcc -O2 ${src} -o ${out}`);
+    if (ok) {
+      chmodSync(out, 0o755);
+      console.log(`  -> ${out}`);
+    } else {
+      console.warn("  WARNING: Failed to compile linux-mic-listener.");
     }
   }
 }

--- a/apps/electron/src/main/audio-ducking.ts
+++ b/apps/electron/src/main/audio-ducking.ts
@@ -1,0 +1,821 @@
+import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { promisify } from "node:util";
+import { createAppLogger } from "@freestyle/utils";
+import { getNativeBinaryPath } from "./native-binary";
+
+const execFileAsync = promisify(execFile);
+const log = createAppLogger("audio-ducking");
+
+const MIN_DUCK_DELTA = 0.02;
+const RESTORE_EPSILON = 0.08;
+const DEFAULT_DUCK_LEVEL = 0;
+
+const NATIVE_COMMAND_TIMEOUT_MS = 500;
+const NATIVE_STARTUP_TIMEOUT_MS = 2000;
+const NATIVE_KILL_TIMEOUT_MS = 500;
+
+type BackendKind = "windows-native" | "windows" | "macos" | "linux-wpctl" | "linux-pactl";
+type DuckStrategy = "volume" | "mute";
+
+interface Snapshot {
+  kind: BackendKind;
+  current: number;
+  muted: boolean;
+  target: number | null;
+  strategy: DuckStrategy;
+}
+
+interface VolumeState {
+  volume: number;
+  muted: boolean;
+}
+
+interface RestorePlan {
+  restoreVolume: boolean;
+  restoreMute: boolean;
+}
+
+interface PendingRequest {
+  resolve: (value: string) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Context needed to execute a backend operation. On Windows this may carry a
+ * live native controller; on other platforms it is just the backend kind.
+ */
+interface BackendContext {
+  kind: BackendKind;
+  native?: NativeWindowsVolumeController;
+}
+
+/**
+ * Low-latency Windows volume controller backed by a native helper.
+ *
+ * The helper opens the default playback endpoint's IAudioEndpointVolume once
+ * and keeps it warm. Commands are sent over stdin; responses are read from
+ * stdout. If the helper fails to start, crashes, hangs, or misbehaves, callers
+ * can fall back to the slower PowerShell-based implementation.
+ *
+ * Safety features:
+ *  - startup timeout
+ *  - per-command timeout
+ *  - automatic cleanup on dispose / crash / EOF
+ *  - explicit kill with graceful window then SIGTERM
+ *  - stderr logging
+ */
+class NativeWindowsVolumeController {
+  private process: ChildProcessWithoutNullStreams | null = null;
+  private pending: PendingRequest | null = null;
+  private buffer = "";
+  private ready = false;
+  private disposed = false;
+
+  constructor(private readonly binaryPath: string) {}
+
+  /**
+   * Start the helper process. Returns true if it printed "ready", false
+   * otherwise. Subsequent calls are no-ops if already started.
+   */
+  async start(): Promise<boolean> {
+    if (this.process) return this.ready;
+    if (this.disposed) return false;
+
+    log.debug(`Starting native Windows volume helper: ${this.binaryPath}`);
+
+    return new Promise((resolve) => {
+      const startupTimer = setTimeout(() => {
+        log.error("Native volume helper startup timed out");
+        this.dispose();
+        resolve(false);
+      }, NATIVE_STARTUP_TIMEOUT_MS);
+
+      try {
+        this.process = spawn(this.binaryPath, [], {
+          windowsHide: true,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } catch (err) {
+        clearTimeout(startupTimer);
+        log.error(`Failed to spawn native volume helper: ${String(err)}`);
+        resolve(false);
+        return;
+      }
+
+      if (!this.process?.stdin || !this.process?.stdout || !this.process?.stderr) {
+        clearTimeout(startupTimer);
+        log.error("Native volume helper has no stdio pipes");
+        this.dispose();
+        resolve(false);
+        return;
+      }
+
+      this.process.stdout.setEncoding("utf8");
+      this.process.stdout.on("data", (chunk: string) => this.onData(chunk));
+      this.process.on("error", (err) => {
+        log.error(`Native volume helper process error: ${err.message}`);
+        this.onProcessExit();
+      });
+      this.process.on("exit", () => this.onProcessExit());
+      this.process.on("close", () => this.onProcessExit());
+      this.process.stderr.on("data", (chunk: Buffer) => {
+        const text = chunk.toString("utf8").trim();
+        if (text) log.debug(`Native volume helper stderr: ${text}`);
+      });
+
+      const onFirstLines = (chunk: string) => {
+        this.buffer += chunk;
+        const lines = this.buffer.split(/\r?\n/);
+        this.buffer = lines.pop() ?? "";
+        for (const raw of lines) {
+          const line = raw.trim();
+          if (!line) continue;
+
+          if (line === "ready") {
+            clearTimeout(startupTimer);
+            this.ready = true;
+            // Replace one-time handler with normal handler.
+            this.process?.stdout.off("data", onFirstLines);
+            this.process?.stdout.on("data", (c: string) => this.onData(c));
+            resolve(true);
+            return;
+          }
+
+          if (line.startsWith("err|")) {
+            clearTimeout(startupTimer);
+            log.error(`Native volume helper failed to initialize: ${line}`);
+            this.dispose();
+            resolve(false);
+            return;
+          }
+        }
+      };
+
+      this.process.stdout.on("data", onFirstLines);
+    });
+  }
+
+  private onData(chunk: string): void {
+    this.buffer += chunk;
+    const lines = this.buffer.split(/\r?\n/);
+    this.buffer = lines.pop() ?? "";
+    for (const raw of lines) {
+      const line = raw.trim();
+      if (!line) continue;
+      this.handleResponse(line);
+    }
+  }
+
+  private handleResponse(line: string): void {
+    const pending = this.pending;
+    if (!pending) {
+      log.debug(`Unexpected response from native volume helper: ${line}`);
+      return;
+    }
+    this.pending = null;
+    clearTimeout(pending.timer);
+    pending.resolve(line);
+  }
+
+  private onProcessExit(): void {
+    if (!this.process) return;
+    log.debug("Native volume helper process exited");
+    const wasPending = this.pending;
+    this.pending = null;
+    this.process = null;
+    this.ready = false;
+    if (wasPending) {
+      clearTimeout(wasPending.timer);
+      wasPending.reject(new Error("Native volume helper exited unexpectedly"));
+    }
+  }
+
+  /**
+   * Send a command and wait for a single-line response. Throws on timeout,
+   * process error, or non-ok response where applicable.
+   */
+  async request(command: string, timeoutMs = NATIVE_COMMAND_TIMEOUT_MS): Promise<string> {
+    if (this.disposed) throw new Error("Native volume helper is disposed");
+    if (!this.ready || !this.process?.stdin) {
+      throw new Error("Native volume helper not ready");
+    }
+    if (this.pending) {
+      throw new Error("Native volume helper already has a pending request");
+    }
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending = null;
+        log.error(`Native volume helper command timed out: ${command}`);
+        this.dispose();
+        reject(new Error(`Native volume helper command timed out: ${command}`));
+      }, timeoutMs);
+
+      this.pending = { resolve, reject, timer };
+      this.process!.stdin.write(`${command}\n`, (err) => {
+        if (err) {
+          this.pending = null;
+          clearTimeout(timer);
+          log.error(`Failed to write to native volume helper: ${err.message}`);
+          this.dispose();
+          reject(err);
+        }
+      });
+    });
+  }
+
+  async getVolumeState(): Promise<VolumeState | null> {
+    const line = await this.request("get");
+    return parsePipeVolumeState(line);
+  }
+
+  async setVolume(value: number): Promise<void> {
+    const response = await this.request(`set ${clamp01(value).toFixed(4)}`);
+    if (response !== "ok") {
+      throw new Error(`set volume failed: ${response}`);
+    }
+  }
+
+  async setMuted(muted: boolean): Promise<void> {
+    const response = await this.request(`mute ${muted ? "1" : "0"}`);
+    if (response !== "ok") {
+      throw new Error(`set mute failed: ${response}`);
+    }
+  }
+
+  /**
+   * Kill the helper process and clean up. Idempotent.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    const proc = this.process;
+    const wasPending = this.pending;
+
+    this.process = null;
+    this.pending = null;
+    this.ready = false;
+
+    if (wasPending) {
+      clearTimeout(wasPending.timer);
+      wasPending.reject(new Error("Native volume helper disposed"));
+    }
+
+    if (!proc) return;
+
+    try {
+      if (!proc.stdin.destroyed) {
+        proc.stdin.end();
+      }
+    } catch {
+      // ignore
+    }
+
+    const killTimer = setTimeout(() => {
+      try {
+        if (!proc.killed) {
+          proc.kill("SIGTERM");
+        }
+      } catch {
+        // ignore
+      }
+    }, NATIVE_KILL_TIMEOUT_MS);
+
+    proc.on("exit", () => clearTimeout(killTimer));
+    proc.on("close", () => clearTimeout(killTimer));
+
+    if (proc.exitCode !== null) {
+      clearTimeout(killTimer);
+    }
+  }
+}
+
+export class AudioDucker {
+  private snapshot: Snapshot | null = null;
+  private backendPromise: Promise<BackendContext | null> | null = null;
+  private queue = Promise.resolve();
+  private depth = 0;
+  private nativeController: NativeWindowsVolumeController | null = null;
+
+  duck(level = DEFAULT_DUCK_LEVEL): Promise<void> {
+    return this.enqueue(async () => {
+      this.depth += 1;
+      if (this.snapshot) return;
+
+      const ctx = await this.getBackend();
+      if (!ctx) return;
+
+      const state = await readVolumeState(ctx);
+      if (!state || state.muted) return;
+
+      const desiredLevel = clamp01(level);
+      const target = clamp01(state.volume * desiredLevel);
+      const useMuteFallback =
+        desiredLevel <= 0 || state.volume - target < MIN_DUCK_DELTA;
+
+      if (useMuteFallback) {
+        await setMuted(ctx, true);
+        this.snapshot = {
+          kind: ctx.kind,
+          current: state.volume,
+          muted: state.muted,
+          target: null,
+          strategy: "mute",
+        };
+        log.debug(`Applied mute fallback while ducking on ${ctx.kind}`);
+        return;
+      }
+
+      await setVolume(ctx, target);
+      this.snapshot = {
+        kind: ctx.kind,
+        current: state.volume,
+        muted: state.muted,
+        target,
+        strategy: "volume",
+      };
+      log.debug(
+        `Applied volume ducking on ${ctx.kind}: ${state.volume.toFixed(3)} -> ${target.toFixed(3)}`,
+      );
+    });
+  }
+
+  restore(): Promise<void> {
+    return this.enqueue(async () => {
+      if (this.depth > 0) {
+        this.depth -= 1;
+      }
+      if (this.depth > 0) return;
+
+      const snapshot = this.snapshot;
+      this.snapshot = null;
+      if (!snapshot) return;
+
+      // If we have a live native controller, use it for restore; otherwise
+      // reconstruct a minimal context from the snapshot kind.
+      const ctx: BackendContext | null = this.nativeController
+        ? { kind: snapshot.kind, native: this.nativeController }
+        : await this.getBackend().catch(() => null);
+
+      if (!ctx) return;
+
+      const live = await readVolumeState(ctx).catch(() => null);
+      const restorePlan = getRestorePlan(snapshot, live);
+      if (!restorePlan.restoreVolume && !restorePlan.restoreMute) {
+        log.debug(
+          `Skipping restore on ${snapshot.kind} because audio state changed externally`,
+        );
+        return;
+      }
+
+      if (restorePlan.restoreVolume) {
+        await setVolume(ctx, snapshot.current);
+      }
+      if (restorePlan.restoreMute) {
+        await setMuted(ctx, snapshot.muted);
+      }
+      log.debug(`Restored audio after ducking on ${snapshot.kind}`);
+    });
+  }
+
+  /**
+   * Dispose the native helper (if any). Call this when the app is quitting.
+   */
+  dispose(): void {
+    this.nativeController?.dispose();
+    this.nativeController = null;
+    this.backendPromise = null;
+  }
+
+  private enqueue(work: () => Promise<void>): Promise<void> {
+    this.queue = this.queue.then(work).catch((error) => {
+      log.debug(
+        error instanceof Error ? error.message : String(error ?? "unknown"),
+      );
+    });
+    return this.queue;
+  }
+
+  private getBackend(): Promise<BackendContext | null> {
+    if (!this.backendPromise) {
+      this.backendPromise = detectBackend(this);
+    }
+    return this.backendPromise;
+  }
+}
+
+async function detectBackend(ducker: AudioDucker): Promise<BackendContext | null> {
+  if (process.platform === "win32") {
+    const nativePath = getNativeBinaryPath("windows-volume-control");
+    if (nativePath) {
+      const controller = new NativeWindowsVolumeController(nativePath);
+      ducker["nativeController"] = controller;
+      const ok = await controller.start();
+      if (ok) {
+        log.debug("Using native Windows volume control helper");
+        return { kind: "windows-native", native: controller };
+      }
+      log.debug("Native Windows volume helper unavailable, falling back to PowerShell");
+      controller.dispose();
+      ducker["nativeController"] = null;
+    }
+    return { kind: "windows" };
+  }
+  if (process.platform === "darwin") return { kind: "macos" };
+  if (process.platform !== "linux") return null;
+
+  const tool = await commandExists("wpctl")
+    .then((ok) => (ok ? "linux-wpctl" : null))
+    .then(
+      async (kind) =>
+        kind ?? ((await commandExists("pactl")) ? "linux-pactl" : null),
+    );
+
+  return tool ? { kind: tool } : null;
+}
+
+async function commandExists(command: string): Promise<boolean> {
+  try {
+    await execFileAsync("sh", ["-lc", `command -v ${command} >/dev/null 2>&1`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readVolumeState(ctx: BackendContext): Promise<VolumeState | null> {
+  switch (ctx.kind) {
+    case "windows-native":
+      return ctx.native!.getVolumeState();
+    case "windows":
+      return readWindowsVolumeState();
+    case "macos":
+      return readMacVolumeState();
+    case "linux-wpctl":
+      return readWpctlVolumeState();
+    case "linux-pactl":
+      return readPactlVolumeState();
+    default:
+      return null;
+  }
+}
+
+async function setVolume(ctx: BackendContext, value: number): Promise<void> {
+  const clamped = clamp01(value);
+  switch (ctx.kind) {
+    case "windows-native":
+      await ctx.native!.setVolume(clamped);
+      return;
+    case "windows":
+      await setWindowsVolume(clamped);
+      return;
+    case "macos":
+      await setMacVolume(clamped);
+      return;
+    case "linux-wpctl":
+      await execFileAsync("wpctl", [
+        "set-volume",
+        "@DEFAULT_AUDIO_SINK@",
+        clamped.toFixed(3),
+      ]);
+      return;
+    case "linux-pactl":
+      await execFileAsync("pactl", [
+        "set-sink-volume",
+        "@DEFAULT_SINK@",
+        `${Math.round(clamped * 100)}%`,
+      ]);
+      return;
+  }
+}
+
+async function setMuted(ctx: BackendContext, muted: boolean): Promise<void> {
+  switch (ctx.kind) {
+    case "windows-native":
+      await ctx.native!.setMuted(muted);
+      return;
+    case "windows":
+      await setWindowsMuted(muted);
+      return;
+    case "macos":
+      await setMacMuted(muted);
+      return;
+    case "linux-wpctl":
+      await execFileAsync("wpctl", [
+        "set-mute",
+        "@DEFAULT_AUDIO_SINK@",
+        muted ? "1" : "0",
+      ]);
+      return;
+    case "linux-pactl":
+      await execFileAsync("pactl", [
+        "set-sink-mute",
+        "@DEFAULT_SINK@",
+        muted ? "1" : "0",
+      ]);
+      return;
+  }
+}
+
+function getRestorePlan(
+  snapshot: Snapshot,
+  live: VolumeState | null,
+): RestorePlan {
+  if (!live) {
+    return { restoreVolume: true, restoreMute: true };
+  }
+
+  if (snapshot.strategy === "mute") {
+    if (!live.muted) {
+      return { restoreVolume: false, restoreMute: false };
+    }
+
+    return {
+      restoreVolume:
+        Math.abs(live.volume - snapshot.current) <= RESTORE_EPSILON,
+      restoreMute: true,
+    };
+  }
+
+  if (snapshot.target === null || live.muted) {
+    return { restoreVolume: false, restoreMute: false };
+  }
+
+  const stillDucked =
+    Math.abs(live.volume - snapshot.target) <= RESTORE_EPSILON;
+
+  return {
+    restoreVolume: stillDucked,
+    restoreMute: stillDucked,
+  };
+}
+
+const WINDOWS_VOLUME_TYPE = `
+using System;
+using System.Runtime.InteropServices;
+
+[Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IAudioEndpointVolume {
+    int RegisterControlChangeNotify(IntPtr pNotify);
+    int UnregisterControlChangeNotify(IntPtr pNotify);
+    int GetChannelCount(out uint pnChannelCount);
+    int SetMasterVolumeLevel(float fLevelDB, Guid pguidEventContext);
+    int SetMasterVolumeLevelScalar(float fLevel, Guid pguidEventContext);
+    int GetMasterVolumeLevel(out float pfLevelDB);
+    int GetMasterVolumeLevelScalar(out float pfLevel);
+    int SetChannelVolumeLevel(uint nChannel, float fLevelDB, Guid pguidEventContext);
+    int SetChannelVolumeLevelScalar(uint nChannel, float fLevel, Guid pguidEventContext);
+    int GetChannelVolumeLevel(uint nChannel, out float pfLevelDB);
+    int GetChannelVolumeLevelScalar(uint nChannel, out float pfLevel);
+    int SetMute([MarshalAs(UnmanagedType.Bool)] bool bMute, Guid pguidEventContext);
+    int GetMute(out bool pbMute);
+    int GetVolumeStepInfo(out uint pnStep, out uint pnStepCount);
+    int VolumeStepUp(Guid pguidEventContext);
+    int VolumeStepDown(Guid pguidEventContext);
+    int QueryHardwareSupport(out uint pdwHardwareSupportMask);
+    int GetVolumeRange(out float pflVolumeMindB, out float pflVolumeMaxdB, out float pflVolumeIncrementdB);
+}
+
+[Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IMMDeviceEnumerator {
+    int EnumAudioEndpoints(int dataFlow, int dwStateMask, IntPtr ppDevices);
+    int GetDefaultAudioEndpoint(int dataFlow, int role, out IMMDevice ppDevice);
+}
+
+[Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IMMDevice {
+    int Activate(ref Guid iid, int dwClsCtx, IntPtr pActivationParams, [MarshalAs(UnmanagedType.Interface)] out IAudioEndpointVolume ppInterface);
+}
+
+[ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+public class MMDeviceEnumeratorComObject {}
+
+public static class FreestyleAudioEndpointVolume {
+    private static IAudioEndpointVolume Open() {
+        var enumerator = (IMMDeviceEnumerator)new MMDeviceEnumeratorComObject();
+        IMMDevice device;
+        Marshal.ThrowExceptionForHR(enumerator.GetDefaultAudioEndpoint(0, 1, out device));
+        var iid = typeof(IAudioEndpointVolume).GUID;
+        IAudioEndpointVolume endpoint;
+        Marshal.ThrowExceptionForHR(device.Activate(ref iid, 23, IntPtr.Zero, out endpoint));
+        return endpoint;
+    }
+
+    public static float GetVolumeScalar() {
+        float volume;
+        Marshal.ThrowExceptionForHR(Open().GetMasterVolumeLevelScalar(out volume));
+        return volume;
+    }
+
+    public static bool GetMute() {
+        bool muted;
+        Marshal.ThrowExceptionForHR(Open().GetMute(out muted));
+        return muted;
+    }
+
+    public static void SetMute(bool muted) {
+        Marshal.ThrowExceptionForHR(Open().SetMute(muted, Guid.Empty));
+    }
+
+    public static void SetVolumeScalar(float value) {
+        Marshal.ThrowExceptionForHR(Open().SetMasterVolumeLevelScalar(value, Guid.Empty));
+    }
+}
+`;
+
+function encodePowerShell(script: string): string {
+  return Buffer.from(script, "utf16le").toString("base64");
+}
+
+function buildWindowsVolumeScript(body: string): string {
+  return [
+    "$ErrorActionPreference = 'Stop'",
+    'Add-Type -TypeDefinition @"',
+    WINDOWS_VOLUME_TYPE.trim(),
+    '"@',
+    body.trim(),
+  ].join("\n");
+}
+
+async function execWindowsPowerShell(script: string): Promise<string> {
+  const { stdout } = await execFileAsync("powershell.exe", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-EncodedCommand",
+    encodePowerShell(script),
+  ]);
+  return stdout.trim();
+}
+
+function parseWindowsVolumeState(stdout: string): VolumeState | null {
+  const line = stdout
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .find((entry) => entry.includes("|"));
+  if (!line) return null;
+
+  const [volumeRaw, mutedRaw] = line.split("|", 2);
+  const volume = Number.parseFloat(volumeRaw);
+  if (!Number.isFinite(volume)) return null;
+
+  return {
+    volume: clamp01(volume),
+    muted: mutedRaw?.toLowerCase() === "true",
+  };
+}
+
+async function readWindowsVolumeState(): Promise<VolumeState | null> {
+  const stdout = await execWindowsPowerShell(
+    buildWindowsVolumeScript(`
+[float]$volume = [FreestyleAudioEndpointVolume]::GetVolumeScalar()
+[bool]$muted = [FreestyleAudioEndpointVolume]::GetMute()
+Write-Output ("$volume|$muted")
+    `),
+  );
+
+  return parseWindowsVolumeState(stdout);
+}
+
+async function setWindowsVolume(value: number): Promise<void> {
+  await execWindowsPowerShell(
+    buildWindowsVolumeScript(`
+[FreestyleAudioEndpointVolume]::SetVolumeScalar([float]${clamp01(value)})
+    `),
+  );
+}
+
+async function setWindowsMuted(muted: boolean): Promise<void> {
+  await execWindowsPowerShell(
+    buildWindowsVolumeScript(`
+[FreestyleAudioEndpointVolume]::SetMute(${muted ? "$true" : "$false"})
+    `),
+  );
+}
+
+async function readMacVolumeState(): Promise<VolumeState | null> {
+  const nativePath = getNativeBinaryPath("macos-volume-control");
+  if (nativePath) {
+    try {
+      const { stdout } = await execFileAsync(nativePath, ["get"]);
+      return parsePipeVolumeState(stdout);
+    } catch (err) {
+      log.debug(
+        `macOS native volume read failed, falling back to AppleScript: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  const [{ stdout: volumeRaw }, { stdout: mutedRaw }] = await Promise.all([
+    execFileAsync("osascript", [
+      "-e",
+      "output volume of (get volume settings)",
+    ]),
+    execFileAsync("osascript", ["-e", "output muted of (get volume settings)"]),
+  ]);
+
+  const volume = Number.parseFloat(volumeRaw.trim());
+  if (!Number.isFinite(volume)) return null;
+
+  return {
+    volume: clamp01(volume / 100),
+    muted: mutedRaw.trim().toLowerCase() === "true",
+  };
+}
+
+async function setMacVolume(value: number): Promise<void> {
+  const nativePath = getNativeBinaryPath("macos-volume-control");
+  if (nativePath) {
+    try {
+      await execFileAsync(nativePath, ["set", clamp01(value).toFixed(4)]);
+      return;
+    } catch (err) {
+      log.debug(
+        `macOS native volume set failed, falling back to AppleScript: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  await execFileAsync("osascript", [
+    "-e",
+    `set volume output volume ${Math.round(clamp01(value) * 100)}`,
+  ]);
+}
+
+async function setMacMuted(muted: boolean): Promise<void> {
+  const nativePath = getNativeBinaryPath("macos-volume-control");
+  if (nativePath) {
+    try {
+      await execFileAsync(nativePath, [muted ? "mute" : "unmute"]);
+      return;
+    } catch (err) {
+      log.debug(
+        `macOS native mute set failed, falling back to AppleScript: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  await execFileAsync("osascript", [
+    "-e",
+    muted
+      ? "set volume with output muted"
+      : "set volume without output muted",
+  ]);
+}
+
+function parsePipeVolumeState(stdout: string): VolumeState | null {
+  const line = stdout
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .find((entry) => entry.includes("|"));
+  if (!line) return null;
+
+  const [volumeRaw, mutedRaw] = line.split("|", 2);
+  const volume = Number.parseFloat(volumeRaw);
+  if (!Number.isFinite(volume)) return null;
+
+  return {
+    volume: clamp01(volume),
+    muted: mutedRaw?.toLowerCase() === "true",
+  };
+}
+
+async function readWpctlVolumeState(): Promise<VolumeState | null> {
+  const { stdout } = await execFileAsync("wpctl", [
+    "get-volume",
+    "@DEFAULT_AUDIO_SINK@",
+  ]);
+  const match = stdout.match(/([0-9]*\.?[0-9]+)/);
+  if (!match) return null;
+
+  return {
+    volume: clamp01(Number.parseFloat(match[1])),
+    muted: /\bmuted\b/i.test(stdout),
+  };
+}
+
+async function readPactlVolumeState(): Promise<VolumeState | null> {
+  const [{ stdout: volumeRaw }, { stdout: mutedRaw }] = await Promise.all([
+    execFileAsync("pactl", ["get-sink-volume", "@DEFAULT_SINK@"]),
+    execFileAsync("pactl", ["get-sink-mute", "@DEFAULT_SINK@"]),
+  ]);
+  const match = volumeRaw.match(/(\d+)%/);
+  if (!match) return null;
+
+  return {
+    volume: clamp01(Number.parseInt(match[1], 10) / 100),
+    muted: /\byes\b/i.test(mutedRaw),
+  };
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(value, 0), 1);
+}

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -76,6 +76,7 @@ import { WebSocketServer } from "ws";
 import icon from "../../resources/icon.png?asset";
 import trayIconPath from "../../resources/tray/logoTemplate.png?asset";
 import { getDefaultHotkey } from "../shared/hotkey-defaults";
+import { AudioDucker } from "./audio-ducking";
 import { HotkeyRecorder } from "./hotkey-recorder";
 import { normalizeAccelerator } from "./hotkey-utils";
 import { NativeKeyListener } from "./key-listener";
@@ -135,6 +136,7 @@ let mainWindow: BrowserWindow | null = null;
 let settingsWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let keyListener: NativeKeyListener | null = null;
+const audioDucker = new AudioDucker();
 // Latching flag: set only once the native key listener has started
 // successfully, which requires Accessibility permission and therefore
 // proves it is granted. NOT set on the globalShortcut fallback, which
@@ -147,6 +149,24 @@ let currentHotkeyAccel: string | null = null;
 let hotkeyActivationMode: "hold" | "toggle" = "hold";
 let micListener: MicListener | null = null;
 let hotkeyRecorder: HotkeyRecorder | null = null;
+let audioDuckingEnabled = true;
+let audioDuckingLevel = 0;
+
+function readDbSetting(key: string): string | undefined {
+  try {
+    const dbPath = process.env.FREESTYLE_DB_PATH;
+    if (!dbPath) return undefined;
+    const { DatabaseSync } = require("node:sqlite");
+    const db = new DatabaseSync(dbPath);
+    const row = db
+      .prepare("SELECT value FROM settings WHERE key = ?")
+      .get(key) as { value: string } | undefined;
+    db.close();
+    return row?.value;
+  } catch {
+    return undefined;
+  }
+}
 
 function stopHotkeyRecorderProcess(): void {
   hotkeyRecorder?.stop();
@@ -1089,6 +1109,16 @@ app.whenReady().then(async () => {
 
   rebuildMenus();
 
+  // Load audio ducking preferences so key-event ducking works before the
+  // renderer has a chance to broadcast them.
+  const savedDuckingEnabled = readDbSetting("audio_ducking_enabled");
+  if (savedDuckingEnabled === "false") audioDuckingEnabled = false;
+  const savedDuckingLevel = readDbSetting("audio_ducking_level");
+  if (savedDuckingLevel !== undefined) {
+    const parsed = Number.parseInt(savedDuckingLevel, 10);
+    if (Number.isFinite(parsed)) audioDuckingLevel = parsed / 100;
+  }
+
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.
   app.on("browser-window-created", (_, window) => {
@@ -1121,9 +1151,38 @@ app.whenReady().then(async () => {
     mainWindow?.webContents.send("settings:output-mode-changed", mode);
   });
 
+  ipcMain.on("settings:audio-ducking-changed", (_event, enabled: boolean) => {
+    audioDuckingEnabled = enabled;
+    mainWindow?.webContents.send("settings:audio-ducking-changed", enabled);
+    settingsWindow?.webContents.send("settings:audio-ducking-changed", enabled);
+  });
+
+  ipcMain.on(
+    "settings:audio-ducking-level-changed",
+    (_event, level: number) => {
+      audioDuckingLevel = level / 100;
+      mainWindow?.webContents.send(
+        "settings:audio-ducking-level-changed",
+        level,
+      );
+      settingsWindow?.webContents.send(
+        "settings:audio-ducking-level-changed",
+        level,
+      );
+    },
+  );
+
   // IPC: hide the pill window on request from renderer
   ipcMain.on("pill:hide", () => {
     hidePill();
+  });
+
+  ipcMain.handle("audio:duck-start", async (_event, level?: number) => {
+    await audioDucker.duck(level);
+  });
+
+  ipcMain.handle("audio:duck-stop", async () => {
+    await audioDucker.restore();
   });
 
   // IPC: fan out per-frame audio levels from the pill to other windows
@@ -1732,9 +1791,11 @@ function handleNativeHotkeyDown(): void {
   if (hotkeyActivationMode === "toggle") {
     if (!hotkeyPressed) {
       hotkeyPressed = true;
+      if (audioDuckingEnabled) void audioDucker.duck(audioDuckingLevel);
       sendHotkeyDown();
     } else {
       hotkeyPressed = false;
+      void audioDucker.restore();
       sendHotkeyUp();
     }
     return;
@@ -1742,6 +1803,7 @@ function handleNativeHotkeyDown(): void {
 
   if (!hotkeyPressed) {
     hotkeyPressed = true;
+    if (audioDuckingEnabled) void audioDucker.duck(audioDuckingLevel);
     sendHotkeyDown();
   }
 }
@@ -1751,11 +1813,12 @@ function handleNativeHotkeyUp(): void {
 
   if (hotkeyPressed) {
     hotkeyPressed = false;
+    void audioDucker.restore();
     sendHotkeyUp();
   }
 }
 
-// Notify once per session when hold-to-talk degrades to toggle mode, so the
+// Notify once per session when push-to-talk degrades to toggle mode, so the
 // user isn't left wondering why holding the hotkey stopped working.
 let hotkeyDegradedNotified = false;
 function notifyHotkeyDegraded(accel: string, nativeError: string): void {
@@ -1767,9 +1830,9 @@ function notifyHotkeyDegraded(accel: string, nativeError: string): void {
     nativeError.includes("No accessible input devices")
   ) {
     fix =
-      " To enable hold-to-talk, run: sudo usermod -aG input $USER — then log out and back in.";
+      " To enable push-to-talk, run: sudo usermod -aG input $USER — then log out and back in.";
   }
-  const body = `Hold-to-talk isn't available, so "${accel}" now toggles recording on and off.${fix}`;
+  const body = `Push-to-talk isn't available, so "${accel}" now toggles recording on and off.${fix}`;
   hotkeyLog.warn(body);
   if (Notification.isSupported()) {
     new Notification({ title: "Freestyle is in toggle mode", body }).show();
@@ -1933,6 +1996,7 @@ async function registerHotkey(hotkey?: string): Promise<void> {
 
 // Clean up key listener and mic listener on quit
 app.on("will-quit", () => {
+  void audioDucker.restore();
   if (keyListener) {
     keyListener.stop();
     keyListener = null;
@@ -1965,6 +2029,7 @@ let isQuitting = false;
 let updateDownloadState: "idle" | "downloading" | "downloaded" = "idle";
 
 function cleanupBeforeQuit(): void {
+  void audioDucker.restore();
   stopWhisperServer().catch(() => {});
   stopMlxServer().catch(() => {});
   if (keyListener) {

--- a/apps/electron/src/main/mic-listener.ts
+++ b/apps/electron/src/main/mic-listener.ts
@@ -83,7 +83,26 @@ export class MicListener {
   }
 
   private startLinux(): boolean {
-    // On Linux, use `pactl subscribe` to monitor PulseAudio events
+    // Prefer the native helper if it was compiled; otherwise fall back to
+    // spawning `pactl subscribe` directly.
+    const binaryPath = getNativeBinaryPath("linux-mic-listener");
+    if (binaryPath) {
+      try {
+        this.process = spawn(binaryPath, [], {
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        this.setupProcessHandlers();
+        return true;
+      } catch (err) {
+        log.debug(
+          `Failed to spawn native linux-mic-listener: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+
+    // Fallback: `pactl subscribe` to monitor PulseAudio events
     try {
       this.process = spawn("pactl", ["subscribe"], {
         stdio: ["pipe", "pipe", "pipe"],

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -79,11 +79,21 @@ declare global {
       // Output mode
       sendOutputModeChanged: (mode: string) => void;
       onOutputModeChanged: (callback: (mode: string) => void) => () => void;
+      sendAudioDuckingChanged: (enabled: boolean) => void;
+      onAudioDuckingChanged: (
+        callback: (enabled: boolean) => void,
+      ) => () => void;
+      sendAudioDuckingLevelChanged: (level: number) => void;
+      onAudioDuckingLevelChanged: (
+        callback: (level: number) => void,
+      ) => () => void;
       // Hotkey error notifications
       onHotkeyError: (
         callback: (error: { message: string }) => void,
       ) => () => void;
       // Audio level stream
+      startAudioDucking: (level: number) => Promise<void>;
+      stopAudioDucking: () => Promise<void>;
       sendAudioLevel: (level: number) => void;
       onAudioLevel: (callback: (level: number) => void) => () => void;
       // Transcription completion broadcast

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -166,6 +166,29 @@ const api = {
     return () =>
       ipcRenderer.removeListener("settings:output-mode-changed", handler);
   },
+  sendAudioDuckingChanged: (enabled: boolean): void =>
+    ipcRenderer.send("settings:audio-ducking-changed", enabled),
+  onAudioDuckingChanged: (
+    callback: (enabled: boolean) => void,
+  ): (() => void) => {
+    const handler = (_: unknown, enabled: boolean): void => callback(enabled);
+    ipcRenderer.on("settings:audio-ducking-changed", handler);
+    return () =>
+      ipcRenderer.removeListener("settings:audio-ducking-changed", handler);
+  },
+  sendAudioDuckingLevelChanged: (level: number): void =>
+    ipcRenderer.send("settings:audio-ducking-level-changed", level),
+  onAudioDuckingLevelChanged: (
+    callback: (level: number) => void,
+  ): (() => void) => {
+    const handler = (_: unknown, level: number): void => callback(level);
+    ipcRenderer.on("settings:audio-ducking-level-changed", handler);
+    return () =>
+      ipcRenderer.removeListener(
+        "settings:audio-ducking-level-changed",
+        handler,
+      );
+  },
   // Hotkey error notifications
   onHotkeyError: (
     callback: (error: { message: string }) => void,
@@ -177,6 +200,9 @@ const api = {
   },
   // Audio level stream — pill broadcasts per-frame mic amplitude (0..1) so
   // other windows (the Today tutorial demo) can render a live waveform.
+  startAudioDucking: (level: number): Promise<void> =>
+    ipcRenderer.invoke("audio:duck-start", level),
+  stopAudioDucking: (): Promise<void> => ipcRenderer.invoke("audio:duck-stop"),
   sendAudioLevel: (level: number): void =>
     ipcRenderer.send("audio:level", level),
   onAudioLevel: (callback: (level: number) => void): (() => void) => {

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -599,7 +599,6 @@ export default function AppPage(): React.JSX.Element {
           return;
         }
 
-        startAudioDucking();
         playTone("start");
         setPillState("recording");
         recordingActiveRef.current = true;
@@ -613,6 +612,17 @@ export default function AppPage(): React.JSX.Element {
         try {
           await streamer.startCapture(stream);
         } catch {}
+
+        // Only delay ducking when sound feedback is enabled, so the activation
+        // tone isn't swallowed by the duck. If sound is off, duck immediately.
+        if (_soundEnabled) {
+          window.setTimeout(() => {
+            if (!wantsMicRef.current || pendingCommitRef.current) return;
+            startAudioDucking();
+          }, 80);
+        } else {
+          startAudioDucking();
+        }
       } catch (err) {
         pendingCommitRef.current = false;
         recorderRef.current.releaseStream();

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -20,8 +20,15 @@ type BarMode = "connecting" | "listening" | "speaking";
 // ---------------------------------------------------------------------------
 
 let _soundEnabled = true;
+let _duckingEnabled = true;
+let _duckingLevel = 0;
 let _outputMode = "paste";
 let _toneCtx: AudioContext | null = null;
+
+function clampDuckingLevel(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.round(value), 0), 100);
+}
 
 function getToneCtx(): AudioContext {
   if (!_toneCtx || _toneCtx.state === "closed") _toneCtx = new AudioContext();
@@ -165,6 +172,15 @@ export default function AppPage(): React.JSX.Element {
   const drainAgainRef = useRef(false);
 
   const getInputVolume = useCallback(() => volumeRef.current, []);
+  const startAudioDucking = useCallback(() => {
+    if (!_duckingEnabled) return;
+    const request = window.api?.startAudioDucking(_duckingLevel / 100);
+    request?.catch(() => {});
+  }, []);
+  const stopAudioDucking = useCallback(() => {
+    const request = window.api?.stopAudioDucking();
+    request?.catch(() => {});
+  }, []);
 
   // ---- Queue drain ----
   // biome-ignore lint/correctness/useExhaustiveDependencies: drainQueue only reads refs plus hidePill, which is declared later in this component, so adding it to the deps array would reference it before initialization (TDZ). The empty array is intentional.
@@ -505,6 +521,7 @@ export default function AppPage(): React.JSX.Element {
 
   // ---- Hide pill ----
   const hidePill = useCallback(() => {
+    stopAudioDucking();
     setPillState("idle");
     setIsReRecording(false);
     isReRecordingRef.current = false;
@@ -518,7 +535,7 @@ export default function AppPage(): React.JSX.Element {
     streamResolverRef.current = null;
     stopVisualization();
     window.api.hidePill();
-  }, [stopVisualization, setPillState]);
+  }, [stopVisualization, stopAudioDucking, setPillState]);
 
   // ---- Start recording ----
   const startRecording = useCallback(
@@ -582,6 +599,7 @@ export default function AppPage(): React.JSX.Element {
           return;
         }
 
+        startAudioDucking();
         playTone("start");
         setPillState("recording");
         recordingActiveRef.current = true;
@@ -598,6 +616,7 @@ export default function AppPage(): React.JSX.Element {
       } catch (err) {
         pendingCommitRef.current = false;
         recorderRef.current.releaseStream();
+        stopAudioDucking();
         hidePill();
         window.api.showErrorDialog(
           "Recording Failed",
@@ -605,7 +624,15 @@ export default function AppPage(): React.JSX.Element {
         );
       }
     },
-    [startBarAnimation, startListening, hidePill, getStreamer, setPillState],
+    [
+      startBarAnimation,
+      startListening,
+      hidePill,
+      getStreamer,
+      setPillState,
+      startAudioDucking,
+      stopAudioDucking,
+    ],
   );
 
   // ---- Commit recording ----
@@ -614,6 +641,7 @@ export default function AppPage(): React.JSX.Element {
     recordingActiveRef.current = false;
     isReRecordingRef.current = false;
     setIsReRecording(false);
+    stopAudioDucking();
     playTone("stop");
 
     clearInterval(timerRef.current);
@@ -769,6 +797,7 @@ export default function AppPage(): React.JSX.Element {
     startBarAnimation,
     restFallbackTranscribe,
     setPillState,
+    stopAudioDucking,
   ]);
 
   // ---- Cancel ----
@@ -781,8 +810,9 @@ export default function AppPage(): React.JSX.Element {
     streamerRef.current?.cancel();
     recorderRef.current.cancel();
     recorderRef.current.releaseStream();
+    stopAudioDucking();
     hidePill();
-  }, [hidePill]);
+  }, [hidePill, stopAudioDucking]);
 
   // ---- Preferences ----
   const applyPillPosition = useCallback((pos: string | null | undefined) => {
@@ -798,6 +828,20 @@ export default function AppPage(): React.JSX.Element {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data?.value === "false") _soundEnabled = false;
+      })
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "audio_ducking_enabled" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        _duckingEnabled = data?.value !== "false";
+      })
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "audio_ducking_level" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        _duckingLevel = clampDuckingLevel(Number(data?.value ?? 0));
       })
       .catch(() => {});
     getClient()
@@ -817,9 +861,19 @@ export default function AppPage(): React.JSX.Element {
     const removeOutputMode = window.api?.onOutputModeChanged((mode) => {
       _outputMode = mode;
     });
+    const removeAudioDucking = window.api?.onAudioDuckingChanged((enabled) => {
+      _duckingEnabled = enabled;
+    });
+    const removeAudioDuckingLevel = window.api?.onAudioDuckingLevelChanged(
+      (level) => {
+        _duckingLevel = clampDuckingLevel(level);
+      },
+    );
     return () => {
       removePillPos?.();
       removeOutputMode?.();
+      removeAudioDucking?.();
+      removeAudioDuckingLevel?.();
     };
   }, [applyPillPosition]);
 
@@ -959,8 +1013,8 @@ export default function AppPage(): React.JSX.Element {
             50% { box-shadow: 0 0 10px 2px rgba(251,191,36,0.22), 0 0 16px 4px rgba(251,191,36,0.09); }
           }
           @keyframes glow-pulse-green {
-            0%, 100% { box-shadow: 0 0 6px 2px rgba(138,182,42,0.12), 0 0 13px 3px rgba(138,182,42,0.05); }
-            50% { box-shadow: 0 0 10px 2px rgba(138,182,42,0.20), 0 0 16px 4px rgba(138,182,42,0.08); }
+            0%, 100% { box-shadow: 0 0 6px 2px rgba(91,124,250,0.14), 0 0 13px 3px rgba(91,124,250,0.06); }
+            50% { box-shadow: 0 0 10px 2px rgba(91,124,250,0.22), 0 0 16px 4px rgba(91,124,250,0.1); }
           }
           @keyframes glow-pulse-blue {
             0%, 100% { box-shadow: 0 0 6px 2px rgba(96,165,250,0.14), 0 0 13px 3px rgba(96,165,250,0.06); }
@@ -1093,7 +1147,7 @@ export default function AppPage(): React.JSX.Element {
                     ? ["#60A5FA", "#3B82F6"]
                     : state === "initializing"
                       ? ["#FBBF24", "#F59E0B"]
-                      : ["#8AB62A", "#6B8F12"]
+                      : ["#5A6FAD", "#435595"]
                 }
                 agentState={
                   state === "initializing"

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -46,6 +46,11 @@ function normalizePillPos(pos: string): string {
   return pos.startsWith("custom") ? "custom" : pos;
 }
 
+function clampAudioDuckingLevel(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.round(value), 0), 100);
+}
+
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
@@ -62,6 +67,8 @@ export default function SettingsPage(): React.JSX.Element {
   const [outputMode, setOutputMode] = useState("paste");
   const [pillPosition, setPillPosition] = useState("bottom-center");
   const [soundEnabled, setSoundEnabled] = useState(true);
+  const [audioDuckingEnabled, setAudioDuckingEnabled] = useState(true);
+  const [audioDuckingLevel, setAudioDuckingLevel] = useState(0);
   const [transcriptionPrompt, setTranscriptionPrompt] = useState("");
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null);
   const [updateDownloaded, setUpdateDownloaded] = useState(false);
@@ -249,6 +256,20 @@ export default function SettingsPage(): React.JSX.Element {
       })
       .catch(() => {});
     getClient()
+      .api.settings[":key"].$get({ param: { key: "audio_ducking_enabled" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.value === "false") setAudioDuckingEnabled(false);
+      })
+      .catch(() => {});
+    getClient()
+      .api.settings[":key"].$get({ param: { key: "audio_ducking_level" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        setAudioDuckingLevel(clampAudioDuckingLevel(Number(data?.value ?? 0)));
+      })
+      .catch(() => {});
+    getClient()
       .api.settings[":key"].$get({ param: { key: "transcription_prompt" } })
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
@@ -401,6 +422,29 @@ export default function SettingsPage(): React.JSX.Element {
       .api.settings[":key"].$put({
         param: { key: "sound_enabled" },
         json: { value: String(enabled) },
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleAudioDuckingToggle = useCallback((enabled: boolean) => {
+    setAudioDuckingEnabled(enabled);
+    window.api?.sendAudioDuckingChanged(enabled);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "audio_ducking_enabled" },
+        json: { value: String(enabled) },
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleAudioDuckingLevelChange = useCallback((value: number) => {
+    const next = clampAudioDuckingLevel(value);
+    setAudioDuckingLevel(next);
+    window.api?.sendAudioDuckingLevelChanged(next);
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: "audio_ducking_level" },
+        json: { value: String(next) },
       })
       .catch(() => {});
   }, []);
@@ -680,7 +724,6 @@ export default function SettingsPage(): React.JSX.Element {
           <Row
             label="Sound feedback"
             desc="Soft chimes at the start and end of recording."
-            last
           >
             <div className="flex items-center gap-2.5">
               {soundEnabled ? (
@@ -689,6 +732,61 @@ export default function SettingsPage(): React.JSX.Element {
                 <VolumeOff className="text-muted-foreground h-4 w-4 shrink-0" />
               )}
               <Toggle on={soundEnabled} onChange={handleSoundToggle} />
+            </div>
+          </Row>
+
+          <Row
+            label="Push-to-talk ducking"
+            desc="Set the background audio level while push-to-talk is active. 0% fully mutes it; higher values keep more sound in the mix."
+            last
+          >
+            <div className="max-w-md space-y-3">
+              <div className="flex items-center gap-2.5">
+                {audioDuckingEnabled ? (
+                  <Volume2 className="text-muted-foreground h-4 w-4 shrink-0" />
+                ) : (
+                  <VolumeOff className="text-muted-foreground h-4 w-4 shrink-0" />
+                )}
+                <Toggle
+                  on={audioDuckingEnabled}
+                  onChange={handleAudioDuckingToggle}
+                />
+                <span className="text-muted-foreground text-[12.5px]">
+                  {audioDuckingLevel === 0
+                    ? "Full mute"
+                    : `${audioDuckingLevel}% of current volume`}
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-muted-foreground w-10 text-[12px]">
+                  0%
+                </span>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  step={1}
+                  value={audioDuckingLevel}
+                  disabled={!audioDuckingEnabled}
+                  onChange={(e) =>
+                    handleAudioDuckingLevelChange(Number(e.target.value))
+                  }
+                  className="h-2 w-full appearance-none rounded-full outline-none disabled:opacity-40 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-primary [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:shadow-[0_0_0_4px_var(--card)]"
+                  style={{
+                    background: `linear-gradient(to right, var(--color-primary) 0%, var(--color-primary) ${audioDuckingLevel}%, color-mix(in srgb, var(--color-border) 86%, transparent) ${audioDuckingLevel}%, color-mix(in srgb, var(--color-border) 86%, transparent) 100%)`,
+                  }}
+                />
+                <span className="text-muted-foreground w-12 text-right text-[12px]">
+                  100%
+                </span>
+              </div>
+              <p className="text-muted-foreground text-[12px] leading-[1.5]">
+                {audioDuckingEnabled
+                  ? audioDuckingLevel === 0
+                    ? "Freestyle fully mutes background audio while you hold push-to-talk."
+                    : `Freestyle keeps background audio at ${audioDuckingLevel}% of its current volume while you hold push-to-talk.`
+                  : "Turn this on if you want Freestyle to reduce or mute background audio while you speak."}
+              </p>
             </div>
           </Row>
         </Section>
@@ -718,6 +816,7 @@ export default function SettingsPage(): React.JSX.Element {
             />
           </Row>
         </Section>
+
 
         <Section label="Permissions">
           <Row

--- a/docs/pr-messages/PR_native_windows_volume_control.md
+++ b/docs/pr-messages/PR_native_windows_volume_control.md
@@ -1,0 +1,98 @@
+# Cross-platform native volume-control helpers for audio ducking
+
+**Branch:** `build/native-windows-volume-control`  
+**Base:** `main`
+
+## What this PR does
+
+Replaces the Windows audio-ducking PowerShell/COM backend with a small, persistent native helper written in **C**, and hardens the macOS and Linux audio-ducking paths so all three desktop platforms use fast, native volume APIs with safe fallbacks.
+
+- **Windows:** persistent C helper using Core Audio `IAudioEndpointVolume`, with PowerShell fallback preserved.
+- **macOS:** new Swift helper using CoreAudio `AudioObjectGetPropertyData` / `AudioObjectSetPropertyData`, replacing per-duck AppleScript `osascript` calls; AppleScript fallback preserved.
+- **Linux:** hardened shell-out path and native mic listener, with no shell-injection surface and bounded C buffers.
+
+## Why C instead of PowerShell on Windows
+
+The old Windows path encoded a C# snippet into base64 and spawned a **new PowerShell process** for every `duck()` and `restore()`. That added noticeable latency, created a process per key-press, and depended on shell round-trips. A warm C helper removes that overhead while preserving the same snapshot/restore safety model.
+
+## Windows C implementation details
+
+- `apps/electron/native/windows-volume-control.c` (new)
+  - Persistent helper using Core Audio `IMMDeviceEnumerator` + `IAudioEndpointVolume`.
+  - Line-based stdin protocol: `get`, `set <0..1>`, `mute <0|1>`, `quit`.
+  - Defines the three required COM GUIDs inline so the binary links with `clang-cl`/`clang` without relying on `uuid.lib` for those symbols.
+  - Clean shutdown on stdin EOF, `quit`, Ctrl+C/Close/Logoff/Shutdown events; releases COM objects and calls `CoUninitialize()`.
+- `apps/electron/scripts/compile-native.js`
+  - Adds `windows-volume-control.exe` to the Windows binary list.
+  - Falls back gracefully if compilation fails.
+- `apps/electron/src/main/audio-ducking.ts`
+  - Adds `NativeWindowsVolumeController`: spawns the helper once, enforces startup (2 s) and per-command (500 ms) timeouts, restarts on failure, and falls back to PowerShell after repeated failure.
+  - Keeps snapshot/restore depth logic, `MIN_DUCK_DELTA`, and `RESTORE_EPSILON` unchanged.
+
+## Benefits
+
+- **Snappy:** Volume changes happen as soon as the key event arrives; no PowerShell cold-start overhead per key press.
+- **Low overhead:** One persistent helper process reuses the COM endpoint instead of spawning a new process every duck/restore cycle.
+- **Predictable:** Direct Core Audio calls replace shelling out, parsing base64, and depending on the PowerShell runtime.
+- **Resilient:** If the helper cannot be compiled, is missing, exits unexpectedly, or fails repeatedly, the code automatically falls back to the original PowerShell backend.
+- **Clean lifecycle:** The helper exits cleanly on stdin EOF, an explicit `quit` command, or console/session events; all COM objects are released and `CoUninitialize()` is called.
+- **Self-contained:** Inline GUID definitions let it link on Windows build hosts that only have `clang-cl` available and lack `uuid.lib`.
+
+## Safety mechanisms
+
+- **Snapshot/restore depth tracking** remains unchanged, so nested duck/restore calls cannot leave the system volume stuck.
+- **`MIN_DUCK_DELTA` and `RESTORE_EPSILON`** are preserved, preventing tiny, inaudible volume adjustments and noisy restore attempts.
+- **Startup timeout (2 s)** prevents the UI from waiting forever if the helper binary hangs on launch.
+- **Per-command timeout (500 ms)** aborts a stuck helper command and triggers a restart.
+- **Restart-on-failure with a failure budget** avoids an infinite crash loop; after repeated failures the controller switches back to the proven PowerShell fallback.
+- **Safe disposal** kills the helper process and releases all handles/resources when the app quits or the controller is torn down.
+- **Unexpected-exit handling** detects when the helper dies and restarts it on the next duck request.
+
+## macOS implementation hardening
+
+The macOS audio-ducking path was hardened as part of this change:
+
+- **Native CoreAudio helper:** Added `apps/electron/native/macos-volume-control.swift`, a small Swift binary that replaces AppleScript `osascript` calls. It reads and writes the default output device’s `kAudioHardwareServiceDeviceProperty_VirtualMasterVolume` and `kAudioDevicePropertyMute` via `AudioObjectGetPropertyData` / `AudioObjectSetPropertyData`.
+- **Simple argv protocol:** `get` returns `volume|muted`; `set <0..1>` adjusts output volume; `mute` / `unmute` toggle mute.
+- **Fallback preserved:** `audio-ducking.ts` detects `process.platform === "darwin"` and prefers the native helper when compiled, falling back to AppleScript if the binary is missing or fails.
+- **Build integration:** `apps/electron/scripts/compile-native.js` compiles `macos-volume-control` with `-framework CoreAudio -framework Foundation` during packaging.
+- **No shell injection surface:** When the native helper is unavailable, `osascript` is invoked through `execFileAsync` with fixed argument arrays; no user-controlled strings reach a shell.
+- **Safety model unchanged:** Snapshot/restore depth tracking, `MIN_DUCK_DELTA`, and `RESTORE_EPSILON` apply to the macOS path exactly as before.
+
+## Linux implementation hardening
+
+The Linux audio-ducking path was reviewed and hardened as part of this change:
+
+- **No shell injection surface:** `audio-ducking.ts` invokes `pactl`/`wpctl` through `execFileAsync` with fixed argument arrays; no user-controlled strings are passed to a shell.
+- **Bounded C helpers:** `linux-key-listener.c` uses `strncpy` with explicit null-termination and `snprintf` with fixed-size buffers; no raw `strcpy`, `strcat`, `sprintf`, `gets`, or `system` calls are present.
+- **Fixed commands only:** `linux-mic-listener.c` uses `popen` only with hard-coded `pactl` commands and reads output with `fgets` into fixed buffers.
+- **Single-process/single-thread:** the helpers do not share mutable state across threads, so `strtok` non-reentrancy is not a practical concern.
+
+## Known limitations
+
+- `windows-mic-listener.exe` still fails to link on the clang-cl-only build host because of the same unresolved COM GUID issue. This is pre-existing; mic detection falls back to the legacy path.
+- The helper targets the default multimedia playback endpoint only. Per-application ducking is out of scope.
+
+## How to test
+
+1. `pnpm typecheck` in `apps/electron` should pass for both node and web.
+2. `pnpm compile:native` on Windows should produce `resources/bin/win32-x64/windows-volume-control.exe`.
+3. `pnpm compile:native` on macOS should produce `resources/bin/darwin-*/macos-volume-control`.
+4. Manually pipe commands to the Windows helper and verify `get`, `set`, `mute`, and `quit` respond correctly.
+5. Run the macOS helper with `get`, `set`, `mute`, and `unmute` and verify volume/mute state changes.
+6. Run `pnpm build:win` and confirm the installer is signed and contains the new binary.
+7. In the running app, hold the push-to-hold key; system volume should duck immediately and restore on release.
+
+## Checklist
+
+- [x] Windows native helper implemented in C using Core Audio.
+- [x] Windows native helper compiles with the available toolchain.
+- [x] macOS native helper implemented in Swift using CoreAudio.
+- [x] macOS native helper compiles with the available toolchain.
+- [x] Linux shell-out and native helper paths hardened.
+- [x] TypeScript typechecks pass.
+- [x] Windows PowerShell fallback preserved.
+- [x] macOS AppleScript fallback preserved.
+- [x] Snapshot/restore safety logic unchanged.
+- [x] Build script updated for all three platforms.
+- [x] Windows installer built and signed.

--- a/docs/pr-messages/README.md
+++ b/docs/pr-messages/README.md
@@ -1,0 +1,11 @@
+# Pull request messages
+
+This directory contains prepared pull-request descriptions for the current feature batch. They are organized by category so each branch can be reviewed and merged independently.
+
+| File | Branch | Category |
+|---|---|---|
+| `PR_native_windows_volume_control.md` | `feat/native-windows-volume-control` | Native Windows audio-ducking helper |
+| `PR_branding_icons.md` | `pr/branding-icons` | Royal-blue icon/branding refresh |
+| `PR_openapi_providers.md` | `pr/openapi-providers` | OpenAPI-compatible providers |
+
+The integration build that combines these branches is `build/audio-ducking-rename-branding`.


### PR DESCRIPTION
# Cross-platform native volume-control helpers for audio ducking

**Branch:** `build/native-windows-volume-control`  
**Base:** `main`

## What this PR does

Replaces the Windows audio-ducking PowerShell/COM backend with a small, persistent native helper written in **C**, and hardens the macOS and Linux audio-ducking paths so all three desktop platforms use fast, native volume APIs with safe fallbacks.

- **Windows:** persistent C helper using Core Audio `IAudioEndpointVolume`, with PowerShell fallback preserved.
- **macOS:** new Swift helper using CoreAudio `AudioObjectGetPropertyData` / `AudioObjectSetPropertyData`, replacing per-duck AppleScript `osascript` calls; AppleScript fallback preserved.
- **Linux:** hardened shell-out path and native mic listener, with no shell-injection surface and bounded C buffers.

## Merge sequence

This is the first PR in the stack. Merge this before #2 (OpenAPI providers), #3 (color themes), and #4 (dark/light mode).