### PR TITLE
feat: run the server standalone (Docker) and connect the app to it

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -24,3 +24,17 @@ artifactProvider:
 targets:
   - name: github
     includeNames: /(^|.*\/)(.*\.(dmg|zip|exe|msi|AppImage|deb|snap|blockmap)|latest.*\.yml|mlx_asr_worker-.*\.tar\.gz)$/
+
+  # Re-tag the server container image (built & pushed during CI on the release
+  # branch, tagged with the git SHA) to the release version and :latest.
+  # Craft auto-authenticates to ghcr.io via GITHUB_TOKEN/GITHUB_API_TOKEN.
+  - name: docker
+    id: versioned
+    source: ghcr.io/freestyle-voice/freestyle-server
+    target: ghcr.io/freestyle-voice/freestyle-server
+  - name: docker
+    id: latest
+    source: ghcr.io/freestyle-voice/freestyle-server
+    target:
+      image: ghcr.io/freestyle-voice/freestyle-server
+      format: "{{{image}}}:latest"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,6 +245,50 @@ jobs:
             apps/electron/dist/*.blockmap
           if-no-files-found: warn
 
+  build-server-image:
+    name: Build server image
+    needs: [lint, typecheck, test-server]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Only authenticate + push on branch pushes (main / release/**).
+      # PRs (incl. forks) build the image to validate the Dockerfile, no push.
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/freestyle-voice/freestyle-server
+          # The release SHA tag is what the Craft docker target copies from.
+          tags: |
+            type=raw,value=${{ github.sha }}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/server/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   ci-status:
     name: CI Status
     if: always()
@@ -256,6 +300,7 @@ jobs:
       - build-linux
       - build-mac
       - build-windows
+      - build-server-image
     runs-on: ubuntu-latest
     steps:
       - name: Check CI result

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: write
   issues: write
+  packages: write
 
 jobs:
   publish:

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -146,6 +146,12 @@ function getServerUrl(): string {
   return parsed.success ? parsed.data : "";
 }
 
+/** Optional bearer token sent to a configured server ("" = none). */
+function getServerToken(): string {
+  const raw = readSettings().serverToken;
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let httpServer: any = null;
 let serverPort = DEFAULT_PORT;
@@ -1194,6 +1200,15 @@ app.whenReady().then(async () => {
     const parsed = serverUrlSchema.safeParse(url);
     if (parsed.success) writeSettings({ serverUrl: parsed.data });
     return getServerUrl();
+  });
+
+  // IPC: read/persist the optional bearer token for a configured server.
+  ipcMain.handle("server:token", () => getServerToken());
+  ipcMain.handle("server:set-token", (_event, token: unknown) => {
+    writeSettings({
+      serverToken: typeof token === "string" ? token.trim() : "",
+    });
+    return getServerToken();
   });
 
   ipcMain.handle(

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -136,12 +136,12 @@ function writeSettings(patch: Record<string, unknown>): void {
 }
 
 /**
- * The base URL of a remote Freestyle server, if the user has configured one.
- * When set, the app connects to that server instead of running one locally.
- * Returns an empty string when using the default local server.
+ * The configured Freestyle server URL, if the user has set one. When present,
+ * the app connects to that server instead of running one locally. Returns an
+ * empty string when using the default local server.
  */
-function getRemoteServerUrl(): string {
-  const raw = readSettings().remoteServerUrl;
+function getServerUrl(): string {
+  const raw = readSettings().serverUrl;
   if (typeof raw !== "string") return "";
   // Strip any trailing slash so callers can append paths cleanly.
   return raw.trim().replace(/\/+$/, "");
@@ -1185,16 +1185,16 @@ app.whenReady().then(async () => {
   // IPC: expose the server port to the renderer
   ipcMain.handle("server:port", () => serverPort);
 
-  // IPC: read the configured remote server URL ("" = use the local server)
-  ipcMain.handle("server:remote-url", () => getRemoteServerUrl());
+  // IPC: read the configured server URL ("" = use the local server)
+  ipcMain.handle("server:url", () => getServerUrl());
 
-  // IPC: persist the remote server URL. Takes effect for API/WebSocket calls
-  // immediately; switching between local and remote requires a restart to
-  // start/stop the local server.
-  ipcMain.handle("server:set-remote-url", (_event, url: unknown) => {
+  // IPC: persist the server URL. Takes effect for API/WebSocket calls
+  // immediately; switching between local and a configured URL requires a
+  // restart to start/stop the local server.
+  ipcMain.handle("server:set-url", (_event, url: unknown) => {
     const value = typeof url === "string" ? url.trim() : "";
-    writeSettings({ remoteServerUrl: value });
-    return getRemoteServerUrl();
+    writeSettings({ serverUrl: value });
+    return getServerUrl();
   });
 
   ipcMain.handle(
@@ -1325,12 +1325,12 @@ app.whenReady().then(async () => {
     );
   });
 
-  // When a remote server URL is configured, the app talks to that server
-  // instead of running one locally. Skip all local server startup in that case.
-  const remoteServerUrl = getRemoteServerUrl();
+  // When a server URL is configured, the app talks to that server instead of
+  // running one locally. Skip all local server startup in that case.
+  const serverUrl = getServerUrl();
 
-  if (remoteServerUrl) {
-    log.info(`Using remote Freestyle server at ${remoteServerUrl}`);
+  if (serverUrl) {
+    log.info(`Using configured Freestyle server at ${serverUrl}`);
   } else {
     // Set database path for the server before any API calls
     process.env.FREESTYLE_DB_PATH = join(
@@ -1389,7 +1389,7 @@ app.whenReady().then(async () => {
     }
   }
 
-  if (!remoteServerUrl && !is.dev) {
+  if (!serverUrl && !is.dev) {
     void activateManagedMlxRuntimeForAppVersion(app.getVersion()).catch(
       (err) => {
         log.warn(

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -55,6 +55,7 @@ import {
   stopWhisperServer,
 } from "@freestyle/server";
 import { createAppLogger } from "@freestyle/utils";
+import { serverUrlSchema } from "@freestyle/validations";
 import {
   app,
   BrowserWindow,
@@ -141,10 +142,8 @@ function writeSettings(patch: Record<string, unknown>): void {
  * empty string when using the default local server.
  */
 function getServerUrl(): string {
-  const raw = readSettings().serverUrl;
-  if (typeof raw !== "string") return "";
-  // Strip any trailing slash so callers can append paths cleanly.
-  return raw.trim().replace(/\/+$/, "");
+  const parsed = serverUrlSchema.safeParse(readSettings().serverUrl);
+  return parsed.success ? parsed.data : "";
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1190,10 +1189,10 @@ app.whenReady().then(async () => {
 
   // IPC: persist the server URL. Takes effect for API/WebSocket calls
   // immediately; switching between local and a configured URL requires a
-  // restart to start/stop the local server.
+  // restart to start/stop the local server. Invalid values are ignored.
   ipcMain.handle("server:set-url", (_event, url: unknown) => {
-    const value = typeof url === "string" ? url.trim() : "";
-    writeSettings({ serverUrl: value });
+    const parsed = serverUrlSchema.safeParse(url);
+    if (parsed.success) writeSettings({ serverUrl: parsed.data });
     return getServerUrl();
   });
 

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -44,17 +44,17 @@ import { rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { electronApp, is, optimizer } from "@electron-toolkit/utils";
-import server, {
+import {
   activateManagedMlxRuntimeForAppVersion,
   autoStartWhisperServer,
   closeDb,
   prefetchManagedMlxRuntimeForAppRelease,
   reconcileUnsupportedMlxVoiceDefault,
+  startServer as startFreestyleServer,
   stopMlxServer,
   stopWhisperServer,
 } from "@freestyle/server";
 import { createAppLogger } from "@freestyle/utils";
-import { serve } from "@hono/node-server";
 import {
   app,
   BrowserWindow,
@@ -72,7 +72,6 @@ import {
   Tray,
 } from "electron";
 import { autoUpdater } from "electron-updater";
-import { WebSocketServer } from "ws";
 import icon from "../../resources/icon.png?asset";
 import trayIconPath from "../../resources/tray/logoTemplate.png?asset";
 import { isActiveAudioPlaybackMode } from "../shared/audio-playback";
@@ -134,6 +133,18 @@ function writeSettings(patch: Record<string, unknown>): void {
   } catch {
     // ignore
   }
+}
+
+/**
+ * The base URL of a remote Freestyle server, if the user has configured one.
+ * When set, the app connects to that server instead of running one locally.
+ * Returns an empty string when using the default local server.
+ */
+function getRemoteServerUrl(): string {
+  const raw = readSettings().remoteServerUrl;
+  if (typeof raw !== "string") return "";
+  // Strip any trailing slash so callers can append paths cleanly.
+  return raw.trim().replace(/\/+$/, "");
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1174,6 +1185,18 @@ app.whenReady().then(async () => {
   // IPC: expose the server port to the renderer
   ipcMain.handle("server:port", () => serverPort);
 
+  // IPC: read the configured remote server URL ("" = use the local server)
+  ipcMain.handle("server:remote-url", () => getRemoteServerUrl());
+
+  // IPC: persist the remote server URL. Takes effect for API/WebSocket calls
+  // immediately; switching between local and remote requires a restart to
+  // start/stop the local server.
+  ipcMain.handle("server:set-remote-url", (_event, url: unknown) => {
+    const value = typeof url === "string" ? url.trim() : "";
+    writeSettings({ remoteServerUrl: value });
+    return getRemoteServerUrl();
+  });
+
   ipcMain.handle(
     "dialog:show-error",
     async (_event, title: string, detail: string) => {
@@ -1302,63 +1325,71 @@ app.whenReady().then(async () => {
     );
   });
 
-  // Set database path for the server before any API calls
-  process.env.FREESTYLE_DB_PATH = join(app.getPath("userData"), "freestyle.db");
+  // When a remote server URL is configured, the app talks to that server
+  // instead of running one locally. Skip all local server startup in that case.
+  const remoteServerUrl = getRemoteServerUrl();
 
-  process.env.FREESTYLE_ENV = is.dev ? "development" : "production";
-  if (!is.dev) {
-    process.env.FREESTYLE_MLX_ASR_RELEASE_TAG ||= app.getVersion();
-  }
-
-  // Run non-critical server startup tasks now that the DB path is set
-  reconcileUnsupportedMlxVoiceDefault();
-  autoStartWhisperServer();
-
-  // Start the Hono HTTP server with WebSocket support (or reuse an existing one)
-  function startServer(port: number): void {
-    const wss = new WebSocketServer({ noServer: true });
-    httpServer = serve(
-      {
-        fetch: server.fetch,
-        port,
-        websocket: { server: wss },
-      },
-      (info) => {
-        serverPort = info.port;
-        log.info(`Server running on http://localhost:${info.port}`);
-      },
-    );
-
-    httpServer.on("error", (err: NodeJS.ErrnoException) => {
-      if (err.code === "EADDRINUSE" && port === DEFAULT_PORT) {
-        log.warn(`Port ${DEFAULT_PORT} in use, falling back to random port`);
-        startServer(0);
-      } else {
-        log.error(`Server failed to start: ${err}`);
-      }
-    });
-  }
-
-  // Check if a Freestyle server is already running on the default port.
-  let existingServer = false;
-  try {
-    const res = await net.fetch(`http://127.0.0.1:${DEFAULT_PORT}/api/health`);
-    if (res.ok) {
-      const data = (await res.json()) as { status?: string; name?: string };
-      existingServer = data?.status === "ok" && data?.name === "freestyle";
-    }
-  } catch {}
-
-  if (existingServer) {
-    serverPort = DEFAULT_PORT;
-    log.info(
-      `Reusing existing Freestyle server on http://localhost:${DEFAULT_PORT}`,
-    );
+  if (remoteServerUrl) {
+    log.info(`Using remote Freestyle server at ${remoteServerUrl}`);
   } else {
-    startServer(DEFAULT_PORT);
+    // Set database path for the server before any API calls
+    process.env.FREESTYLE_DB_PATH = join(
+      app.getPath("userData"),
+      "freestyle.db",
+    );
+
+    process.env.FREESTYLE_ENV = is.dev ? "development" : "production";
+    if (!is.dev) {
+      process.env.FREESTYLE_MLX_ASR_RELEASE_TAG ||= app.getVersion();
+    }
+
+    // Run non-critical server startup tasks now that the DB path is set
+    reconcileUnsupportedMlxVoiceDefault();
+    autoStartWhisperServer();
+
+    // Start the Hono HTTP server with WebSocket support (or reuse an existing one)
+    const startServer = (port: number): void => {
+      startFreestyleServer({ port, host: "127.0.0.1" })
+        .then(({ server, port: boundPort }) => {
+          httpServer = server;
+          serverPort = boundPort;
+          log.info(`Server running on http://localhost:${boundPort}`);
+        })
+        .catch((err: NodeJS.ErrnoException) => {
+          if (err.code === "EADDRINUSE" && port === DEFAULT_PORT) {
+            log.warn(
+              `Port ${DEFAULT_PORT} in use, falling back to random port`,
+            );
+            startServer(0);
+          } else {
+            log.error(`Server failed to start: ${err}`);
+          }
+        });
+    };
+
+    // Check if a Freestyle server is already running on the default port.
+    let existingServer = false;
+    try {
+      const res = await net.fetch(
+        `http://127.0.0.1:${DEFAULT_PORT}/api/health`,
+      );
+      if (res.ok) {
+        const data = (await res.json()) as { status?: string; name?: string };
+        existingServer = data?.status === "ok" && data?.name === "freestyle";
+      }
+    } catch {}
+
+    if (existingServer) {
+      serverPort = DEFAULT_PORT;
+      log.info(
+        `Reusing existing Freestyle server on http://localhost:${DEFAULT_PORT}`,
+      );
+    } else {
+      startServer(DEFAULT_PORT);
+    }
   }
 
-  if (!is.dev) {
+  if (!remoteServerUrl && !is.dev) {
     void activateManagedMlxRuntimeForAppVersion(app.getVersion()).catch(
       (err) => {
         log.warn(

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -22,8 +22,8 @@ declare global {
       hidePill: () => void;
       showErrorDialog: (title: string, message: string) => Promise<void>;
       getServerPort: () => Promise<number>;
-      getRemoteServerUrl: () => Promise<string>;
-      setRemoteServerUrl: (url: string) => Promise<string>;
+      getServerUrl: () => Promise<string>;
+      setServerUrl: (url: string) => Promise<string>;
       onHotkeyDown: (callback: () => void) => () => void;
       onHotkeyUp: (callback: () => void) => () => void;
       onPillCancel: (callback: () => void) => () => void;

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -24,6 +24,8 @@ declare global {
       getServerPort: () => Promise<number>;
       getServerUrl: () => Promise<string>;
       setServerUrl: (url: string) => Promise<string>;
+      getServerToken: () => Promise<string>;
+      setServerToken: (token: string) => Promise<string>;
       onHotkeyDown: (callback: () => void) => () => void;
       onHotkeyUp: (callback: () => void) => () => void;
       onPillCancel: (callback: () => void) => () => void;

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -22,6 +22,8 @@ declare global {
       hidePill: () => void;
       showErrorDialog: (title: string, message: string) => Promise<void>;
       getServerPort: () => Promise<number>;
+      getRemoteServerUrl: () => Promise<string>;
+      setRemoteServerUrl: (url: string) => Promise<string>;
       onHotkeyDown: (callback: () => void) => () => void;
       onHotkeyUp: (callback: () => void) => () => void;
       onPillCancel: (callback: () => void) => () => void;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -30,11 +30,10 @@ const api = {
   showErrorDialog: (title: string, message: string): Promise<void> =>
     ipcRenderer.invoke("dialog:show-error", title, message),
   getServerPort: (): Promise<number> => ipcRenderer.invoke("server:port"),
-  // Remote server URL ("" = use the bundled local server)
-  getRemoteServerUrl: (): Promise<string> =>
-    ipcRenderer.invoke("server:remote-url"),
-  setRemoteServerUrl: (url: string): Promise<string> =>
-    ipcRenderer.invoke("server:set-remote-url", url),
+  // Server URL ("" = use the bundled local server)
+  getServerUrl: (): Promise<string> => ipcRenderer.invoke("server:url"),
+  setServerUrl: (url: string): Promise<string> =>
+    ipcRenderer.invoke("server:set-url", url),
   onHotkeyDown: (callback: () => void): (() => void) => {
     const handler = (): void => callback();
     ipcRenderer.on("hotkey:down", handler);

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -34,6 +34,10 @@ const api = {
   getServerUrl: (): Promise<string> => ipcRenderer.invoke("server:url"),
   setServerUrl: (url: string): Promise<string> =>
     ipcRenderer.invoke("server:set-url", url),
+  // Optional bearer token for a configured server ("" = none)
+  getServerToken: (): Promise<string> => ipcRenderer.invoke("server:token"),
+  setServerToken: (token: string): Promise<string> =>
+    ipcRenderer.invoke("server:set-token", token),
   onHotkeyDown: (callback: () => void): (() => void) => {
     const handler = (): void => callback();
     ipcRenderer.on("hotkey:down", handler);

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -30,6 +30,11 @@ const api = {
   showErrorDialog: (title: string, message: string): Promise<void> =>
     ipcRenderer.invoke("dialog:show-error", title, message),
   getServerPort: (): Promise<number> => ipcRenderer.invoke("server:port"),
+  // Remote server URL ("" = use the bundled local server)
+  getRemoteServerUrl: (): Promise<string> =>
+    ipcRenderer.invoke("server:remote-url"),
+  setRemoteServerUrl: (url: string): Promise<string> =>
+    ipcRenderer.invoke("server:set-remote-url", url),
   onHotkeyDown: (callback: () => void): (() => void) => {
     const handler = (): void => callback();
     ipcRenderer.on("hotkey:down", handler);

--- a/apps/electron/src/renderer/index.html
+++ b/apps/electron/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http://localhost:* http://127.0.0.1:*"
+      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
     />
   </head>
 

--- a/apps/electron/src/renderer/pill.html
+++ b/apps/electron/src/renderer/pill.html
@@ -5,7 +5,7 @@
     <title>Freestyle</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http://localhost:* http://127.0.0.1:*"
+      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
     />
   </head>
 

--- a/apps/electron/src/renderer/src/components/ui/input-group.tsx
+++ b/apps/electron/src/renderer/src/components/ui/input-group.tsx
@@ -1,0 +1,153 @@
+import { Button } from "@renderer/components/ui/button";
+import { Input } from "@renderer/components/ui/input";
+import { Textarea } from "@renderer/components/ui/textarea";
+import { cn } from "@renderer/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-lg border border-input transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]",
+        "inline-end":
+          "order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]",
+        "block-start":
+          "order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2",
+        "block-end":
+          "order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  },
+);
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return;
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus();
+      }}
+      {...props}
+    />
+  );
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-3px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "",
+        "icon-xs":
+          "size-6 rounded-[calc(var(--radius)-3px)] p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  },
+);
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size"> &
+  VariantProps<typeof inputGroupButtonVariants>) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  );
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupText,
+  InputGroupTextarea,
+};

--- a/apps/electron/src/renderer/src/components/ui/textarea.tsx
+++ b/apps/electron/src/renderer/src/components/ui/textarea.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@renderer/lib/utils";
+import type * as React from "react";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/apps/electron/src/renderer/src/lib/analytics.ts
+++ b/apps/electron/src/renderer/src/lib/analytics.ts
@@ -1,4 +1,4 @@
-import { getApiBase } from "@renderer/lib/api";
+import { getApiBase, getAuthHeaders } from "@renderer/lib/api";
 
 /**
  * Capture a PostHog event from the renderer.
@@ -19,7 +19,7 @@ export function capture(
   try {
     fetch(`${getApiBase()}/api/telemetry`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...getAuthHeaders() },
       body: JSON.stringify({ event, properties }),
       // Survive the renderer navigating away (e.g. when onboarding completes).
       keepalive: true,

--- a/apps/electron/src/renderer/src/lib/api.ts
+++ b/apps/electron/src/renderer/src/lib/api.ts
@@ -6,6 +6,8 @@ const HEALTH_TIMEOUT_MS = 3000;
 let resolvedPort: number = DEFAULT_PORT;
 // Configured server URL ("" = use the local server).
 let serverUrl = "";
+// Optional bearer token for a configured server ("" = none).
+let serverToken = "";
 let initialized = false;
 
 /** Base URL of the locally-run server (used when no server URL is configured). */
@@ -17,6 +19,15 @@ export function getApiBase(): string {
   return serverUrl || getLocalApiBase();
 }
 
+/** Bearer token for the configured server, or "" when none is set. */
+export function getServerToken(): string {
+  return serverToken;
+}
+
+function authHeaders(token: string): Record<string, string> | undefined {
+  return token ? { Authorization: `Bearer ${token}` } : undefined;
+}
+
 export async function initApiBase(): Promise<void> {
   if (initialized) return;
   await refreshApiBase();
@@ -25,31 +36,59 @@ export async function initApiBase(): Promise<void> {
 
 /**
  * Verify a Freestyle server is reachable and identifies itself at `base`.
- * Used for both the live API base and ad-hoc connectivity tests (settings).
+ * `/api/health` is unauthenticated, so this checks reachability only.
  */
 export async function checkServerHealth(
   base: string,
   timeoutMs = HEALTH_TIMEOUT_MS,
 ): Promise<boolean> {
   try {
-    const res = await fetch(`${base}/api/health`, {
-      signal: AbortSignal.timeout(timeoutMs),
-    });
+    const res = await hc<AppType>(base).api.health.$get(
+      {},
+      { init: { signal: AbortSignal.timeout(timeoutMs) } },
+    );
     if (!res.ok) return false;
-    const data = (await res.json()) as { status?: string; name?: string };
+    const data = await res.json();
     return data.status === "ok" && data.name === "freestyle";
   } catch {
     return false;
   }
 }
 
-/** Re-read the server location (configured URL or local port) and verify it's reachable. */
+/**
+ * Verify the bearer token is accepted by hitting an authenticated endpoint.
+ * Returns true when the token is valid (or when no token is required).
+ */
+export async function checkServerAuth(
+  base: string,
+  token: string,
+  timeoutMs = HEALTH_TIMEOUT_MS,
+): Promise<boolean> {
+  try {
+    const res = await hc<AppType>(base, {
+      headers: authHeaders(token),
+    }).api["device-id"].$get(
+      {},
+      { init: { signal: AbortSignal.timeout(timeoutMs) } },
+    );
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Re-read the server location/token and verify it's reachable. */
 export async function refreshApiBase(): Promise<boolean> {
   try {
     // Main returns an already-validated, normalized value.
     serverUrl = await window.api.getServerUrl();
   } catch {
     serverUrl = "";
+  }
+  try {
+    serverToken = await window.api.getServerToken();
+  } catch {
+    serverToken = "";
   }
   if (!serverUrl) {
     try {
@@ -62,5 +101,5 @@ export async function refreshApiBase(): Promise<boolean> {
 }
 
 export function getClient() {
-  return hc<AppType>(getApiBase());
+  return hc<AppType>(getApiBase(), { headers: authHeaders(serverToken) });
 }

--- a/apps/electron/src/renderer/src/lib/api.ts
+++ b/apps/electron/src/renderer/src/lib/api.ts
@@ -3,9 +3,12 @@ import { hc } from "hono/client";
 
 const DEFAULT_PORT = 4649;
 let resolvedPort: number = DEFAULT_PORT;
+// Base URL of a configured remote server ("" = use the local server).
+let remoteBase = "";
 let initialized = false;
 
 export function getApiBase(): string {
+  if (remoteBase) return remoteBase;
   return `http://127.0.0.1:${resolvedPort}`;
 }
 
@@ -15,12 +18,21 @@ export async function initApiBase(): Promise<void> {
   initialized = true;
 }
 
-/** Re-read the server port and verify the API is reachable. */
+/** Re-read the server location (remote URL or local port) and verify it's reachable. */
 export async function refreshApiBase(): Promise<boolean> {
   try {
-    resolvedPort = await window.api.getServerPort();
+    remoteBase = (await window.api.getRemoteServerUrl())
+      .trim()
+      .replace(/\/+$/, "");
   } catch {
-    resolvedPort = DEFAULT_PORT;
+    remoteBase = "";
+  }
+  if (!remoteBase) {
+    try {
+      resolvedPort = await window.api.getServerPort();
+    } catch {
+      resolvedPort = DEFAULT_PORT;
+    }
   }
   try {
     const res = await getClient().api.health.$get(

--- a/apps/electron/src/renderer/src/lib/api.ts
+++ b/apps/electron/src/renderer/src/lib/api.ts
@@ -2,20 +2,45 @@ import type { AppType } from "@freestyle/server";
 import { hc } from "hono/client";
 
 const DEFAULT_PORT = 4649;
+const HEALTH_TIMEOUT_MS = 3000;
 let resolvedPort: number = DEFAULT_PORT;
 // Configured server URL ("" = use the local server).
 let serverUrl = "";
 let initialized = false;
 
-export function getApiBase(): string {
-  if (serverUrl) return serverUrl;
+/** Base URL of the locally-run server (used when no server URL is configured). */
+export function getLocalApiBase(): string {
   return `http://127.0.0.1:${resolvedPort}`;
+}
+
+export function getApiBase(): string {
+  return serverUrl || getLocalApiBase();
 }
 
 export async function initApiBase(): Promise<void> {
   if (initialized) return;
   await refreshApiBase();
   initialized = true;
+}
+
+/**
+ * Verify a Freestyle server is reachable and identifies itself at `base`.
+ * Used for both the live API base and ad-hoc connectivity tests (settings).
+ */
+export async function checkServerHealth(
+  base: string,
+  timeoutMs = HEALTH_TIMEOUT_MS,
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${base}/api/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return false;
+    const data = (await res.json()) as { status?: string; name?: string };
+    return data.status === "ok" && data.name === "freestyle";
+  } catch {
+    return false;
+  }
 }
 
 /** Re-read the server location (configured URL or local port) and verify it's reachable. */
@@ -32,21 +57,7 @@ export async function refreshApiBase(): Promise<boolean> {
       resolvedPort = DEFAULT_PORT;
     }
   }
-  try {
-    const res = await getClient().api.health.$get(
-      {},
-      {
-        init: {
-          signal: AbortSignal.timeout(3000),
-        },
-      },
-    );
-    if (!res.ok) return false;
-    const data = (await res.json()) as { status?: string; name?: string };
-    return data.status === "ok" && data.name === "freestyle";
-  } catch {
-    return false;
-  }
+  return checkServerHealth(getApiBase());
 }
 
 export function getClient() {

--- a/apps/electron/src/renderer/src/lib/api.ts
+++ b/apps/electron/src/renderer/src/lib/api.ts
@@ -24,8 +24,16 @@ export function getServerToken(): string {
   return serverToken;
 }
 
-function authHeaders(token: string): Record<string, string> | undefined {
-  return token ? { Authorization: `Bearer ${token}` } : undefined;
+function authHeaders(token: string): Record<string, string> {
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * Auth headers for the configured server, for use in raw `fetch()` calls.
+ * Empty when no token is set.
+ */
+export function getAuthHeaders(): Record<string, string> {
+  return authHeaders(serverToken);
 }
 
 export async function initApiBase(): Promise<void> {
@@ -101,5 +109,5 @@ export async function refreshApiBase(): Promise<boolean> {
 }
 
 export function getClient() {
-  return hc<AppType>(getApiBase(), { headers: authHeaders(serverToken) });
+  return hc<AppType>(getApiBase(), { headers: getAuthHeaders() });
 }

--- a/apps/electron/src/renderer/src/lib/api.ts
+++ b/apps/electron/src/renderer/src/lib/api.ts
@@ -46,7 +46,8 @@ export async function checkServerHealth(
 /** Re-read the server location (configured URL or local port) and verify it's reachable. */
 export async function refreshApiBase(): Promise<boolean> {
   try {
-    serverUrl = (await window.api.getServerUrl()).trim().replace(/\/+$/, "");
+    // Main returns an already-validated, normalized value.
+    serverUrl = await window.api.getServerUrl();
   } catch {
     serverUrl = "";
   }

--- a/apps/electron/src/renderer/src/lib/api.ts
+++ b/apps/electron/src/renderer/src/lib/api.ts
@@ -3,12 +3,12 @@ import { hc } from "hono/client";
 
 const DEFAULT_PORT = 4649;
 let resolvedPort: number = DEFAULT_PORT;
-// Base URL of a configured remote server ("" = use the local server).
-let remoteBase = "";
+// Configured server URL ("" = use the local server).
+let serverUrl = "";
 let initialized = false;
 
 export function getApiBase(): string {
-  if (remoteBase) return remoteBase;
+  if (serverUrl) return serverUrl;
   return `http://127.0.0.1:${resolvedPort}`;
 }
 
@@ -18,16 +18,14 @@ export async function initApiBase(): Promise<void> {
   initialized = true;
 }
 
-/** Re-read the server location (remote URL or local port) and verify it's reachable. */
+/** Re-read the server location (configured URL or local port) and verify it's reachable. */
 export async function refreshApiBase(): Promise<boolean> {
   try {
-    remoteBase = (await window.api.getRemoteServerUrl())
-      .trim()
-      .replace(/\/+$/, "");
+    serverUrl = (await window.api.getServerUrl()).trim().replace(/\/+$/, "");
   } catch {
-    remoteBase = "";
+    serverUrl = "";
   }
-  if (!remoteBase) {
+  if (!serverUrl) {
     try {
       resolvedPort = await window.api.getServerPort();
     } catch {

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -50,8 +50,11 @@ export class Streamer {
   private pcmChunks: Int16Array[] = [];
   private pcmSampleCount = 0;
 
-  constructor(baseUrl: string, callbacks: StreamerCallbacks) {
-    this.wsUrl = `${baseUrl.replace(/^http/, "ws")}/stream`;
+  constructor(baseUrl: string, callbacks: StreamerCallbacks, token = "") {
+    // Browsers can't set headers on a WebSocket, so the bearer token (when
+    // configured) is passed as a query param and validated on the upgrade.
+    const query = token ? `?token=${encodeURIComponent(token)}` : "";
+    this.wsUrl = `${baseUrl.replace(/^http/, "ws")}/stream${query}`;
     this.callbacks = callbacks;
     this.openWebSocket();
   }

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -1,6 +1,11 @@
 import { Orb } from "@renderer/components/ui/orb";
 import { capture } from "@renderer/lib/analytics";
-import { getApiBase, getClient, refreshApiBase } from "@renderer/lib/api";
+import {
+  getApiBase,
+  getClient,
+  getServerToken,
+  refreshApiBase,
+} from "@renderer/lib/api";
 import { Recorder } from "@renderer/lib/recorder";
 import { Streamer } from "@renderer/lib/streamer";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -342,41 +347,46 @@ export default function AppPage(): React.JSX.Element {
   // biome-ignore lint/correctness/useExhaustiveDependencies: singleton
   const getStreamer = useCallback((): Streamer => {
     if (!streamerRef.current) {
-      streamerRef.current = new Streamer(getApiBase(), {
-        onConfig: (config) => {
-          supportsSessionTransportRef.current = config.sessionTransport;
-          if (wantsMicRef.current) {
-            recordingSessionUsesTransportRef.current = config.sessionTransport;
-          }
-        },
-        onReady: () => {},
-        onPartial: () => {},
-        onFinal: (text) => {
-          const resolver = streamResolverRef.current;
-          if (!resolver) return;
-          streamResolverRef.current = null;
-          resolver({ raw: text, cleaned: text });
-        },
-        onCleaned: () => {},
-        onError: (msg) => {
-          const resolver = streamResolverRef.current;
-          if (resolver) {
+      streamerRef.current = new Streamer(
+        getApiBase(),
+        {
+          onConfig: (config) => {
+            supportsSessionTransportRef.current = config.sessionTransport;
+            if (wantsMicRef.current) {
+              recordingSessionUsesTransportRef.current =
+                config.sessionTransport;
+            }
+          },
+          onReady: () => {},
+          onPartial: () => {},
+          onFinal: (text) => {
+            const resolver = streamResolverRef.current;
+            if (!resolver) return;
             streamResolverRef.current = null;
-            const fallback = restFallbackTranscribe(msg);
-            if (fallback) {
-              void fallback.then(resolver);
+            resolver({ raw: text, cleaned: text });
+          },
+          onCleaned: () => {},
+          onError: (msg) => {
+            const resolver = streamResolverRef.current;
+            if (resolver) {
+              streamResolverRef.current = null;
+              const fallback = restFallbackTranscribe(msg);
+              if (fallback) {
+                void fallback.then(resolver);
+                return;
+              }
+              resolver({ raw: "", cleaned: "", error: msg });
               return;
             }
-            resolver({ raw: "", cleaned: "", error: msg });
-            return;
-          }
-          if (!supportsSessionTransportRef.current) return;
-          if (!pillActiveRef.current) return;
-          if (wantsMicRef.current) return;
-          hidePill();
-          window.api.showErrorDialog("Transcription Failed", msg);
+            if (!supportsSessionTransportRef.current) return;
+            if (!pillActiveRef.current) return;
+            if (wantsMicRef.current) return;
+            hidePill();
+            window.api.showErrorDialog("Transcription Failed", msg);
+          },
         },
-      });
+        getServerToken(),
+      );
     }
     return streamerRef.current;
   }, []);

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -2,6 +2,7 @@ import { Orb } from "@renderer/components/ui/orb";
 import { capture } from "@renderer/lib/analytics";
 import {
   getApiBase,
+  getAuthHeaders,
   getClient,
   getServerToken,
   refreshApiBase,
@@ -320,6 +321,7 @@ export default function AppPage(): React.JSX.Element {
       const headers: Record<string, string> = {
         "Content-Type": "audio/wav",
         "x-audio-duration-ms": String(Date.now() - startTimeRef.current),
+        ...getAuthHeaders(),
       };
       if (appContextRef.current)
         headers["x-app-context"] = encodeAppContext(appContextRef.current);
@@ -768,6 +770,7 @@ export default function AppPage(): React.JSX.Element {
     const headers: Record<string, string> = {
       "Content-Type": "audio/wav",
       "x-audio-duration-ms": String(recordingDuration),
+      ...getAuthHeaders(),
     };
     if (appContextRef.current)
       headers["x-app-context"] = encodeAppContext(appContextRef.current);

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -361,9 +361,9 @@ export default function SettingsPage(): React.JSX.Element {
       .then((v) => setShowOnLaunch(v))
       .catch(() => {});
 
-    // Remote server URL ("" = local server)
+    // Server URL ("" = local server)
     window.api
-      ?.getRemoteServerUrl()
+      ?.getServerUrl()
       .then((url) => {
         setSavedServerUrl(url);
         setServerUrlInput(url);
@@ -506,7 +506,7 @@ export default function SettingsPage(): React.JSX.Element {
 
   const handleSaveServerUrl = useCallback(async () => {
     const saved =
-      (await window.api?.setRemoteServerUrl(serverUrlInput)) ??
+      (await window.api?.setServerUrl(serverUrlInput)) ??
       serverUrlInput.trim().replace(/\/+$/, "");
     setSavedServerUrl(saved);
     setServerUrlInput(saved);
@@ -669,7 +669,7 @@ export default function SettingsPage(): React.JSX.Element {
         <Section label="Server">
           <Row
             label="Server URL"
-            desc="Leave empty to use the built-in local server. Enter the URL of a self-hosted Freestyle server (e.g. http://your-vm:4649) to connect to it instead. Restart the app after changing this."
+            desc="Leave empty to use the built-in local server. Enter the URL of a self-hosted Freestyle server (e.g. http://your-vm:4649) to use that instead. Restart the app after changing this."
             last
           >
             <div className="flex w-full max-w-md flex-col gap-2">

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -22,6 +22,8 @@ import {
   Check,
   Download,
   ExternalLink,
+  Eye,
+  EyeOff,
   Key,
   Keyboard,
   Languages,
@@ -102,6 +104,7 @@ export default function SettingsPage(): React.JSX.Element {
   const [savedServerUrl, setSavedServerUrl] = useState("");
   const [serverTokenInput, setServerTokenInput] = useState("");
   const [savedServerToken, setSavedServerToken] = useState("");
+  const [showToken, setShowToken] = useState(false);
   const [serverUrlError, setServerUrlError] = useState<string | null>(null);
   const [serverTest, setServerTest] = useState<
     "idle" | "testing" | "ok" | "unreachable" | "unauthorized"
@@ -544,6 +547,18 @@ export default function SettingsPage(): React.JSX.Element {
     await refreshApiBase();
     await testServer(savedUrl, savedToken);
   }, [serverUrlInput, serverTokenInput, testServer]);
+
+  const handleResetServer = useCallback(async () => {
+    const savedUrl = (await window.api?.setServerUrl("")) ?? "";
+    const savedToken = (await window.api?.setServerToken("")) ?? "";
+    setSavedServerUrl(savedUrl);
+    setServerUrlInput(savedUrl);
+    setSavedServerToken(savedToken);
+    setServerTokenInput(savedToken);
+    setServerUrlError(null);
+    setServerTest("idle");
+    await refreshApiBase();
+  }, []);
 
   const clearHistory = useCallback(async () => {
     if (!confirm(t("settings.data.clearHistoryConfirm"))) {
@@ -1009,7 +1024,30 @@ export default function SettingsPage(): React.JSX.Element {
             desc="Leave empty to use the built-in local server. Point this at a self-hosted Freestyle server (e.g. http://your-vm:4649) to use that instead, with an access token if it requires one. Restart the app after changing this."
             last
           >
-            <div className="flex w-full max-w-md flex-col gap-2">
+            <div className="flex w-full max-w-md flex-col gap-2.5">
+              <div className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    "mono inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-[3px] text-[9px] uppercase tracking-[0.14em]",
+                    savedServerUrl
+                      ? "bg-secondary text-secondary-foreground"
+                      : "bg-accent text-accent-foreground",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "h-1.5 w-1.5 rounded-full",
+                      savedServerUrl ? "bg-muted-foreground" : "bg-primary",
+                    )}
+                  />
+                  {savedServerUrl ? "Custom server" : "Local server"}
+                </span>
+                {savedServerUrl && (
+                  <span className="text-muted-foreground min-w-0 truncate text-xs">
+                    {savedServerUrl}
+                  </span>
+                )}
+              </div>
               <div className="border-border bg-card flex items-center gap-2 rounded-lg border px-3">
                 <Server className="text-muted-foreground h-4 w-4 shrink-0" />
                 <input
@@ -1025,11 +1063,16 @@ export default function SettingsPage(): React.JSX.Element {
                   className="text-foreground min-w-0 flex-1 bg-transparent py-2 text-sm outline-none"
                 />
               </div>
-              <div className="border-border bg-card flex items-center gap-2 rounded-lg border px-3">
+              <div
+                className={cn(
+                  "border-border bg-card flex items-center gap-2 rounded-lg border px-3 transition-opacity",
+                  !serverUrlInput.trim() && "opacity-55",
+                )}
+              >
                 <Key className="text-muted-foreground h-4 w-4 shrink-0" />
                 <input
                   id="settings-server-token"
-                  type="password"
+                  type={showToken ? "text" : "password"}
                   value={serverTokenInput}
                   onChange={(e) => {
                     setServerTokenInput(e.target.value);
@@ -1038,6 +1081,20 @@ export default function SettingsPage(): React.JSX.Element {
                   placeholder="Access token (optional)"
                   className="text-foreground min-w-0 flex-1 bg-transparent py-2 text-sm outline-none"
                 />
+                {serverTokenInput && (
+                  <button
+                    type="button"
+                    onClick={() => setShowToken((v) => !v)}
+                    aria-label={showToken ? "Hide token" : "Show token"}
+                    className="text-muted-foreground hover:text-foreground shrink-0 transition-colors"
+                  >
+                    {showToken ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </button>
+                )}
               </div>
               <div className="flex items-center gap-2">
                 <button
@@ -1058,6 +1115,18 @@ export default function SettingsPage(): React.JSX.Element {
                 >
                   Test connection
                 </button>
+                {(savedServerUrl ||
+                  savedServerToken ||
+                  serverUrlInput.trim() ||
+                  serverTokenInput.trim()) && (
+                  <button
+                    type="button"
+                    onClick={handleResetServer}
+                    className="text-muted-foreground hover:text-foreground inline-flex shrink-0 items-center rounded-md px-2 py-1.5 text-xs font-medium transition-colors"
+                  >
+                    Reset to local
+                  </button>
+                )}
                 {serverTest === "testing" && (
                   <span className="text-muted-foreground text-xs">
                     Testing…

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -1,3 +1,4 @@
+import { serverUrlSchema } from "@freestyle/validations";
 import { KeyComboDisplay } from "@renderer/components/key-combo";
 import { LanguageSelector } from "@renderer/components/language-selector";
 import { Select } from "@renderer/components/ui/select";
@@ -96,6 +97,7 @@ export default function SettingsPage(): React.JSX.Element {
   const [showOnLaunch, setShowOnLaunch] = useState(true);
   const [serverUrlInput, setServerUrlInput] = useState("");
   const [savedServerUrl, setSavedServerUrl] = useState("");
+  const [serverUrlError, setServerUrlError] = useState<string | null>(null);
   const [serverTest, setServerTest] = useState<
     "idle" | "testing" | "ok" | "fail"
   >("idle");
@@ -488,16 +490,26 @@ export default function SettingsPage(): React.JSX.Element {
   }, []);
 
   const testServerUrl = useCallback(async (rawUrl: string) => {
-    const base = rawUrl.trim().replace(/\/+$/, "") || getLocalApiBase();
+    const parsed = serverUrlSchema.safeParse(rawUrl);
+    if (!parsed.success) {
+      setServerUrlError(parsed.error.issues[0].message);
+      setServerTest("idle");
+      return;
+    }
+    const base = parsed.data || getLocalApiBase();
     setServerTest("testing");
     const ok = await checkServerHealth(base, 5000);
     setServerTest(ok ? "ok" : "fail");
   }, []);
 
   const handleSaveServerUrl = useCallback(async () => {
-    const saved =
-      (await window.api?.setServerUrl(serverUrlInput)) ??
-      serverUrlInput.trim().replace(/\/+$/, "");
+    const parsed = serverUrlSchema.safeParse(serverUrlInput);
+    if (!parsed.success) {
+      setServerUrlError(parsed.error.issues[0].message);
+      return;
+    }
+    setServerUrlError(null);
+    const saved = (await window.api?.setServerUrl(parsed.data)) ?? parsed.data;
     setSavedServerUrl(saved);
     setServerUrlInput(saved);
     await testServerUrl(saved);
@@ -672,6 +684,7 @@ export default function SettingsPage(): React.JSX.Element {
                   onChange={(e) => {
                     setServerUrlInput(e.target.value);
                     setServerTest("idle");
+                    setServerUrlError(null);
                   }}
                   placeholder="http://127.0.0.1:4649 (local)"
                   className="border-border bg-card text-foreground min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm"
@@ -707,6 +720,11 @@ export default function SettingsPage(): React.JSX.Element {
                   <span className="text-destructive text-xs">Unreachable</span>
                 )}
               </div>
+              {serverUrlError && (
+                <span className="text-destructive text-xs">
+                  {serverUrlError}
+                </span>
+              )}
             </div>
           </Row>
         </Section>

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -509,13 +509,14 @@ export default function SettingsPage(): React.JSX.Element {
       return;
     }
     const base = parsed.data || getLocalApiBase();
-    const trimmedToken = token.trim();
     setServerTest("testing");
     if (!(await checkServerHealth(base, 5000))) {
       setServerTest("unreachable");
       return;
     }
-    if (trimmedToken && !(await checkServerAuth(base, trimmedToken, 5000))) {
+    // Always probe an authenticated endpoint so we catch both a wrong token and
+    // a server that requires a token when none was entered.
+    if (!(await checkServerAuth(base, token.trim(), 5000))) {
       setServerTest("unauthorized");
       return;
     }

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -9,6 +9,7 @@ import {
   useHotkeyRecorder,
 } from "@renderer/hooks/use-hotkey-recorder";
 import {
+  checkServerAuth,
   checkServerHealth,
   getClient,
   getLocalApiBase,
@@ -20,6 +21,7 @@ import {
   Check,
   Download,
   ExternalLink,
+  Key,
   Keyboard,
   Languages,
   Mic,
@@ -97,9 +99,11 @@ export default function SettingsPage(): React.JSX.Element {
   const [showOnLaunch, setShowOnLaunch] = useState(true);
   const [serverUrlInput, setServerUrlInput] = useState("");
   const [savedServerUrl, setSavedServerUrl] = useState("");
+  const [serverTokenInput, setServerTokenInput] = useState("");
+  const [savedServerToken, setSavedServerToken] = useState("");
   const [serverUrlError, setServerUrlError] = useState<string | null>(null);
   const [serverTest, setServerTest] = useState<
-    "idle" | "testing" | "ok" | "fail"
+    "idle" | "testing" | "ok" | "unreachable" | "unauthorized"
   >("idle");
 
   const microphoneOptions = useMemo(
@@ -367,12 +371,19 @@ export default function SettingsPage(): React.JSX.Element {
       .then((v) => setShowOnLaunch(v))
       .catch(() => {});
 
-    // Server URL ("" = local server)
+    // Server URL + token ("" = local server / no auth)
     window.api
       ?.getServerUrl()
       .then((url) => {
         setSavedServerUrl(url);
         setServerUrlInput(url);
+      })
+      .catch(() => {});
+    window.api
+      ?.getServerToken()
+      .then((token) => {
+        setSavedServerToken(token);
+        setServerTokenInput(token);
       })
       .catch(() => {});
 
@@ -489,7 +500,7 @@ export default function SettingsPage(): React.JSX.Element {
     window.api?.setShowDashboardOnLaunch(enabled);
   }, []);
 
-  const testServerUrl = useCallback(async (rawUrl: string) => {
+  const testServer = useCallback(async (rawUrl: string, token: string) => {
     const parsed = serverUrlSchema.safeParse(rawUrl);
     if (!parsed.success) {
       setServerUrlError(parsed.error.issues[0].message);
@@ -497,23 +508,37 @@ export default function SettingsPage(): React.JSX.Element {
       return;
     }
     const base = parsed.data || getLocalApiBase();
+    const trimmedToken = token.trim();
     setServerTest("testing");
-    const ok = await checkServerHealth(base, 5000);
-    setServerTest(ok ? "ok" : "fail");
+    if (!(await checkServerHealth(base, 5000))) {
+      setServerTest("unreachable");
+      return;
+    }
+    if (trimmedToken && !(await checkServerAuth(base, trimmedToken, 5000))) {
+      setServerTest("unauthorized");
+      return;
+    }
+    setServerTest("ok");
   }, []);
 
-  const handleSaveServerUrl = useCallback(async () => {
+  const handleSaveServer = useCallback(async () => {
     const parsed = serverUrlSchema.safeParse(serverUrlInput);
     if (!parsed.success) {
       setServerUrlError(parsed.error.issues[0].message);
       return;
     }
     setServerUrlError(null);
-    const saved = (await window.api?.setServerUrl(parsed.data)) ?? parsed.data;
-    setSavedServerUrl(saved);
-    setServerUrlInput(saved);
-    await testServerUrl(saved);
-  }, [serverUrlInput, testServerUrl]);
+    const savedUrl =
+      (await window.api?.setServerUrl(parsed.data)) ?? parsed.data;
+    const savedToken =
+      (await window.api?.setServerToken(serverTokenInput)) ??
+      serverTokenInput.trim();
+    setSavedServerUrl(savedUrl);
+    setServerUrlInput(savedUrl);
+    setSavedServerToken(savedToken);
+    setServerTokenInput(savedToken);
+    await testServer(savedUrl, savedToken);
+  }, [serverUrlInput, serverTokenInput, testServer]);
 
   const clearHistory = useCallback(async () => {
     if (!confirm(t("settings.data.clearHistoryConfirm"))) {
@@ -672,36 +697,63 @@ export default function SettingsPage(): React.JSX.Element {
           <Row
             label="Server URL"
             desc="Leave empty to use the built-in local server. Enter the URL of a self-hosted Freestyle server (e.g. http://your-vm:4649) to use that instead. Restart the app after changing this."
+          >
+            <div className="flex w-full max-w-md items-center gap-2">
+              <Server className="text-muted-foreground h-4 w-4 shrink-0" />
+              <input
+                id="settings-server-url"
+                type="text"
+                value={serverUrlInput}
+                onChange={(e) => {
+                  setServerUrlInput(e.target.value);
+                  setServerTest("idle");
+                  setServerUrlError(null);
+                }}
+                placeholder="http://127.0.0.1:4649 (local)"
+                className="border-border bg-card text-foreground min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm"
+              />
+            </div>
+            {serverUrlError && (
+              <span className="text-destructive mt-2 block text-xs">
+                {serverUrlError}
+              </span>
+            )}
+          </Row>
+          <Row
+            label="Access token"
+            desc="Optional. Required only if your server is configured with FREESTYLE_AUTH_TOKEN. Sent as a bearer token on requests."
             last
           >
             <div className="flex w-full max-w-md flex-col gap-2">
               <div className="flex items-center gap-2">
-                <Server className="text-muted-foreground h-4 w-4 shrink-0" />
+                <Key className="text-muted-foreground h-4 w-4 shrink-0" />
                 <input
-                  id="settings-server-url"
-                  type="text"
-                  value={serverUrlInput}
+                  id="settings-server-token"
+                  type="password"
+                  value={serverTokenInput}
                   onChange={(e) => {
-                    setServerUrlInput(e.target.value);
+                    setServerTokenInput(e.target.value);
                     setServerTest("idle");
-                    setServerUrlError(null);
                   }}
-                  placeholder="http://127.0.0.1:4649 (local)"
+                  placeholder="None"
                   className="border-border bg-card text-foreground min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm"
                 />
               </div>
               <div className="flex items-center gap-2">
                 <button
                   type="button"
-                  onClick={handleSaveServerUrl}
-                  disabled={serverUrlInput.trim() === savedServerUrl.trim()}
+                  onClick={handleSaveServer}
+                  disabled={
+                    serverUrlInput.trim() === savedServerUrl.trim() &&
+                    serverTokenInput.trim() === savedServerToken.trim()
+                  }
                   className="bg-foreground text-background hover:bg-foreground/90 inline-flex shrink-0 items-center rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
                 >
                   {t("common.save")}
                 </button>
                 <button
                   type="button"
-                  onClick={() => testServerUrl(serverUrlInput)}
+                  onClick={() => testServer(serverUrlInput, serverTokenInput)}
                   className="border-border hover:bg-secondary inline-flex shrink-0 items-center rounded-md border px-3 py-1.5 text-xs font-medium transition-colors"
                 >
                   Test connection
@@ -713,18 +765,18 @@ export default function SettingsPage(): React.JSX.Element {
                 )}
                 {serverTest === "ok" && (
                   <span className="text-primary inline-flex items-center gap-1 text-xs">
-                    <Check className="h-3.5 w-3.5" /> Reachable
+                    <Check className="h-3.5 w-3.5" /> Connected
                   </span>
                 )}
-                {serverTest === "fail" && (
+                {serverTest === "unreachable" && (
                   <span className="text-destructive text-xs">Unreachable</span>
                 )}
+                {serverTest === "unauthorized" && (
+                  <span className="text-destructive text-xs">
+                    Token rejected
+                  </span>
+                )}
               </div>
-              {serverUrlError && (
-                <span className="text-destructive text-xs">
-                  {serverUrlError}
-                </span>
-              )}
             </div>
           </Row>
         </Section>

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -13,6 +13,7 @@ import {
   checkServerHealth,
   getClient,
   getLocalApiBase,
+  refreshApiBase,
 } from "@renderer/lib/api";
 import { LANGUAGES } from "@renderer/lib/languages";
 import { requestMicAccess, resolveMicStatus } from "@renderer/lib/permissions";
@@ -537,6 +538,9 @@ export default function SettingsPage(): React.JSX.Element {
     setServerUrlInput(savedUrl);
     setSavedServerToken(savedToken);
     setServerTokenInput(savedToken);
+    // Apply the new base/token to this window's client immediately. Switching
+    // the local server on/off still needs a restart (see the row description).
+    await refreshApiBase();
     await testServer(savedUrl, savedToken);
   }, [serverUrlInput, serverTokenInput, testServer]);
 

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -21,6 +21,7 @@ import {
   Monitor,
   Moon,
   Pause,
+  Server,
   Sun,
   Trash2,
   Volume2,
@@ -89,6 +90,11 @@ export default function SettingsPage(): React.JSX.Element {
   const [autoUpdate, setAutoUpdate] = useState(true);
   const [launchAtStartup, setLaunchAtStartup] = useState(false);
   const [showOnLaunch, setShowOnLaunch] = useState(true);
+  const [serverUrlInput, setServerUrlInput] = useState("");
+  const [savedServerUrl, setSavedServerUrl] = useState("");
+  const [serverTest, setServerTest] = useState<
+    "idle" | "testing" | "ok" | "fail"
+  >("idle");
 
   const microphoneOptions = useMemo(
     () => [
@@ -355,6 +361,15 @@ export default function SettingsPage(): React.JSX.Element {
       .then((v) => setShowOnLaunch(v))
       .catch(() => {});
 
+    // Remote server URL ("" = local server)
+    window.api
+      ?.getRemoteServerUrl()
+      .then((url) => {
+        setSavedServerUrl(url);
+        setServerUrlInput(url);
+      })
+      .catch(() => {});
+
     // Auto-updater events
     const removeAvail = window.api?.onUpdateAvailable((info) => {
       setUpdateAvailable(info.version);
@@ -467,6 +482,36 @@ export default function SettingsPage(): React.JSX.Element {
     setShowOnLaunch(enabled);
     window.api?.setShowDashboardOnLaunch(enabled);
   }, []);
+
+  const testServerUrl = useCallback(async (rawUrl: string) => {
+    const base = rawUrl.trim().replace(/\/+$/, "");
+    setServerTest("testing");
+    try {
+      const target = base
+        ? `${base}/api/health`
+        : `http://127.0.0.1:4649/api/health`;
+      const res = await fetch(target, {
+        signal: AbortSignal.timeout(5000),
+      });
+      const data = (await res.json()) as { status?: string; name?: string };
+      setServerTest(
+        res.ok && data.status === "ok" && data.name === "freestyle"
+          ? "ok"
+          : "fail",
+      );
+    } catch {
+      setServerTest("fail");
+    }
+  }, []);
+
+  const handleSaveServerUrl = useCallback(async () => {
+    const saved =
+      (await window.api?.setRemoteServerUrl(serverUrlInput)) ??
+      serverUrlInput.trim().replace(/\/+$/, "");
+    setSavedServerUrl(saved);
+    setServerUrlInput(saved);
+    await testServerUrl(saved);
+  }, [serverUrlInput, testServerUrl]);
 
   const clearHistory = useCallback(async () => {
     if (!confirm(t("settings.data.clearHistoryConfirm"))) {
@@ -618,6 +663,61 @@ export default function SettingsPage(): React.JSX.Element {
             last
           >
             <Toggle on={showOnLaunch} onChange={handleShowOnLaunchToggle} />
+          </Row>
+        </Section>
+
+        <Section label="Server">
+          <Row
+            label="Server URL"
+            desc="Leave empty to use the built-in local server. Enter the URL of a self-hosted Freestyle server (e.g. http://your-vm:4649) to connect to it instead. Restart the app after changing this."
+            last
+          >
+            <div className="flex w-full max-w-md flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <Server className="text-muted-foreground h-4 w-4 shrink-0" />
+                <input
+                  id="settings-server-url"
+                  type="text"
+                  value={serverUrlInput}
+                  onChange={(e) => {
+                    setServerUrlInput(e.target.value);
+                    setServerTest("idle");
+                  }}
+                  placeholder="http://127.0.0.1:4649 (local)"
+                  className="border-border bg-card text-foreground min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleSaveServerUrl}
+                  disabled={serverUrlInput.trim() === savedServerUrl.trim()}
+                  className="bg-foreground text-background hover:bg-foreground/90 inline-flex shrink-0 items-center rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
+                >
+                  {t("common.save")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => testServerUrl(serverUrlInput)}
+                  className="border-border hover:bg-secondary inline-flex shrink-0 items-center rounded-md border px-3 py-1.5 text-xs font-medium transition-colors"
+                >
+                  Test connection
+                </button>
+                {serverTest === "testing" && (
+                  <span className="text-muted-foreground text-xs">
+                    Testing…
+                  </span>
+                )}
+                {serverTest === "ok" && (
+                  <span className="text-primary inline-flex items-center gap-1 text-xs">
+                    <Check className="h-3.5 w-3.5" /> Reachable
+                  </span>
+                )}
+                {serverTest === "fail" && (
+                  <span className="text-destructive text-xs">Unreachable</span>
+                )}
+              </div>
+            </div>
           </Row>
         </Section>
 

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -1,6 +1,12 @@
 import { serverUrlSchema } from "@freestyle/validations";
 import { KeyComboDisplay } from "@renderer/components/key-combo";
 import { LanguageSelector } from "@renderer/components/language-selector";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@renderer/components/ui/input-group";
 import { Select } from "@renderer/components/ui/select";
 import {
   comboDisplayKeys,
@@ -1048,29 +1054,30 @@ export default function SettingsPage(): React.JSX.Element {
                   </span>
                 )}
               </div>
-              <div className="border-border bg-card flex items-center gap-2 rounded-lg border px-3">
-                <Server className="text-muted-foreground h-4 w-4 shrink-0" />
-                <input
+              <InputGroup>
+                <InputGroupInput
                   id="settings-server-url"
                   type="text"
                   value={serverUrlInput}
+                  aria-invalid={!!serverUrlError}
                   onChange={(e) => {
                     setServerUrlInput(e.target.value);
                     setServerTest("idle");
                     setServerUrlError(null);
                   }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleSaveServer();
+                  }}
                   placeholder="http://127.0.0.1:4649 (local)"
-                  className="text-foreground min-w-0 flex-1 bg-transparent py-2 text-sm outline-none"
                 />
-              </div>
-              <div
-                className={cn(
-                  "border-border bg-card flex items-center gap-2 rounded-lg border px-3 transition-opacity",
-                  !serverUrlInput.trim() && "opacity-55",
-                )}
+                <InputGroupAddon>
+                  <Server />
+                </InputGroupAddon>
+              </InputGroup>
+              <InputGroup
+                className={cn(!serverUrlInput.trim() && "opacity-55")}
               >
-                <Key className="text-muted-foreground h-4 w-4 shrink-0" />
-                <input
+                <InputGroupInput
                   id="settings-server-token"
                   type={showToken ? "text" : "password"}
                   value={serverTokenInput}
@@ -1078,24 +1085,26 @@ export default function SettingsPage(): React.JSX.Element {
                     setServerTokenInput(e.target.value);
                     setServerTest("idle");
                   }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleSaveServer();
+                  }}
                   placeholder="Access token (optional)"
-                  className="text-foreground min-w-0 flex-1 bg-transparent py-2 text-sm outline-none"
                 />
+                <InputGroupAddon>
+                  <Key />
+                </InputGroupAddon>
                 {serverTokenInput && (
-                  <button
-                    type="button"
-                    onClick={() => setShowToken((v) => !v)}
-                    aria-label={showToken ? "Hide token" : "Show token"}
-                    className="text-muted-foreground hover:text-foreground shrink-0 transition-colors"
-                  >
-                    {showToken ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
-                  </button>
+                  <InputGroupAddon align="inline-end">
+                    <InputGroupButton
+                      size="icon-xs"
+                      aria-label={showToken ? "Hide token" : "Show token"}
+                      onClick={() => setShowToken((v) => !v)}
+                    >
+                      {showToken ? <EyeOff /> : <Eye />}
+                    </InputGroupButton>
+                  </InputGroupAddon>
                 )}
-              </div>
+              </InputGroup>
               <div className="flex items-center gap-2">
                 <button
                   type="button"
@@ -1111,7 +1120,8 @@ export default function SettingsPage(): React.JSX.Element {
                 <button
                   type="button"
                   onClick={() => testServer(serverUrlInput, serverTokenInput)}
-                  className="border-border hover:bg-secondary inline-flex shrink-0 items-center rounded-md border px-3 py-1.5 text-xs font-medium transition-colors"
+                  disabled={serverTest === "testing"}
+                  className="border-border hover:bg-secondary inline-flex shrink-0 items-center rounded-md border px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
                 >
                   Test connection
                 </button>

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -698,94 +698,6 @@ export default function SettingsPage(): React.JSX.Element {
           </Row>
         </Section>
 
-        <Section label="Server">
-          <Row
-            label="Server URL"
-            desc="Leave empty to use the built-in local server. Enter the URL of a self-hosted Freestyle server (e.g. http://your-vm:4649) to use that instead. Restart the app after changing this."
-          >
-            <div className="flex w-full max-w-md items-center gap-2">
-              <Server className="text-muted-foreground h-4 w-4 shrink-0" />
-              <input
-                id="settings-server-url"
-                type="text"
-                value={serverUrlInput}
-                onChange={(e) => {
-                  setServerUrlInput(e.target.value);
-                  setServerTest("idle");
-                  setServerUrlError(null);
-                }}
-                placeholder="http://127.0.0.1:4649 (local)"
-                className="border-border bg-card text-foreground min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm"
-              />
-            </div>
-            {serverUrlError && (
-              <span className="text-destructive mt-2 block text-xs">
-                {serverUrlError}
-              </span>
-            )}
-          </Row>
-          <Row
-            label="Access token"
-            desc="Optional. Required only if your server is configured with FREESTYLE_AUTH_TOKEN. Sent as a bearer token on requests."
-            last
-          >
-            <div className="flex w-full max-w-md flex-col gap-2">
-              <div className="flex items-center gap-2">
-                <Key className="text-muted-foreground h-4 w-4 shrink-0" />
-                <input
-                  id="settings-server-token"
-                  type="password"
-                  value={serverTokenInput}
-                  onChange={(e) => {
-                    setServerTokenInput(e.target.value);
-                    setServerTest("idle");
-                  }}
-                  placeholder="None"
-                  className="border-border bg-card text-foreground min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm"
-                />
-              </div>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={handleSaveServer}
-                  disabled={
-                    serverUrlInput.trim() === savedServerUrl.trim() &&
-                    serverTokenInput.trim() === savedServerToken.trim()
-                  }
-                  className="bg-foreground text-background hover:bg-foreground/90 inline-flex shrink-0 items-center rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
-                >
-                  {t("common.save")}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => testServer(serverUrlInput, serverTokenInput)}
-                  className="border-border hover:bg-secondary inline-flex shrink-0 items-center rounded-md border px-3 py-1.5 text-xs font-medium transition-colors"
-                >
-                  Test connection
-                </button>
-                {serverTest === "testing" && (
-                  <span className="text-muted-foreground text-xs">
-                    Testing…
-                  </span>
-                )}
-                {serverTest === "ok" && (
-                  <span className="text-primary inline-flex items-center gap-1 text-xs">
-                    <Check className="h-3.5 w-3.5" /> Connected
-                  </span>
-                )}
-                {serverTest === "unreachable" && (
-                  <span className="text-destructive text-xs">Unreachable</span>
-                )}
-                {serverTest === "unauthorized" && (
-                  <span className="text-destructive text-xs">
-                    Token rejected
-                  </span>
-                )}
-              </div>
-            </div>
-          </Row>
-        </Section>
-
         <Section label={t("settings.sections.recording")}>
           <Row
             label={t("settings.recording.hotkey")}
@@ -1088,6 +1000,89 @@ export default function SettingsPage(): React.JSX.Element {
               <Trash2 className="h-3.5 w-3.5" />
               {t("settings.data.clearHistory")}
             </button>
+          </Row>
+        </Section>
+
+        <Section label="Server" tight>
+          <Row
+            label="Server URL"
+            desc="Leave empty to use the built-in local server. Point this at a self-hosted Freestyle server (e.g. http://your-vm:4649) to use that instead, with an access token if it requires one. Restart the app after changing this."
+            last
+          >
+            <div className="flex w-full max-w-md flex-col gap-2">
+              <div className="border-border bg-card flex items-center gap-2 rounded-lg border px-3">
+                <Server className="text-muted-foreground h-4 w-4 shrink-0" />
+                <input
+                  id="settings-server-url"
+                  type="text"
+                  value={serverUrlInput}
+                  onChange={(e) => {
+                    setServerUrlInput(e.target.value);
+                    setServerTest("idle");
+                    setServerUrlError(null);
+                  }}
+                  placeholder="http://127.0.0.1:4649 (local)"
+                  className="text-foreground min-w-0 flex-1 bg-transparent py-2 text-sm outline-none"
+                />
+              </div>
+              <div className="border-border bg-card flex items-center gap-2 rounded-lg border px-3">
+                <Key className="text-muted-foreground h-4 w-4 shrink-0" />
+                <input
+                  id="settings-server-token"
+                  type="password"
+                  value={serverTokenInput}
+                  onChange={(e) => {
+                    setServerTokenInput(e.target.value);
+                    setServerTest("idle");
+                  }}
+                  placeholder="Access token (optional)"
+                  className="text-foreground min-w-0 flex-1 bg-transparent py-2 text-sm outline-none"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleSaveServer}
+                  disabled={
+                    serverUrlInput.trim() === savedServerUrl.trim() &&
+                    serverTokenInput.trim() === savedServerToken.trim()
+                  }
+                  className="bg-foreground text-background hover:bg-foreground/90 inline-flex shrink-0 items-center rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
+                >
+                  {t("common.save")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => testServer(serverUrlInput, serverTokenInput)}
+                  className="border-border hover:bg-secondary inline-flex shrink-0 items-center rounded-md border px-3 py-1.5 text-xs font-medium transition-colors"
+                >
+                  Test connection
+                </button>
+                {serverTest === "testing" && (
+                  <span className="text-muted-foreground text-xs">
+                    Testing…
+                  </span>
+                )}
+                {serverTest === "ok" && (
+                  <span className="text-primary inline-flex items-center gap-1 text-xs">
+                    <Check className="h-3.5 w-3.5" /> Connected
+                  </span>
+                )}
+                {serverTest === "unreachable" && (
+                  <span className="text-destructive text-xs">Unreachable</span>
+                )}
+                {serverTest === "unauthorized" && (
+                  <span className="text-destructive text-xs">
+                    Token rejected
+                  </span>
+                )}
+              </div>
+              {serverUrlError && (
+                <span className="text-destructive text-xs">
+                  {serverUrlError}
+                </span>
+              )}
+            </div>
           </Row>
         </Section>
       </div>

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -7,7 +7,11 @@ import {
   keyDisplayLabel,
   useHotkeyRecorder,
 } from "@renderer/hooks/use-hotkey-recorder";
-import { getClient } from "@renderer/lib/api";
+import {
+  checkServerHealth,
+  getClient,
+  getLocalApiBase,
+} from "@renderer/lib/api";
 import { LANGUAGES } from "@renderer/lib/languages";
 import { requestMicAccess, resolveMicStatus } from "@renderer/lib/permissions";
 import { cn } from "@renderer/lib/utils";
@@ -484,24 +488,10 @@ export default function SettingsPage(): React.JSX.Element {
   }, []);
 
   const testServerUrl = useCallback(async (rawUrl: string) => {
-    const base = rawUrl.trim().replace(/\/+$/, "");
+    const base = rawUrl.trim().replace(/\/+$/, "") || getLocalApiBase();
     setServerTest("testing");
-    try {
-      const target = base
-        ? `${base}/api/health`
-        : `http://127.0.0.1:4649/api/health`;
-      const res = await fetch(target, {
-        signal: AbortSignal.timeout(5000),
-      });
-      const data = (await res.json()) as { status?: string; name?: string };
-      setServerTest(
-        res.ok && data.status === "ok" && data.name === "freestyle"
-          ? "ok"
-          : "fail",
-      );
-    } catch {
-      setServerTest("fail");
-    }
+    const ok = await checkServerHealth(base, 5000);
+    setServerTest(ok ? "ok" : "fail");
   }, []);
 
   const handleSaveServerUrl = useCallback(async () => {

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -46,9 +46,14 @@ WORKDIR /app
 COPY --from=build /app ./
 
 # SQLite database lives on a volume so it survives container restarts.
-RUN mkdir -p /data
+# Owned by the unprivileged `node` user the container runs as.
+RUN mkdir -p /data && chown -R node:node /data
+USER node
 VOLUME ["/data"]
 
 EXPOSE 4649
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||4649)+'/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 CMD ["node", "dist/startup.js"]

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -7,7 +7,9 @@
 # root, then use `pnpm deploy` to produce a self-contained directory (its
 # own node_modules with only production dependencies) for the runtime image.
 #
-# Build from the repository root:
+# Released images are published to ghcr.io/freestyle-voice/freestyle-server
+# (tagged with each release version and :latest). To build locally instead,
+# run from the repository root:
 #   docker build -f apps/server/Dockerfile -t freestyle-server .
 # Run (open):
 #   docker run -p 4649:4649 -v freestyle-data:/data freestyle-server

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -9,8 +9,11 @@
 #
 # Build from the repository root:
 #   docker build -f apps/server/Dockerfile -t freestyle-server .
-# Run:
+# Run (open):
 #   docker run -p 4649:4649 -v freestyle-data:/data freestyle-server
+# Run (require a bearer token):
+#   docker run -p 4649:4649 -v freestyle-data:/data \
+#     -e FREESTYLE_AUTH_TOKEN=your-secret freestyle-server
 # ---------------------------------------------------------------------------
 
 FROM node:22-slim AS build

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+
+# ---------------------------------------------------------------------------
+# Build the standalone Freestyle server.
+#
+# The server is a workspace package, so we install + build it from the repo
+# root, then use `pnpm deploy` to produce a self-contained directory (its
+# own node_modules with only production dependencies) for the runtime image.
+#
+# Build from the repository root:
+#   docker build -f apps/server/Dockerfile -t freestyle-server .
+# Run:
+#   docker run -p 4649:4649 -v freestyle-data:/data freestyle-server
+# ---------------------------------------------------------------------------
+
+FROM node:22-slim AS build
+RUN corepack enable
+WORKDIR /repo
+
+# Copy the whole monorepo (see .dockerignore for exclusions) so workspace
+# package manifests are available for resolution.
+COPY . .
+
+# Install only what the server needs and skip lifecycle scripts (the Electron
+# app's postinstall rebuilds native modules we don't need here).
+RUN pnpm install --frozen-lockfile --filter @freestyle/server... --ignore-scripts
+
+# Build the server bundle (workspace deps are inlined by pkgroll).
+RUN pnpm --filter @freestyle/server build
+
+# Produce a self-contained deployment with production deps only.
+RUN pnpm --filter @freestyle/server deploy --prod --legacy /app
+
+# ---------------------------------------------------------------------------
+# Runtime image
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS runtime
+
+ENV NODE_ENV=production \
+    FREESTYLE_ENV=production \
+    FREESTYLE_DB_PATH=/data/freestyle.db \
+    HOST=0.0.0.0 \
+    PORT=4649
+
+WORKDIR /app
+COPY --from=build /app ./
+
+# SQLite database lives on a volume so it survives container restarts.
+RUN mkdir -p /data
+VOLUME ["/data"]
+
+EXPOSE 4649
+
+CMD ["node", "dist/startup.js"]

--- a/apps/server/Dockerfile.dockerignore
+++ b/apps/server/Dockerfile.dockerignore
@@ -1,0 +1,10 @@
+**/node_modules
+**/dist
+**/out
+**/.turbo
+**/.wrangler
+**/build
+.git
+**/.DS_Store
+**/*.log
+apps/electron/native/**/build

--- a/apps/server/Dockerfile.dockerignore
+++ b/apps/server/Dockerfile.dockerignore
@@ -7,4 +7,3 @@
 .git
 **/.DS_Store
 **/*.log
-apps/electron/native/**/build

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,7 +2,8 @@
   "name": "@freestyle/server",
   "type": "module",
   "scripts": {
-    "build": "tsc --emitDeclarationOnly && pkgroll --minify src/index.ts",
+    "build": "tsc --emitDeclarationOnly && pkgroll --minify",
+    "start": "node dist/startup.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -13,7 +14,13 @@
       "development": "./src/index.ts"
     }
   },
+  "bin": {
+    "freestyle-server": "./dist/startup.js"
+  },
   "main": "./src/index.ts",
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.79",
     "@ai-sdk/elevenlabs": "^2.0.33",
@@ -21,8 +28,6 @@
     "@ai-sdk/groq": "^3.0.39",
     "@ai-sdk/mistral": "^3.0.37",
     "@ai-sdk/openai": "^3.0.65",
-    "@freestyle/utils": "workspace:*",
-    "@freestyle/validations": "workspace:*",
     "@hono/mcp": "^0.3.0",
     "@hono/node-server": "^2.0.4",
     "@hono/zod-validator": "^0.8.0",
@@ -37,6 +42,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@freestyle/utils": "workspace:*",
+    "@freestyle/validations": "workspace:*",
     "@types/json-schema": "^7.0.15",
     "@types/node": "latest",
     "@types/ws": "^8.18.1",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,5 +1,7 @@
+import { type ServerType, serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { WebSocketServer } from "ws";
 import { reconcileUnsupportedMlxVoiceDefault } from "./lib/mlx-asr/reconcile.js";
 import {
   activateManagedMlxRuntimeForAppVersion,
@@ -27,6 +29,53 @@ const app = new Hono()
   })
   .get("/", (c) => c.text("Freestyle API"))
   .route("/", routes);
+
+export interface StartServerOptions {
+  /** Port to listen on. Defaults to 4649. Use 0 for a random free port. */
+  port?: number;
+  /**
+   * Host/interface to bind to. Defaults to "127.0.0.1" (loopback only).
+   * Set to "0.0.0.0" to accept connections from outside the machine
+   * (e.g. when running the server standalone inside a container/VM).
+   */
+  host?: string;
+}
+
+export interface RunningServer {
+  /** The underlying Node HTTP server. */
+  server: ServerType;
+  /** The actual port the server bound to (resolved when port is 0). */
+  port: number;
+}
+
+/**
+ * Start the Freestyle HTTP server with WebSocket support.
+ *
+ * Shared by the Electron main process (loopback, in-process) and the
+ * standalone container entrypoint (see startup.ts).
+ */
+export function startServer(
+  options: StartServerOptions = {},
+): Promise<RunningServer> {
+  const { port = 4649, host = "127.0.0.1" } = options;
+  const wss = new WebSocketServer({ noServer: true });
+
+  return new Promise((resolve, reject) => {
+    const server = serve(
+      {
+        fetch: app.fetch,
+        port,
+        hostname: host,
+        websocket: { server: wss },
+      },
+      (info) => {
+        resolve({ server, port: info.port });
+      },
+    );
+    // Reject if the server fails to bind (e.g. EADDRINUSE) before listening.
+    server.once("error", reject);
+  });
+}
 
 export { closeDb } from "./lib/db.js";
 export { stopMlxServer } from "./lib/mlx-asr/server.js";

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,7 +1,9 @@
 import { type ServerType, serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { HTTPException } from "hono/http-exception";
 import { WebSocketServer } from "ws";
+import { authMiddleware, setAuthToken } from "./lib/auth.js";
 import { reconcileUnsupportedMlxVoiceDefault } from "./lib/mlx-asr/reconcile.js";
 import {
   activateManagedMlxRuntimeForAppVersion,
@@ -23,7 +25,10 @@ const app = new Hono()
     }
     return cors()(c, next);
   })
+  .use(authMiddleware)
   .onError((err, c) => {
+    // Let Hono's own exceptions (e.g. bearerAuth's 401) keep their response.
+    if (err instanceof HTTPException) return err.getResponse();
     captureException(err);
     return c.json({ error: "Internal server error" }, 500);
   })
@@ -39,6 +44,12 @@ export interface StartServerOptions {
    * (e.g. when running the server standalone inside a container/VM).
    */
   host?: string;
+  /**
+   * Bearer token required for API/WebSocket requests. When omitted (or empty),
+   * the server is unauthenticated — appropriate for the loopback Electron
+   * server, but set this for standalone/remote deployments.
+   */
+  token?: string;
 }
 
 export interface RunningServer {
@@ -56,7 +67,8 @@ export interface RunningServer {
 export function startServer(
   options: StartServerOptions = {},
 ): Promise<RunningServer> {
-  const { port = 4649, host = "127.0.0.1" } = options;
+  const { port = 4649, host = "127.0.0.1", token } = options;
+  setAuthToken(token);
   const wss = new WebSocketServer({ noServer: true });
 
   return new Promise((resolve, reject) => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -42,9 +42,8 @@ export interface StartServerOptions {
 }
 
 export interface RunningServer {
-  /** The underlying Node HTTP server. */
   server: ServerType;
-  /** The actual port the server bound to (resolved when port is 0). */
+  /** The actual port bound (useful when `port` was 0). */
   port: number;
 }
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -27,8 +27,16 @@ const app = new Hono()
   })
   .use(authMiddleware)
   .onError((err, c) => {
-    // Let Hono's own exceptions (e.g. bearerAuth's 401) keep their response.
-    if (err instanceof HTTPException) return err.getResponse();
+    // Let Hono's own exceptions (e.g. bearerAuth's 401) keep their response,
+    // but still report genuine server errors.
+    if (err instanceof HTTPException) {
+      if (err.status >= 500) captureException(err);
+      const res = err.getResponse();
+      // Preserve CORS so the cross-origin renderer can read auth errors.
+      const origin = c.req.header("origin");
+      if (origin) res.headers.set("Access-Control-Allow-Origin", origin);
+      return res;
+    }
     captureException(err);
     return c.json({ error: "Internal server error" }, 500);
   })

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from "hono";
 import { bearerAuth } from "hono/bearer-auth";
+import { timingSafeEqual } from "hono/utils/buffer";
 
 // The active bearer token. Empty means auth is disabled (the default), which
 // keeps the loopback/in-process Electron server open as before. A value is
@@ -31,7 +32,8 @@ export const authMiddleware: MiddlewareHandler = async (c, next) => {
   if (EXEMPT_PATHS.has(c.req.path)) return next();
 
   if (c.req.header("upgrade")?.toLowerCase() === "websocket") {
-    if (c.req.query("token") === token) return next();
+    // Constant-time compare, matching what bearerAuth does for the HTTP path.
+    if (await timingSafeEqual(c.req.query("token") ?? "", token)) return next();
     return c.json({ error: "Unauthorized" }, 401);
   }
 

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -1,0 +1,39 @@
+import type { MiddlewareHandler } from "hono";
+import { bearerAuth } from "hono/bearer-auth";
+
+// The active bearer token. Empty means auth is disabled (the default), which
+// keeps the loopback/in-process Electron server open as before. A value is
+// set by startServer({ token }) for standalone/remote deployments.
+let authToken = "";
+
+export function setAuthToken(token: string | undefined): void {
+  authToken = token?.trim() ?? "";
+}
+
+export function getAuthToken(): string {
+  return authToken;
+}
+
+// Liveness endpoint stays open so Docker/health probes work without a token.
+const EXEMPT_PATHS = new Set(["/api/health"]);
+
+/**
+ * Enforces bearer-token auth when a token is configured. No-op otherwise.
+ *
+ * - `/api/health` is always exempt (liveness probes).
+ * - WebSocket upgrades (e.g. `/stream`) authenticate via a `?token=` query
+ *   param, since browsers can't set the `Authorization` header on a socket.
+ * - Everything else uses Hono's builtin bearerAuth (`Authorization: Bearer`).
+ */
+export const authMiddleware: MiddlewareHandler = async (c, next) => {
+  const token = getAuthToken();
+  if (!token) return next();
+  if (EXEMPT_PATHS.has(c.req.path)) return next();
+
+  if (c.req.header("upgrade")?.toLowerCase() === "websocket") {
+    if (c.req.query("token") === token) return next();
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  return bearerAuth({ token })(c, next);
+};

--- a/apps/server/src/startup.ts
+++ b/apps/server/src/startup.ts
@@ -51,6 +51,8 @@ function shutdown(signal: string): void {
     }
     process.exit(0);
   });
+  // Don't wait forever for in-flight connections (e.g. open WebSockets).
+  setTimeout(() => process.exit(0), 10_000).unref();
 }
 
 process.on("SIGINT", () => shutdown("SIGINT"));

--- a/apps/server/src/startup.ts
+++ b/apps/server/src/startup.ts
@@ -27,8 +27,15 @@ if (!process.env.FREESTYLE_DB_PATH) {
   process.exit(1);
 }
 
-const { server } = await startServer({ port, host });
-console.log(`Freestyle server running on http://${host}:${port}`);
+const { server, port: boundPort } = await startServer({ port, host }).catch(
+  (err) => {
+    console.error(
+      `Failed to start server: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  },
+);
+console.log(`Freestyle server running on http://${host}:${boundPort}`);
 
 function shutdown(signal: string): void {
   console.log(`Received ${signal}, shutting down...`);

--- a/apps/server/src/startup.ts
+++ b/apps/server/src/startup.ts
@@ -1,0 +1,46 @@
+/**
+ * Standalone entrypoint for running the Freestyle server outside of Electron.
+ *
+ * Used by the Docker image (see Dockerfile) to run the server inside a
+ * container/VM. The Electron app calls `startServer()` directly instead.
+ *
+ * Configuration via environment variables:
+ *   - FREESTYLE_DB_PATH (required) — path to the SQLite database file.
+ *   - PORT  — port to listen on (default 4649).
+ *   - HOST  — interface to bind to (default 0.0.0.0, all interfaces).
+ */
+
+import { closeDb, startServer } from "./index.js";
+
+const port = process.env.PORT ? Number(process.env.PORT) : 4649;
+const host = process.env.HOST ?? "0.0.0.0";
+
+if (Number.isNaN(port)) {
+  console.error(`Invalid PORT value: ${process.env.PORT}`);
+  process.exit(1);
+}
+
+if (!process.env.FREESTYLE_DB_PATH) {
+  console.error(
+    "FREESTYLE_DB_PATH environment variable is required. Set it to the desired SQLite database file path.",
+  );
+  process.exit(1);
+}
+
+const { server } = await startServer({ port, host });
+console.log(`Freestyle server running on http://${host}:${port}`);
+
+function shutdown(signal: string): void {
+  console.log(`Received ${signal}, shutting down...`);
+  server.close(() => {
+    try {
+      closeDb();
+    } catch {
+      // ignore
+    }
+    process.exit(0);
+  });
+}
+
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/apps/server/src/startup.ts
+++ b/apps/server/src/startup.ts
@@ -8,12 +8,14 @@
  *   - FREESTYLE_DB_PATH (required) — path to the SQLite database file.
  *   - PORT  — port to listen on (default 4649).
  *   - HOST  — interface to bind to (default 0.0.0.0, all interfaces).
+ *   - FREESTYLE_AUTH_TOKEN — if set, require this bearer token on requests.
  */
 
 import { closeDb, startServer } from "./index.js";
 
 const port = process.env.PORT ? Number(process.env.PORT) : 4649;
 const host = process.env.HOST ?? "0.0.0.0";
+const token = process.env.FREESTYLE_AUTH_TOKEN;
 
 if (Number.isNaN(port)) {
   console.error(`Invalid PORT value: ${process.env.PORT}`);
@@ -27,14 +29,16 @@ if (!process.env.FREESTYLE_DB_PATH) {
   process.exit(1);
 }
 
-const { server, port: boundPort } = await startServer({ port, host }).catch(
-  (err) => {
-    console.error(
-      `Failed to start server: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    process.exit(1);
-  },
-);
+const { server, port: boundPort } = await startServer({
+  port,
+  host,
+  token,
+}).catch((err) => {
+  console.error(
+    `Failed to start server: ${err instanceof Error ? err.message : String(err)}`,
+  );
+  process.exit(1);
+});
 console.log(`Freestyle server running on http://${host}:${boundPort}`);
 
 function shutdown(signal: string): void {

--- a/apps/server/tests/auth.test.ts
+++ b/apps/server/tests/auth.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import app from "../src/index.js";
+import { setAuthToken } from "../src/lib/auth.js";
+
+const TOKEN = "test-secret";
+
+afterEach(() => {
+  // Reset so other suites (and cases) run unauthenticated.
+  setAuthToken("");
+});
+
+describe("Bearer auth", () => {
+  it("is disabled by default (no token configured)", async () => {
+    const res = await app.request("/api/device-id");
+    expect(res.status).toBe(200);
+  });
+
+  it("leaves /api/health open even when a token is set", async () => {
+    setAuthToken(TOKEN);
+    const res = await app.request("/api/health");
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects requests without a token", async () => {
+    setAuthToken(TOKEN);
+    const res = await app.request("/api/device-id");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects requests with the wrong token", async () => {
+    setAuthToken(TOKEN);
+    const res = await app.request("/api/device-id", {
+      headers: { Authorization: "Bearer wrong" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts requests with the correct token", async () => {
+    setAuthToken(TOKEN);
+    const res = await app.request("/api/device-id", {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a websocket upgrade with the wrong ?token=", async () => {
+    setAuthToken(TOKEN);
+    const res = await app.request("/stream?token=wrong", {
+      headers: { upgrade: "websocket" },
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/server/tests/server-url.test.ts
+++ b/apps/server/tests/server-url.test.ts
@@ -1,0 +1,25 @@
+import { serverUrlSchema } from "@freestyle/validations";
+import { describe, expect, it } from "vitest";
+
+describe("serverUrlSchema", () => {
+  const parse = (v: string) => serverUrlSchema.safeParse(v);
+
+  it("treats empty/whitespace as the local server", () => {
+    expect(parse("").success && parse("").data).toBe("");
+    expect(parse("   ").success && parse("   ").data).toBe("");
+  });
+
+  it("strips trailing slashes", () => {
+    const r = parse("http://your-vm:4649/");
+    expect(r.success && r.data).toBe("http://your-vm:4649");
+  });
+
+  it("lowercases scheme and host for reliable ws rewriting", () => {
+    const r = parse("  HTTPS://VM:4649/api/  ");
+    expect(r.success && r.data).toBe("https://vm:4649/api");
+  });
+
+  it("rejects invalid URLs", () => {
+    expect(parse("not a url").success).toBe(false);
+  });
+});

--- a/packages/validations/src/index.ts
+++ b/packages/validations/src/index.ts
@@ -4,5 +4,6 @@ export * from "./formats.js";
 export * from "./local-llm.js";
 export * from "./models.js";
 export * from "./query.js";
+export * from "./server.js";
 export * from "./settings.js";
 export * from "./vocabulary.js";

--- a/packages/validations/src/server.ts
+++ b/packages/validations/src/server.ts
@@ -1,0 +1,15 @@
+import { z } from "zod/v3";
+
+/**
+ * Server URL for the desktop app. An empty string means "use the built-in
+ * local server"; otherwise it must be a valid URL. Trailing slashes are
+ * stripped so callers can append paths cleanly.
+ */
+export const serverUrlSchema = z
+  .string()
+  .trim()
+  .refine(
+    (v) => v === "" || z.string().url().safeParse(v).success,
+    "Must be a valid URL",
+  )
+  .transform((v) => v.replace(/\/+$/, ""));

--- a/packages/validations/src/server.ts
+++ b/packages/validations/src/server.ts
@@ -12,4 +12,13 @@ export const serverUrlSchema = z
     (v) => v === "" || z.string().url().safeParse(v).success,
     "Must be a valid URL",
   )
-  .transform((v) => v.replace(/\/+$/, ""));
+  // Normalize via the URL parser (lowercases scheme/host so the renderer's
+  // http->ws rewrite is reliable), then drop any trailing slash.
+  .transform((v) => {
+    if (v === "") return "";
+    try {
+      return new URL(v).href.replace(/\/+$/, "");
+    } catch {
+      return v.replace(/\/+$/, "");
+    }
+  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,12 +186,6 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.65
         version: 3.0.65(zod@4.4.3)
-      '@freestyle/utils':
-        specifier: workspace:*
-        version: link:../../packages/utils
-      '@freestyle/validations':
-        specifier: workspace:*
-        version: link:../../packages/validations
       '@hono/mcp':
         specifier: ^0.3.0
         version: 0.3.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(hono-rate-limiter@0.5.3(hono@4.12.22))(hono@4.12.22)(zod@4.4.3)
@@ -229,6 +223,12 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@freestyle/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
+      '@freestyle/validations':
+        specifier: workspace:*
+        version: link:../../packages/validations
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15


### PR DESCRIPTION
## What

Lets the Freestyle server run on its own — in a VM/container — and lets the desktop app connect to it instead of the bundled in-process server. Optionally protect that server with a bearer token.

Today `apps/server` is a library that only runs inside Electron. This PR makes it deployable standalone and makes the app's server location configurable, with optional auth.

## Server (`apps/server`)

- **`startServer({ port, host, token })`** — extracted the HTTP + WebSocket listener (previously inlined in the Electron main process) into a shared, exported function. Binds to a configurable host/port, resolves the actual bound port, and rejects on bind errors.
- **`startup.ts`** — standalone entrypoint (Docker `CMD`). Reads `PORT` / `HOST` / `FREESTYLE_DB_PATH` / `FREESTYLE_AUTH_TOKEN`; graceful shutdown with a force-exit fallback.
- **Bearer auth** (`lib/auth.ts`) — opt-in via the `token` option. No-op when unset (keeps the loopback Electron server open). `/api/health` stays exempt for liveness probes; WebSocket upgrades authenticate via a `?token=` query param (browsers can't set the `Authorization` header on a socket); constant-time token comparison.
- **`Dockerfile`** — multi-stage build via `pnpm deploy`, runs on Node 22 (for built-in `node:sqlite`) as a non-root user, with a `HEALTHCHECK`. SQLite DB on a `/data` volume.
- `onError` now preserves Hono `HTTPException` responses (and their CORS headers) instead of masking them as 500s.
- The two workspace packages are inlined by pkgroll so the deployed server is self-contained.

## Electron

- Main process reuses the shared `startServer()`; it **skips** the local server when a Server URL is configured.
- New **Server** settings section: a Server URL field (empty = built-in local server) and an optional Access token. "Test connection" reports reachable / unreachable / token-rejected.
- Server URL is validated with a shared zod schema (`@freestyle/validations`) and normalized (lowercased scheme/host, trailing slash stripped).
- The token is sent as `Authorization: Bearer` on all API calls (incl. the raw `/api/transcribe` and `/api/telemetry` fetches) and as `?token=` on the streaming WebSocket.
- Widened the renderer CSP `connect-src` to allow remote origins.

## Scope / notes

- **Single-user per instance** — the server has one shared SQLite DB; no tenancy was added. History/settings/keys live in the VM's `/data` volume.
- **Auth is optional**; without `FREESTYLE_AUTH_TOKEN` the server is open (intended for a private network/tunnel). Plain HTTP — terminate TLS at a reverse proxy for internet exposure. The WS token rides in the URL query (browser limitation), so any proxy in front should avoid logging query strings.
- On a Linux VM only cloud providers work; MLX is Apple-Silicon-only and whisper.cpp needs a platform binary.

## Testing

- Unit: server suite incl. bearer-auth (header + WS query-token) and server-URL schema — 142 passing.
- Manual (production Docker image, `FREESTYLE_AUTH_TOKEN` set): health exempt (200), API 401 -> 200 with token, WS 401 (none/bad) -> OPEN (valid), container reports `healthy`, graceful stop ~0.2s.
- Electron typecheck (node + web) and Biome clean.