### PR TITLE
fix(ui): use popper positioning for select dropdowns

### DIFF
--- a/apps/electron/src/renderer/src/components/ui/select.tsx
+++ b/apps/electron/src/renderer/src/components/ui/select.tsx
@@ -57,7 +57,7 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = "item-aligned",
+  position = "popper",
   align = "center",
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {


### PR DESCRIPTION
In dark theme, select/dropdown lists in Settings (e.g. Microphone, Language) rendered with a light background while text stayed dark, making items barely visible. `SelectContent` defaulted to Radix's `item-aligned` positioning, which wraps the listbox in extra positioning elements that don't carry the `bg-popover` surface. Switching the default to `popper` (the upstream shadcn default) makes the dark popover background reliably cover the whole list.

## Testing
- `pnpm typecheck:web` (passes)
- No callsite passes an explicit `position`, and none rely on item-aligned semantics, so all dropdowns inherit the new `popper` default.

Fixes #204

<!--
## Plan
Root cause: apps/electron/src/renderer/src/components/ui/select.tsx:60 — SelectContent
defaulted to position="item-aligned". Radix item-aligned mode renders the listbox inside
additional internal positioning wrappers; the bg-popover/text-popover-foreground classes
sit only on the outer SelectPrimitive.Content, so the visible list surface could appear
page-light in dark theme (issue #204, Windows 11). popper mode (upstream shadcn default)
renders content directly in the styled Content element, so the dark bg-popover covers the
full list. The popper-specific classes already present (translate offsets at lines 71-72,
min-w-(--radix-select-trigger-width) at line 83) activate correctly under the new default.

Theme tokens are correct (globals.css: --popover flips to #1E1C16 under .dark); the bug was
purely the Radix positioning mode, not the token values. Dark mode is applied via next-themes
attribute="class" on <html>.

Change: single default-prop swap "item-aligned" -> "popper". No callsite overrides position.
-->