### PR TITLE
Fix model finder provider icons

### DIFF
--- a/apps/electron/src/renderer/index.html
+++ b/apps/electron/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
+      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://models.dev; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
     />
   </head>
 

--- a/apps/electron/src/renderer/pill.html
+++ b/apps/electron/src/renderer/pill.html
@@ -5,7 +5,7 @@
     <title>Freestyle</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://models.dev; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
+      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
     />
   </head>
 

--- a/apps/electron/src/renderer/pill.html
+++ b/apps/electron/src/renderer/pill.html
@@ -5,7 +5,7 @@
     <title>Freestyle</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
+      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://models.dev; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
     />
   </head>
 

--- a/apps/electron/src/renderer/src/components/model-row.tsx
+++ b/apps/electron/src/renderer/src/components/model-row.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@renderer/lib/utils";
 import { Check, Key, Sparkles } from "lucide-react";
-import { Badge } from "./ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { Button } from "./ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
@@ -11,6 +11,37 @@ export const PROVIDER_FILTER_MARKS: Record<string, string> = {
   groq: "GQ",
   mistral: "M",
 };
+
+function providerLogoUrl(providerId: string): string | undefined {
+  const slug = providerId.trim().toLowerCase();
+  return slug ? `https://models.dev/logos/${slug}.svg` : undefined;
+}
+
+export function ProviderAvatar({
+  providerId,
+  providerName,
+  className,
+}: {
+  providerId: string;
+  providerName: string;
+  className?: string;
+}): React.JSX.Element {
+  const fallback =
+    PROVIDER_FILTER_MARKS[providerId] ?? providerName.slice(0, 2);
+
+  return (
+    <Avatar size="sm" className={cn("bg-background", className)}>
+      <AvatarImage
+        src={providerLogoUrl(providerId)}
+        alt=""
+        className="p-[2px] dark:invert dark:group-data-[variant=default]/button:invert-0"
+      />
+      <AvatarFallback className="text-[8px] font-semibold uppercase leading-none">
+        {fallback}
+      </AvatarFallback>
+    </Avatar>
+  );
+}
 
 export const MODEL_ROW_PAGE_SIZE = 20;
 
@@ -25,15 +56,11 @@ export function ProviderModelHeader({
 }): React.JSX.Element {
   return (
     <div className="border-border bg-card text-muted-foreground sticky top-0 z-10 flex items-center gap-1.5 border-b px-5 py-1.5 text-[10px] font-semibold uppercase tracking-wider">
-      {PROVIDER_FILTER_MARKS[providerId] && (
-        <Badge
-          variant="outline"
-          className="h-4 min-w-4 border-current/35 px-1 text-[8px] leading-none"
-          aria-hidden="true"
-        >
-          {PROVIDER_FILTER_MARKS[providerId]}
-        </Badge>
-      )}
+      <ProviderAvatar
+        providerId={providerId}
+        providerName={providerName}
+        className="size-4"
+      />
       <span>{providerName}</span>
       {!hasKey && (
         <span className="text-destructive ml-2 normal-case tracking-normal">

--- a/apps/electron/src/renderer/src/components/ui/avatar.tsx
+++ b/apps/electron/src/renderer/src/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+import { cn } from "@renderer/lib/utils";
+import { Avatar as AvatarPrimitive } from "radix-ui";
+import type * as React from "react";
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg";
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn(
+        "aspect-square size-full rounded-full object-cover",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Avatar,
+  AvatarBadge,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarImage,
+};

--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -1,9 +1,13 @@
-import { PROVIDER_FILTER_MARKS } from "@renderer/components/model-row";
+import {
+  PROVIDER_FILTER_MARKS,
+  ProviderAvatar,
+} from "@renderer/components/model-row";
 import { Badge } from "@renderer/components/ui/badge";
 import { Button } from "@renderer/components/ui/button";
 import { Input } from "@renderer/components/ui/input";
 import {
   InputGroup,
+  InputGroupAddon,
   InputGroupInput,
 } from "@renderer/components/ui/input-group";
 import { Progress } from "@renderer/components/ui/progress";
@@ -283,16 +287,18 @@ export function ModelList({
         >
           {type === "voice" ? "All voice models" : "Cleanup model"}
         </span>
-        <div className="border-border bg-background ml-3 flex min-w-0 flex-1 items-center gap-2 rounded-md border px-2.5 py-1">
-          <Search className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-          <Input
+        <InputGroup className="ml-3 h-9 flex-1 rounded-md">
+          <InputGroupAddon>
+            <Search />
+          </InputGroupAddon>
+          <InputGroupInput
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search…"
-            className="placeholder:text-muted-foreground/70 h-auto min-w-0 flex-1 rounded-none border-none bg-transparent px-0 py-0 text-[12.5px] shadow-none focus-visible:ring-0"
+            className="placeholder:text-muted-foreground/70 text-[12.5px]"
           />
-        </div>
+        </InputGroup>
         <Button
           variant="ghost"
           size="icon-sm"
@@ -609,6 +615,7 @@ function FilterBar({
       {providers.map((p) => (
         <Chip
           key={p.id}
+          providerId={p.id}
           label={p.label}
           mark={p.mark}
           on={active === p.id}
@@ -620,11 +627,13 @@ function FilterBar({
 }
 
 function Chip({
+  providerId,
   label,
   mark,
   on,
   onClick,
 }: {
+  providerId?: string;
   label: string;
   mark?: string;
   on: boolean;
@@ -638,12 +647,11 @@ function Chip({
       className="gap-1.5 rounded-full"
     >
       {mark && (
-        <span
-          className="border-current/35 inline-flex h-4 min-w-4 items-center justify-center rounded-full border px-1 text-[8px] font-semibold leading-none"
-          aria-hidden="true"
-        >
-          {mark}
-        </span>
+        <ProviderAvatar
+          providerId={providerId ?? ""}
+          providerName={label}
+          className="size-4"
+        />
       )}
       {label}
     </Button>


### PR DESCRIPTION
## Summary
- Use the shadcn Avatar component for provider filter/header icons with models.dev logo URLs and text fallbacks.
- Switch the model finder search field to InputGroupInput so the input background matches its surrounding control.
- Allow renderer images from https://models.dev in CSP for provider logos.

## Testing
- pnpm --filter @freestyle/electron typecheck:web
- git diff --check