### PR TITLE
fix: stop whisper server before deleting model file

### DIFF
--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -252,11 +252,17 @@ export function cancelDownload(modelId: string): boolean {
   return true;
 }
 
-export function deleteModel(modelId: string): boolean {
+export async function deleteModel(modelId: string): Promise<boolean> {
   const model = getWhisperModel(modelId);
   if (!model) return false;
 
   cancelDownload(modelId);
+
+  // Stop the whisper server before deleting — on Windows the server
+  // process holds the model file open, so unlinkSync would fail with
+  // EPERM/EBUSY while it's running.
+  const { stopServer } = await import("./server.js");
+  await stopServer();
 
   const path = getModelPath(model);
   try {

--- a/apps/server/src/routes/whisper.ts
+++ b/apps/server/src/routes/whisper.ts
@@ -78,9 +78,9 @@ const whisper = new Hono()
     const cancelled = cancelDownload(modelId);
     return c.json({ ok: cancelled });
   })
-  .delete("/models/:model", (c) => {
+  .delete("/models/:model", async (c) => {
     const modelId = c.req.param("model");
-    const deleted = deleteModel(modelId);
+    const deleted = await deleteModel(modelId);
 
     if (deleted) {
       capture("whisper model deleted", { model_id: modelId });


### PR DESCRIPTION
On Windows, the whisper-server process holds the model file open, so `unlinkSync` fails with EPERM/EBUSY when the user clicks delete. The empty `catch {}` silently swallows the error, making the model appear deleted in the UI while it remains on disk.

This stops the server before unlinking, matching what `deleteMlxModel` already does. Uses a dynamic import to avoid a circular dependency between `models.ts` and `server.ts`.

## Testing

- `tsc --noEmit` — passes
- `vitest run` — 169 tests pass
- `biome check` — clean

Fixes #205

<!--
## Plan

Root cause: `deleteModel` in `apps/server/src/lib/whisper/models.ts` calls
`unlinkSync` on the model file without first stopping the whisper-server
process. On Windows, the server holds the file open (file locking), so the
unlink fails silently (caught by empty catch block).

Fix:
1. Make `deleteModel` async
2. Call `stopServer()` before `unlinkSync` (via dynamic import to avoid
   circular dep between models.ts ↔ server.ts)
3. Update the route handler in `routes/whisper.ts` to await the now-async
   `deleteModel`

This mirrors the pattern already used by `deleteMlxModel` in
`apps/server/src/lib/mlx-asr/models.ts` which calls `stopMlxServer()`
before `rmSync`.
-->