### PR TITLE
feat: improve onboarding local model download UX

### DIFF
--- a/apps/electron/src/renderer/src/components/model-setup-panel.tsx
+++ b/apps/electron/src/renderer/src/components/model-setup-panel.tsx
@@ -1,0 +1,160 @@
+import type { VoiceItem } from "@renderer/lib/models";
+import { formatBytes, formatSpeed } from "@renderer/lib/models";
+import { cn, ON_DEVICE_PHRASE } from "@renderer/lib/utils";
+import { Download, HardDrive, Loader2, RefreshCw } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "./ui/button";
+import { Progress } from "./ui/progress";
+
+type ModelSetupPanelProps = {
+  model: VoiceItem | undefined;
+  onDownload: () => void;
+  onRetry: () => void;
+  /** When true, offline setup is encouraged but not required to continue. */
+  optional?: boolean;
+};
+
+export function ModelSetupPanel({
+  model,
+  onDownload,
+  onRetry,
+  optional = false,
+}: ModelSetupPanelProps): React.JSX.Element | null {
+  const { t } = useTranslation();
+
+  if (!model || model.kind !== "local") return null;
+
+  const status = model.status ?? "not_downloaded";
+  if (status === "ready") return null;
+
+  const sizeLabel =
+    model.sizeBytes != null ? formatBytes(model.sizeBytes) : null;
+  const progress = model.state?.downloadProgress;
+  const hasProgress = !!progress;
+  const isActive =
+    status === "downloading" ||
+    status === "verifying" ||
+    model.state?.phase === "building_binary";
+  const isError = status === "error";
+  const isIdle = status === "not_downloaded" && !isActive;
+
+  return (
+    <div
+      className={cn(
+        "bg-card border-border mt-6 w-full rounded-[12px] border px-4 py-3.5",
+        isError && "border-destructive/40",
+      )}
+      role={isActive ? "status" : undefined}
+      aria-live={isActive ? "polite" : undefined}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className={cn(
+            "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px]",
+            isError ? "bg-destructive/10" : "bg-accent",
+          )}
+        >
+          {isActive ? (
+            <Loader2 className="text-primary h-4 w-4 animate-spin" />
+          ) : isError ? (
+            <HardDrive className="text-destructive h-4 w-4" />
+          ) : (
+            <HardDrive className="text-primary h-4 w-4" />
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <p className="text-foreground text-[13.5px] leading-snug font-medium">
+            {isError
+              ? t("onboarding.modelSetup.errorTitle")
+              : isActive
+                ? model.state?.phase === "building_binary"
+                  ? t("onboarding.modelSetup.buildingEngine")
+                  : t("onboarding.modelSetup.downloading", {
+                      name: model.name,
+                    })
+                : optional
+                  ? t("onboarding.modelSetup.optionalTitle")
+                  : t("onboarding.modelSetup.title")}
+          </p>
+
+          <p className="text-muted-foreground mt-1 text-[12px] leading-snug">
+            {isError
+              ? (model.state?.error ?? t("onboarding.modelSetup.errorFallback"))
+              : isActive
+                ? model.state?.phase === "building_binary"
+                  ? t("onboarding.modelSetup.buildingEngineDesc")
+                  : t("onboarding.modelSetup.downloadingDesc", {
+                      phrase: ON_DEVICE_PHRASE,
+                    })
+                : t("onboarding.modelSetup.idleDesc", {
+                    name: model.name,
+                    size: sizeLabel ? ` (${sizeLabel})` : "",
+                    phrase: ON_DEVICE_PHRASE,
+                  })}
+          </p>
+
+          {isActive && (
+            <div className="mt-3 space-y-1.5">
+              <Progress
+                value={hasProgress ? (progress?.percent ?? 0) : undefined}
+                className={cn("h-[6px]", !hasProgress && "animate-pulse")}
+              />
+              <div className="text-muted-foreground mono flex justify-between text-[10px]">
+                {model.state?.phase === "building_binary" && !hasProgress ? (
+                  <span>{t("onboarding.modelSetup.buildingEngine")}</span>
+                ) : hasProgress ? (
+                  <>
+                    <span>
+                      {formatBytes(progress!.bytesDownloaded)} /{" "}
+                      {formatBytes(progress!.bytesTotal)}
+                    </span>
+                    <span>
+                      {progress!.speedBps > 0 &&
+                        formatSpeed(progress!.speedBps)}
+                      {progress!.percent > 0 && ` · ${progress!.percent}%`}
+                    </span>
+                  </>
+                ) : (
+                  <span>{t("onboarding.modelSetup.preparing")}</span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {isIdle && (
+            <Button
+              variant="default"
+              size="sm"
+              className="mt-3"
+              onClick={onDownload}
+            >
+              <Download data-icon="inline-start" />
+              {sizeLabel
+                ? t("onboarding.modelSetup.downloadButton", { size: sizeLabel })
+                : t("onboarding.modelSetup.downloadButtonShort")}
+            </Button>
+          )}
+
+          {isError && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-3"
+              onClick={onRetry}
+            >
+              <RefreshCw data-icon="inline-start" />
+              {t("onboarding.modelSetup.retry")}
+            </Button>
+          )}
+
+          {optional && isIdle && (
+            <p className="text-muted-foreground mono mt-2 text-[10px] tracking-wide uppercase">
+              {t("onboarding.modelSetup.optionalHint")}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/electron/src/renderer/src/components/model-setup-panel.tsx
+++ b/apps/electron/src/renderer/src/components/model-setup-panel.tsx
@@ -10,15 +10,12 @@ type ModelSetupPanelProps = {
   model: VoiceItem | undefined;
   onDownload: () => void;
   onRetry: () => void;
-  /** When true, offline setup is encouraged but not required to continue. */
-  optional?: boolean;
 };
 
 export function ModelSetupPanel({
   model,
   onDownload,
   onRetry,
-  optional = false,
 }: ModelSetupPanelProps): React.JSX.Element | null {
   const { t } = useTranslation();
 
@@ -41,7 +38,7 @@ export function ModelSetupPanel({
   return (
     <div
       className={cn(
-        "bg-card border-border mt-6 w-full rounded-[12px] border px-4 py-3.5",
+        "bg-card border-border mt-6 w-full rounded-[14px] border px-4 py-3.5",
         isError && "border-destructive/40",
       )}
       role={isActive ? "status" : undefined}
@@ -73,9 +70,7 @@ export function ModelSetupPanel({
                   : t("onboarding.modelSetup.downloading", {
                       name: model.name,
                     })
-                : optional
-                  ? t("onboarding.modelSetup.optionalTitle")
-                  : t("onboarding.modelSetup.title")}
+                : t("onboarding.modelSetup.title")}
           </p>
 
           <p className="text-muted-foreground mt-1 text-[12px] leading-snug">
@@ -146,12 +141,6 @@ export function ModelSetupPanel({
               <RefreshCw data-icon="inline-start" />
               {t("onboarding.modelSetup.retry")}
             </Button>
-          )}
-
-          {optional && isIdle && (
-            <p className="text-muted-foreground mono mt-2 text-[10px] tracking-wide uppercase">
-              {t("onboarding.modelSetup.optionalHint")}
-            </p>
           )}
         </div>
       </div>

--- a/apps/electron/src/renderer/src/components/model-setup-panel.tsx
+++ b/apps/electron/src/renderer/src/components/model-setup-panel.tsx
@@ -97,7 +97,7 @@ export function ModelSetupPanel({
           {isActive && (
             <div className="mt-3 space-y-1.5">
               <Progress
-                value={hasProgress ? (progress?.percent ?? 0) : undefined}
+                value={hasProgress ? (progress?.percent ?? 0) : 100}
                 className={cn("h-[6px]", !hasProgress && "animate-pulse")}
               />
               <div className="text-muted-foreground mono flex justify-between text-[10px]">

--- a/apps/electron/src/renderer/src/locales/en.json
+++ b/apps/electron/src/renderer/src/locales/en.json
@@ -54,8 +54,25 @@
       "titleEmphasis": "speak?",
       "autoDetect": "Auto-detect"
     },
+    "modelSetup": {
+      "title": "Download your private voice model",
+      "optionalTitle": "Set up offline dictation",
+      "idleDesc": "{{name}} runs on {{phrase}} and needs a one-time download{{size}}.",
+      "downloading": "Downloading {{name}}…",
+      "downloadingDesc": "This stays on {{phrase}} — nothing is sent to the cloud.",
+      "buildingEngine": "Preparing transcription engine…",
+      "buildingEngineDesc": "Building the local speech engine. This only happens once.",
+      "preparing": "Starting download…",
+      "downloadButton": "Download ({{size}})",
+      "downloadButtonShort": "Download model",
+      "retry": "Try again",
+      "errorTitle": "Couldn't finish setup",
+      "errorFallback": "Something went wrong while downloading the model.",
+      "optionalHint": "Optional — skip if you're using cloud only",
+      "waitingToFinish": "Download your voice model to continue",
+      "waitingWhileDownloading": "Finish once the download completes"
+    },
     "tutorial": {
-      "almostReady": "Almost ready — ",
       "finish": "Start using Freestyle",
       "chooseModel": "Choose a different model",
       "usingModel": "Using {{name}} · Choose a different model"

--- a/apps/electron/src/renderer/src/locales/en.json
+++ b/apps/electron/src/renderer/src/locales/en.json
@@ -56,7 +56,6 @@
     },
     "modelSetup": {
       "title": "Download your private voice model",
-      "optionalTitle": "Set up offline dictation",
       "idleDesc": "{{name}} runs on {{phrase}} and needs a one-time download{{size}}.",
       "downloading": "Downloading {{name}}…",
       "downloadingDesc": "This stays on {{phrase}} — nothing is sent to the cloud.",
@@ -68,7 +67,6 @@
       "retry": "Try again",
       "errorTitle": "Couldn't finish setup",
       "errorFallback": "Something went wrong while downloading the model.",
-      "optionalHint": "Optional — skip if you're using cloud only",
       "waitingToFinish": "Download your voice model to continue",
       "waitingWhileDownloading": "Finish once the download completes"
     },

--- a/apps/electron/src/renderer/src/locales/template.json
+++ b/apps/electron/src/renderer/src/locales/template.json
@@ -57,7 +57,6 @@
     },
     "modelSetup": {
       "title": "Download your private voice model",
-      "optionalTitle": "Set up offline dictation",
       "idleDesc": "{{name}} runs on {{phrase}} and needs a one-time download{{size}}.",
       "downloading": "Downloading {{name}}…",
       "downloadingDesc": "This stays on {{phrase}} — nothing is sent to the cloud.",
@@ -69,7 +68,6 @@
       "retry": "Try again",
       "errorTitle": "Couldn't finish setup",
       "errorFallback": "Something went wrong while downloading the model.",
-      "optionalHint": "Optional — skip if you're using cloud only",
       "waitingToFinish": "Download your voice model to continue",
       "waitingWhileDownloading": "Finish once the download completes"
     },

--- a/apps/electron/src/renderer/src/locales/template.json
+++ b/apps/electron/src/renderer/src/locales/template.json
@@ -55,8 +55,25 @@
       "titleEmphasis": "speak?",
       "autoDetect": "Auto-detect"
     },
+    "modelSetup": {
+      "title": "Download your private voice model",
+      "optionalTitle": "Set up offline dictation",
+      "idleDesc": "{{name}} runs on {{phrase}} and needs a one-time download{{size}}.",
+      "downloading": "Downloading {{name}}…",
+      "downloadingDesc": "This stays on {{phrase}} — nothing is sent to the cloud.",
+      "buildingEngine": "Preparing transcription engine…",
+      "buildingEngineDesc": "Building the local speech engine. This only happens once.",
+      "preparing": "Starting download…",
+      "downloadButton": "Download ({{size}})",
+      "downloadButtonShort": "Download model",
+      "retry": "Try again",
+      "errorTitle": "Couldn't finish setup",
+      "errorFallback": "Something went wrong while downloading the model.",
+      "optionalHint": "Optional — skip if you're using cloud only",
+      "waitingToFinish": "Download your voice model to continue",
+      "waitingWhileDownloading": "Finish once the download completes"
+    },
     "tutorial": {
-      "almostReady": "Almost ready — ",
       "finish": "Start using Freestyle",
       "chooseModel": "Choose a different model",
       "usingModel": "Using {{name}} · Choose a different model"

--- a/apps/electron/src/renderer/src/onboarding.tsx
+++ b/apps/electron/src/renderer/src/onboarding.tsx
@@ -721,7 +721,7 @@ export default function OnboardingPage(): React.JSX.Element {
   }, [localSetupModel, downloadLocalModel]);
 
   const retryLocalDownload = useCallback(() => {
-    if (!localSetupModel?.defId) return;
+    if (!localSetupModel?.defId || window.api?.isE2E) return;
     capture("onboarding_model_download_started", {
       model_id: localSetupModel.modelId,
       retry: true,

--- a/apps/electron/src/renderer/src/onboarding.tsx
+++ b/apps/electron/src/renderer/src/onboarding.tsx
@@ -3,6 +3,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import markDark from "@renderer/assets/mark-dark.svg";
 import markLight from "@renderer/assets/mark-light.svg";
 import { KeyComboDisplay } from "@renderer/components/key-combo";
+import { ModelSetupPanel } from "@renderer/components/model-setup-panel";
 import { TutorialDemo } from "@renderer/components/tutorial-demo";
 import { Button } from "@renderer/components/ui/button";
 import {
@@ -33,7 +34,6 @@ import {
   buildVoiceItems,
   FREESTYLE_CLOUD_MODEL_ID,
   FREESTYLE_CLOUD_PROVIDER_ID,
-  formatBytes,
   type MlxAsrStatus,
   PROVIDER_DISPLAY_NAMES,
   PROVIDER_KEY_URLS,
@@ -529,10 +529,10 @@ export default function OnboardingPage(): React.JSX.Element {
     mlxQwen && mlxStatus?.canRun ? mlxQwen : (whisperBase ?? mlxQwen);
 
   // Auto-setup: once the MLX capability check and cloud session both settle,
-  // commit a default and start downloads in the background — the user never
-  // has to choose a model. Signed in → Freestyle Cloud is the default; the
-  // on-device model is still set up underneath as an offline/signed-out
-  // fallback. Signed out → the on-device model is the default.
+  // commit a default local model. Signed in → Freestyle Cloud is the default;
+  // the on-device model is still offered as an offline fallback. Signed out →
+  // the on-device model is the default. Download starts when the user taps
+  // Download on the setup panel.
   useEffect(() => {
     if (
       autoPicked.current ||
@@ -549,18 +549,11 @@ export default function OnboardingPage(): React.JSX.Element {
       "auto",
       !cloudUser,
     );
-    if (recommended.status === "not_downloaded" && !window.api?.isE2E) {
-      capture("onboarding_model_auto_setup", {
-        model_id: recommended.modelId,
-      });
-      downloadLocalModel(recommended.defId, recommended.localEngine);
-    }
     if (cloudUser) commitFreestyleCloudDefault();
   }, [
     recommended,
     selectLocalModel,
     mlxResolved,
-    downloadLocalModel,
     cloudLoading,
     cloudUser,
     commitFreestyleCloudDefault,
@@ -677,32 +670,27 @@ export default function OnboardingPage(): React.JSX.Element {
     !!chosen &&
     (chosen.kind === "cloud" ? !!chosen.hasKey : chosen.status === "ready");
 
-  // One quiet line describing the background setup, shown while it runs.
-  // The user never chooses the model, but they should see what's being
-  // installed on their machine — name and size, not a mystery download.
-  const setupStatus = ((): string | null => {
-    if (!chosen || chosen.kind !== "local" || chosenReady) return null;
-    if (chosen.state?.phase === "building_binary") {
-      return "Preparing your transcription engine…";
-    }
-    const size =
-      chosen.sizeBytes != null ? ` (${formatBytes(chosen.sizeBytes)})` : "";
-    if (
-      chosen.status === "downloading" ||
-      chosen.status === "verifying" ||
-      chosen.status === "not_downloaded"
-    ) {
-      const p = chosen.state?.downloadProgress;
-      const pct = p?.bytesTotal ? ` ${p.percent}%` : "";
-      return `Downloading ${chosen.name}${size}, your private transcription model…${pct}`;
-    }
-    return null;
-  })();
+  const localSetupModel = chosen?.kind === "local" ? chosen : recommended;
+  const localSetupOptional = !!cloudUser && chosen?.kind === "cloud";
+  const mustHaveLocalReady = chosen?.kind === "local" && !chosenReady;
+  const localSetupActive =
+    localSetupModel?.kind === "local" &&
+    (localSetupModel.status === "downloading" ||
+      localSetupModel.status === "verifying" ||
+      localSetupModel.state?.phase === "building_binary");
 
-  const setupError =
-    chosen?.kind === "local" && chosen.status === "error"
-      ? (chosen.state?.error ?? "Model download failed")
-      : null;
+  const startLocalDownload = useCallback(() => {
+    if (!localSetupModel?.defId || window.api?.isE2E) return;
+    capture("onboarding_model_download_started", {
+      model_id: localSetupModel.modelId,
+    });
+    downloadLocalModel(localSetupModel.defId, localSetupModel.localEngine);
+  }, [localSetupModel, downloadLocalModel]);
+
+  const retryLocalDownload = useCallback(() => {
+    if (!localSetupModel?.defId) return;
+    downloadLocalModel(localSetupModel.defId, localSetupModel.localEngine);
+  }, [localSetupModel, downloadLocalModel]);
 
   return (
     <div className="bg-background flex h-screen flex-col">
@@ -769,8 +757,10 @@ export default function OnboardingPage(): React.JSX.Element {
           <LanguageStep
             language={language}
             onSelect={saveLanguage}
-            setupStatus={setupStatus}
-            setupError={setupError}
+            localModel={localSetupModel}
+            localSetupOptional={localSetupOptional}
+            onDownloadLocal={startLocalDownload}
+            onRetryLocal={retryLocalDownload}
             onBack={() => {
               capture("onboarding_language_back_clicked");
               setStep("permissions");
@@ -792,8 +782,18 @@ export default function OnboardingPage(): React.JSX.Element {
             captureHint={captureHint}
             modelReady={chosenReady}
             modelName={chosen?.name}
-            setupStatus={setupStatus}
-            setupError={setupError}
+            localModel={localSetupModel}
+            localSetupOptional={localSetupOptional}
+            onDownloadLocal={startLocalDownload}
+            onRetryLocal={retryLocalDownload}
+            canFinish={!mustHaveLocalReady}
+            finishBlockedReason={
+              mustHaveLocalReady
+                ? localSetupActive
+                  ? "downloading"
+                  : "notReady"
+                : null
+            }
             onOpenSelector={() => {
               capture("onboarding_model_selector_opened");
               setShowSelector(true);
@@ -1206,15 +1206,19 @@ function CloudTermsFooter(): React.JSX.Element {
 function LanguageStep({
   language,
   onSelect,
-  setupStatus,
-  setupError,
+  localModel,
+  localSetupOptional,
+  onDownloadLocal,
+  onRetryLocal,
   onBack,
   onContinue,
 }: {
   language: string;
   onSelect: (id: string) => void;
-  setupStatus: string | null;
-  setupError: string | null;
+  localModel: VoiceItem | undefined;
+  localSetupOptional: boolean;
+  onDownloadLocal: () => void;
+  onRetryLocal: () => void;
   onBack: () => void;
   onContinue: () => void;
 }): React.JSX.Element {
@@ -1249,17 +1253,13 @@ function LanguageStep({
           {t("onboarding.language.autoDetect")}
         </Button>
       </div>
-      {/* Background model setup — quiet status, never a decision. */}
-      {setupStatus && (
-        <p className="mono text-muted-foreground mt-6 text-center text-[11px]">
-          {setupStatus}
-        </p>
-      )}
-      {setupError && (
-        <p className="text-destructive mt-6 text-center text-[12px] leading-snug">
-          {setupError}
-        </p>
-      )}
+
+      <ModelSetupPanel
+        model={localModel}
+        optional={localSetupOptional}
+        onDownload={onDownloadLocal}
+        onRetry={onRetryLocal}
+      />
 
       <div className="mt-7 flex items-center justify-between">
         <Button variant="outline" onClick={onBack}>
@@ -1591,8 +1591,12 @@ function TutorialStep({
   captureHint,
   modelReady,
   modelName,
-  setupStatus,
-  setupError,
+  localModel,
+  localSetupOptional,
+  onDownloadLocal,
+  onRetryLocal,
+  canFinish,
+  finishBlockedReason,
   onOpenSelector,
   onStartRecording,
   onCancelRecording,
@@ -1606,8 +1610,12 @@ function TutorialStep({
   captureHint: string;
   modelReady: boolean;
   modelName?: string;
-  setupStatus: string | null;
-  setupError: string | null;
+  localModel: VoiceItem | undefined;
+  localSetupOptional: boolean;
+  onDownloadLocal: () => void;
+  onRetryLocal: () => void;
+  canFinish: boolean;
+  finishBlockedReason: "downloading" | "notReady" | null;
   onOpenSelector: () => void;
   onStartRecording: () => void;
   onCancelRecording: () => void;
@@ -1624,18 +1632,12 @@ function TutorialStep({
         onDictation={onDictation}
       />
 
-      {/* Background setup catching up — practice unlocks when it lands. */}
-      {!modelReady && setupStatus && (
-        <p className="mono text-muted-foreground mt-3 text-center text-[11px]">
-          {t("onboarding.tutorial.almostReady")}
-          {setupStatus.charAt(0).toLowerCase() + setupStatus.slice(1)}
-        </p>
-      )}
-      {!modelReady && setupError && (
-        <p className="text-destructive mt-3 text-center text-[12px]">
-          {setupError}
-        </p>
-      )}
+      <ModelSetupPanel
+        model={localModel}
+        optional={localSetupOptional}
+        onDownload={onDownloadLocal}
+        onRetry={onRetryLocal}
+      />
 
       {/* The model is visible and changeable here — where it can be tested. */}
       <div className="mt-3 flex justify-center">
@@ -1689,10 +1691,19 @@ function TutorialStep({
         <Button variant="outline" onClick={onBack}>
           {t("common.back")}
         </Button>
-        <Button variant="default" onClick={onFinish}>
-          {t("onboarding.tutorial.finish")}
-          <ArrowRight data-icon="inline-end" />
-        </Button>
+        <div className="flex flex-col items-end gap-1.5">
+          {!canFinish && finishBlockedReason && (
+            <p className="text-muted-foreground text-[11px]">
+              {finishBlockedReason === "downloading"
+                ? t("onboarding.modelSetup.waitingWhileDownloading")
+                : t("onboarding.modelSetup.waitingToFinish")}
+            </p>
+          )}
+          <Button variant="default" onClick={onFinish} disabled={!canFinish}>
+            {t("onboarding.tutorial.finish")}
+            <ArrowRight data-icon="inline-end" />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/electron/src/renderer/src/onboarding.tsx
+++ b/apps/electron/src/renderer/src/onboarding.tsx
@@ -132,6 +132,12 @@ export default function OnboardingPage(): React.JSX.Element {
   const [language, setLanguage] = useState<string>(defaultLanguage);
   const autoPicked = useRef(false);
   const warmed = useRef(false);
+  // Tracks the most recent explicit local pick so cloud users who briefly
+  // selected a different on-device model still download the right one.
+  const lastLocalSetupRef = useRef<{
+    defId: string;
+    engine: "whisper" | "mlx";
+  } | null>(null);
   // True once we know whether MLX can run on this machine — so the auto-pick
   // waits for the Qwen-vs-Whisper decision instead of settling on Whisper
   // Base while the MLX status request is still in flight.
@@ -439,9 +445,12 @@ export default function OnboardingPage(): React.JSX.Element {
         if (engine === "mlx") {
           setSelectedMlxDefId(defId);
           setSelectedWhisperDefId(null);
-        } else {
+        } else if (engine === "whisper") {
           setSelectedWhisperDefId(defId);
           setSelectedMlxDefId(null);
+        }
+        if (engine) {
+          lastLocalSetupRef.current = { defId, engine };
         }
         setSelectedModel(null);
       }
@@ -529,19 +538,24 @@ export default function OnboardingPage(): React.JSX.Element {
     mlxQwen && mlxStatus?.canRun ? mlxQwen : (whisperBase ?? mlxQwen);
 
   // Auto-setup: once the MLX capability check and cloud session both settle,
-  // commit a default local model. Signed in → Freestyle Cloud is the default;
-  // the on-device model is still offered as an offline fallback. Signed out →
-  // the on-device model is the default. Download starts when the user taps
-  // Download on the setup panel.
+  // commit a default local model. Signed in → Freestyle Cloud is the default
+  // and the on-device fallback downloads silently in the background. Signed
+  // out → the on-device model is the default; download starts from the
+  // setup panel when the user taps Download.
   useEffect(() => {
     if (
       autoPicked.current ||
       cloudLoading ||
       !mlxResolved ||
-      !recommended?.defId
+      !recommended?.defId ||
+      !recommended.localEngine
     )
       return;
     autoPicked.current = true;
+    lastLocalSetupRef.current = {
+      defId: recommended.defId,
+      engine: recommended.localEngine,
+    };
     selectLocalModel(
       recommended.defId,
       recommended.name,
@@ -549,11 +563,20 @@ export default function OnboardingPage(): React.JSX.Element {
       "auto",
       !cloudUser,
     );
-    if (cloudUser) commitFreestyleCloudDefault();
+    if (cloudUser) {
+      commitFreestyleCloudDefault();
+      if (recommended.status === "not_downloaded" && !window.api?.isE2E) {
+        capture("onboarding_model_auto_setup", {
+          model_id: recommended.modelId,
+        });
+        downloadLocalModel(recommended.defId, recommended.localEngine);
+      }
+    }
   }, [
     recommended,
     selectLocalModel,
     mlxResolved,
+    downloadLocalModel,
     cloudLoading,
     cloudUser,
     commitFreestyleCloudDefault,
@@ -670,8 +693,18 @@ export default function OnboardingPage(): React.JSX.Element {
     !!chosen &&
     (chosen.kind === "cloud" ? !!chosen.hasKey : chosen.status === "ready");
 
-  const localSetupModel = chosen?.kind === "local" ? chosen : recommended;
-  const localSetupOptional = !!cloudUser && chosen?.kind === "cloud";
+  const localSetupModel = ((): VoiceItem | undefined => {
+    if (chosen?.kind === "local") return chosen;
+    if (lastLocalSetupRef.current) {
+      const { defId, engine } = lastLocalSetupRef.current;
+      return allVoiceItems.find(
+        (v) =>
+          v.kind === "local" && v.defId === defId && v.localEngine === engine,
+      );
+    }
+    return recommended;
+  })();
+  const showLocalSetupPanel = !cloudUser;
   const mustHaveLocalReady = chosen?.kind === "local" && !chosenReady;
   const localSetupActive =
     localSetupModel?.kind === "local" &&
@@ -689,6 +722,10 @@ export default function OnboardingPage(): React.JSX.Element {
 
   const retryLocalDownload = useCallback(() => {
     if (!localSetupModel?.defId) return;
+    capture("onboarding_model_download_started", {
+      model_id: localSetupModel.modelId,
+      retry: true,
+    });
     downloadLocalModel(localSetupModel.defId, localSetupModel.localEngine);
   }, [localSetupModel, downloadLocalModel]);
 
@@ -757,8 +794,7 @@ export default function OnboardingPage(): React.JSX.Element {
           <LanguageStep
             language={language}
             onSelect={saveLanguage}
-            localModel={localSetupModel}
-            localSetupOptional={localSetupOptional}
+            localModel={showLocalSetupPanel ? localSetupModel : undefined}
             onDownloadLocal={startLocalDownload}
             onRetryLocal={retryLocalDownload}
             onBack={() => {
@@ -782,8 +818,7 @@ export default function OnboardingPage(): React.JSX.Element {
             captureHint={captureHint}
             modelReady={chosenReady}
             modelName={chosen?.name}
-            localModel={localSetupModel}
-            localSetupOptional={localSetupOptional}
+            localModel={showLocalSetupPanel ? localSetupModel : undefined}
             onDownloadLocal={startLocalDownload}
             onRetryLocal={retryLocalDownload}
             canFinish={!mustHaveLocalReady}
@@ -1207,7 +1242,6 @@ function LanguageStep({
   language,
   onSelect,
   localModel,
-  localSetupOptional,
   onDownloadLocal,
   onRetryLocal,
   onBack,
@@ -1216,7 +1250,6 @@ function LanguageStep({
   language: string;
   onSelect: (id: string) => void;
   localModel: VoiceItem | undefined;
-  localSetupOptional: boolean;
   onDownloadLocal: () => void;
   onRetryLocal: () => void;
   onBack: () => void;
@@ -1256,7 +1289,6 @@ function LanguageStep({
 
       <ModelSetupPanel
         model={localModel}
-        optional={localSetupOptional}
         onDownload={onDownloadLocal}
         onRetry={onRetryLocal}
       />
@@ -1592,7 +1624,6 @@ function TutorialStep({
   modelReady,
   modelName,
   localModel,
-  localSetupOptional,
   onDownloadLocal,
   onRetryLocal,
   canFinish,
@@ -1611,7 +1642,6 @@ function TutorialStep({
   modelReady: boolean;
   modelName?: string;
   localModel: VoiceItem | undefined;
-  localSetupOptional: boolean;
   onDownloadLocal: () => void;
   onRetryLocal: () => void;
   canFinish: boolean;
@@ -1634,7 +1664,6 @@ function TutorialStep({
 
       <ModelSetupPanel
         model={localModel}
-        optional={localSetupOptional}
         onDownload={onDownloadLocal}
         onRetry={onRetryLocal}
       />


### PR DESCRIPTION
## Problem

First-time local users could reach the onboarding tutorial, or finish onboarding, before the on-device voice model finished downloading — or without knowing a download was needed at all. Silent setup surfaced only as a tiny status line, and failures like **\"Whisper model not downloaded\"** could appear as a native error dialog with no in-app recovery path.

<img width="800" height="710" alt="Screenshot 2026-06-30 at 5 57 57 PM" src="https://github.com/user-attachments/assets/8e45c5a9-de9f-412c-be39-f6e93e4716f7" />

<img width="800" height="718" alt="Screenshot 2026-06-30 at 5 58 04 PM" src="https://github.com/user-attachments/assets/681d53f7-8fc8-4269-a8b2-04699a7cee1d" />

## Changes

### Local model setup panel
- Adds a `ModelSetupPanel` card on the **language** and **tutorial** onboarding steps for local-only users.
- **Idle:** explains the one-time local model download with a **Download (size)** button.
- **Downloading / building engine:** shows progress with bytes, speed, percent, and an indeterminate pulse state matching `voice-row.tsx`.
- **Error:** shows a human-readable error and **Try again** recovery path.
- Uses `aria-live="polite"` while setup is active.

### Onboarding flow
- Local-only users now start the model download explicitly from the setup panel.
- Tutorial **Finish** is disabled for local users until the selected local model is `ready`.
- Cloud users keep the previous frictionless behavior: Freestyle Cloud stays the default, the offline fallback downloads silently in the background, and the setup panel is hidden.
- Tracks the last explicit local model pick so fallback downloads target the model the user chose, even if they later switch back to cloud.
- Adds retry analytics with `onboarding_model_download_started` and `{ retry: true }`.

### i18n
- Adds `onboarding.modelSetup.*` keys in `en.json` and `template.json`.
- Removes unused `onboarding.tutorial.almostReady` from `en.json`.

## Testing

- [x] `pnpm --filter @freestyle-voice/electron typecheck:web`
- [x] `pnpm biome check apps/electron/src/renderer/src/onboarding.tsx apps/electron/src/renderer/src/components/model-setup-panel.tsx apps/electron/src/renderer/src/locales/en.json apps/electron/src/renderer/src/locales/template.json`
- [ ] `pnpm dev` → tray → **Reset Onboarding**
- [ ] Delete `~/.cache/freestyle/whisper-models/ggml-small-q5_1.bin` to simulate first run
- [ ] Local path: Language step shows the download card with **Download** button
- [ ] Local path: Tap Download → progress bar updates with bytes/percent
- [ ] Local path: Tutorial **Finish** stays disabled until download completes
- [ ] Cloud path: Sign in with Freestyle Cloud → no setup panel; offline fallback downloads silently
- [ ] Induce a download error → **Try again** works

## Follow-up

- Translate `onboarding.modelSetup.*` into non-English locale files.
- Remove stale `almostReady` keys from other locale files.