### PR TITLE
fix(server): resolve cloud user via better-auth getSession

### DIFF
--- a/apps/electron/src/main/plugins/manifest.ts
+++ b/apps/electron/src/main/plugins/manifest.ts
@@ -281,7 +281,7 @@ export function resolvePluginAsset(
   const plugin = plugins.find((p) => p.slug === pluginSlug);
   // A missing plugin has no directory (`dir: ""`); resolving against it would
   // fall back to `process.cwd()` and could leak files from the app root.
-  if (!plugin || !plugin.dir) return null;
+  if (!plugin?.dir) return null;
 
   const decoded = decodeURIComponent(assetPath).replace(/^\/+/, "");
   const resolved = path.resolve(plugin.dir, decoded);

--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -70,6 +70,12 @@ function authClientErrorMessage(error: unknown, fallback: string): string {
       : fallback;
 }
 
+function authClientErrorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const e = error as Record<string, unknown>;
+  return typeof e.status === "number" ? e.status : undefined;
+}
+
 export function freestyleCloudUrl(): string {
   return (process.env.FREESTYLE_CLOUD_URL || DEFAULT_CLOUD_URL).replace(
     /\/+$/,
@@ -123,14 +129,18 @@ export async function pollDeviceToken(
 }
 
 export async function fetchCloudUser(token: string): Promise<CloudUser> {
-  const res = await fetch(`${freestyleCloudUrl()}/v1/me`, {
-    headers: { authorization: `Bearer ${token}` },
-    signal: AbortSignal.timeout(10_000),
+  const { data, error } = await createCloudAuthClient().getSession({
+    fetchOptions: {
+      headers: { authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(10_000),
+    },
   });
-  if (res.status === 401) throw new FreestyleCloudAuthError();
-  if (!res.ok) throw new Error(`Failed to load profile (${res.status})`);
-  const data = (await res.json()) as { user: CloudUser };
-  return data.user;
+  if (authClientErrorStatus(error) === 401) throw new FreestyleCloudAuthError();
+  if (error || !data?.user) {
+    throw new Error(authClientErrorMessage(error, "Failed to load profile"));
+  }
+  const { id, email, name, image } = data.user;
+  return { id, email, name, image };
 }
 
 export async function signOutCloud(token: string): Promise<void> {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "files": {
     "includes": ["**", "!**/*.css", "!freestyle-design"]
   },


### PR DESCRIPTION
## What

Replaces the hand-rolled `GET /v1/me` fetch in `fetchCloudUser` (`apps/server/src/lib/freestyle-cloud.ts`) with better-auth's built-in `getSession`, authenticated by the device-flow bearer token.

## Why

The device-authorization grant returns only an opaque bearer `access_token` (no cookie, no user profile), so the server must exchange it for user info once at sign-in. Since the cloud auth server already has the **bearer plugin**, we can use better-auth's standard `getSession` endpoint (`/auth/get-session`) instead of maintaining a custom `/v1/me` endpoint. This is the same single network round-trip — a cleanup, not a behavior change.

## Changes

- `fetchCloudUser` now calls `createCloudAuthClient().getSession({ fetchOptions: { headers: { authorization: Bearer ... } } })`.
- Maps the returned session `user` (`id, email, emailVerified, name, image, …`) down to the existing `CloudUser` shape (`id, email, name, image`), so `setSession` / `auth.ts` are untouched.
- Adds `authClientErrorStatus` helper to preserve 401 → `FreestyleCloudAuthError` behavior; other failures throw a generic error; 10s timeout retained.

## Notes / cloud-side assumptions

- better-auth is mounted at `/auth` on the cloud Worker (client `baseURL` is `\${freestyleCloudUrl()}/auth`), so `getSession` resolves to `/auth/get-session`.
- The device-flow `access_token` resolves to a real session the bearer plugin can read.

## Verification

- `pnpm --filter @freestyle-voice/server build` — clean
- `pnpm --filter @freestyle-voice/server test` — 179 passed (incl. `cloud-auth.test.ts`)