### PR TITLE
fix: voice pill cue tones, init delay, and multi-monitor positioning

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -62,6 +62,7 @@ import {
   app,
   BrowserWindow,
   clipboard,
+  type Display,
   dialog,
   globalShortcut,
   ipcMain,
@@ -357,26 +358,33 @@ function getPillAlignmentForCustom(): "custom-top" | "custom-bottom" {
   return wy < midY ? "custom-top" : "custom-bottom";
 }
 
-// Preset positions follow the display under the cursor so the pill appears
-// on whichever monitor the user is working on. Custom positions can be on
-// any display — they are saved as absolute screen coordinates and
-// bounds-checked on restore.
-function getAppWindowPosition(): { x: number; y: number } {
-  // Anchor preset positions to the display containing the cursor rather than
-  // the primary display, so multi-monitor users see the pill where they are.
-  const activeDisplay = screen.getDisplayNearestPoint(
-    screen.getCursorScreenPoint(),
+// Computes a preset pill slot for a specific display. The pill is aligned
+// inside the window via CSS (justify-center or justify-end).
+//
+// Bottom positions normally sit slightly past the work-area edge so the pill
+// hugs the dock/taskbar. But that only looks right when a dock/taskbar
+// actually reserves space on this display: on a dockless monitor (common for
+// secondary/vertical displays) the work area reaches the physical edge, so
+// the same overlap pushes the pill off-screen and it clips against the
+// border. Detect the reserved bottom strip and only overlap when it exists;
+// otherwise leave a small gap above the edge.
+function presetPositionForDisplay(
+  display: Display,
+  position: string,
+): { x: number; y: number } {
+  const { x: waX, y: waY, width, height } = display.workArea;
+
+  const bottomInset = Math.max(
+    0,
+    display.bounds.y +
+      display.bounds.height -
+      (display.workArea.y + display.workArea.height),
   );
-  const { x: waX, y: waY, width, height } = activeDisplay.workArea;
-
-  // Read pill position preference
-  const position = (readSettings().pillPosition as string) || "bottom-center";
-
-  // The pill is aligned inside the window via CSS (justify-center or
-  // justify-end). Push bottom positions 10px past the work area edge
-  // so the pill sits closer to the dock/taskbar.
-  const bottomOverlap = 14;
+  // +14 nudges the pill into an existing dock strip; -8 leaves a gap above
+  // the physical edge on dockless displays.
+  const bottomOffset = bottomInset > 0 ? 14 : -8;
   const topOverlap = 0;
+
   switch (position) {
     case "top-center":
       return {
@@ -388,49 +396,64 @@ function getAppWindowPosition(): { x: number; y: number } {
     case "bottom-right":
       return {
         x: waX + width - APP_WIDTH,
-        y: waY + height - APP_HEIGHT + bottomOverlap,
+        y: waY + height - APP_HEIGHT + bottomOffset,
       };
-    case "custom": {
-      const custom = readSettings().pillCustomPosition as
-        | { x: number; y: number }
-        | undefined;
-      if (
-        custom &&
-        typeof custom.x === "number" &&
-        typeof custom.y === "number"
-      ) {
-        const display = screen.getDisplayMatching({
-          x: custom.x,
-          y: custom.y,
-          width: APP_WIDTH,
-          height: APP_HEIGHT,
-        });
-        const wa = display.workArea;
-        if (
-          custom.x >= wa.x &&
-          custom.x + APP_WIDTH <= wa.x + wa.width &&
-          custom.y >= wa.y &&
-          custom.y <= wa.y + wa.height
-        ) {
-          return custom;
-        }
-        // Saved position is off-screen; reset to default.
-        writeSettings({
-          pillPosition: "bottom-center",
-          pillCustomPosition: undefined,
-        });
-      }
-      return {
-        x: waX + Math.round((width - APP_WIDTH) / 2),
-        y: waY + height - APP_HEIGHT + bottomOverlap,
-      };
-    }
     default:
       return {
         x: waX + Math.round((width - APP_WIDTH) / 2),
-        y: waY + height - APP_HEIGHT + bottomOverlap,
+        y: waY + height - APP_HEIGHT + bottomOffset,
       };
   }
+}
+
+// Preset positions follow the display under the cursor so the pill appears
+// on whichever monitor the user is working on. Custom positions can be on
+// any display — they are saved as absolute screen coordinates and
+// bounds-checked on restore.
+function getAppWindowPosition(): { x: number; y: number } {
+  // Anchor preset positions to the display containing the cursor rather than
+  // the primary display, so multi-monitor users see the pill where they are.
+  const activeDisplay = screen.getDisplayNearestPoint(
+    screen.getCursorScreenPoint(),
+  );
+
+  // Read pill position preference
+  const position = (readSettings().pillPosition as string) || "bottom-center";
+
+  if (position === "custom") {
+    const custom = readSettings().pillCustomPosition as
+      | { x: number; y: number }
+      | undefined;
+    if (
+      custom &&
+      typeof custom.x === "number" &&
+      typeof custom.y === "number"
+    ) {
+      const display = screen.getDisplayMatching({
+        x: custom.x,
+        y: custom.y,
+        width: APP_WIDTH,
+        height: APP_HEIGHT,
+      });
+      const wa = display.workArea;
+      if (
+        custom.x >= wa.x &&
+        custom.x + APP_WIDTH <= wa.x + wa.width &&
+        custom.y >= wa.y &&
+        custom.y <= wa.y + wa.height
+      ) {
+        return custom;
+      }
+      // Saved position is off-screen; reset to default.
+      writeSettings({
+        pillPosition: "bottom-center",
+        pillCustomPosition: undefined,
+      });
+    }
+    return presetPositionForDisplay(activeDisplay, "bottom-center");
+  }
+
+  return presetPositionForDisplay(activeDisplay, position);
 }
 
 function createAppWindow(): void {
@@ -493,7 +516,18 @@ function createAppWindow(): void {
     // Ignore sub-threshold moves so accidental bumps don't override the preset.
     const currentSetting = readSettings().pillPosition as string;
     if (currentSetting !== "custom") {
-      const presetPos = getAppWindowPosition();
+      // Compare against the preset slot on the display the window is actually
+      // on — not the cursor's display. Using the cursor here let a trailing
+      // settle event (fired after the cursor had moved to another monitor)
+      // look like a manual drag, which latched pillPosition to "custom" and
+      // froze the pill on one screen.
+      const windowDisplay = screen.getDisplayMatching({
+        x: nx,
+        y: ny,
+        width: APP_WIDTH,
+        height: APP_HEIGHT,
+      });
+      const presetPos = presetPositionForDisplay(windowDisplay, currentSetting);
       if (Math.abs(nx - presetPos.x) < 10 && Math.abs(ny - presetPos.y) < 10)
         return;
     }

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -147,6 +147,11 @@ export default function AppPage(): React.JSX.Element {
   const appContextRef = useRef<string | null>(null);
   const pendingCommitRef = useRef(false);
   const pillActiveRef = useRef(false);
+  // Tracks the in-flight prepareSystemAudio() (ducking) call. Ducking runs
+  // concurrently with mic acquisition, so every restore must wait for this
+  // to settle — otherwise a restore that lands before the duck applies is a
+  // no-op and leaves the system volume stuck low.
+  const duckingPromiseRef = useRef<Promise<unknown> | undefined>(undefined);
   const barModeRef = useRef<BarMode | null>(null);
   const scanIndexRef = useRef(0);
   const scanTickRef = useRef(0);
@@ -596,6 +601,15 @@ export default function AppPage(): React.JSX.Element {
     isTranscriptionIdle,
   ]);
 
+  // Restore the system volume, but only after any in-flight duck has settled
+  // so the restore can't be a no-op that leaves the volume stuck low.
+  const restoreSystemAudioSafely = useCallback(async (): Promise<void> => {
+    try {
+      await duckingPromiseRef.current;
+      await window.api?.restoreSystemAudio();
+    } catch {}
+  }, []);
+
   // ---- Start recording ----
   const startRecording = useCallback(
     async (forReRecord = false) => {
@@ -630,17 +644,22 @@ export default function AppPage(): React.JSX.Element {
       setPillState("initializing");
       startBarAnimation("connecting");
 
-      try {
-        if (_audioPlaybackMode !== "off") {
-          await window.api
-            ?.prepareSystemAudio(_audioPlaybackMode)
-            .catch(() => {});
-        }
-        if (!wantsMicRef.current) {
-          window.api?.restoreSystemAudio().catch(() => {});
-          return;
-        }
+      // Play the start cue immediately, before ducking lowers the system
+      // volume — otherwise the tone is attenuated to DUCKED_VOLUME and is
+      // effectively inaudible.
+      playTone("start");
 
+      // Duck/pause system audio concurrently with mic acquisition. The pause
+      // path can spawn a slow media-control subprocess; awaiting it before
+      // getUserMedia is what made the "initializing" state drag on. Restores
+      // go through restoreSystemAudioSafely(), which waits on this promise so a
+      // cancel can't race the duck.
+      duckingPromiseRef.current =
+        _audioPlaybackMode !== "off"
+          ? window.api?.prepareSystemAudio(_audioPlaybackMode).catch(() => {})
+          : undefined;
+
+      try {
         recordingSessionUsesTransportRef.current =
           supportsSessionTransportRef.current;
 
@@ -649,7 +668,7 @@ export default function AppPage(): React.JSX.Element {
         if (!wantsMicRef.current) {
           recorderRef.current.cancel();
           recorderRef.current.releaseStream();
-          window.api?.restoreSystemAudio().catch(() => {});
+          void restoreSystemAudioSafely();
           if (forReRecord) {
             resumeTranscribingOrHide();
           }
@@ -660,7 +679,7 @@ export default function AppPage(): React.JSX.Element {
           wantsMicRef.current = false;
           recorderRef.current.cancel();
           recorderRef.current.releaseStream();
-          window.api?.restoreSystemAudio().catch(() => {});
+          void restoreSystemAudioSafely();
           streamerRef.current?.cancel();
           if (forReRecord) {
             resumeTranscribingOrHide();
@@ -670,7 +689,6 @@ export default function AppPage(): React.JSX.Element {
           return;
         }
 
-        playTone("start");
         setPillState("recording");
         recordingActiveRef.current = true;
         startTimeRef.current = Date.now();
@@ -686,7 +704,7 @@ export default function AppPage(): React.JSX.Element {
       } catch (err) {
         pendingCommitRef.current = false;
         recorderRef.current.releaseStream();
-        window.api?.restoreSystemAudio().catch(() => {});
+        void restoreSystemAudioSafely();
         hidePill();
         window.api.showErrorDialog(
           "Recording Failed",
@@ -701,6 +719,7 @@ export default function AppPage(): React.JSX.Element {
       getStreamer,
       setPillState,
       resumeTranscribingOrHide,
+      restoreSystemAudioSafely,
     ],
   );
 
@@ -708,7 +727,19 @@ export default function AppPage(): React.JSX.Element {
   const commitRecording = useCallback(async () => {
     wantsMicRef.current = false;
     recordingActiveRef.current = false;
-    playTone("stop");
+
+    // Restore the system volume first, then play the stop cue so it isn't
+    // muted by ducking. Fire-and-forget so the transcription pipeline below
+    // isn't blocked on the restore. This runs on every commit path, so the
+    // branches below don't restore again. Gate on whether this session ducked
+    // (not the current mode setting, which can change mid-recording) so a
+    // toggle to "off" while recording can't strand the volume low.
+    void (async () => {
+      if (duckingPromiseRef.current) {
+        await restoreSystemAudioSafely();
+      }
+      playTone("stop");
+    })();
 
     clearInterval(timerRef.current);
     timerRef.current = 0;
@@ -727,7 +758,6 @@ export default function AppPage(): React.JSX.Element {
     if (recordingDuration < 500) {
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
-      window.api?.restoreSystemAudio().catch(() => {});
       streamerRef.current?.cancel();
       window.api?.sendRecordingCancelled();
       resumeTranscribingOrHide();
@@ -741,7 +771,6 @@ export default function AppPage(): React.JSX.Element {
     if (recordingSessionUsesTransportRef.current && streamerRef.current) {
       recorderRef.current.cancel();
       recorderRef.current.releaseStream();
-      window.api?.restoreSystemAudio().catch(() => {});
 
       setPendingCount((c) => c + 1);
       const transcribePromise = new Promise<TranscribeResult>((resolve) => {
@@ -781,7 +810,6 @@ export default function AppPage(): React.JSX.Element {
       wavBlob = streamerRef.current?.getWavBlob() ?? null;
     }
     recorderRef.current.releaseStream();
-    window.api?.restoreSystemAudio().catch(() => {});
 
     if (!pillActiveRef.current) {
       return;
@@ -877,6 +905,7 @@ export default function AppPage(): React.JSX.Element {
     setPillState,
     resumeTranscribingOrHide,
     isTranscriptionIdle,
+    restoreSystemAudioSafely,
   ]);
 
   // ---- Cancel ----
@@ -889,10 +918,10 @@ export default function AppPage(): React.JSX.Element {
     streamerRef.current?.cancel();
     recorderRef.current.cancel();
     recorderRef.current.releaseStream();
-    window.api?.restoreSystemAudio().catch(() => {});
+    void restoreSystemAudioSafely();
     window.api?.sendRecordingCancelled();
     hidePill();
-  }, [hidePill]);
+  }, [hidePill, restoreSystemAudioSafely]);
 
   // ---- Preferences ----
   const applyPillPosition = useCallback((pos: string | null | undefined) => {


### PR DESCRIPTION
## Summary

Fixes three issues with the voice pill, all reported together. With audio **duck/pause** mode enabled, two of them share a root cause: ducking was awaited *before* recording started and the cue tones played while the volume was ducked.

### 1. Cue tones inaudible
The start cue played *after* `prepareSystemAudio` dropped the system volume to `DUCKED_VOLUME` (0.15), and the stop cue played *before* the volume was restored — so both were heavily attenuated.

- Play the **start** cue immediately on hotkey press, before ducking.
- Play the **stop** cue **after** restoring the volume.

### 2. Init delay on every press (even on cloud providers)
The "initializing" state awaited `prepareSystemAudio()` (the pause path spawns a slow media-control subprocess) *before* acquiring the mic, so every press paid that cost regardless of STT provider.

- Run ducking **concurrently** with mic acquisition instead of awaiting it first.
- All restores now go through a single duck-aware helper that waits for the in-flight duck to settle, so a fast cancel/commit can't restore before the duck applies and leave the system volume stuck low.

### 3. Multi-monitor positioning
- **Stuck on one screen:** the drag-detection in the `move` listener compared the settled window position against `getAppWindowPosition()` recomputed with the **cursor's** display. A trailing settle event (after the cursor had moved to another monitor) looked like a manual drag and latched `pillPosition` to `"custom"`, freezing the pill. It now compares against the preset slot of the **display the window is actually on**.
- **No bottom padding on vertical/dockless monitors:** the bottom offset unconditionally pushed the pill past the work-area edge (which only looks right where a dock reserves space). It's now dock-aware — overlap only when a dock/taskbar exists, otherwise leave a gap so the pill doesn't clip the physical edge.

## Testing
- `typecheck:node` + `typecheck:web` clean
- `electron-vite build` succeeds
- Biome clean
- No unit tests cover these paths (electron uses Playwright e2e only); the multi-monitor/vertical-clip behavior needs hardware verification.