### PR TITLE
feat(server): send cleanup preferences to cloud v2 endpoints

### DIFF
--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -188,18 +188,25 @@ export async function transcribeWithFreestyleCloud(opts: {
   language?: string;
   appContext?: string | null;
   mode: "raw" | "combined";
+  intensity?: string;
+  customPrompt?: string | null;
 }): Promise<CloudTranscribeResult> {
-  const headers: Record<string, string> = {};
-  if (opts.language) headers["x-language"] = opts.language;
-  if (opts.appContext)
-    headers["x-app-context"] = encodeURIComponent(opts.appContext);
-  if (opts.mode === "raw") headers["x-skip-post-process"] = "true";
   const audio = opts.audio as Uint8Array<ArrayBuffer>;
 
-  return cloudJson<CloudTranscribeResult>("/v1/transcribe", opts.token, {
+  // v2 carries the audio plus every cleanup preference in a single
+  // multipart payload — the cloud no longer reads saved preferences.
+  const form = new FormData();
+  form.append("audio", new Blob([audio], { type: "audio/wav" }), "audio.wav");
+  if (opts.language) form.append("language", opts.language);
+  if (opts.appContext) form.append("appContext", opts.appContext);
+  if (opts.mode === "raw") form.append("skipPostProcess", "true");
+  if (opts.intensity) form.append("intensity", opts.intensity);
+  if (opts.customPrompt) form.append("customPrompt", opts.customPrompt);
+
+  return cloudJson<CloudTranscribeResult>("/v2/transcribe", opts.token, {
     method: "POST",
-    headers,
-    body: new Blob([audio], { type: "audio/wav" }),
+    // Do not set content-type: fetch adds the multipart boundary itself.
+    body: form,
   });
 }
 
@@ -208,17 +215,21 @@ export async function postProcessWithFreestyleCloud(opts: {
   text: string;
   appContext?: string | null;
   language?: string;
+  intensity?: string;
+  customPrompt?: string | null;
 }): Promise<{
   cleaned: string;
   usage?: { inputTokens?: number; outputTokens?: number };
 }> {
-  return cloudJson("/v1/post-process", opts.token, {
+  return cloudJson("/v2/post-process", opts.token, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
       text: opts.text,
       appContext: opts.appContext ?? null,
       language: opts.language,
+      intensity: opts.intensity,
+      customPrompt: opts.customPrompt ?? null,
     }),
   });
 }

--- a/apps/server/src/lib/post-process.ts
+++ b/apps/server/src/lib/post-process.ts
@@ -167,6 +167,8 @@ export async function postProcess(
           text: normalizedRawText,
           appContext,
           language: options.language,
+          intensity: getCleanupIntensity(),
+          customPrompt: getCleanupCustomPrompt(),
         });
         inputTokens = result.usage?.inputTokens ?? 0;
         outputTokens = result.usage?.outputTokens ?? 0;

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -16,7 +16,11 @@ import {
   parseAppContext,
   plugins,
 } from "../lib/plugins/index.js";
-import { postProcess } from "../lib/post-process.js";
+import {
+  getCleanupCustomPrompt,
+  getCleanupIntensity,
+  postProcess,
+} from "../lib/post-process.js";
 import { capture, captureException } from "../lib/posthog.js";
 import { getDefaultModels } from "../lib/providers.js";
 import { invalidateSession } from "../lib/sessions.js";
@@ -143,6 +147,8 @@ const transcribeRoute = new Hono().post("/", async (c) => {
         language,
         appContext,
         mode: "combined",
+        intensity: getCleanupIntensity(),
+        customPrompt: getCleanupCustomPrompt(),
       });
       rawText = sanitizeTranscriptText(result.raw ?? "");
       const cleaned = applyDictionaryReplacements(


### PR DESCRIPTION
## Summary

Migrates the Freestyle Cloud transcribe and post-process calls from **v1 to v2**. Cleanup preferences (`intensity`, `customPrompt`, `language`, `appContext`, `skipPostProcess`) now travel in the request payload rather than being stored server-side.

## Changes

- `transcribeWithFreestyleCloud` now POSTs `multipart/form-data` (audio + preference fields) to `/v2/transcribe` instead of a raw `audio/wav` body with headers.
- `postProcessWithFreestyleCloud` sends `intensity`/`customPrompt` in the JSON body to `/v2/post-process`.
- Callers pass `getCleanupIntensity()` / `getCleanupCustomPrompt()`:
  - `routes/transcribe.ts` (combined mode)
  - `lib/post-process.ts` (cloud cleanup)

The raw-mode streaming provider call is unchanged (it skips cleanup, so no prefs needed).

## Verification

- `biome check` — clean
- `tsc --noEmit` (@freestyle-voice/server) — clean
- `pnpm --filter @freestyle-voice/server build` — pass
- `pnpm --filter @freestyle-voice/server test` — 181 passed

## Notes / follow-ups

- `syncCleanupPreferences` (`PUT /v1/preferences`) is intentionally left in place — the cloud still keeps the v1 preferences endpoint and table (non-breaking). Since v2 carries prefs in the payload, this sync is now redundant and can be removed in a later cleanup once v2 is fully rolled out.

Requires cloud PR: freestyle-voice/cloud#24
