### PR TITLE
fix: keep source language during cleanup in auto-detect mode

### DIFF
--- a/apps/server/src/lib/editor/prompts.ts
+++ b/apps/server/src/lib/editor/prompts.ts
@@ -79,11 +79,14 @@ function normalizeLanguageCode(language: string): string {
   return language.trim().toLowerCase().replace(/_/g, "-");
 }
 
+const AUTO_LANGUAGE_CONSTRAINT =
+  "\n\nLanguage constraint: return the final edited text in the same language and script as the transcript. Do not translate to English or any other language. If the transcript mixes languages, preserve each span in the language spoken. The English examples in the instructions above demonstrate editing behavior only; they do not change the output language.";
+
 export function buildLanguageBlock(language: string | undefined): string {
-  if (!language?.trim()) return "";
+  if (!language?.trim()) return AUTO_LANGUAGE_CONSTRAINT;
 
   const normalized = normalizeLanguageCode(language);
-  if (normalized === "auto") return "";
+  if (normalized === "auto") return AUTO_LANGUAGE_CONSTRAINT;
 
   const baseCode = normalized.split("-")[0] ?? normalized;
   const label = LANGUAGE_LABELS[normalized] ?? LANGUAGE_LABELS[baseCode];

--- a/apps/server/tests/prompts.test.ts
+++ b/apps/server/tests/prompts.test.ts
@@ -7,9 +7,14 @@ import {
 } from "../src/lib/editor/prompts.js";
 
 describe("buildLanguageBlock", () => {
-  it("returns nothing for auto-detect", () => {
-    expect(buildLanguageBlock("auto")).toBe("");
-    expect(buildLanguageBlock(undefined)).toBe("");
+  it("keeps the source language for auto-detect instead of translating", () => {
+    for (const value of ["auto", undefined]) {
+      const block = buildLanguageBlock(value);
+      expect(block).toContain(
+        "return the final edited text in the same language and script",
+      );
+      expect(block).toContain("Do not translate");
+    }
   });
 
   it("adds a same-language constraint for known languages", () => {


### PR DESCRIPTION
When language is set to auto-detect, the ASR step transcribes correctly, but the LLM cleanup step received no language constraint (`buildLanguageBlock` returned an empty string for `auto`/`undefined`). The cleanup model — prompted entirely in English with English examples — was then free to translate non-English transcripts (e.g. Russian) into English. This emits the same "do not translate, keep the spoken language" constraint for auto-detect too.

## Testing
`pnpm build` and `pnpm test` in `apps/server` — 169 tests pass.

Closes #203

<!--
## Plan
Root cause: translation happens in the post-process (LLM cleanup) stage, not ASR.
- `getLanguageSetting()` returns `undefined` for "auto" (lib/language.ts).
- `buildLanguageBlock(undefined)` previously returned "" (editor/prompts.ts), so no
  "do not translate" instruction reached the cleanup model in auto-detect mode.
- The cleanup preset prompts are English with English examples, biasing output to English.

Fix: introduce AUTO_LANGUAGE_CONSTRAINT and return it for both the empty/undefined and
"auto" cases instead of "". It instructs the model to detect and preserve whatever
language was spoken without naming a specific one. Named-language behavior is unchanged.

Tests: updated prompts.test.ts auto-detect case to assert the constraint is present.
-->