### PR TITLE
fix: support pnpm 11 electron installs

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -79,11 +79,5 @@
     "tailwindcss": "^4.3.0",
     "typescript": "^5.9.3",
     "vite": "^7.2.6"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "electron",
-      "esbuild"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,5 @@
   "nano-staged": {
     "*.{ts,tsx,js,json}": "biome check --write --no-errors-on-unmatched"
   },
-  "packageManager": "pnpm@10.32.1",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "electron",
-      "esbuild"
-    ]
-  }
+  "packageManager": "pnpm@10.32.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,8 @@ packages:
   - "apps/*"
   - "packages/*"
   - "plugins/*"
+allowBuilds:
+  electron: true
+  esbuild: true
+  electron-winstaller: false
+  msw: false


### PR DESCRIPTION
pnpm 11 no longer reads package.json -> pnpm.onlyBuiltDependencies. 

Without the new allowBuilds setting, it blocks Electron’s install script, so the Electron binary never gets installed and pnpm dev dies with the “Electron uninstall” / “Electron failed to install correctly” error. Moving the allowlist to pnpm-workspace.yaml lets electron and esbuild run their required postinstall scripts again