### PR TITLE
fix: make plugin protocol/IPC registration and DB init idempotent

### DIFF
--- a/apps/electron/src/main/plugins/ui-host.ts
+++ b/apps/electron/src/main/plugins/ui-host.ts
@@ -53,15 +53,20 @@ export interface PluginUiHostDeps {
 }
 
 let viewManager: PluginViewManager | null = null;
+let currentDeps: PluginUiHostDeps | null = null;
+let ipcRegistered = false;
 
 export { PLUGIN_SCHEME_PRIVILEGE } from "./ui.js";
 
 /**
  * Wire up the plugin UI host: the asset protocol, the view manager, and all
- * IPC. Call once after the dashboard window exists. Plugin discovery is
- * refreshed lazily via {@link refreshPluginUi}.
+ * IPC. Safe to call multiple times (e.g. when the settings window is closed
+ * and re-opened) — the protocol and IPC handlers are registered only once,
+ * while the window and deps reference are updated on every call.
  */
 export function initPluginUiHost(deps: PluginUiHostDeps): void {
+  currentDeps = deps;
+
   registerPluginProtocol();
 
   viewManager = new PluginViewManager(
@@ -70,13 +75,16 @@ export function initPluginUiHost(deps: PluginUiHostDeps): void {
   );
   viewManager.attachWindow(deps.window);
 
+  if (ipcRegistered) return;
+  ipcRegistered = true;
+
   ipcMain.handle("plugins:list", () =>
     serializePlugins(getDiscoveredPlugins()),
   );
 
   ipcMain.handle("plugins:refresh", async () => {
     const { pluginsSetting, userDataDir, disabledPlugins } =
-      await deps.getDiscoverySources();
+      await currentDeps!.getDiscoverySources();
     refreshDiscoveredPlugins(pluginsSetting, userDataDir, disabledPlugins);
     return serializePlugins(getDiscoveredPlugins());
   });
@@ -84,31 +92,31 @@ export function initPluginUiHost(deps: PluginUiHostDeps): void {
   ipcMain.handle(
     "plugins:set-enabled",
     async (_e, specifier: string, enabled: boolean) => {
-      await deps.setPluginEnabled(specifier, enabled);
+      await currentDeps!.setPluginEnabled(specifier, enabled);
       const { pluginsSetting, userDataDir, disabledPlugins } =
-        await deps.getDiscoverySources();
+        await currentDeps!.getDiscoverySources();
       refreshDiscoveredPlugins(pluginsSetting, userDataDir, disabledPlugins);
       return serializePlugins(getDiscoveredPlugins());
     },
   );
 
-  ipcMain.handle("plugins:catalog", () => deps.getCatalog());
+  ipcMain.handle("plugins:catalog", () => currentDeps!.getCatalog());
 
   ipcMain.handle(
     "plugins:install",
     async (_e, npmName: string, version: string | undefined) => {
-      await deps.installPlugin(npmName, version);
+      await currentDeps!.installPlugin(npmName, version);
       const { pluginsSetting, userDataDir, disabledPlugins } =
-        await deps.getDiscoverySources();
+        await currentDeps!.getDiscoverySources();
       refreshDiscoveredPlugins(pluginsSetting, userDataDir, disabledPlugins);
       return serializePlugins(getDiscoveredPlugins());
     },
   );
 
   ipcMain.handle("plugins:uninstall", async (_e, specifier: string) => {
-    await deps.uninstallPlugin(specifier);
+    await currentDeps!.uninstallPlugin(specifier);
     const { pluginsSetting, userDataDir, disabledPlugins } =
-      await deps.getDiscoverySources();
+      await currentDeps!.getDiscoverySources();
     refreshDiscoveredPlugins(pluginsSetting, userDataDir, disabledPlugins);
     return serializePlugins(getDiscoveredPlugins());
   });
@@ -147,7 +155,7 @@ export function initPluginUiHost(deps: PluginUiHostDeps): void {
       payload: HostActions[C],
     ) => {
       try {
-        await deps.onAction(channel, payload);
+        await currentDeps!.onAction(channel, payload);
       } catch (err) {
         log.error(
           `plugin action "${String(channel)}" failed: ${
@@ -164,7 +172,7 @@ export function initPluginUiHost(deps: PluginUiHostDeps): void {
   ipcMain.handle(
     "plugin-bridge:fetch",
     async (_e, req: PluginFetchRequest): Promise<PluginFetchResponse> => {
-      const config = deps.getBridgeConfig();
+      const config = currentDeps!.getBridgeConfig();
       const url = `${config.serverUrl}${req.path}`;
       const body = deserializeBody(req.body);
 

--- a/apps/electron/src/main/plugins/ui.ts
+++ b/apps/electron/src/main/plugins/ui.ts
@@ -13,6 +13,7 @@ const log = createAppLogger("plugins-ui");
 export const PLUGIN_SCHEME = "freestyle-plugin";
 
 let discovered: DiscoveredPlugin[] = [];
+let protocolRegistered = false;
 
 export const PLUGIN_SCHEME_PRIVILEGE: Electron.CustomScheme = {
   scheme: PLUGIN_SCHEME,
@@ -28,8 +29,13 @@ export const PLUGIN_SCHEME_PRIVILEGE: Electron.CustomScheme = {
  * Register the `freestyle-plugin://<pluginName>/<assetPath>` handler. Serves
  * files **only** from the requested plugin's package directory; any path that
  * escapes the plugin root (or names an unknown plugin) is rejected.
+ *
+ * Safe to call multiple times — the protocol is only registered once.
  */
 export function registerPluginProtocol(): void {
+  if (protocolRegistered) return;
+  protocolRegistered = true;
+
   protocol.handle(PLUGIN_SCHEME, (request) => {
     const url = new URL(request.url);
     // URL shape: freestyle-plugin://<pluginSlug>/<assetPath>. The slug is

--- a/apps/server/src/lib/db.ts
+++ b/apps/server/src/lib/db.ts
@@ -13,15 +13,20 @@ export function getDb(): DatabaseSync {
     );
   }
 
-  db = new DatabaseSync(dbPath);
+  const instance = new DatabaseSync(dbPath);
 
   // Performance and safety pragmas
-  db.exec("PRAGMA journal_mode = WAL");
-  db.exec("PRAGMA busy_timeout = 5000");
-  db.exec("PRAGMA foreign_keys = ON");
-  db.exec("PRAGMA synchronous = NORMAL");
+  instance.exec("PRAGMA journal_mode = WAL");
+  instance.exec("PRAGMA busy_timeout = 5000");
+  instance.exec("PRAGMA foreign_keys = ON");
+  instance.exec("PRAGMA synchronous = NORMAL");
 
-  initSchema(db);
+  initSchema(instance);
+
+  // Cache only after schema init succeeds — if initSchema() throws, the next
+  // getDb() call will retry from scratch instead of returning an instance
+  // with missing tables.
+  db = instance;
 
   return db;
 }

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -140,7 +140,7 @@ export function initSchema(db: DatabaseSync): void {
   // created but the version not yet bumped).
   db.exec("BEGIN");
   try {
-    _applyMigrations(db, currentVersion);
+    applyMigrations(db, currentVersion);
     db.exec("COMMIT");
   } catch (err) {
     db.exec("ROLLBACK");
@@ -148,7 +148,7 @@ export function initSchema(db: DatabaseSync): void {
   }
 }
 
-function _applyMigrations(db: DatabaseSync, currentVersion: number): void {
+function applyMigrations(db: DatabaseSync, currentVersion: number): void {
   if (currentVersion < 1) {
     db.exec(`
       CREATE TABLE IF NOT EXISTS settings (

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -133,6 +133,22 @@ export function initSchema(db: DatabaseSync): void {
     .get() as { version: number } | undefined;
   const currentVersion = row?.version ?? 0;
 
+  if (currentVersion >= SCHEMA_VERSION) return;
+
+  // Run all migrations inside a transaction so a failure mid-way rolls back
+  // cleanly instead of leaving the DB in a partial state (e.g. some tables
+  // created but the version not yet bumped).
+  db.exec("BEGIN");
+  try {
+    _applyMigrations(db, currentVersion);
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+}
+
+function _applyMigrations(db: DatabaseSync, currentVersion: number): void {
   if (currentVersion < 1) {
     db.exec(`
       CREATE TABLE IF NOT EXISTS settings (


### PR DESCRIPTION
## Summary

Two crash fixes for errors reported in PostHog error tracking.

### 1. `Failed to register protocol: freestyle-plugin`

**Root cause:** `registerPluginProtocol()` and `initPluginUiHost()` are called every time `createSettingsWindow()` runs. When the user closes the settings window (`settingsWindow = null`) and reopens it, `protocol.handle()` throws because the `freestyle-plugin` handler is already registered globally in Electron — it persists across window lifecycles. The same issue applies to all `ipcMain.handle()` registrations in `initPluginUiHost()`.

**Fix:** Guard `registerPluginProtocol()` and IPC handler registration with idempotency flags so they only run once. The window reference and deps are updated on every call via a `currentDeps` module-level variable, so IPC handlers always use the latest window's callbacks.

- `apps/electron/src/main/plugins/ui.ts` — added `protocolRegistered` guard
- `apps/electron/src/main/plugins/ui-host.ts` — added `ipcRegistered` guard + `currentDeps` mutable reference

### 2. `no such table: sessions`

**Root cause:** `getDb()` in `apps/server/src/lib/db.ts` cached the `DatabaseSync` instance in the module-level `db` variable **before** calling `initSchema()`. If `initSchema()` threw for any reason (disk full, permissions, corrupted DB), subsequent `getDb()` calls returned the cached instance without retrying schema initialization — leaving the `sessions` table (migration 9) missing.

**Fix:** Use a local `instance` variable during initialization and only assign to the module-level `db` cache after `initSchema()` succeeds. If schema init fails, the next `getDb()` call retries from scratch.

- `apps/server/src/lib/db.ts` — defer cache assignment until after `initSchema()`

### Verification

- Electron app typecheck + build: passing
- Server tests: 169/169 passing