### PR TITLE
Phase 1 prs for stability improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,6 +261,10 @@ jobs:
         working-directory: apps/electron
         run: pnpm run build:linux
 
+      - name: Verify native binaries in package
+        working-directory: apps/electron
+        run: node scripts/verify-native-binaries.mjs
+
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -269,7 +273,7 @@ jobs:
             apps/electron/dist/*.AppImage
             apps/electron/dist/*.deb
             apps/electron/dist/latest*.yml
-          if-no-files-found: warn
+          if-no-files-found: error
 
   build-mac:
     name: Build (macOS)
@@ -315,6 +319,10 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+      - name: Verify native binaries in package
+        working-directory: apps/electron
+        run: node scripts/verify-native-binaries.mjs
+
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -325,7 +333,7 @@ jobs:
             apps/electron/dist/*.zip
             apps/electron/dist/latest*.yml
             apps/electron/dist/*.blockmap
-          if-no-files-found: warn
+          if-no-files-found: error
 
   build-windows:
     name: Build (Windows)
@@ -358,6 +366,10 @@ jobs:
         working-directory: apps/electron
         run: pnpm run build:win
 
+      - name: Verify native binaries in package
+        working-directory: apps/electron
+        run: node scripts/verify-native-binaries.mjs
+
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -367,7 +379,7 @@ jobs:
             apps/electron/dist/*.msi
             apps/electron/dist/latest*.yml
             apps/electron/dist/*.blockmap
-          if-no-files-found: warn
+          if-no-files-found: error
 
   build-server-image:
     name: Build server image

--- a/apps/electron/native/linux-key-listener.c
+++ b/apps/electron/native/linux-key-listener.c
@@ -6,8 +6,6 @@
  * Outputs "KEY_DOWN" and "KEY_UP" to stdout.
  *
  * Requires read access to /dev/input/event* (typically via input group).
- * If /dev/input is not accessible this listener fails to start and the
- * app falls back to Electron globalShortcut (toggle mode) instead.
  *
  * Compile: gcc -O2 linux-key-listener.c -o linux-key-listener
  *

--- a/apps/electron/native/linux-key-listener.c
+++ b/apps/electron/native/linux-key-listener.c
@@ -6,7 +6,8 @@
  * Outputs "KEY_DOWN" and "KEY_UP" to stdout.
  *
  * Requires read access to /dev/input/event* (typically via input group).
- * Falls back to X11 XRecord if /dev/input is not accessible.
+ * If /dev/input is not accessible this listener fails to start and the
+ * app falls back to Electron globalShortcut (toggle mode) instead.
  *
  * Compile: gcc -O2 linux-key-listener.c -o linux-key-listener
  *
@@ -24,6 +25,7 @@
 #include <dirent.h>
 #include <poll.h>
 #include <signal.h>
+#include <sys/ioctl.h>
 #include <linux/input.h>
 #include <errno.h>
 

--- a/apps/electron/scripts/compile-native.js
+++ b/apps/electron/scripts/compile-native.js
@@ -25,6 +25,11 @@ const platform = process.platform;
 const arch = process.arch;
 const outputDir = join(BIN_DIR, `${platform}-${arch}`);
 
+// Binaries that failed to compile. Local dev tolerates missing binaries
+// (features degrade to legacy fallbacks), but CI must never package a
+// build that silently lost its native binaries.
+const failures = [];
+
 function ensureDir(dir) {
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 }
@@ -100,6 +105,7 @@ function compileMacOS() {
       chmodSync(out, 0o755);
       console.log(`  -> ${out}`);
     } else {
+      failures.push(bin.name);
       console.warn(
         `  WARNING: Failed to compile ${bin.name}. Hotkey/paste may fall back to legacy mode.`,
       );
@@ -149,6 +155,7 @@ function compileWindows() {
     }
 
     if (!ok) {
+      failures.push(bin.name);
       console.warn(
         `  WARNING: Failed to compile ${bin.name}. Feature may fall back to legacy mode.`,
       );
@@ -219,6 +226,7 @@ function compileLinux() {
         chmodSync(out, 0o755);
         console.log(`  -> ${out} (XTest only)`);
       } else {
+        failures.push("linux-fast-paste");
         console.warn("  WARNING: Failed to compile linux-fast-paste.");
       }
     }
@@ -234,6 +242,7 @@ function compileLinux() {
       chmodSync(out, 0o755);
       console.log(`  -> ${out}`);
     } else {
+      failures.push("linux-key-listener");
       console.warn("  WARNING: Failed to compile linux-key-listener.");
     }
   }
@@ -258,6 +267,14 @@ switch (platform) {
     console.log(
       `[compile:native] Unsupported platform: ${platform}, skipping.`,
     );
+}
+
+if (failures.length > 0 && process.env.CI) {
+  console.error(
+    `\n[compile:native] FAILED in CI: could not compile ${failures.join(", ")}.\n` +
+      "Packaged builds must never ship without their native binaries.\n",
+  );
+  process.exit(1);
 }
 
 console.log("\n[compile:native] Done.\n");

--- a/apps/electron/scripts/compile-native.js
+++ b/apps/electron/scripts/compile-native.js
@@ -25,9 +25,6 @@ const platform = process.platform;
 const arch = process.arch;
 const outputDir = join(BIN_DIR, `${platform}-${arch}`);
 
-// Binaries that failed to compile. Local dev tolerates missing binaries
-// (features degrade to legacy fallbacks), but CI must never package a
-// build that silently lost its native binaries.
 const failures = [];
 
 function ensureDir(dir) {

--- a/apps/electron/scripts/verify-native-binaries.mjs
+++ b/apps/electron/scripts/verify-native-binaries.mjs
@@ -1,20 +1,5 @@
 #!/usr/bin/env node
 
-/**
- * Verifies that every native binary the app depends on was compiled AND
- * made it into the packaged build. Run after `electron-builder` in CI.
- *
- * Without this check, a toolchain failure on a CI runner ships an
- * installer whose hotkey/paste/mic features silently degrade to legacy
- * fallbacks (see specs/app-stability-audit.md §3.6).
- *
- * Checks two locations:
- *  1. Source:   resources/bin/<platform>-<arch>/          (compile:native output)
- *  2. Packaged: dist/<unpacked>/.../Resources|resources/bin/  (electron-builder extraResources)
- *
- * Pass --source-only to skip the packaged check (e.g. before packaging).
- */
-
 import { readdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -26,7 +11,6 @@ const platform = process.platform;
 const arch = process.arch;
 const sourceOnly = process.argv.includes("--source-only");
 
-// Keep in sync with compile-native.js and src/main/native-binary.ts.
 const EXPECTED = {
   darwin: [
     "macos-key-listener",
@@ -54,7 +38,6 @@ function findPackagedBinDir() {
   const dist = join(ROOT, "dist");
   try {
     if (platform === "darwin") {
-      // dist/mac[-arm64]/Freestyle.app/Contents/Resources/bin
       for (const entry of readdirSync(dist)) {
         if (!entry.startsWith("mac")) continue;
         const macDir = join(dist, entry);
@@ -68,9 +51,7 @@ function findPackagedBinDir() {
     } else {
       return join(dist, "linux-unpacked", "resources", "bin");
     }
-  } catch {
-    // fall through
-  }
+  } catch {}
   return null;
 }
 

--- a/apps/electron/scripts/verify-native-binaries.mjs
+++ b/apps/electron/scripts/verify-native-binaries.mjs
@@ -91,11 +91,16 @@ function checkDir(label, dir) {
     );
     return false;
   }
-  console.log(`[verify-native] OK: ${label} has all ${expected.length} binaries.`);
+  console.log(
+    `[verify-native] OK: ${label} has all ${expected.length} binaries.`,
+  );
   return true;
 }
 
-let ok = checkDir("source", join(ROOT, "resources", "bin", `${platform}-${arch}`));
+let ok = checkDir(
+  "source",
+  join(ROOT, "resources", "bin", `${platform}-${arch}`),
+);
 
 if (!sourceOnly) {
   const packagedBinDir = findPackagedBinDir();

--- a/apps/electron/scripts/verify-native-binaries.mjs
+++ b/apps/electron/scripts/verify-native-binaries.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+/**
+ * Verifies that every native binary the app depends on was compiled AND
+ * made it into the packaged build. Run after `electron-builder` in CI.
+ *
+ * Without this check, a toolchain failure on a CI runner ships an
+ * installer whose hotkey/paste/mic features silently degrade to legacy
+ * fallbacks (see specs/app-stability-audit.md §3.6).
+ *
+ * Checks two locations:
+ *  1. Source:   resources/bin/<platform>-<arch>/          (compile:native output)
+ *  2. Packaged: dist/<unpacked>/.../Resources|resources/bin/  (electron-builder extraResources)
+ *
+ * Pass --source-only to skip the packaged check (e.g. before packaging).
+ */
+
+import { readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+
+const platform = process.platform;
+const arch = process.arch;
+const sourceOnly = process.argv.includes("--source-only");
+
+// Keep in sync with compile-native.js and src/main/native-binary.ts.
+const EXPECTED = {
+  darwin: [
+    "macos-key-listener",
+    "macos-fast-paste",
+    "macos-mic-listener",
+    "macos-output-volume",
+    "macos-media-control",
+  ],
+  win32: [
+    "windows-key-listener.exe",
+    "windows-fast-paste.exe",
+    "windows-mic-listener.exe",
+    "windows-output-volume.exe",
+  ],
+  linux: ["linux-key-listener", "linux-fast-paste"],
+};
+
+const expected = EXPECTED[platform];
+if (!expected) {
+  console.log(`[verify-native] Unsupported platform ${platform}, skipping.`);
+  process.exit(0);
+}
+
+function findPackagedBinDir() {
+  const dist = join(ROOT, "dist");
+  try {
+    if (platform === "darwin") {
+      // dist/mac[-arm64]/Freestyle.app/Contents/Resources/bin
+      for (const entry of readdirSync(dist)) {
+        if (!entry.startsWith("mac")) continue;
+        const macDir = join(dist, entry);
+        for (const app of readdirSync(macDir)) {
+          if (!app.endsWith(".app")) continue;
+          return join(macDir, app, "Contents", "Resources", "bin");
+        }
+      }
+    } else if (platform === "win32") {
+      return join(dist, "win-unpacked", "resources", "bin");
+    } else {
+      return join(dist, "linux-unpacked", "resources", "bin");
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+function checkDir(label, dir) {
+  const missing = [];
+  for (const name of expected) {
+    const path = join(dir, name);
+    try {
+      const stats = statSync(path);
+      if (!stats.isFile() || stats.size === 0) missing.push(name);
+    } catch {
+      missing.push(name);
+    }
+  }
+  if (missing.length > 0) {
+    console.error(
+      `[verify-native] MISSING in ${label} (${dir}): ${missing.join(", ")}`,
+    );
+    return false;
+  }
+  console.log(`[verify-native] OK: ${label} has all ${expected.length} binaries.`);
+  return true;
+}
+
+let ok = checkDir("source", join(ROOT, "resources", "bin", `${platform}-${arch}`));
+
+if (!sourceOnly) {
+  const packagedBinDir = findPackagedBinDir();
+  if (!packagedBinDir) {
+    console.error(
+      "[verify-native] Could not locate the unpacked package under dist/. Did electron-builder run?",
+    );
+    ok = false;
+  } else {
+    ok = checkDir("packaged app", packagedBinDir) && ok;
+  }
+}
+
+process.exit(ok ? 0 : 1);

--- a/apps/electron/src/main/audio-control/controller.ts
+++ b/apps/electron/src/main/audio-control/controller.ts
@@ -117,7 +117,7 @@ export class AudioPlaybackController {
       if (process.platform === "darwin") {
         this.macosMediaPlayback.restoreSync();
       } else if (process.platform === "linux") {
-        void linuxMediaPlayback.resumePlayback();
+        linuxMediaPlayback.resumePlaybackSync();
       } else if (process.platform === "win32") {
         windowsMediaPlayback.resumePlaybackSync();
       }

--- a/apps/electron/src/main/audio-control/interfaces/volume-ducker.interface.ts
+++ b/apps/electron/src/main/audio-control/interfaces/volume-ducker.interface.ts
@@ -3,16 +3,6 @@ export interface VolumeDucker {
   duck(): Promise<boolean>;
   restore(): Promise<void>;
   restoreSync(): boolean;
-  /**
-   * Pre-duck snapshot for crash recovery, persisted to disk by the facade.
-   * Null when not ducked.
-   */
   snapshotForRecovery(): unknown;
-  /**
-   * Restore volume from a snapshot persisted by a previous run that died
-   * while ducked. Implementations must verify the system still looks ducked
-   * before applying (the user may have fixed the volume by hand). Returns
-   * true when the volume was restored.
-   */
   recoverFromSnapshot(snapshot: unknown): Promise<boolean>;
 }

--- a/apps/electron/src/main/audio-control/interfaces/volume-ducker.interface.ts
+++ b/apps/electron/src/main/audio-control/interfaces/volume-ducker.interface.ts
@@ -3,4 +3,16 @@ export interface VolumeDucker {
   duck(): Promise<boolean>;
   restore(): Promise<void>;
   restoreSync(): boolean;
+  /**
+   * Pre-duck snapshot for crash recovery, persisted to disk by the facade.
+   * Null when not ducked.
+   */
+  snapshotForRecovery(): unknown;
+  /**
+   * Restore volume from a snapshot persisted by a previous run that died
+   * while ducked. Implementations must verify the system still looks ducked
+   * before applying (the user may have fixed the volume by hand). Returns
+   * true when the volume was restored.
+   */
+  recoverFromSnapshot(snapshot: unknown): Promise<boolean>;
 }

--- a/apps/electron/src/main/audio-control/linux-audio-ducker.ts
+++ b/apps/electron/src/main/audio-control/linux-audio-ducker.ts
@@ -199,7 +199,6 @@ export class LinuxVolumeDucker implements VolumeDucker {
       return false;
     }
 
-    // wpctl volumes are 0-1 scalars; pactl volumes are percentages.
     const duckedLevel =
       snapshot.method === "wpctl"
         ? DUCKED_VOLUME
@@ -207,8 +206,6 @@ export class LinuxVolumeDucker implements VolumeDucker {
     const epsilon = snapshot.method === "wpctl" ? 0.05 : 5;
     if (snapshot.previousVolume <= duckedLevel) return false;
 
-    // Only recover when the system still looks ducked — if the user already
-    // fixed the volume by hand, don't yank it back down/up.
     const current = await readVolume();
     if (!current || current.method !== snapshot.method) return false;
     if (current.previousVolume > duckedLevel + epsilon) return false;

--- a/apps/electron/src/main/audio-control/linux-audio-ducker.ts
+++ b/apps/electron/src/main/audio-control/linux-audio-ducker.ts
@@ -185,6 +185,37 @@ export class LinuxVolumeDucker implements VolumeDucker {
     }
   }
 
+  snapshotForRecovery(): unknown {
+    return this.snapshot;
+  }
+
+  async recoverFromSnapshot(raw: unknown): Promise<boolean> {
+    if (process.platform !== "linux") return false;
+    const snapshot = raw as Partial<SinkVolumeSnapshot> | null;
+    if (
+      (snapshot?.method !== "wpctl" && snapshot?.method !== "pactl") ||
+      typeof snapshot.previousVolume !== "number"
+    ) {
+      return false;
+    }
+
+    // wpctl volumes are 0-1 scalars; pactl volumes are percentages.
+    const duckedLevel =
+      snapshot.method === "wpctl"
+        ? DUCKED_VOLUME
+        : Math.round(DUCKED_VOLUME * 100);
+    const epsilon = snapshot.method === "wpctl" ? 0.05 : 5;
+    if (snapshot.previousVolume <= duckedLevel) return false;
+
+    // Only recover when the system still looks ducked — if the user already
+    // fixed the volume by hand, don't yank it back down/up.
+    const current = await readVolume();
+    if (!current || current.method !== snapshot.method) return false;
+    if (current.previousVolume > duckedLevel + epsilon) return false;
+
+    return writeVolume(snapshot.method, snapshot.previousVolume);
+  }
+
   restoreSync(): boolean {
     if (process.platform !== "linux") return true;
     if (!this.active) return true;

--- a/apps/electron/src/main/audio-control/linux-media-playback.ts
+++ b/apps/electron/src/main/audio-control/linux-media-playback.ts
@@ -5,7 +5,7 @@
  * 2. Optional playerctl when installed
  */
 
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import { createAppLogger } from "@freestyle-voice/utils";
 import { AUDIO_CONTROL_CMD_TIMEOUT_MS } from "./audio-control-constants";
@@ -183,6 +183,42 @@ export async function resumePlayback(): Promise<void> {
   }
 
   log.info(`Resumed ${pausedMprisServices.length} MPRIS target(s)`);
+
+  pausedMprisServices = [];
+}
+
+function runCmdSync(command: string, args: string[]): void {
+  try {
+    execFileSync(command, args, {
+      timeout: AUDIO_CONTROL_CMD_TIMEOUT_MS,
+      stdio: "ignore",
+    });
+  } catch {
+    // Quit cleanup should never block app shutdown on media resume failure.
+  }
+}
+
+/**
+ * Synchronous variant for quit cleanup — the async resume never completes
+ * once the process starts exiting, leaving the user's media paused.
+ */
+export function resumePlaybackSync(): void {
+  if (pausedMprisServices.length === 0) return;
+
+  for (const target of pausedMprisServices) {
+    if (target.startsWith(MPRIS_PREFIX)) {
+      runCmdSync("busctl", [
+        "--user",
+        "call",
+        target,
+        MPRIS_PATH,
+        MPRIS_PLAYER,
+        "Play",
+      ]);
+    } else {
+      runCmdSync("playerctl", ["-p", target, "play"]);
+    }
+  }
 
   pausedMprisServices = [];
 }

--- a/apps/electron/src/main/audio-control/linux-media-playback.ts
+++ b/apps/electron/src/main/audio-control/linux-media-playback.ts
@@ -193,15 +193,9 @@ function runCmdSync(command: string, args: string[]): void {
       timeout: AUDIO_CONTROL_CMD_TIMEOUT_MS,
       stdio: "ignore",
     });
-  } catch {
-    // Quit cleanup should never block app shutdown on media resume failure.
-  }
+  } catch {}
 }
 
-/**
- * Synchronous variant for quit cleanup — the async resume never completes
- * once the process starts exiting, leaving the user's media paused.
- */
 export function resumePlaybackSync(): void {
   if (pausedMprisServices.length === 0) return;
 

--- a/apps/electron/src/main/audio-control/macos-audio-ducker.ts
+++ b/apps/electron/src/main/audio-control/macos-audio-ducker.ts
@@ -108,8 +108,6 @@ export class MacosVolumeDucker implements VolumeDucker {
     const binaryPath = getNativeBinaryPath("macos-output-volume");
     if (!binaryPath) return false;
 
-    // Only recover when the system still looks ducked — if the user already
-    // fixed the volume by hand, don't yank it back down/up.
     const current = parseSnapshot(await execFileText(binaryPath, ["get"]));
     if (current.previousVolume > DUCKED_VOLUME + 0.05) return false;
 

--- a/apps/electron/src/main/audio-control/macos-audio-ducker.ts
+++ b/apps/electron/src/main/audio-control/macos-audio-ducker.ts
@@ -90,6 +90,41 @@ export class MacosVolumeDucker implements VolumeDucker {
     this.active = false;
   }
 
+  snapshotForRecovery(): unknown {
+    return this.snapshot;
+  }
+
+  async recoverFromSnapshot(raw: unknown): Promise<boolean> {
+    if (process.platform !== "darwin") return false;
+    const snapshot = raw as Partial<DeviceVolumeSnapshot<number>> | null;
+    if (
+      typeof snapshot?.previousVolume !== "number" ||
+      typeof snapshot.deviceId !== "number" ||
+      snapshot.previousVolume <= DUCKED_VOLUME
+    ) {
+      return false;
+    }
+
+    const binaryPath = getNativeBinaryPath("macos-output-volume");
+    if (!binaryPath) return false;
+
+    // Only recover when the system still looks ducked — if the user already
+    // fixed the volume by hand, don't yank it back down/up.
+    const current = parseSnapshot(await execFileText(binaryPath, ["get"]));
+    if (current.previousVolume > DUCKED_VOLUME + 0.05) return false;
+
+    try {
+      await execFileText(binaryPath, [
+        "set",
+        String(snapshot.previousVolume),
+        String(snapshot.deviceId),
+      ]);
+    } catch {
+      await execFileText(binaryPath, ["set", String(snapshot.previousVolume)]);
+    }
+    return true;
+  }
+
   restoreSync(): boolean {
     if (process.platform !== "darwin") return true;
     if (!this.active) return true;

--- a/apps/electron/src/main/audio-control/volume-ducker.ts
+++ b/apps/electron/src/main/audio-control/volume-ducker.ts
@@ -1,7 +1,13 @@
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createAppLogger } from "@freestyle-voice/utils";
+import { app } from "electron";
 import type { VolumeDucker } from "./interfaces/volume-ducker.interface";
 import { LinuxVolumeDucker } from "./linux-audio-ducker";
 import { MacosVolumeDucker } from "./macos-audio-ducker";
 import { WindowsVolumeDucker } from "./windows-audio-ducker";
+
+const log = createAppLogger("volume-ducker");
 
 const duckers: Partial<Record<NodeJS.Platform, VolumeDucker>> = {
   darwin: new MacosVolumeDucker(),
@@ -13,14 +19,80 @@ function currentDucker(): VolumeDucker | null {
   return duckers[process.platform] ?? null;
 }
 
+// If the app dies while ducked (crash, SIGKILL, power loss), the in-memory
+// pre-duck snapshot is lost and the user's system volume stays stuck at the
+// ducked level. Persist the snapshot around each duck so the next launch can
+// recover it.
+function recoveryFilePath(): string {
+  return join(app.getPath("userData"), "duck-recovery.json");
+}
+
+function persistRecoverySnapshot(snapshot: unknown): void {
+  if (snapshot == null) return;
+  try {
+    writeFileSync(
+      recoveryFilePath(),
+      JSON.stringify({ platform: process.platform, snapshot }),
+      "utf8",
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`Failed to persist duck recovery snapshot: ${message}`);
+  }
+}
+
+function clearRecoverySnapshot(): void {
+  try {
+    unlinkSync(recoveryFilePath());
+  } catch {
+    // Already gone
+  }
+}
+
 export async function duckVolume(): Promise<boolean> {
-  return (await currentDucker()?.duck()) ?? false;
+  const ducker = currentDucker();
+  if (!ducker) return false;
+  const ducked = await ducker.duck();
+  if (ducked) persistRecoverySnapshot(ducker.snapshotForRecovery());
+  return ducked;
 }
 
 export async function restoreVolume(): Promise<void> {
   await currentDucker()?.restore();
+  clearRecoverySnapshot();
 }
 
 export function restoreVolumeSync(): boolean {
-  return currentDucker()?.restoreSync() ?? true;
+  const restored = currentDucker()?.restoreSync() ?? true;
+  if (restored) clearRecoverySnapshot();
+  return restored;
+}
+
+/**
+ * Restore volume left ducked by a previous run that died mid-dictation.
+ * Call once at startup. No-op when the previous run exited cleanly.
+ */
+export async function recoverDuckedVolumeFromCrash(): Promise<void> {
+  let state: { platform?: string; snapshot?: unknown };
+  try {
+    state = JSON.parse(readFileSync(recoveryFilePath(), "utf8"));
+  } catch {
+    return; // No recovery file — the previous run exited cleanly.
+  }
+
+  // Clear before restoring so a failing restore can't repeat every launch.
+  clearRecoverySnapshot();
+  if (state?.platform !== process.platform) return;
+
+  const ducker = currentDucker();
+  if (!ducker) return;
+
+  try {
+    if (await ducker.recoverFromSnapshot(state.snapshot)) {
+      log.info("Restored system volume left ducked by a previous session");
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`Duck recovery failed: ${message}`);
+  }
 }

--- a/apps/electron/src/main/audio-control/volume-ducker.ts
+++ b/apps/electron/src/main/audio-control/volume-ducker.ts
@@ -19,10 +19,6 @@ function currentDucker(): VolumeDucker | null {
   return duckers[process.platform] ?? null;
 }
 
-// If the app dies while ducked (crash, SIGKILL, power loss), the in-memory
-// pre-duck snapshot is lost and the user's system volume stays stuck at the
-// ducked level. Persist the snapshot around each duck so the next launch can
-// recover it.
 function recoveryFilePath(): string {
   return join(app.getPath("userData"), "duck-recovery.json");
 }
@@ -44,9 +40,7 @@ function persistRecoverySnapshot(snapshot: unknown): void {
 function clearRecoverySnapshot(): void {
   try {
     unlinkSync(recoveryFilePath());
-  } catch {
-    // Already gone
-  }
+  } catch {}
 }
 
 export async function duckVolume(): Promise<boolean> {
@@ -68,19 +62,14 @@ export function restoreVolumeSync(): boolean {
   return restored;
 }
 
-/**
- * Restore volume left ducked by a previous run that died mid-dictation.
- * Call once at startup. No-op when the previous run exited cleanly.
- */
 export async function recoverDuckedVolumeFromCrash(): Promise<void> {
   let state: { platform?: string; snapshot?: unknown };
   try {
     state = JSON.parse(readFileSync(recoveryFilePath(), "utf8"));
   } catch {
-    return; // No recovery file — the previous run exited cleanly.
+    return;
   }
 
-  // Clear before restoring so a failing restore can't repeat every launch.
   clearRecoverySnapshot();
   if (state?.platform !== process.platform) return;
 

--- a/apps/electron/src/main/audio-control/windows-audio-ducker.ts
+++ b/apps/electron/src/main/audio-control/windows-audio-ducker.ts
@@ -108,8 +108,6 @@ export class WindowsVolumeDucker implements VolumeDucker {
     const binaryPath = getNativeBinaryPath("windows-output-volume");
     if (!binaryPath) return false;
 
-    // Only recover when the system still looks ducked — if the user already
-    // fixed the volume by hand, don't yank it back down/up.
     const current = parseSnapshot(await execFileText(binaryPath, ["get"]));
     if (current.previousVolume > DUCKED_VOLUME + 0.05) return false;
 

--- a/apps/electron/src/main/audio-control/windows-audio-ducker.ts
+++ b/apps/electron/src/main/audio-control/windows-audio-ducker.ts
@@ -90,6 +90,41 @@ export class WindowsVolumeDucker implements VolumeDucker {
     this.active = false;
   }
 
+  snapshotForRecovery(): unknown {
+    return this.snapshot;
+  }
+
+  async recoverFromSnapshot(raw: unknown): Promise<boolean> {
+    if (process.platform !== "win32") return false;
+    const snapshot = raw as Partial<DeviceVolumeSnapshot<string>> | null;
+    if (
+      typeof snapshot?.previousVolume !== "number" ||
+      typeof snapshot.deviceId !== "string" ||
+      snapshot.previousVolume <= DUCKED_VOLUME
+    ) {
+      return false;
+    }
+
+    const binaryPath = getNativeBinaryPath("windows-output-volume");
+    if (!binaryPath) return false;
+
+    // Only recover when the system still looks ducked — if the user already
+    // fixed the volume by hand, don't yank it back down/up.
+    const current = parseSnapshot(await execFileText(binaryPath, ["get"]));
+    if (current.previousVolume > DUCKED_VOLUME + 0.05) return false;
+
+    try {
+      await execFileText(binaryPath, [
+        "set",
+        String(snapshot.previousVolume),
+        snapshot.deviceId,
+      ]);
+    } catch {
+      await execFileText(binaryPath, ["set", String(snapshot.previousVolume)]);
+    }
+    return true;
+  }
+
   restoreSync(): boolean {
     if (process.platform !== "win32") return true;
     if (!this.active) return true;

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1398,8 +1398,6 @@ app.on("second-instance", () => {
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(async () => {
   void startLinuxPasteHelper();
-  // If a previous run died while dictating, the system volume may still be
-  // stuck at the ducked level — restore it before anything else.
   void recoverDuckedVolumeFromCrash();
 
   // Set app user model id for windows
@@ -2121,10 +2119,6 @@ function sendHotkeyUp(): void {
   settingsWindow?.webContents.send("hotkey:up");
 }
 
-// Hold-to-talk relies on a KEY_UP that is not guaranteed to arrive (macOS
-// event monitors can drop key-ups; a dying listener process emits nothing).
-// If a hold-mode press never sees its release, force the release instead of
-// leaving the mic hot and the hotkey dead until app restart.
 const HOTKEY_STUCK_TIMEOUT_MS = 5 * 60 * 1000;
 let hotkeyStuckTimer: NodeJS.Timeout | null = null;
 
@@ -2211,8 +2205,6 @@ function notifyPasteFailed(): void {
   if (process.platform === "linux") {
     if (isWaylandSession()) {
       const desktop = (process.env.XDG_CURRENT_DESKTOP ?? "").toLowerCase();
-      // wtype doesn't work on GNOME/Mutter (no virtual-keyboard protocol) —
-      // don't send GNOME users to install a tool that can't help them.
       hint = desktop.includes("gnome")
         ? " If a permission dialog appears on the next paste, allow Freestyle to control input."
         : " If a permission dialog appears on the next paste, allow it — or install wtype (e.g. sudo apt install wtype).";
@@ -2311,11 +2303,6 @@ async function registerHotkey(hotkey?: string): Promise<void> {
         hotkeyLog.debug(`Native key listener ready for "${accel}"`);
       },
       onPermanentFailure: () => {
-        // The listener started fine and then died for good (event tap torn
-        // down, repeated crashes past the restart cap). Without this, the
-        // user has no hotkey, no fallback, and no explanation until app
-        // restart — install the globalShortcut fallback the same way a
-        // failed initial start does.
         if (keyListener !== listener) return;
         hotkeyLog.error(
           "Native key listener permanently failed; falling back to Electron globalShortcut (toggle mode).",
@@ -2352,8 +2339,6 @@ async function registerHotkey(hotkey?: string): Promise<void> {
 
     if (started) {
       accessibilityConfirmed = true;
-      // A healthy native listener means hold-to-talk works again; re-arm the
-      // degradation notice so a later regression in this session notifies.
       hotkeyDegradedNotified = false;
     } else {
       hotkeyLog.warn(

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -980,6 +980,7 @@ function hidePill(): void {
   // state so the next press starts fresh — e.g. after ESC while still
   // holding the dictation key.
   hotkeyPressed = false;
+  clearHotkeyStuckWatchdog();
   // Unregister Escape shortcut when pill is hidden
   try {
     globalShortcut.unregister("Escape");
@@ -1995,6 +1996,7 @@ app.whenReady().then(async () => {
   ipcMain.on("hotkey:set-mode", (_event, mode: string) => {
     hotkeyActivationMode = mode === "toggle" ? "toggle" : "hold";
     hotkeyPressed = false;
+    clearHotkeyStuckWatchdog();
     scheduleHotkeyRegistration(currentHotkeyAccel ?? undefined);
   });
 });
@@ -2115,6 +2117,33 @@ function sendHotkeyUp(): void {
   settingsWindow?.webContents.send("hotkey:up");
 }
 
+// Hold-to-talk relies on a KEY_UP that is not guaranteed to arrive (macOS
+// event monitors can drop key-ups; a dying listener process emits nothing).
+// If a hold-mode press never sees its release, force the release instead of
+// leaving the mic hot and the hotkey dead until app restart.
+const HOTKEY_STUCK_TIMEOUT_MS = 5 * 60 * 1000;
+let hotkeyStuckTimer: NodeJS.Timeout | null = null;
+
+function clearHotkeyStuckWatchdog(): void {
+  if (hotkeyStuckTimer) {
+    clearTimeout(hotkeyStuckTimer);
+    hotkeyStuckTimer = null;
+  }
+}
+
+function armHotkeyStuckWatchdog(): void {
+  clearHotkeyStuckWatchdog();
+  hotkeyStuckTimer = setTimeout(() => {
+    hotkeyStuckTimer = null;
+    if (!hotkeyPressed) return;
+    hotkeyLog.warn(
+      "Hold-mode hotkey saw no key-up for 5 minutes; forcing release.",
+    );
+    hotkeyPressed = false;
+    sendHotkeyUp();
+  }, HOTKEY_STUCK_TIMEOUT_MS);
+}
+
 function handleNativeHotkeyDown(): void {
   if (hotkeyActivationMode === "toggle") {
     if (!hotkeyPressed) {
@@ -2129,6 +2158,7 @@ function handleNativeHotkeyDown(): void {
 
   if (!hotkeyPressed) {
     hotkeyPressed = true;
+    armHotkeyStuckWatchdog();
     sendHotkeyDown();
   }
 }
@@ -2138,6 +2168,7 @@ function handleNativeHotkeyUp(): void {
 
   if (hotkeyPressed) {
     hotkeyPressed = false;
+    clearHotkeyStuckWatchdog();
     sendHotkeyUp();
   }
 }
@@ -2239,6 +2270,7 @@ async function registerHotkey(hotkey?: string): Promise<void> {
       keyListener = null;
     }
     hotkeyPressed = false;
+    clearHotkeyStuckWatchdog();
     globalShortcut.unregisterAll();
 
     if (!hotkey) {
@@ -2265,6 +2297,34 @@ async function registerHotkey(hotkey?: string): Promise<void> {
       onReady: () => {
         hotkeyLog.debug(`Native key listener ready for "${accel}"`);
       },
+      onPermanentFailure: () => {
+        // The listener started fine and then died for good (event tap torn
+        // down, repeated crashes past the restart cap). Without this, the
+        // user has no hotkey, no fallback, and no explanation until app
+        // restart — install the globalShortcut fallback the same way a
+        // failed initial start does.
+        if (keyListener !== listener) return;
+        hotkeyLog.error(
+          "Native key listener permanently failed; falling back to Electron globalShortcut (toggle mode).",
+        );
+        listener.stop();
+        keyListener = null;
+        if (hotkeyPressed) {
+          hotkeyPressed = false;
+          clearHotkeyStuckWatchdog();
+          sendHotkeyUp();
+        }
+        const registeredAccel = registerGlobalShortcutToggle(accel);
+        if (registeredAccel) {
+          notifyHotkeyDegraded(accel, nativeError);
+        } else {
+          const errorPayload = {
+            message: `The hotkey listener stopped working and "${accel}" could not be re-registered. Restart Freestyle or pick a different combination in Settings.`,
+          };
+          mainWindow?.webContents.send("hotkey:error", errorPayload);
+          settingsWindow?.webContents.send("hotkey:error", errorPayload);
+        }
+      },
     });
     keyListener = listener;
 
@@ -2279,6 +2339,9 @@ async function registerHotkey(hotkey?: string): Promise<void> {
 
     if (started) {
       accessibilityConfirmed = true;
+      // A healthy native listener means hold-to-talk works again; re-arm the
+      // degradation notice so a later regression in this session notifies.
+      hotkeyDegradedNotified = false;
     } else {
       hotkeyLog.warn(
         "Native key listener unavailable, falling back to Electron globalShortcut (toggle mode).",

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -2205,8 +2205,17 @@ function notifyPasteFailed(): void {
   const shortcut = process.platform === "darwin" ? "Cmd+V" : "Ctrl+V";
   let hint = "";
   if (process.platform === "linux") {
-    const tool = isWaylandSession() ? "wtype" : "xdotool";
-    hint = ` Installing ${tool} may fix this (e.g. sudo apt install ${tool}).`;
+    if (isWaylandSession()) {
+      const desktop = (process.env.XDG_CURRENT_DESKTOP ?? "").toLowerCase();
+      // wtype doesn't work on GNOME/Mutter (no virtual-keyboard protocol) —
+      // don't send GNOME users to install a tool that can't help them.
+      hint = desktop.includes("gnome")
+        ? " If a permission dialog appears on the next paste, allow Freestyle to control input."
+        : " If a permission dialog appears on the next paste, allow it — or install wtype (e.g. sudo apt install wtype).";
+    } else {
+      hint =
+        " Installing xdotool may fix this (e.g. sudo apt install xdotool).";
+    }
   }
   if (Notification.isSupported()) {
     new Notification({

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -82,6 +82,7 @@ import { isActiveAudioPlaybackMode } from "../shared/audio-playback";
 import { getDefaultHotkey } from "../shared/hotkey-defaults";
 import { SETTINGS_KEYS } from "../shared/settings-keys";
 import { AudioPlaybackController } from "./audio-control/controller";
+import { recoverDuckedVolumeFromCrash } from "./audio-control/volume-ducker";
 import { HotkeyRecorder } from "./hotkey-recorder";
 import { normalizeAccelerator } from "./hotkey-utils";
 import { NativeKeyListener } from "./key-listener";
@@ -1397,6 +1398,9 @@ app.on("second-instance", () => {
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(async () => {
   void startLinuxPasteHelper();
+  // If a previous run died while dictating, the system volume may still be
+  // stuck at the ducked level — restore it before anything else.
+  void recoverDuckedVolumeFromCrash();
 
   // Set app user model id for windows
   electronApp.setAppUserModelId("com.freestyle.app");

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -25,6 +25,12 @@ interface KeyListenerOptions {
   onKeyUp: KeyEventCallback;
   onError?: (error: string) => void;
   onReady?: () => void;
+  /**
+   * Fired when the listener gives up restarting for good (restart cap
+   * exceeded). The listener ran at some point but is now permanently dead —
+   * callers should install a fallback so the hotkey keeps working.
+   */
+  onPermanentFailure?: () => void;
 }
 
 const BINARY_NAMES: Record<string, string> = {
@@ -506,6 +512,7 @@ export class NativeKeyListener {
       this.options.onError?.(
         "Key listener exceeded max restart attempts. Give up.",
       );
+      this.options.onPermanentFailure?.();
       return;
     }
 
@@ -540,34 +547,6 @@ export class NativeKeyListener {
       }
       this.process = null;
     }
-  }
-
-  /**
-   * Update the hotkey. Restarts the listener with the new hotkey.
-   */
-  updateHotkey(hotkey: string): void {
-    this.options.hotkey = hotkey;
-    // Stop without permanently destroying
-    this.destroyed = false;
-    if (this.restartTimer) {
-      clearTimeout(this.restartTimer);
-      this.restartTimer = null;
-    }
-    this.cancelMacSoloFnDown();
-    if (this.process) {
-      try {
-        this.process.kill("SIGTERM");
-      } catch {
-        // Process may already be dead
-      }
-      this.process = null;
-    }
-    this.macModState.clear();
-    this.macFlagState.clear();
-    this.macHotkeyActive = false;
-    this.macFnDown = false;
-    this.restartAttempts = 0;
-    this.start();
   }
 
   get isRunning(): boolean {

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -25,11 +25,6 @@ interface KeyListenerOptions {
   onKeyUp: KeyEventCallback;
   onError?: (error: string) => void;
   onReady?: () => void;
-  /**
-   * Fired when the listener gives up restarting for good (restart cap
-   * exceeded). The listener ran at some point but is now permanently dead —
-   * callers should install a fallback so the hotkey keeps working.
-   */
   onPermanentFailure?: () => void;
 }
 

--- a/apps/electron/src/main/linux-setup.ts
+++ b/apps/electron/src/main/linux-setup.ts
@@ -15,6 +15,11 @@ export interface LinuxSetupStatus {
   wayland: boolean;
   /** Can read at least one /dev/input/event* device (global hotkey listener). */
   inputAccess: boolean;
+  /**
+   * Can write /dev/uinput — the primary Wayland paste path. Without it,
+   * Wayland pastes fall back to the RemoteDesktop portal, then wtype.
+   */
+  uinputAccess: boolean;
   /** The paste fallback tool this session needs (xdotool or wtype). */
   pasteToolRequired: string;
   /** Same as pasteToolRequired when installed, null when missing. */
@@ -44,6 +49,15 @@ function hasInputAccess(): boolean {
   }
 }
 
+function hasUinputAccess(): boolean {
+  try {
+    accessSync("/dev/uinput", constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function checkLinuxSetup(): Promise<LinuxSetupStatus> {
   const wayland = isWaylandSession();
   const pasteToolRequired = wayland ? "wtype" : "xdotool";
@@ -53,6 +67,7 @@ export async function checkLinuxSetup(): Promise<LinuxSetupStatus> {
   return {
     wayland,
     inputAccess: hasInputAccess(),
+    uinputAccess: hasUinputAccess(),
     pasteToolRequired,
     pasteTool,
   };

--- a/apps/electron/src/main/linux-setup.ts
+++ b/apps/electron/src/main/linux-setup.ts
@@ -15,10 +15,6 @@ export interface LinuxSetupStatus {
   wayland: boolean;
   /** Can read at least one /dev/input/event* device (global hotkey listener). */
   inputAccess: boolean;
-  /**
-   * Can write /dev/uinput — the primary Wayland paste path. Without it,
-   * Wayland pastes fall back to the RemoteDesktop portal, then wtype.
-   */
   uinputAccess: boolean;
   /** The paste fallback tool this session needs (xdotool or wtype). */
   pasteToolRequired: string;

--- a/apps/electron/src/main/mic-listener.ts
+++ b/apps/electron/src/main/mic-listener.ts
@@ -113,9 +113,12 @@ export class MicListener {
       }
     });
 
-    this.process.on("close", () => {
+    this.process.on("close", (code) => {
       this.process = null;
-      if (!this.destroyed) {
+      // Restart only on abnormal exit — a clean exit (e.g. pactl present but
+      // the PulseAudio socket is gone) would otherwise respawn every 5s
+      // forever.
+      if (!this.destroyed && code !== 0) {
         this.scheduleRestart();
       }
     });

--- a/apps/electron/src/main/mic-listener.ts
+++ b/apps/electron/src/main/mic-listener.ts
@@ -115,9 +115,6 @@ export class MicListener {
 
     this.process.on("close", (code) => {
       this.process = null;
-      // Restart only on abnormal exit — a clean exit (e.g. pactl present but
-      // the PulseAudio socket is gone) would otherwise respawn every 5s
-      // forever.
       if (!this.destroyed && code !== 0) {
         this.scheduleRestart();
       }

--- a/apps/electron/src/main/paste.ts
+++ b/apps/electron/src/main/paste.ts
@@ -150,8 +150,6 @@ function handleLinuxUinputLine(line: string): void {
 }
 
 export function startLinuxPasteHelper(force = false): Promise<boolean> {
-  // `force` lets the cross-family fallback try uinput even when the session
-  // was detected as X11 (env-based detection can misclassify).
   if (process.platform !== "linux" || (!force && !isWaylandSession())) {
     return Promise.resolve(false);
   }
@@ -288,9 +286,6 @@ function linuxPasteArgs(isTerminal: boolean): string[] {
   return isTerminal ? ["--terminal"] : [];
 }
 
-// The XDG RemoteDesktop portal grants a persistable input-injection session.
-// The native binary prints a restore token on success; reusing it makes every
-// paste after the first permission dialog silent.
 function portalTokenPath(): string {
   return join(app.getPath("userData"), "portal-restore-token");
 }
@@ -316,9 +311,7 @@ function savePortalToken(token: string): void {
 function clearPortalToken(): void {
   try {
     unlinkSync(portalTokenPath());
-  } catch {
-    // Already gone
-  }
+  } catch {}
 }
 
 async function pasteLinuxPortal(isTerminal: boolean): Promise<boolean> {
@@ -330,8 +323,6 @@ async function pasteLinuxPortal(isTerminal: boolean): Promise<boolean> {
   if (token) args.push("--restore-token", token);
 
   try {
-    // The binary's internal portal timeout is 10s (covers the first-use
-    // permission dialog); give the process a little extra before killing it.
     const { code, stdout } = await execFileWithOutput(binaryPath, args, 15_000);
     if (code === 0) {
       const newToken = stdout.trim().split("\n").pop()?.trim();
@@ -339,8 +330,6 @@ async function pasteLinuxPortal(isTerminal: boolean): Promise<boolean> {
       return true;
     }
     if (token && (code === 2 || code === 3)) {
-      // The saved grant was revoked — drop the stale token so the next
-      // attempt re-prompts instead of failing forever.
       clearPortalToken();
     }
     log.warn(`Portal paste failed (exit ${code})`);
@@ -375,9 +364,6 @@ async function pasteLinux(isTerminal: boolean): Promise<PasteMethod> {
     await pasteLinuxLegacy(false, isTerminal);
     return "legacy";
   } catch (err) {
-    // Session-type detection is env-var based and can misclassify (e.g. a
-    // Wayland session without XDG_SESSION_TYPE) — cross-try the Wayland
-    // injectors before giving up.
     log.warn("X11 paste backends failed, cross-trying Wayland backends");
     if (await sendPersistentUinputPaste(isTerminal, true)) return "native";
     if (await pasteLinuxPortal(isTerminal)) return "native";
@@ -390,8 +376,6 @@ async function pasteLinuxWayland(isTerminal: boolean): Promise<PasteMethod> {
     return "native";
   }
 
-  // GNOME/Mutter doesn't implement the virtual-keyboard protocol wtype
-  // needs, so the RemoteDesktop portal is the standard fallback there.
   log.warn("Persistent uinput paste failed, trying RemoteDesktop portal");
   if (await pasteLinuxPortal(isTerminal)) {
     return "native";
@@ -402,7 +386,6 @@ async function pasteLinuxWayland(isTerminal: boolean): Promise<PasteMethod> {
     await pasteLinuxLegacy(true, isTerminal);
     return "legacy";
   } catch (err) {
-    // Cross-try the X11 injectors in case the session was misdetected.
     log.warn("Wayland paste backends failed, cross-trying X11 backends");
     const binary = getNativeBinaryPath("linux-fast-paste");
     if (binary) {
@@ -436,11 +419,6 @@ async function pasteLinuxLegacy(
   }
 }
 
-// The settle delay runs between sending the paste keystroke and restoring the
-// prior clipboard. It is invisible to the user (the transcript has already
-// been pasted) but it is the only protection against slow targets (remote
-// desktop, loaded IDEs) that process Ctrl/Cmd+V after we restore — those
-// would paste the OLD clipboard. Keep it generous.
 const PASTE_SETTLE_MS: Record<string, number> = {
   darwin: 300,
   win32: 300,
@@ -460,9 +438,6 @@ function pasteSettleMs(method: PasteMethod): number {
   return table[process.platform] ?? 500;
 }
 
-// Clipboard flavors Electron can read back and re-write. Anything else
-// (file copies, app-private data) cannot be snapshotted, so overwriting it
-// with plain text on restore would destroy the user's copy.
 const RESTORABLE_TEXT_FORMATS = new Set([
   "text/plain",
   "text/html",
@@ -512,8 +487,6 @@ function restoreClipboard(
 ): void {
   if (!snapshot.restorable) return;
   try {
-    // If the clipboard no longer holds our transcript, the user (or another
-    // app) copied something during the settle window — don't clobber it.
     if (clipboard.readText() !== transcript) {
       log.debug("clipboard changed since paste; skipping restore");
       return;
@@ -531,8 +504,6 @@ function restoreClipboard(
   }
 }
 
-// Serialized: two overlapping dictations must not interleave their clipboard
-// save/paste/restore sequences.
 let pasteChain: Promise<void> = Promise.resolve();
 
 export function pasteIntoFocusedApp(

--- a/apps/electron/src/main/paste.ts
+++ b/apps/electron/src/main/paste.ts
@@ -4,8 +4,10 @@ import {
   execFile,
   spawn,
 } from "node:child_process";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { createAppLogger } from "@freestyle-voice/utils";
-import { clipboard } from "electron";
+import { app, clipboard } from "electron";
 import { isLinuxTerminalFocused } from "./linux-terminal-focus";
 import { getNativeBinaryPath } from "./native-binary";
 
@@ -28,9 +30,13 @@ async function tryExecAsync(cmd: string, label: string): Promise<boolean> {
   }
 }
 
-function execFileAsync(path: string, args: string[] = []): Promise<number> {
+function execFileWithOutput(
+  path: string,
+  args: string[] = [],
+  timeoutMs?: number,
+): Promise<{ code: number; stdout: string }> {
   return new Promise((resolve, reject) => {
-    execFile(path, args, (err) => {
+    execFile(path, args, { timeout: timeoutMs }, (err, stdout) => {
       if (err) {
         const status = (err as { status?: unknown }).status;
         const exitCode =
@@ -40,15 +46,23 @@ function execFileAsync(path: string, args: string[] = []): Promise<number> {
               ? err.code
               : undefined;
         if (exitCode !== undefined) {
-          resolve(exitCode);
+          resolve({ code: exitCode, stdout: stdout ?? "" });
         } else {
           reject(err);
         }
       } else {
-        resolve(0);
+        resolve({ code: 0, stdout: stdout ?? "" });
       }
     });
   });
+}
+
+async function execFileAsync(
+  path: string,
+  args: string[] = [],
+): Promise<number> {
+  const { code } = await execFileWithOutput(path, args);
+  return code;
 }
 
 export function isWaylandSession(): boolean {
@@ -135,8 +149,10 @@ function handleLinuxUinputLine(line: string): void {
   }
 }
 
-export function startLinuxPasteHelper(): Promise<boolean> {
-  if (process.platform !== "linux" || !isWaylandSession()) {
+export function startLinuxPasteHelper(force = false): Promise<boolean> {
+  // `force` lets the cross-family fallback try uinput even when the session
+  // was detected as X11 (env-based detection can misclassify).
+  if (process.platform !== "linux" || (!force && !isWaylandSession())) {
     return Promise.resolve(false);
   }
   if (linuxUinputHelper && linuxUinputReady) {
@@ -223,9 +239,10 @@ export function stopLinuxPasteHelper(): void {
 
 async function sendPersistentUinputPaste(
   isTerminal: boolean,
+  force = false,
 ): Promise<boolean> {
   const run = async (): Promise<boolean> => {
-    if (!(await startLinuxPasteHelper())) return false;
+    if (!(await startLinuxPasteHelper(force))) return false;
     const helper = linuxUinputHelper;
     if (!helper?.stdin.writable) return false;
 
@@ -271,6 +288,70 @@ function linuxPasteArgs(isTerminal: boolean): string[] {
   return isTerminal ? ["--terminal"] : [];
 }
 
+// The XDG RemoteDesktop portal grants a persistable input-injection session.
+// The native binary prints a restore token on success; reusing it makes every
+// paste after the first permission dialog silent.
+function portalTokenPath(): string {
+  return join(app.getPath("userData"), "portal-restore-token");
+}
+
+function readPortalToken(): string | null {
+  try {
+    const token = readFileSync(portalTokenPath(), "utf8").trim();
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+function savePortalToken(token: string): void {
+  try {
+    writeFileSync(portalTokenPath(), token, "utf8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`Failed to persist portal restore token: ${message}`);
+  }
+}
+
+function clearPortalToken(): void {
+  try {
+    unlinkSync(portalTokenPath());
+  } catch {
+    // Already gone
+  }
+}
+
+async function pasteLinuxPortal(isTerminal: boolean): Promise<boolean> {
+  const binaryPath = getNativeBinaryPath("linux-fast-paste");
+  if (!binaryPath) return false;
+
+  const args = ["--portal", ...linuxPasteArgs(isTerminal)];
+  const token = readPortalToken();
+  if (token) args.push("--restore-token", token);
+
+  try {
+    // The binary's internal portal timeout is 10s (covers the first-use
+    // permission dialog); give the process a little extra before killing it.
+    const { code, stdout } = await execFileWithOutput(binaryPath, args, 15_000);
+    if (code === 0) {
+      const newToken = stdout.trim().split("\n").pop()?.trim();
+      if (newToken) savePortalToken(newToken);
+      return true;
+    }
+    if (token && (code === 2 || code === 3)) {
+      // The saved grant was revoked — drop the stale token so the next
+      // attempt re-prompts instead of failing forever.
+      clearPortalToken();
+    }
+    log.warn(`Portal paste failed (exit ${code})`);
+    return false;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`Portal paste error: ${message}`);
+    return false;
+  }
+}
+
 async function pasteLinux(isTerminal: boolean): Promise<PasteMethod> {
   const binaryPath = getNativeBinaryPath("linux-fast-paste");
   const wayland = isWaylandSession();
@@ -284,17 +365,24 @@ async function pasteLinux(isTerminal: boolean): Promise<PasteMethod> {
       binaryPath,
       linuxPasteArgs(isTerminal),
     );
-    if (exitCode !== 0) {
-      log.warn(
-        `Native paste failed (exit ${exitCode}), falling back to xdotool`,
-      );
-      await pasteLinuxLegacy(false, isTerminal);
-      return "legacy";
+    if (exitCode === 0) {
+      return "native";
     }
-    return "native";
+    log.warn(`Native paste failed (exit ${exitCode}), falling back to xdotool`);
   }
-  await pasteLinuxLegacy(false, isTerminal);
-  return "legacy";
+
+  try {
+    await pasteLinuxLegacy(false, isTerminal);
+    return "legacy";
+  } catch (err) {
+    // Session-type detection is env-var based and can misclassify (e.g. a
+    // Wayland session without XDG_SESSION_TYPE) — cross-try the Wayland
+    // injectors before giving up.
+    log.warn("X11 paste backends failed, cross-trying Wayland backends");
+    if (await sendPersistentUinputPaste(isTerminal, true)) return "native";
+    if (await pasteLinuxPortal(isTerminal)) return "native";
+    throw err;
+  }
 }
 
 async function pasteLinuxWayland(isTerminal: boolean): Promise<PasteMethod> {
@@ -302,9 +390,32 @@ async function pasteLinuxWayland(isTerminal: boolean): Promise<PasteMethod> {
     return "native";
   }
 
-  log.warn("Persistent uinput paste failed, falling back to wtype");
-  await pasteLinuxLegacy(true, isTerminal);
-  return "legacy";
+  // GNOME/Mutter doesn't implement the virtual-keyboard protocol wtype
+  // needs, so the RemoteDesktop portal is the standard fallback there.
+  log.warn("Persistent uinput paste failed, trying RemoteDesktop portal");
+  if (await pasteLinuxPortal(isTerminal)) {
+    return "native";
+  }
+
+  log.warn("Portal paste failed, falling back to wtype");
+  try {
+    await pasteLinuxLegacy(true, isTerminal);
+    return "legacy";
+  } catch (err) {
+    // Cross-try the X11 injectors in case the session was misdetected.
+    log.warn("Wayland paste backends failed, cross-trying X11 backends");
+    const binary = getNativeBinaryPath("linux-fast-paste");
+    if (binary) {
+      const exitCode = await execFileAsync(binary, linuxPasteArgs(isTerminal));
+      if (exitCode === 0) return "native";
+    }
+    try {
+      await pasteLinuxLegacy(false, isTerminal);
+      return "legacy";
+    } catch {
+      throw err;
+    }
+  }
 }
 
 async function pasteLinuxLegacy(

--- a/apps/electron/src/main/paste.ts
+++ b/apps/electron/src/main/paste.ts
@@ -325,23 +325,119 @@ async function pasteLinuxLegacy(
   }
 }
 
-// Native binaries inject keystrokes directly at the OS level, so the target
-// app receives them much faster than shell-spawned commands. Settle times
-// are reduced accordingly. If using the legacy fallback, the original higher
-// values are used.
+// The settle delay runs between sending the paste keystroke and restoring the
+// prior clipboard. It is invisible to the user (the transcript has already
+// been pasted) but it is the only protection against slow targets (remote
+// desktop, loaded IDEs) that process Ctrl/Cmd+V after we restore — those
+// would paste the OLD clipboard. Keep it generous.
 const PASTE_SETTLE_MS: Record<string, number> = {
-  darwin: 150,
-  win32: 150,
-  linux: 100,
+  darwin: 300,
+  win32: 300,
+  linux: 300,
 };
 
 const PASTE_SETTLE_LEGACY_MS: Record<string, number> = {
   darwin: 500,
   win32: 600,
-  linux: 300,
+  linux: 500,
 };
 
-export async function pasteIntoFocusedApp(
+function pasteSettleMs(method: PasteMethod): number {
+  const override = Number(process.env.FREESTYLE_PASTE_SETTLE_MS);
+  if (Number.isFinite(override) && override >= 0) return override;
+  const table = method === "native" ? PASTE_SETTLE_MS : PASTE_SETTLE_LEGACY_MS;
+  return table[process.platform] ?? 500;
+}
+
+// Clipboard flavors Electron can read back and re-write. Anything else
+// (file copies, app-private data) cannot be snapshotted, so overwriting it
+// with plain text on restore would destroy the user's copy.
+const RESTORABLE_TEXT_FORMATS = new Set([
+  "text/plain",
+  "text/html",
+  "text/rtf",
+]);
+
+type ClipboardSnapshot =
+  | { restorable: false }
+  | {
+      restorable: true;
+      text: string;
+      html?: string;
+      rtf?: string;
+      image?: Electron.NativeImage;
+    };
+
+function snapshotClipboard(): ClipboardSnapshot {
+  try {
+    const formats = clipboard.availableFormats();
+    const unknown = formats.filter(
+      (f) => !RESTORABLE_TEXT_FORMATS.has(f) && !f.startsWith("image/"),
+    );
+    if (unknown.length > 0) {
+      log.debug(
+        `clipboard holds non-restorable formats (${unknown.join(", ")}); leaving transcript on clipboard after paste`,
+      );
+      return { restorable: false };
+    }
+    const hasImage = formats.some((f) => f.startsWith("image/"));
+    return {
+      restorable: true,
+      text: clipboard.readText(),
+      html: formats.includes("text/html") ? clipboard.readHTML() : undefined,
+      rtf: formats.includes("text/rtf") ? clipboard.readRTF() : undefined,
+      image: hasImage ? clipboard.readImage() : undefined,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`Failed to snapshot clipboard: ${message}`);
+    return { restorable: false };
+  }
+}
+
+function restoreClipboard(
+  snapshot: ClipboardSnapshot,
+  transcript: string,
+): void {
+  if (!snapshot.restorable) return;
+  try {
+    // If the clipboard no longer holds our transcript, the user (or another
+    // app) copied something during the settle window — don't clobber it.
+    if (clipboard.readText() !== transcript) {
+      log.debug("clipboard changed since paste; skipping restore");
+      return;
+    }
+    const data: Electron.Data = { text: snapshot.text };
+    if (snapshot.html !== undefined) data.html = snapshot.html;
+    if (snapshot.rtf !== undefined) data.rtf = snapshot.rtf;
+    if (snapshot.image && !snapshot.image.isEmpty()) {
+      data.image = snapshot.image;
+    }
+    clipboard.write(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`Failed to restore clipboard: ${message}`);
+  }
+}
+
+// Serialized: two overlapping dictations must not interleave their clipboard
+// save/paste/restore sequences.
+let pasteChain: Promise<void> = Promise.resolve();
+
+export function pasteIntoFocusedApp(
+  text: string,
+  beforePaste?: () => Promise<void> | void,
+): Promise<void> {
+  const run = (): Promise<void> => doPasteIntoFocusedApp(text, beforePaste);
+  const result = pasteChain.then(run, run);
+  pasteChain = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+async function doPasteIntoFocusedApp(
   text: string,
   beforePaste?: () => Promise<void> | void,
 ): Promise<void> {
@@ -350,7 +446,7 @@ export async function pasteIntoFocusedApp(
   log.debug(`pasting ${text?.length ?? 0} chars`);
   if (!text?.trim()) return;
 
-  const prior = clipboard.readText();
+  const prior = snapshotClipboard();
   clipboard.writeText(text);
 
   let pasted = false;
@@ -376,20 +472,12 @@ export async function pasteIntoFocusedApp(
     }
     pasted = true;
 
-    const settleTable =
-      method === "native" ? PASTE_SETTLE_MS : PASTE_SETTLE_LEGACY_MS;
-    const settleMs = settleTable[process.platform] ?? 500;
-    await new Promise((r) => setTimeout(r, settleMs));
+    await new Promise((r) => setTimeout(r, pasteSettleMs(method)));
   } finally {
     // When every paste backend failed, the clipboard is the only copy of the
     // transcript the user still has — leave it there instead of restoring.
     if (pasted) {
-      try {
-        clipboard.writeText(prior);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        log.warn(`Failed to restore clipboard: ${message}`);
-      }
+      restoreClipboard(prior, text);
     }
   }
 }

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -41,6 +41,7 @@ declare global {
       checkLinuxSetup: () => Promise<{
         wayland: boolean;
         inputAccess: boolean;
+        uinputAccess: boolean;
         pasteToolRequired: string;
         pasteTool: string | null;
       } | null>;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -68,6 +68,7 @@ const api = {
   checkLinuxSetup: (): Promise<{
     wayland: boolean;
     inputAccess: boolean;
+    uinputAccess: boolean;
     pasteToolRequired: string;
     pasteTool: string | null;
   } | null> => ipcRenderer.invoke("permissions:check-linux-setup"),

--- a/apps/electron/src/renderer/src/onboarding.tsx
+++ b/apps/electron/src/renderer/src/onboarding.tsx
@@ -79,10 +79,11 @@ const DEFAULT_HOTKEY =
   getDefaultHotkey();
 
 // Linux system-setup state reported by the main process (input-group access
-// for the hotkey listener, xdotool/wtype for the paste fallback).
+// for the hotkey listener, /dev/uinput or xdotool/wtype for pasting).
 type LinuxSetup = {
   wayland: boolean;
   inputAccess: boolean;
+  uinputAccess: boolean;
   pasteToolRequired: string;
   pasteTool: string | null;
 };
@@ -983,25 +984,31 @@ function PermissionsStep({
           />
         )}
 
-        {IS_LINUX && linuxSetup && !linuxSetup.pasteTool && (
-          <PermCard
-            icon={ClipboardPaste}
-            title={t("onboarding.permissions.pasteTool.title")}
-            desc={
-              <Trans
-                i18nKey="onboarding.permissions.pasteTool.desc"
-                values={{ tool: linuxSetup.pasteToolRequired }}
-                components={{ code: <code className="text-foreground" /> }}
-              />
-            }
-            granted={false}
-            action={
-              <PermButton onClick={onRecheckLinuxSetup}>
-                {t("common.recheck")}
-              </PermButton>
-            }
-          />
-        )}
+        {/* On Wayland, /dev/uinput access (or the RemoteDesktop portal)
+            handles pasting without wtype — only warn when neither the
+            primary path nor the fallback tool is available. */}
+        {IS_LINUX &&
+          linuxSetup &&
+          !linuxSetup.pasteTool &&
+          !(linuxSetup.wayland && linuxSetup.uinputAccess) && (
+            <PermCard
+              icon={ClipboardPaste}
+              title={t("onboarding.permissions.pasteTool.title")}
+              desc={
+                <Trans
+                  i18nKey="onboarding.permissions.pasteTool.desc"
+                  values={{ tool: linuxSetup.pasteToolRequired }}
+                  components={{ code: <code className="text-foreground" /> }}
+                />
+              }
+              granted={false}
+              action={
+                <PermButton onClick={onRecheckLinuxSetup}>
+                  {t("common.recheck")}
+                </PermButton>
+              }
+            />
+          )}
       </div>
 
       <div className="mt-7 flex items-center justify-between gap-3.5">

--- a/apps/electron/src/renderer/src/onboarding.tsx
+++ b/apps/electron/src/renderer/src/onboarding.tsx
@@ -79,7 +79,7 @@ const DEFAULT_HOTKEY =
   getDefaultHotkey();
 
 // Linux system-setup state reported by the main process (input-group access
-// for the hotkey listener, /dev/uinput or xdotool/wtype for pasting).
+// for the hotkey listener, xdotool/wtype for the paste fallback).
 type LinuxSetup = {
   wayland: boolean;
   inputAccess: boolean;
@@ -984,9 +984,6 @@ function PermissionsStep({
           />
         )}
 
-        {/* On Wayland, /dev/uinput access (or the RemoteDesktop portal)
-            handles pasting without wtype — only warn when neither the
-            primary path nor the fallback tool is available. */}
         {IS_LINUX &&
           linuxSetup &&
           !linuxSetup.pasteTool &&

--- a/apps/electron/src/renderer/src/pages/dictionary.tsx
+++ b/apps/electron/src/renderer/src/pages/dictionary.tsx
@@ -1,6 +1,6 @@
 import {
-  type CreateDictionaryInput,
-  createDictionarySchema,
+  type DictionaryInput,
+  dictionarySchema,
 } from "@freestyle-voice/validations";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@renderer/components/ui/button";
@@ -76,8 +76,8 @@ export default function DictionaryPage(): React.JSX.Element {
     handleSubmit,
     reset: resetFormValues,
     formState: { errors: formErrors },
-  } = useForm<CreateDictionaryInput>({
-    resolver: zodResolver(createDictionarySchema),
+  } = useForm<DictionaryInput>({
+    resolver: zodResolver(dictionarySchema),
     defaultValues: { key: "", value: "" },
   });
 
@@ -99,7 +99,7 @@ export default function DictionaryPage(): React.JSX.Element {
   );
 
   const saveEntry = useCallback(
-    async (data: CreateDictionaryInput) => {
+    async (data: DictionaryInput) => {
       setFormError(null);
 
       try {

--- a/apps/server/src/lib/dictionary-replacements.ts
+++ b/apps/server/src/lib/dictionary-replacements.ts
@@ -5,20 +5,33 @@ const CJK_SCRIPT_RE =
   /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 const WORDLIKE_CHAR_CLASS = "[\\p{L}\\p{N}\\p{M}_]";
 
+// A key always compiles to the same regex, so cache compiled patterns across
+// transcripts instead of recompiling every dictionary row per dictation.
+const REGEX_CACHE_MAX = 5000;
+const regexCache = new Map<string, RegExp>();
+
 function buildDictionaryRegex(key: string): RegExp {
+  const cached = regexCache.get(key);
+  if (cached) return cached;
+
   const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
   // Chinese/Japanese/Korean phrases are commonly written without spaces, so
   // "whole word" boundaries prevent valid replacements inside running text.
+  let regex: RegExp;
   if (CJK_SCRIPT_RE.test(key)) {
-    return new RegExp(escaped, "gu");
+    regex = new RegExp(escaped, "gu");
+  } else {
+    const startsWordLike = /^[\p{L}\p{N}\p{M}_]/u.test(key);
+    const endsWordLike = /[\p{L}\p{N}\p{M}_]$/u.test(key);
+    const prefix = startsWordLike ? `(?<!${WORDLIKE_CHAR_CLASS})` : "";
+    const suffix = endsWordLike ? `(?!${WORDLIKE_CHAR_CLASS})` : "";
+    regex = new RegExp(`${prefix}${escaped}${suffix}`, "giu");
   }
 
-  const startsWordLike = /^[\p{L}\p{N}\p{M}_]/u.test(key);
-  const endsWordLike = /[\p{L}\p{N}\p{M}_]$/u.test(key);
-  const prefix = startsWordLike ? `(?<!${WORDLIKE_CHAR_CLASS})` : "";
-  const suffix = endsWordLike ? `(?!${WORDLIKE_CHAR_CLASS})` : "";
-  return new RegExp(`${prefix}${escaped}${suffix}`, "giu");
+  if (regexCache.size >= REGEX_CACHE_MAX) regexCache.clear();
+  regexCache.set(key, regex);
+  return regex;
 }
 
 export function applyDictionaryReplacements(
@@ -39,7 +52,9 @@ export function applyDictionaryReplacements(
     const matchedIds: number[] = [];
     for (const { id, key, value } of dictRows) {
       const regex = buildDictionaryRegex(key);
-      const nextText = cleanedText.replace(regex, value);
+      // Function replacer: values are inserted literally, so `$&`, `$1`,
+      // `` $` `` etc. in a user's replacement are never interpreted.
+      const nextText = cleanedText.replace(regex, () => value);
       if (nextText !== cleanedText) {
         matchedIds.push(id);
         cleanedText = nextText;
@@ -47,12 +62,10 @@ export function applyDictionaryReplacements(
     }
 
     if (matchedIds.length > 0) {
-      const updateStmt = db.prepare(
-        "UPDATE dictionary SET usage_count = usage_count + 1 WHERE id = ?",
-      );
-      for (const id of matchedIds) {
-        updateStmt.run(id);
-      }
+      const placeholders = matchedIds.map(() => "?").join(",");
+      db.prepare(
+        `UPDATE dictionary SET usage_count = usage_count + 1 WHERE id IN (${placeholders})`,
+      ).run(...matchedIds);
     }
   } catch {
     // Dictionary table may not exist yet

--- a/apps/server/src/lib/dictionary-replacements.ts
+++ b/apps/server/src/lib/dictionary-replacements.ts
@@ -5,8 +5,6 @@ const CJK_SCRIPT_RE =
   /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 const WORDLIKE_CHAR_CLASS = "[\\p{L}\\p{N}\\p{M}_]";
 
-// A key always compiles to the same regex, so cache compiled patterns across
-// transcripts instead of recompiling every dictionary row per dictation.
 const REGEX_CACHE_MAX = 5000;
 const regexCache = new Map<string, RegExp>();
 
@@ -52,8 +50,6 @@ export function applyDictionaryReplacements(
     const matchedIds: number[] = [];
     for (const { id, key, value } of dictRows) {
       const regex = buildDictionaryRegex(key);
-      // Function replacer: values are inserted literally, so `$&`, `$1`,
-      // `` $` `` etc. in a user's replacement are never interpreted.
       const nextText = cleanedText.replace(regex, () => value);
       if (nextText !== cleanedText) {
         matchedIds.push(id);

--- a/apps/server/src/routes/dictionary.ts
+++ b/apps/server/src/routes/dictionary.ts
@@ -1,5 +1,5 @@
 import {
-  createDictionarySchema,
+  dictionarySchema,
   exportSchema,
   updateDictionarySchema,
 } from "@freestyle-voice/validations";
@@ -82,7 +82,7 @@ const dictionary = new Hono()
     if (!row) return c.json({ error: "Not found" }, 404);
     return c.json(row);
   })
-  .post("/", zValidator("json", createDictionarySchema), async (c) => {
+  .post("/", zValidator("json", dictionarySchema), async (c) => {
     const db = getDb();
     const body = c.req.valid("json");
 

--- a/apps/server/src/routes/mcp.ts
+++ b/apps/server/src/routes/mcp.ts
@@ -1,8 +1,8 @@
 import {
-  createDictionarySchema,
   createFormatSchema,
   createVocabularySchema,
   DEFAULT_CLEANUP_INTENSITY,
+  dictionarySchema,
   updateDictionarySchema,
   updateFormatSchema,
   updateVocabularySchema,
@@ -153,7 +153,7 @@ mcpServer.tool(
 mcpServer.tool(
   "dict_create",
   "Create a dictionary entry: an exact replacement applied after transcription (`key` is the text to find, `value` is what to replace it with).",
-  createDictionarySchema.shape,
+  dictionarySchema.shape,
   async (args) => {
     const { data, ok } = await call(dictionary, "POST", "/", args);
     if (!ok) return error(data.error ?? "Failed to create dictionary entry");

--- a/apps/server/tests/dictionary-replacements.test.ts
+++ b/apps/server/tests/dictionary-replacements.test.ts
@@ -111,7 +111,6 @@ describe("applyDictionaryReplacements", () => {
     expect(applyDictionaryReplacements("brb in five", db)).toBe(
       "be right back in five",
     );
-    // Second call exercises the cached regex; global-flag state must not leak.
     expect(applyDictionaryReplacements("brb brb", db)).toBe(
       "be right back be right back",
     );

--- a/apps/server/tests/dictionary-replacements.test.ts
+++ b/apps/server/tests/dictionary-replacements.test.ts
@@ -58,4 +58,62 @@ describe("applyDictionaryReplacements", () => {
 
     expect(result).toBe("concatenate the dog");
   });
+
+  it("inserts replacement values containing $ patterns literally", () => {
+    const db = testDb();
+    const insert = db.prepare(
+      "INSERT INTO dictionary (key, value) VALUES (?, ?)",
+    );
+    insert.run("price", "$&/month");
+    insert.run("cash", "A$$B");
+    insert.run("prefix", "$` and $' and $1");
+
+    expect(applyDictionaryReplacements("the price is low", db)).toBe(
+      "the $&/month is low",
+    );
+    expect(applyDictionaryReplacements("bring cash today", db)).toBe(
+      "bring A$$B today",
+    );
+    expect(applyDictionaryReplacements("add a prefix here", db)).toBe(
+      "add a $` and $' and $1 here",
+    );
+  });
+
+  it("increments usage_count for all matched entries in one pass", () => {
+    const db = testDb();
+    const insert = db.prepare(
+      "INSERT INTO dictionary (key, value) VALUES (?, ?)",
+    );
+    insert.run("foo", "FOO");
+    insert.run("bar", "BAR");
+    insert.run("unused", "UNUSED");
+
+    const result = applyDictionaryReplacements("foo and bar", db);
+
+    expect(result).toBe("FOO and BAR");
+    const rows = db
+      .prepare("SELECT key, usage_count FROM dictionary ORDER BY key")
+      .all() as { key: string; usage_count: number }[];
+    expect(rows).toEqual([
+      { key: "bar", usage_count: 1 },
+      { key: "foo", usage_count: 1 },
+      { key: "unused", usage_count: 0 },
+    ]);
+  });
+
+  it("reuses cached regexes across calls without stale results", () => {
+    const db = testDb();
+    db.prepare("INSERT INTO dictionary (key, value) VALUES (?, ?)").run(
+      "brb",
+      "be right back",
+    );
+
+    expect(applyDictionaryReplacements("brb in five", db)).toBe(
+      "be right back in five",
+    );
+    // Second call exercises the cached regex; global-flag state must not leak.
+    expect(applyDictionaryReplacements("brb brb", db)).toBe(
+      "be right back be right back",
+    );
+  });
 });

--- a/packages/validations/src/dictionary.ts
+++ b/packages/validations/src/dictionary.ts
@@ -3,7 +3,7 @@ import { z } from "zod/v3";
 export const DICTIONARY_KEY_MAX = 200;
 export const DICTIONARY_VALUE_MAX = 5000;
 
-export const createDictionarySchema = z.object({
+export const dictionarySchema = z.object({
   key: z
     .string()
     .min(1, "Key is required")
@@ -14,18 +14,7 @@ export const createDictionarySchema = z.object({
     .max(DICTIONARY_VALUE_MAX, "Value is too long"),
 });
 
-export const updateDictionarySchema = z.object({
-  key: z
-    .string()
-    .min(1, "Key is required")
-    .max(DICTIONARY_KEY_MAX, "Key is too long")
-    .optional(),
-  value: z
-    .string()
-    .min(1, "Value is required")
-    .max(DICTIONARY_VALUE_MAX, "Value is too long")
-    .optional(),
-});
+export const updateDictionarySchema = dictionarySchema.partial();
 
-export type CreateDictionaryInput = z.infer<typeof createDictionarySchema>;
+export type DictionaryInput = z.infer<typeof dictionarySchema>;
 export type UpdateDictionaryInput = z.infer<typeof updateDictionarySchema>;

--- a/packages/validations/src/dictionary.ts
+++ b/packages/validations/src/dictionary.ts
@@ -1,13 +1,30 @@
 import { z } from "zod/v3";
 
+export const DICTIONARY_KEY_MAX = 200;
+export const DICTIONARY_VALUE_MAX = 5000;
+
 export const createDictionarySchema = z.object({
-  key: z.string().min(1, "Key is required"),
-  value: z.string().min(1, "Value is required"),
+  key: z
+    .string()
+    .min(1, "Key is required")
+    .max(DICTIONARY_KEY_MAX, "Key is too long"),
+  value: z
+    .string()
+    .min(1, "Value is required")
+    .max(DICTIONARY_VALUE_MAX, "Value is too long"),
 });
 
 export const updateDictionarySchema = z.object({
-  key: z.string().min(1, "Key is required").optional(),
-  value: z.string().min(1, "Value is required").optional(),
+  key: z
+    .string()
+    .min(1, "Key is required")
+    .max(DICTIONARY_KEY_MAX, "Key is too long")
+    .optional(),
+  value: z
+    .string()
+    .min(1, "Value is required")
+    .max(DICTIONARY_VALUE_MAX, "Value is too long")
+    .optional(),
 });
 
 export type CreateDictionaryInput = z.infer<typeof createDictionarySchema>;


### PR DESCRIPTION
  1. cfb7468 — CI native-build safety. Added the missing
  <sys/ioctl.h> include to the Linux key listener (hard
  compile error on gcc 14+) and fixed its false "XRecord
  fallback" comment; compile-native.js now exits non-zero in
  CI when any binary fails to compile; a new
  verify-native-binaries.mjs asserts every expected binary
  exists in both resources/bin and the electron-builder
  unpacked package, wired into all three platform jobs;
  artifact uploads now use if-no-files-found: error.
  2. 9e9975e — Dictionary engine. Replacement values with $
  patterns are now inserted literally via a function replacer;
  compiled regexes are cached across transcripts; usage
  counts update in a single batched UPDATE ... IN (...);
  key/value length caps added to validation. Four new test
  cases cover the $ patterns, batching, and cache reuse.
  3. 3b4728d — Hotkey resilience. A new onPermanentFailure
  hook fires when the listener exhausts restarts after a
  successful start — main now installs the globalShortcut
  toggle fallback and notifies instead of silently losing
  dictation; a 5-minute stuck-key watchdog force-releases
  hold-mode presses that never see a key-up; the degradation
  notice re-arms after each healthy start; dead updateHotkey()
  removed.
  4. e330124 — Clipboard restore. The prior clipboard is
  snapshotted with all restorable flavors
  (text/HTML/RTF/image) and restored intact; restore is
  skipped when the clipboard holds unreadable formats (file
  copies) or when it changed during the settle window; native
  settle raised to 300 ms (invisible to the user — it only
  delays the restore) with a FREESTYLE_PASTE_SETTLE_MS
  override; paste calls are serialized.
  5. 9ef6b6e — Wayland portal paste. The Wayland chain is now
  uinput → RemoteDesktop portal → wtype, with the portal's
  restore token persisted so only the first paste prompts;
  revoked grants clear the stale token; cross-family fallback
  handles session misdetection; setup checks probe
  /dev/uinput, onboarding stops warning about wtype when
  uinput covers pasting, and GNOME users are no longer told to
  install a tool that can't work for them.
  6. d68df12 — Audio recovery. The pre-duck volume snapshot is
  persisted to disk and recovered on next launch if a run
  died mid-dictation (guarded so a manually-fixed volume is
  never yanked); Linux media resume on quit is now synchronous
  so music actually resumes; the pactl mic subscriber only
  respawns on abnormal exit.