### PR TITLE
Fix Linux whisper-server AVX-512 crash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
         working-directory: apps/electron
         run: node scripts/download-whisper-cpp.mjs --resources
 
-      - name: Verify whisper-server is portable (no AVX-512)
+      - name: Verify whisper binaries are portable (no AVX-512)
         working-directory: apps/electron
         run: node scripts/verify-whisper-portable.mjs
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         run: pnpm --filter @freestyle/server build
 
       - name: Install native build dependencies
-        run: sudo apt-get update && sudo apt-get install -y libx11-dev libxtst-dev libxext-dev libglib2.0-dev cmake libx11-xcb-dev
+        run: sudo apt-get update && sudo apt-get install -y libx11-dev libxtst-dev libxext-dev libglib2.0-dev cmake libx11-xcb-dev binutils
 
       - name: Build whisper.cpp binaries
         working-directory: apps/electron

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,10 @@ jobs:
         working-directory: apps/electron
         run: node scripts/download-whisper-cpp.mjs --resources
 
+      - name: Verify whisper-server is portable (no AVX-512)
+        working-directory: apps/electron
+        run: node scripts/verify-whisper-portable.mjs
+
       - name: Build electron (Linux)
         working-directory: apps/electron
         run: pnpm run build:linux

--- a/apps/electron/scripts/download-whisper-cpp.mjs
+++ b/apps/electron/scripts/download-whisper-cpp.mjs
@@ -99,7 +99,8 @@ async function buildFromSource(outDir) {
 
   console.log("Building (this may take a minute)...");
   mkdirSync(buildDir, { recursive: true });
-  execFileSync("cmake", getWhisperCmakeArgs(), {
+  const forBundledRelease = process.argv.includes("--resources");
+  execFileSync("cmake", getWhisperCmakeArgs({ forBundledRelease }), {
     cwd: buildDir,
     stdio: "inherit",
     timeout: 60_000,

--- a/apps/electron/scripts/download-whisper-cpp.mjs
+++ b/apps/electron/scripts/download-whisper-cpp.mjs
@@ -33,6 +33,7 @@ import { dirname, join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
+import { getWhisperCmakeArgs } from "./whisper-cmake-args.mjs";
 
 const VERSION = "1.8.5";
 const CACHE_DIR = join(homedir(), ".cache", "freestyle", "whisper-bin");
@@ -98,15 +99,11 @@ async function buildFromSource(outDir) {
 
   console.log("Building (this may take a minute)...");
   mkdirSync(buildDir, { recursive: true });
-  execFileSync(
-    "cmake",
-    ["..", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_SHARED_LIBS=OFF"],
-    {
-      cwd: buildDir,
-      stdio: "inherit",
-      timeout: 60_000,
-    },
-  );
+  execFileSync("cmake", getWhisperCmakeArgs(), {
+    cwd: buildDir,
+    stdio: "inherit",
+    timeout: 60_000,
+  });
   execFileSync("cmake", ["--build", ".", "--config", "Release", "-j"], {
     cwd: buildDir,
     stdio: "inherit",

--- a/apps/electron/scripts/verify-whisper-portable.mjs
+++ b/apps/electron/scripts/verify-whisper-portable.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+/**
+ * Fail if a linux-x64 whisper-server binary contains AVX-512 instructions.
+ * Used in CI after building bundled release binaries.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const binary = join(
+  __dirname,
+  "..",
+  "resources",
+  "whisper",
+  "linux-x64",
+  "whisper-server",
+);
+
+if (!existsSync(binary)) {
+  console.error(`whisper-server not found at ${binary}`);
+  process.exit(1);
+}
+
+const disasm = execFileSync("objdump", ["-d", binary], {
+  encoding: "utf8",
+  maxBuffer: 64 * 1024 * 1024,
+});
+
+// EVEX-encoded ops use ZMM registers; baseline AVX2 builds must not contain these.
+if (/\b(zmm|evex)\b/i.test(disasm)) {
+  console.error(
+    "whisper-server contains AVX-512 instructions; rebuild with -DGGML_NATIVE=OFF",
+  );
+  process.exit(1);
+}
+
+console.log("whisper-server is AVX-512-free");

--- a/apps/electron/scripts/verify-whisper-portable.mjs
+++ b/apps/electron/scripts/verify-whisper-portable.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 
 /**
- * Fail if a linux-x64 whisper-server binary contains AVX-512 instructions.
+ * Fail if bundled linux-x64 whisper binaries contain AVX-512 instructions.
  * Used in CI after building bundled release binaries.
+ *
+ * Best-effort check: scans objdump output for EVEX/ZMM/mask-register patterns.
+ * False positives are possible (e.g. symbol names); false negatives are possible
+ * for unusual EVEX encodings. Catches the common GGML_NATIVE regression.
  */
 
 import { execFileSync } from "node:child_process";
@@ -11,31 +15,32 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const binary = join(
-  __dirname,
-  "..",
-  "resources",
-  "whisper",
-  "linux-x64",
-  "whisper-server",
-);
+const whisperDir = join(__dirname, "..", "resources", "whisper", "linux-x64");
 
-if (!existsSync(binary)) {
-  console.error(`whisper-server not found at ${binary}`);
-  process.exit(1);
+const BINARIES = ["whisper-server", "whisper-cli"];
+
+// EVEX-encoded ops use ZMM registers and k0–k7 mask registers; baseline AVX2 builds must not contain these.
+const AVX512_PATTERN = /\b(zmm|evex)\b|%k[0-7]/i;
+
+for (const name of BINARIES) {
+  const binary = join(whisperDir, name);
+
+  if (!existsSync(binary)) {
+    console.error(`${name} not found at ${binary}`);
+    process.exit(1);
+  }
+
+  const disasm = execFileSync("objdump", ["-d", binary], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+
+  if (AVX512_PATTERN.test(disasm)) {
+    console.error(
+      `${name} contains AVX-512 instructions; rebuild with -DGGML_NATIVE=OFF`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`${name} is AVX-512-free`);
 }
-
-const disasm = execFileSync("objdump", ["-d", binary], {
-  encoding: "utf8",
-  maxBuffer: 64 * 1024 * 1024,
-});
-
-// EVEX-encoded ops use ZMM registers; baseline AVX2 builds must not contain these.
-if (/\b(zmm|evex)\b/i.test(disasm)) {
-  console.error(
-    "whisper-server contains AVX-512 instructions; rebuild with -DGGML_NATIVE=OFF",
-  );
-  process.exit(1);
-}
-
-console.log("whisper-server is AVX-512-free");

--- a/apps/electron/scripts/whisper-cmake-args.mjs
+++ b/apps/electron/scripts/whisper-cmake-args.mjs
@@ -15,9 +15,8 @@ export function getWhisperCmakeArgs({ forBundledRelease = false } = {}) {
   ];
 
   const bundleLinux =
-    forBundledRelease ||
-    (process.platform === "linux" &&
-      process.argv.includes("--resources"));
+    process.platform === "linux" &&
+    (forBundledRelease || process.argv.includes("--resources"));
 
   if (bundleLinux) {
     args.push("-DGGML_NATIVE=OFF");

--- a/apps/electron/scripts/whisper-cmake-args.mjs
+++ b/apps/electron/scripts/whisper-cmake-args.mjs
@@ -10,11 +10,7 @@
 export function getWhisperCmakeArgs({ forBundledRelease = false } = {}) {
   const args = ["..", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_SHARED_LIBS=OFF"];
 
-  const bundleLinux =
-    process.platform === "linux" &&
-    (forBundledRelease || process.argv.includes("--resources"));
-
-  if (bundleLinux) {
+  if (process.platform === "linux" && forBundledRelease) {
     args.push("-DGGML_NATIVE=OFF");
   }
 

--- a/apps/electron/scripts/whisper-cmake-args.mjs
+++ b/apps/electron/scripts/whisper-cmake-args.mjs
@@ -8,11 +8,7 @@
  */
 
 export function getWhisperCmakeArgs({ forBundledRelease = false } = {}) {
-  const args = [
-    "..",
-    "-DCMAKE_BUILD_TYPE=Release",
-    "-DBUILD_SHARED_LIBS=OFF",
-  ];
+  const args = ["..", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_SHARED_LIBS=OFF"];
 
   const bundleLinux =
     process.platform === "linux" &&

--- a/apps/electron/scripts/whisper-cmake-args.mjs
+++ b/apps/electron/scripts/whisper-cmake-args.mjs
@@ -1,0 +1,27 @@
+/**
+ * CMake arguments for building whisper.cpp / ggml.
+ *
+ * Linux CI runners (GitHub Actions ubuntu-latest) often have AVX-512. With
+ * GGML_NATIVE=ON, ggml uses -march=native and embeds AVX-512 instructions
+ * in init paths that run unconditionally — whisper-server then SIGILLs on
+ * common consumer CPUs (e.g. Intel 12th/13th gen without AVX-512).
+ */
+
+export function getWhisperCmakeArgs({ forBundledRelease = false } = {}) {
+  const args = [
+    "..",
+    "-DCMAKE_BUILD_TYPE=Release",
+    "-DBUILD_SHARED_LIBS=OFF",
+  ];
+
+  const bundleLinux =
+    forBundledRelease ||
+    (process.platform === "linux" &&
+      process.argv.includes("--resources"));
+
+  if (bundleLinux) {
+    args.push("-DGGML_NATIVE=OFF");
+  }
+
+  return args;
+}


### PR DESCRIPTION
Fixes #289

## Summary
- Build bundled Linux whisper.cpp binaries with `GGML_NATIVE=OFF` so GitHub Actions runner CPU features like AVX-512 are not baked into release artifacts.
- Add a Linux CI verification step that disassembles the bundled `whisper-server` and fails if AVX-512/ZMM instructions are present.
- Install `binutils` in the Linux packaging job for the verifier's `objdump` dependency.

## Root cause
Linux release `whisper-server` was built with `GGML_NATIVE=ON` on CI runners that expose AVX-512. The binary embeds AVX-512 instructions in `ggml_cpu_init()` that run unconditionally at startup. On common consumer CPUs without AVX-512 (e.g. Intel 12th/13th gen), the process crashes with SIGILL right after the GPU init log lines — matching the reports in #289.

Disabling GPU/flash attention does not fix it; this is a CPU instruction-set portability issue, not a GPU driver issue.

## Test plan
- Verified the local failure mode: bundled `whisper-server` crashes with SIGILL in `ggml_cpu_init()` on an AVX2-only CPU, including with `--no-gpu --no-flash-attn`.
- Verified helper output adds `-DGGML_NATIVE=OFF` only for Linux `--resources`/release builds.
- Built a local AppImage from this branch; `whisper-server` starts and reaches `Server ready on port 8178` on the same machine where 0.2.0 failed.