### PR TITLE
[Fix] Register all privileged schemes in one call 

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -288,12 +288,6 @@ function stopHotkeyRecorderProcess(): void {
   hotkeyRecorder = null;
 }
 
-// Register the custom app:// protocol that serves the renderer files, alongside
-// the freestyle-plugin:// scheme for plugin UI assets. Electron honors only one
-// registerSchemesAsPrivileged call before app.ready, so every privileged scheme
-// must share it — splitting them drops the earlier scheme's privileges (e.g.
-// app:// losing `secure`, which makes navigator.mediaDevices undefined).
-// All non-file app:// paths fall back to index.html so BrowserRouter works in production.
 protocol.registerSchemesAsPrivileged([
   {
     scheme: "app",

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -110,8 +110,8 @@ import {
 } from "./plugins/index";
 import {
   initPluginUiHost,
+  PLUGIN_SCHEME_PRIVILEGE,
   refreshPluginUi,
-  registerPluginUiPrivileges,
 } from "./plugins/ui-host";
 import type { BridgeConfig } from "./plugins/view-manager";
 
@@ -288,8 +288,12 @@ function stopHotkeyRecorderProcess(): void {
   hotkeyRecorder = null;
 }
 
-// Register a custom app:// protocol that serves the renderer files.
-// All non-file paths fall back to index.html so BrowserRouter works in production.
+// Register the custom app:// protocol that serves the renderer files, alongside
+// the freestyle-plugin:// scheme for plugin UI assets. Electron honors only one
+// registerSchemesAsPrivileged call before app.ready, so every privileged scheme
+// must share it — splitting them drops the earlier scheme's privileges (e.g.
+// app:// losing `secure`, which makes navigator.mediaDevices undefined).
+// All non-file app:// paths fall back to index.html so BrowserRouter works in production.
 protocol.registerSchemesAsPrivileged([
   {
     scheme: "app",
@@ -300,11 +304,8 @@ protocol.registerSchemesAsPrivileged([
       corsEnabled: true,
     },
   },
+  PLUGIN_SCHEME_PRIVILEGE,
 ]);
-
-// Register the freestyle-plugin:// scheme that serves plugin UI assets. Must
-// also run before app.ready.
-registerPluginUiPrivileges();
 
 function registerAppProtocol(): void {
   protocol.handle("app", (request) => {

--- a/apps/electron/src/main/plugins/ui-host.ts
+++ b/apps/electron/src/main/plugins/ui-host.ts
@@ -11,7 +11,6 @@ import {
   getDiscoveredPlugins,
   refreshDiscoveredPlugins,
   registerPluginProtocol,
-  registerPluginSchemePrivileges,
 } from "./ui.js";
 import {
   type BridgeConfig,
@@ -56,12 +55,11 @@ export interface PluginUiHostDeps {
 let viewManager: PluginViewManager | null = null;
 
 /**
- * Register the plugin scheme privileges. Must run **before** `app.ready`,
- * alongside the `app://` privilege registration.
+ * Privilege descriptor for the plugin asset scheme. Must be registered together
+ * with the `app://` scheme in the single `registerSchemesAsPrivileged` call in
+ * the main entry — Electron honors only one such call before `app.ready`.
  */
-export function registerPluginUiPrivileges(): void {
-  registerPluginSchemePrivileges();
-}
+export { PLUGIN_SCHEME_PRIVILEGE } from "./ui.js";
 
 /**
  * Wire up the plugin UI host: the asset protocol, the view manager, and all

--- a/apps/electron/src/main/plugins/ui-host.ts
+++ b/apps/electron/src/main/plugins/ui-host.ts
@@ -54,11 +54,6 @@ export interface PluginUiHostDeps {
 
 let viewManager: PluginViewManager | null = null;
 
-/**
- * Privilege descriptor for the plugin asset scheme. Must be registered together
- * with the `app://` scheme in the single `registerSchemesAsPrivileged` call in
- * the main entry — Electron honors only one such call before `app.ready`.
- */
 export { PLUGIN_SCHEME_PRIVILEGE } from "./ui.js";
 
 /**

--- a/apps/electron/src/main/plugins/ui.ts
+++ b/apps/electron/src/main/plugins/ui.ts
@@ -15,22 +15,20 @@ export const PLUGIN_SCHEME = "freestyle-plugin";
 let discovered: DiscoveredPlugin[] = [];
 
 /**
- * Privilege registration for the plugin scheme. Must run before `app.ready`
- * (alongside the `app://` scheme registration).
+ * Privilege descriptor for the plugin scheme. Registered together with the
+ * `app://` scheme in a single `registerSchemesAsPrivileged` call in the main
+ * entry — Electron honors only one such call, so all privileged schemes must
+ * share it.
  */
-export function registerPluginSchemePrivileges(): void {
-  protocol.registerSchemesAsPrivileged([
-    {
-      scheme: PLUGIN_SCHEME,
-      privileges: {
-        standard: true,
-        secure: true,
-        supportFetchAPI: true,
-        corsEnabled: true,
-      },
-    },
-  ]);
-}
+export const PLUGIN_SCHEME_PRIVILEGE: Electron.CustomScheme = {
+  scheme: PLUGIN_SCHEME,
+  privileges: {
+    standard: true,
+    secure: true,
+    supportFetchAPI: true,
+    corsEnabled: true,
+  },
+};
 
 /**
  * Register the `freestyle-plugin://<pluginName>/<assetPath>` handler. Serves

--- a/apps/electron/src/main/plugins/ui.ts
+++ b/apps/electron/src/main/plugins/ui.ts
@@ -14,12 +14,6 @@ export const PLUGIN_SCHEME = "freestyle-plugin";
 
 let discovered: DiscoveredPlugin[] = [];
 
-/**
- * Privilege descriptor for the plugin scheme. Registered together with the
- * `app://` scheme in a single `registerSchemesAsPrivileged` call in the main
- * entry — Electron honors only one such call, so all privileged schemes must
- * share it.
- */
 export const PLUGIN_SCHEME_PRIVILEGE: Electron.CustomScheme = {
   scheme: PLUGIN_SCHEME,
   privileges: {


### PR DESCRIPTION
Electron honors only one `registerSchemesAsPrivileged` call before app.ready; the second call (for `freestyle-plugin://`) was replacing the first, stripping the `app://` scheme of its `secure: true` privilege. 