### PR TITLE
feat: sync cleanup preferences to Freestyle Cloud

### DIFF
--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -185,7 +185,7 @@ export async function transcribeWithFreestyleCloud(opts: {
   if (opts.language) headers["x-language"] = opts.language;
   if (opts.appContext)
     headers["x-app-context"] = encodeURIComponent(opts.appContext);
-  if (opts.mode === "raw") headers["x-freestyle-mode"] = "transcribe";
+  if (opts.mode === "raw") headers["x-skip-post-process"] = "true";
   const audio = opts.audio as Uint8Array<ArrayBuffer>;
 
   return cloudJson<CloudTranscribeResult>("/v1/transcribe", opts.token, {
@@ -211,6 +211,25 @@ export async function postProcessWithFreestyleCloud(opts: {
       text: opts.text,
       appContext: opts.appContext ?? null,
       language: opts.language,
+    }),
+  });
+}
+
+/**
+ * Sync cleanup preferences (intensity + custom prompt) to Freestyle Cloud.
+ * Called whenever the user changes their cleanup settings locally.
+ */
+export async function syncCleanupPreferences(opts: {
+  token: string;
+  intensity: string;
+  customPrompt?: string | null;
+}): Promise<void> {
+  await cloudJson("/v1/preferences", opts.token, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      intensity: opts.intensity,
+      customPrompt: opts.customPrompt ?? null,
     }),
   });
 }

--- a/apps/server/src/lib/post-process.ts
+++ b/apps/server/src/lib/post-process.ts
@@ -64,11 +64,11 @@ export function isLlmCleanupEnabled(): boolean {
   return readSetting("llm_cleanup") === "true";
 }
 
-function getCleanupIntensity(): CleanupIntensity {
+export function getCleanupIntensity(): CleanupIntensity {
   return parseCleanupIntensity(readSetting("cleanup_intensity"));
 }
 
-function getCleanupCustomPrompt(): string | undefined {
+export function getCleanupCustomPrompt(): string | undefined {
   return readSetting("cleanup_custom_prompt");
 }
 

--- a/apps/server/src/routes/settings.ts
+++ b/apps/server/src/routes/settings.ts
@@ -8,9 +8,11 @@ import {
 } from "@freestyle-voice/validations";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import { getDb } from "../lib/db.js";
+import { getDb, readSetting } from "../lib/db.js";
+import { syncCleanupPreferences } from "../lib/freestyle-cloud.js";
 import { applyMlxAsrRetentionPolicy } from "../lib/mlx-asr/server.js";
 import { capture } from "../lib/posthog.js";
+import { getSessionToken } from "../lib/sessions.js";
 
 const settings = new Hono()
   .get("/", (c) => {
@@ -85,6 +87,20 @@ const settings = new Hono()
 
     if (key === "mlx_asr_keep_alive_minutes") {
       applyMlxAsrRetentionPolicy();
+    }
+
+    // Sync cleanup preferences to Freestyle Cloud when signed in.
+    if (key === "cleanup_intensity" || key === "cleanup_custom_prompt") {
+      const token = getSessionToken();
+      if (token) {
+        const intensity = readSetting("cleanup_intensity") ?? "low";
+        const customPrompt = readSetting("cleanup_custom_prompt");
+        void syncCleanupPreferences({ token, intensity, customPrompt }).catch(
+          () => {
+            // Best-effort sync — don't fail the local save if cloud is unreachable.
+          },
+        );
+      }
     }
 
     // Don't capture internal/system keys


### PR DESCRIPTION
## Summary

Syncs cleanup preferences (intensity + custom prompt) to Freestyle Cloud whenever the user changes them locally. Also fixes the header mismatch for skip-post-process.

### Changes

**`apps/server/src/lib/freestyle-cloud.ts`**
- Replaced `x-freestyle-mode: transcribe` header with `x-skip-post-process: true` (matches what the cloud server reads).
- Added `syncCleanupPreferences()` — pushes intensity + customPrompt to `PUT /v1/preferences` on the cloud server.

**`apps/server/src/lib/post-process.ts`**
- Exported `getCleanupIntensity()` and `getCleanupCustomPrompt()` (previously private) so they can be used by the settings sync.

**`apps/server/src/routes/settings.ts`**
- When `cleanup_intensity` or `cleanup_custom_prompt` is saved, automatically syncs both values to Freestyle Cloud if the user is signed in.
- Sync is best-effort (fire-and-forget) — a cloud failure won't block the local save.

### How It Works

1. User changes cleanup intensity or custom prompt in the UI
2. Setting is saved to local SQLite DB (unchanged behavior)
3. If signed into Freestyle Cloud, the current intensity + customPrompt are pushed to `PUT /v1/preferences`
4. Cloud stores them per-member; cloud transcribe/post-process endpoints read them from DB at request time

### Companion PR

Cloud-side changes: [freestyle-voice/cloud#8](https://github.com/freestyle-voice/cloud/pull/8) — adds `POST /v1/post-process`, `GET/PUT /v1/preferences`, `cleanup_preferences` table, and intensity presets.