### PR TITLE
fix: prevent Globe/Fn hotkey during modifier chords

### DIFF
--- a/apps/electron/native/macos-key-listener.swift
+++ b/apps/electron/native/macos-key-listener.swift
@@ -330,7 +330,17 @@ guard let monitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, h
 
     if containsFn && !fnIsDown {
         fnIsDown = true
-        emit("FN_DOWN")
+        let otherMods = flags.intersection(modifierMask)
+        if otherMods.isEmpty {
+            emit("FN_DOWN")
+        } else {
+            var parts: [String] = []
+            if otherMods.contains(.control) { parts.append("control") }
+            if otherMods.contains(.option) { parts.append("option") }
+            if otherMods.contains(.shift) { parts.append("shift") }
+            if otherMods.contains(.command) { parts.append("command") }
+            emit("FN_DOWN:" + parts.joined(separator: ","))
+        }
     } else if !containsFn && fnIsDown {
         fnIsDown = false
         emit("FN_UP")

--- a/apps/electron/src/main/hotkey-recorder.ts
+++ b/apps/electron/src/main/hotkey-recorder.ts
@@ -210,8 +210,16 @@ export class HotkeyRecorder {
       return;
     }
 
-    if (line === "FN_DOWN") {
-      this.sendModifiers([...this.pendingModifiers, "Fn"]);
+    if (line === "FN_DOWN" || line.startsWith("FN_DOWN:")) {
+      const chordMods =
+        line === "FN_DOWN"
+          ? []
+          : line
+              .slice("FN_DOWN:".length)
+              .split(",")
+              .map((part) => MAC_FLAG_MODIFIERS[part.trim().toLowerCase()])
+              .filter((part): part is string => Boolean(part));
+      this.sendModifiers([...this.pendingModifiers, ...chordMods, "Fn"]);
       return;
     }
 

--- a/apps/electron/src/main/hotkey-recorder.ts
+++ b/apps/electron/src/main/hotkey-recorder.ts
@@ -217,6 +217,7 @@ export class HotkeyRecorder {
           : line
               .slice("FN_DOWN:".length)
               .split(",")
+              // Token set is defined by macos-key-listener.swift's FN_DOWN:mods emitter.
               .map((part) => MAC_FLAG_MODIFIERS[part.trim().toLowerCase()])
               .filter((part): part is string => Boolean(part));
       this.sendModifiers([...this.pendingModifiers, ...chordMods, "Fn"]);

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -264,11 +264,14 @@ export class NativeKeyListener {
 
     const hotkey = this.options.hotkey.toLowerCase();
 
-    // Fn/Globe key
-    if (line === "FN_DOWN") {
+    // Fn/Globe key — FN_DOWN is solo only; FN_DOWN:mods tracks Fn held with chords.
+    if (line === "FN_DOWN" || line.startsWith("FN_DOWN:")) {
       this.macFnDown = true;
+      const isSoloFn = line === "FN_DOWN";
       if (hotkey === "fn" || hotkey === "globe") {
-        this.options.onKeyDown();
+        if (isSoloFn) {
+          this.options.onKeyDown();
+        }
       } else {
         this.checkMacHotkeyMatch();
       }

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -33,6 +33,8 @@ const BINARY_NAMES: Record<string, string> = {
   linux: "linux-key-listener",
 };
 
+const MAC_SOLO_FN_CHORD_GRACE_MS = 50;
+
 /**
  * Convert an Electron accelerator to the format expected by the native binary.
  * The native binaries accept Electron-style accelerator format directly.
@@ -138,6 +140,7 @@ export class NativeKeyListener {
   private macFlagState = new Set<string>();
   private macFnDown = false;
   private macHotkeyActive = false;
+  private macSoloFnTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(options: KeyListenerOptions) {
     this.options = options;
@@ -270,7 +273,7 @@ export class NativeKeyListener {
       const isSoloFn = line === "FN_DOWN";
       if (hotkey === "fn" || hotkey === "globe") {
         if (isSoloFn) {
-          this.options.onKeyDown();
+          this.scheduleMacSoloFnDown();
         }
       } else {
         this.checkMacHotkeyMatch();
@@ -279,8 +282,12 @@ export class NativeKeyListener {
     }
     if (line === "FN_UP") {
       this.macFnDown = false;
+      this.cancelMacSoloFnDown();
       if (hotkey === "fn" || hotkey === "globe") {
-        this.options.onKeyUp();
+        if (this.macHotkeyActive) {
+          this.macHotkeyActive = false;
+          this.options.onKeyUp();
+        }
       } else {
         this.checkMacCompoundRelease();
       }
@@ -291,6 +298,7 @@ export class NativeKeyListener {
     if (line.startsWith("RIGHT_MOD_DOWN:")) {
       const modName = line.slice(15); // e.g., "RightOption"
       this.macModState.add(modName.toLowerCase());
+      this.cancelMacSoloFnDownIfChorded();
       this.checkMacHotkeyMatch();
       return;
     }
@@ -334,6 +342,7 @@ export class NativeKeyListener {
               .filter(Boolean)
           : [],
       );
+      this.cancelMacSoloFnDownIfChorded();
       this.checkMacCompoundRelease();
       this.checkMacHotkeyMatch();
       return;
@@ -377,6 +386,34 @@ export class NativeKeyListener {
     }
   }
 
+  private scheduleMacSoloFnDown(): void {
+    this.cancelMacSoloFnDown();
+    this.macSoloFnTimer = setTimeout(() => {
+      this.macSoloFnTimer = null;
+      if (!this.macFnDown || this.hasMacNonFnModifierActive()) return;
+      this.macHotkeyActive = true;
+      this.options.onKeyDown();
+    }, MAC_SOLO_FN_CHORD_GRACE_MS);
+  }
+
+  private cancelMacSoloFnDown(): void {
+    if (!this.macSoloFnTimer) return;
+    clearTimeout(this.macSoloFnTimer);
+    this.macSoloFnTimer = null;
+  }
+
+  private cancelMacSoloFnDownIfChorded(): void {
+    if (!this.macSoloFnTimer || !this.hasMacNonFnModifierActive()) return;
+    this.cancelMacSoloFnDown();
+  }
+
+  private hasMacNonFnModifierActive(): boolean {
+    for (const category of this.currentMacModifierCategories()) {
+      if (category !== "fn") return true;
+    }
+    return false;
+  }
+
   /** Match compound hotkeys like Alt+Space using modifier flags + key events. */
   private handleMacKeyEvent(key: string, down: boolean): void {
     const { modifiers, key: hotkeyKey } = parseHotkeyParts(this.options.hotkey);
@@ -412,6 +449,9 @@ export class NativeKeyListener {
 
     const hotkey = this.options.hotkey.toLowerCase();
     const { modifiers, key: hotkeyKey } = parseHotkeyParts(this.options.hotkey);
+
+    // Solo Fn/Globe is edge-triggered through scheduleMacSoloFnDown().
+    if (hotkey === "fn" || hotkey === "globe") return;
 
     // Direct right-modifier hotkey (e.g., hotkey is literally "RightOption")
     if (this.macModState.has(macRightModifierKey(hotkey))) {
@@ -484,6 +524,7 @@ export class NativeKeyListener {
    */
   stop(): void {
     this.destroyed = true;
+    this.cancelMacSoloFnDown();
 
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
@@ -512,6 +553,7 @@ export class NativeKeyListener {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
     }
+    this.cancelMacSoloFnDown();
     if (this.process) {
       try {
         this.process.kill("SIGTERM");

--- a/apps/electron/src/main/native-binary.ts
+++ b/apps/electron/src/main/native-binary.ts
@@ -9,7 +9,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { app } from "electron";
 
-const isDev = !app.isPackaged;
+const isDev = !app?.isPackaged;
 
 const platform = process.platform;
 const arch = process.arch;

--- a/apps/electron/tests/key-listener.test.ts
+++ b/apps/electron/tests/key-listener.test.ts
@@ -72,6 +72,16 @@ test("Fn-first chord within the grace window does not activate solo Fn", async (
   expect(events).toEqual([]);
 });
 
+test("rapid solo Fn release inside the grace window does not activate", async () => {
+  const { listener, events } = createFnListener();
+
+  listener.handleLine("FN_DOWN");
+  listener.handleLine("FN_UP");
+  await wait(75);
+
+  expect(events).toEqual([]);
+});
+
 test("adding a modifier after solo Fn activation keeps hold-to-talk active", async () => {
   const { listener, events } = createFnListener();
 

--- a/apps/electron/tests/key-listener.test.ts
+++ b/apps/electron/tests/key-listener.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "@playwright/test";
+import { HotkeyRecorder } from "../src/main/hotkey-recorder";
+import { NativeKeyListener } from "../src/main/key-listener";
+
+type LineHandler = {
+  handleLine(line: string): void;
+};
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+test.beforeAll(() => {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: "darwin",
+  });
+});
+
+test.afterAll(() => {
+  if (platformDescriptor) {
+    Object.defineProperty(process, "platform", platformDescriptor);
+  }
+});
+
+function createFnListener(): {
+  listener: LineHandler;
+  events: string[];
+} {
+  const events: string[] = [];
+  const listener = new NativeKeyListener({
+    hotkey: "Fn",
+    onKeyDown: () => events.push("down"),
+    onKeyUp: () => events.push("up"),
+  }) as unknown as LineHandler;
+
+  return { listener, events };
+}
+
+test("solo Fn hotkey activates after the chord grace window", async () => {
+  const { listener, events } = createFnListener();
+
+  listener.handleLine("FN_DOWN");
+  expect(events).toEqual([]);
+
+  await wait(75);
+  expect(events).toEqual(["down"]);
+
+  listener.handleLine("FN_UP");
+  expect(events).toEqual(["down", "up"]);
+});
+
+test("modifier-first Fn chord does not activate a solo Fn hotkey", async () => {
+  const { listener, events } = createFnListener();
+
+  listener.handleLine("FN_DOWN:command");
+  await wait(75);
+  listener.handleLine("FN_UP");
+
+  expect(events).toEqual([]);
+});
+
+test("Fn-first chord within the grace window does not activate solo Fn", async () => {
+  const { listener, events } = createFnListener();
+
+  listener.handleLine("FN_DOWN");
+  listener.handleLine("FLAGS:command");
+  await wait(75);
+  listener.handleLine("FN_UP");
+
+  expect(events).toEqual([]);
+});
+
+test("adding a modifier after solo Fn activation keeps hold-to-talk active", async () => {
+  const { listener, events } = createFnListener();
+
+  listener.handleLine("FN_DOWN");
+  await wait(75);
+  listener.handleLine("FLAGS:command");
+  listener.handleLine("FN_UP");
+
+  expect(events).toEqual(["down", "up"]);
+});
+
+test("hotkey recorder preserves modifiers emitted with Fn chord lines", () => {
+  const modifiers: string[][] = [];
+  const recorder = new HotkeyRecorder({
+    onModifiers: (nextModifiers) => modifiers.push(nextModifiers),
+    onCaptured: () => {},
+    onCancel: () => {},
+  }) as unknown as LineHandler;
+
+  recorder.handleLine("FN_DOWN:control,option,shift,command");
+
+  expect(modifiers).toEqual([["Control", "Alt", "Shift", "Command", "Fn"]]);
+});


### PR DESCRIPTION
## Summary
- Globe/Fn dictation starts only after a short solo-key grace window, so modifier chords like Command+Globe or Option+Globe do not start recording.
- The macOS native listener emits `FN_DOWN` for solo Globe and `FN_DOWN:mods` when modifiers are present, preserving compound hotkeys and hotkey rebinding.
- Focused tests cover solo Fn activation, modifier-first chords, Fn-first near-simultaneous chords, post-activation modifiers, and recorder parsing.

## Test plan
- [x] Solo Globe press starts dictation
- [x] Command + Globe does not start dictation
- [x] Option + Globe does not start dictation
- [x] Globe held, then modifier added after activation continues recording until Globe release
- [x] Hotkey rebinding still captures compound shortcuts like Command+Fn
- [x] `corepack pnpm exec playwright test tests/key-listener.test.ts`
- [x] `corepack pnpm run typecheck:node`
- [x] `corepack pnpm exec biome check apps/electron/src/main/key-listener.ts apps/electron/src/main/hotkey-recorder.ts apps/electron/src/main/native-binary.ts apps/electron/tests/key-listener.test.ts`