### PR TITLE
fix(ci): keep package releases out of GitHub "Latest" so app auto-update works

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -98,16 +98,25 @@ jobs:
             exit 1
           fi
 
-          prefix=$(cd "$path" && craft config | jq -r '.releaseBranchPrefix // empty')
+          config=$(cd "$path" && craft config)
+          prefix=$(echo "$config" | jq -r '.releaseBranchPrefix // empty')
           if [[ -z "$prefix" ]]; then
             echo "::error::No releaseBranchPrefix in $path/.craft.yml"
             exit 1
           fi
 
+          # The GitHub target's tagPrefix (e.g. "freestyle-voice@") plus the
+          # version gives the release tag Craft creates. We use it below to keep
+          # package releases out of GitHub's "Latest" selection so the Electron
+          # auto-updater keeps resolving the app release (which alone carries the
+          # latest*.yml update feeds).
+          tagPrefix=$(echo "$config" | jq -r '.targets[] | select(.name=="github") | .tagPrefix // empty')
+
           echo "path=$path" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "branch=$prefix/$version" >> "$GITHUB_OUTPUT"
-          echo "Resolved: path=$path version=$version branch=$prefix/$version"
+          echo "tag=${tagPrefix}${version}" >> "$GITHUB_OUTPUT"
+          echo "Resolved: path=$path version=$version branch=$prefix/$version tag=${tagPrefix}${version}"
 
       - name: Check out release branch
         run: |
@@ -147,6 +156,21 @@ jobs:
           # npm Trusted Publishing. Provenance attestations are generated
           # automatically by trusted publishing; we don't force NPM_CONFIG_PROVENANCE
           # (forcing it can hard-fail depending on repo visibility).
+
+      # Package/plugin tags (e.g. freestyle-voice@0.4.0) are semver-parsed by
+      # GitHub's default `make_latest: legacy` rule, so a package version that
+      # numerically exceeds the app version steals the "Latest" release badge.
+      # electron-updater's GitHubProvider resolves updates via /releases/latest,
+      # and package releases have no latest*.yml feed — so this breaks app
+      # auto-updates. Pin package releases to make_latest=false; GitHub then
+      # re-selects the newest app release (which carries the update feeds).
+      - name: Exclude package release from "Latest"
+        if: success()
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh release edit "${{ steps.pkg.outputs.tag }}" \
+            --repo "${{ github.repository }}" --latest=false
 
       - name: Close issue on success
         if: success()


### PR DESCRIPTION
## Problem

App auto-update is broken. `electron-updater`'s GitHub provider resolves updates via the `GET /releases/latest` endpoint and then downloads the update feed (`latest-mac.yml` / `latest.yml` / `latest-linux.yml`) from **that** release. Right now:

```
GET repos/freestyle-voice/freestyle/releases/latest  ->  freestyle-voice@0.4.0
```

`freestyle-voice@0.4.0` is the **npm SDK package** release — its only asset is `freestyle-voice-0.4.0.tgz`, with **no** `latest*.yml` feed. The updater fetches the feed from it, gets a 404, and aborts. The real app release `0.3.4` (which carries all the `latest*.yml` files + installers) is never consulted because it isn't flagged "Latest".

### Why the wrong release wins

Independent package/plugin pipelines tag releases via each package's `.craft.yml` `tagPrefix` (e.g. `freestyle-voice@0.4.0`, `plugin-audio-transcription@0.2.0`). GitHub's default `make_latest: legacy` rule semver-parses the trailing version, sees `0.4.0 > 0.3.4`, and marks the package release "Latest". Any package version that numerically exceeds the app version hijacks the updater.

## Fix

In `publish-package.yml`, after Craft publishes a package/plugin GitHub release, set `make_latest=false` on it. GitHub then re-selects the newest plain `X.Y.Z` **app** release as "Latest", restoring the updater's resolution. The release stays a normal, visible release — it's just excluded from the Latest pointer.

- Derives the release tag from each package's own `.craft.yml` `tagPrefix` — fully generic, no per-plugin edits needed.
- No change to the app pipeline (`publish.yml`) required.

## Caveat (not retroactive)

This only takes effect on the **next** package publish. Existing releases keep their current flags, so `freestyle-voice@0.4.0` stays "Latest" until then. To unblock current users immediately, run once manually:

```sh
gh release edit "freestyle-voice@0.4.0" --repo freestyle-voice/freestyle --latest=false
gh release edit "0.3.4" --repo freestyle-voice/freestyle --latest
```

## Testing

- `.github/workflows/publish-package.yml` validated as well-formed YAML.
- The new tag derivation mirrors the existing `releaseBranchPrefix` extraction from `craft config`.