### PR TITLE
Rename Freestyle Cloud to Freestyle Transcribe

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1510,9 +1510,9 @@ app.whenReady().then(async () => {
   ipcMain.handle("cloud:prompt-sign-in", async () => {
     const { response } = await dialog.showMessageBox({
       type: "info",
-      message: "Sign in to Freestyle Cloud",
+      message: "Sign in to Freestyle Transcribe",
       detail:
-        "Freestyle Cloud needs you to sign in before it can transcribe or clean up text. Open Models settings to sign in or switch providers.",
+        "Freestyle Transcribe needs you to sign in before it can transcribe or clean up text. Open Models settings to sign in or switch providers.",
       buttons: ["Open Models", "Not Now"],
       defaultId: 0,
       cancelId: 1,

--- a/apps/electron/src/renderer/src/components/cloud-profile.tsx
+++ b/apps/electron/src/renderer/src/components/cloud-profile.tsx
@@ -34,7 +34,7 @@ export function CloudProfileButton(): React.JSX.Element {
         <div className="flex items-center gap-1.5">
           <Cloud className="text-primary size-3.5 shrink-0" />
           <span className="text-foreground text-[12.5px] font-medium">
-            Freestyle Cloud
+            Freestyle Transcribe
           </span>
         </div>
         <p className="text-muted-foreground mt-1 text-[11px] leading-snug">

--- a/apps/electron/src/renderer/src/lib/models.ts
+++ b/apps/electron/src/renderer/src/lib/models.ts
@@ -107,7 +107,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   soniox: "Soniox",
   mistral: "Mistral",
   openrouter: "OpenRouter",
-  "freestyle-cloud": "Freestyle Cloud",
+  "freestyle-cloud": "Freestyle Transcribe",
   "local-llm": "Local LLM",
   "local-whisper": "Local Whisper",
   "local-mlx": "Local MLX",

--- a/apps/electron/src/renderer/src/onboarding.tsx
+++ b/apps/electron/src/renderer/src/onboarding.tsx
@@ -385,7 +385,7 @@ export default function OnboardingPage(): React.JSX.Element {
       setSelectedMlxDefId(null);
     }
     const modelId = model?.model_id ?? FREESTYLE_CLOUD_MODEL_ID;
-    const modelName = model?.model_name ?? "Freestyle Cloud";
+    const modelName = model?.model_name ?? "Freestyle Transcribe";
     getClient()
       .api.models.configured.$post({
         json: {

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -362,7 +362,7 @@ export default function AppPage(): React.JSX.Element {
               return {
                 raw: "",
                 cleaned: "",
-                error: "Sign in to Freestyle Cloud",
+                error: "Sign in to Freestyle Transcribe",
                 cloudAuthRequired: true,
               };
             }
@@ -862,7 +862,7 @@ export default function AppPage(): React.JSX.Element {
             return {
               raw: "",
               cleaned: "",
-              error: "Sign in to Freestyle Cloud",
+              error: "Sign in to Freestyle Transcribe",
               cloudAuthRequired: true,
             };
           }

--- a/apps/electron/src/renderer/src/pages/models/index.tsx
+++ b/apps/electron/src/renderer/src/pages/models/index.tsx
@@ -506,7 +506,7 @@ function FreestyleCloudModeCard({
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <Cloud className="text-primary size-4" />
-            <Eyebrow text="Freestyle Cloud" />
+            <Eyebrow text="Freestyle Transcribe" />
           </div>
           <p className="text-muted-foreground mt-1.5 max-w-[620px] text-[13px] leading-relaxed">
             Fast, managed transcription and cleanup from Freestyle. Use it for
@@ -525,8 +525,8 @@ function FreestyleCloudModeCard({
             onClick={onToggleExpanded}
             aria-label={
               expanded
-                ? "Hide Freestyle Cloud options"
-                : "Show Freestyle Cloud options"
+                ? "Hide Freestyle Transcribe options"
+                : "Show Freestyle Transcribe options"
             }
           >
             <ChevronDown
@@ -541,7 +541,7 @@ function FreestyleCloudModeCard({
           <CloudRouteOption
             icon={Mic}
             title="Transcription"
-            description="Use Freestyle Cloud for speech-to-text, then clean up with your selected model."
+            description="Use Freestyle Transcribe for speech-to-text, then clean up with your selected model."
             active={voiceActive && !cleanupActive}
             disabled={!canUse}
             onClick={onUseTranscription}
@@ -549,7 +549,7 @@ function FreestyleCloudModeCard({
           <CloudRouteOption
             icon={Sparkles}
             title="Cleanup"
-            description="Keep your current transcription model and let Freestyle Cloud polish the text."
+            description="Keep your current transcription model and let Freestyle Transcribe polish the text."
             active={!voiceActive && cleanupActive}
             disabled={!canUse || cleanupDisabled}
             onClick={onUseCleanup}
@@ -557,7 +557,7 @@ function FreestyleCloudModeCard({
           <CloudRouteOption
             icon={Cloud}
             title="All-in-one"
-            description="Send audio once for Freestyle Cloud to transcribe and polish in a single pass."
+            description="Send audio once for Freestyle Transcribe to transcribe and polish in a single pass."
             active={voiceActive && cleanupActive}
             disabled={!canUse}
             onClick={onUseBoth}

--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -359,9 +359,9 @@ export function ModelList({
 
 const FREESTYLE_CLOUD_TIER: AvailableModel = {
   provider_id: "freestyle-cloud",
-  provider_name: "Freestyle Cloud",
+  provider_name: "Freestyle Transcribe",
   model_id: "freestyle-cloud/stt",
-  model_name: "Freestyle Cloud (Managed)",
+  model_name: "Freestyle Transcribe (Managed)",
   type: "voice",
 };
 
@@ -445,7 +445,7 @@ function VoiceTiers({
 
       <div className="grid grid-cols-1 gap-3 p-5 sm:grid-cols-2">
         <TierCard
-          title="Freestyle Cloud"
+          title="Freestyle Transcribe"
           badge="Recommended"
           description="Managed by Freestyle. Fast and accurate, no API key — just sign in."
           detail={

--- a/apps/electron/src/renderer/src/pages/models/pair-card.tsx
+++ b/apps/electron/src/renderer/src/pages/models/pair-card.tsx
@@ -68,7 +68,7 @@ export function PairCard({
           dimmed={!llmCleanup}
           note={
             cleanupDisabled
-              ? "Combined with transcription in one Freestyle Cloud request"
+              ? "Combined with transcription in one Freestyle Transcribe request"
               : undefined
           }
         />

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 
-const SCHEMA_VERSION = 9;
+const SCHEMA_VERSION = 10;
 
 const DEFAULT_FORMAT_RULES = [
   {
@@ -306,6 +306,14 @@ function applyMigrations(db: DatabaseSync, currentVersion: number): void {
         updated_at INTEGER NOT NULL
       )
     `);
+  }
+
+  if (currentVersion < 10) {
+    db.exec(
+      `UPDATE model_configs
+         SET model_name = replace(model_name, 'Freestyle Cloud', 'Freestyle Transcribe')
+       WHERE provider = 'freestyle-cloud' AND model_name LIKE 'Freestyle Cloud%'`,
+    );
   }
 
   // Upsert schema version

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -117,9 +117,9 @@ const LOCAL_MLX_VOICE_MODELS: AvailableModel[] = [
 const BUILTIN_VOICE_MODELS: AvailableModel[] = [
   {
     provider_id: FREESTYLE_CLOUD_PROVIDER_ID,
-    provider_name: "Freestyle Cloud",
+    provider_name: "Freestyle Transcribe",
     model_id: FREESTYLE_CLOUD_TRANSCRIBE_MODEL_ID,
-    model_name: "Freestyle Cloud",
+    model_name: "Freestyle Transcribe",
     family: "freestyle",
     type: "voice",
   },
@@ -199,9 +199,9 @@ const CURATED_LLM_IDS = new Set([
 const BUILTIN_LLM_MODELS: AvailableModel[] = [
   {
     provider_id: FREESTYLE_CLOUD_PROVIDER_ID,
-    provider_name: "Freestyle Cloud",
+    provider_name: "Freestyle Transcribe",
     model_id: FREESTYLE_CLOUD_CLEANUP_MODEL_ID,
-    model_name: "Freestyle Cloud Cleanup",
+    model_name: "Freestyle Transcribe Cleanup",
     family: "freestyle",
     type: "llm",
     curated: true,

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -358,7 +358,7 @@ const stream = new Hono().get(
                       JSON.stringify({
                         type: "error",
                         code: "cloud_auth_required",
-                        message: "Sign in to Freestyle Cloud",
+                        message: "Sign in to Freestyle Transcribe",
                       }),
                     );
                   }


### PR DESCRIPTION
# Overview

In this PR, we renamed Freestyle Cloud to Freestyle Transcribe. The internal codebase is still called Freestyle Cloud. 