### PR TITLE
Phase 2 of some stability cleanups

### DIFF
--- a/apps/docs/user-guide.mdx
+++ b/apps/docs/user-guide.mdx
@@ -10,8 +10,8 @@ Freestyle picks a sensible default hotkey per platform:
 | Platform | Default hotkey |
 | --- | --- |
 | macOS | **Fn (Globe)** — the dedicated dictation key, no modifier conflicts |
-| Windows | **Control+Super** (Ctrl + Windows key) |
-| Linux | **Alt+Super** |
+| Windows | **Ctrl+Alt+Space** |
+| Linux | **Ctrl+Alt+Space** |
 
 Dictation defaults to **Hold (push-to-talk)**. There are two activation modes:
 

--- a/apps/electron/native/linux-fast-paste.c
+++ b/apps/electron/native/linux-fast-paste.c
@@ -52,6 +52,22 @@
 #include <errno.h>
 #endif
 
+#define EVDEV_KEY_V 47
+
+/* Resolve the evdev keycode that produces 'v' under the active keyboard
+ * layout, via X11/XWayland (X keycode = evdev code + 8). Falls back to the
+ * QWERTY position when no X display is reachable. */
+static int resolve_v_evdev_keycode(void) {
+    int code = EVDEV_KEY_V;
+    Display *dpy = XOpenDisplay(NULL);
+    if (dpy) {
+        KeyCode kc = XKeysymToKeycode(dpy, XK_v);
+        if (kc >= 8) code = kc - 8;
+        XCloseDisplay(dpy);
+    }
+    return code;
+}
+
 #ifdef HAVE_GIO
 #include <gio/gio.h>
 
@@ -62,7 +78,6 @@
 
 #define PORTAL_KEY_LEFTCTRL  29
 #define PORTAL_KEY_LEFTSHIFT 42
-#define PORTAL_KEY_V         47
 
 static int portal_exit_code = 0;
 
@@ -73,6 +88,7 @@ typedef struct {
     char            *restore_token;
     guint            signal_id;
     int              use_shift;
+    int              v_keycode;
 } PortalData;
 
 static char *get_sender_path(GDBusConnection *conn) {
@@ -118,7 +134,7 @@ static void portal_send_paste(PortalData *app) {
     g_dbus_connection_call_sync(app->conn, PORTAL_BUS, PORTAL_PATH,
         PORTAL_IFACE, "NotifyKeyboardKeycode",
         g_variant_new("(o@a{sv}iu)", app->session_handle, opts,
-                       (gint32)PORTAL_KEY_V, (guint32)1),
+                       (gint32)app->v_keycode, (guint32)1),
         NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
     if (err) { fprintf(stderr, "V press: %s\n", err->message); g_clear_error(&err); }
 
@@ -128,7 +144,7 @@ static void portal_send_paste(PortalData *app) {
     g_dbus_connection_call_sync(app->conn, PORTAL_BUS, PORTAL_PATH,
         PORTAL_IFACE, "NotifyKeyboardKeycode",
         g_variant_new("(o@a{sv}iu)", app->session_handle, opts,
-                       (gint32)PORTAL_KEY_V, (guint32)0),
+                       (gint32)app->v_keycode, (guint32)0),
         NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
     if (err) { fprintf(stderr, "V release: %s\n", err->message); g_clear_error(&err); }
 
@@ -294,6 +310,7 @@ static gboolean on_portal_timeout(gpointer user_data) {
 static int paste_via_portal(int use_shift, const char *restore_token) {
     PortalData app = { 0 };
     app.use_shift = use_shift;
+    app.v_keycode = resolve_v_evdev_keycode();
     if (restore_token) app.restore_token = g_strdup(restore_token);
 
     GError *err = NULL;
@@ -453,12 +470,17 @@ static int create_uinput_keyboard(void) {
         return -3;
     }
 
-    if (ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0 ||
-        ioctl(fd, UI_SET_KEYBIT, KEY_LEFTCTRL) < 0 ||
-        ioctl(fd, UI_SET_KEYBIT, KEY_LEFTSHIFT) < 0 ||
-        ioctl(fd, UI_SET_KEYBIT, KEY_V) < 0) {
+    if (ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0) {
         close(fd);
         return -4;
+    }
+    /* Enable the whole basic key range so a layout-resolved keycode
+     * (Dvorak/AZERTY V position) is always emittable. */
+    for (int code = 1; code < 248; code++) {
+        if (ioctl(fd, UI_SET_KEYBIT, code) < 0) {
+            close(fd);
+            return -4;
+        }
     }
 
     struct uinput_setup usetup;
@@ -480,6 +502,8 @@ static int create_uinput_keyboard(void) {
 }
 
 static void send_uinput_paste(int fd, int use_shift) {
+    int v_keycode = resolve_v_evdev_keycode();
+
     emit_input(fd, EV_KEY, KEY_LEFTCTRL, 1);
     emit_input(fd, EV_SYN, SYN_REPORT, 0);
 
@@ -490,11 +514,11 @@ static void send_uinput_paste(int fd, int use_shift) {
 
     usleep(8000);
 
-    emit_input(fd, EV_KEY, KEY_V, 1);
+    emit_input(fd, EV_KEY, v_keycode, 1);
     emit_input(fd, EV_SYN, SYN_REPORT, 0);
     usleep(8000);
 
-    emit_input(fd, EV_KEY, KEY_V, 0);
+    emit_input(fd, EV_KEY, v_keycode, 0);
     emit_input(fd, EV_SYN, SYN_REPORT, 0);
 
     usleep(8000);

--- a/apps/electron/native/macos-fast-paste.swift
+++ b/apps/electron/native/macos-fast-paste.swift
@@ -3,6 +3,8 @@
  *
  * Injects Cmd+V at the CGEvent level — much faster than osascript.
  * Requires Accessibility permission (AXIsProcessTrusted).
+ * The V keycode is resolved from the active keyboard layout so paste
+ * works on non-QWERTY layouts (Dvorak, AZERTY, ...).
  *
  * Exit codes:
  *   0 - success
@@ -10,17 +12,48 @@
  *   2 - no accessibility permission
  *
  * Compile:
- *   swiftc -O macos-fast-paste.swift -o macos-fast-paste -framework Cocoa
+ *   swiftc -O macos-fast-paste.swift -o macos-fast-paste -framework Cocoa -framework Carbon
  */
 
+import Carbon.HIToolbox
 import Cocoa
+
+func keyCodeForV() -> CGKeyCode {
+    let fallback: CGKeyCode = 0x09
+    guard let sourceRef = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+          let layoutDataRef = TISGetInputSourceProperty(sourceRef, kTISPropertyUnicodeKeyLayoutData) else {
+        return fallback
+    }
+    let layoutData = Unmanaged<CFData>.fromOpaque(layoutDataRef).takeUnretainedValue() as Data
+    return layoutData.withUnsafeBytes { (buf: UnsafeRawBufferPointer) -> CGKeyCode in
+        guard let layout = buf.bindMemory(to: UCKeyboardLayout.self).baseAddress else {
+            return fallback
+        }
+        let target = UniChar(UnicodeScalar("v").value)
+        var deadKeyState: UInt32 = 0
+        var chars = [UniChar](repeating: 0, count: 4)
+        var length = 0
+        for code in 0..<UInt16(128) {
+            let err = UCKeyTranslate(
+                layout, code, UInt16(kUCKeyActionDown), 0,
+                UInt32(LMGetKbdType()), OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                &deadKeyState, chars.count, &length, &chars)
+            if err == noErr && length == 1 && chars[0] == target {
+                return CGKeyCode(code)
+            }
+        }
+        return fallback
+    }
+}
 
 if !AXIsProcessTrusted() {
     exit(2)
 }
 
-guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: true),
-      let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: false) else {
+let vKey = keyCodeForV()
+
+guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: vKey, keyDown: true),
+      let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: vKey, keyDown: false) else {
     exit(1)
 }
 

--- a/apps/electron/native/windows-fast-paste.c
+++ b/apps/electron/native/windows-fast-paste.c
@@ -19,6 +19,20 @@
 #include <stdio.h>
 #include <string.h>
 
+/* Resolve the virtual key that types 'v' under the focused window's
+ * keyboard layout, so paste works on non-QWERTY layouts. */
+static WORD resolve_v_vk(void) {
+    HKL hkl = NULL;
+    HWND fg = GetForegroundWindow();
+    if (fg) {
+        DWORD tid = GetWindowThreadProcessId(fg, NULL);
+        hkl = GetKeyboardLayout(tid);
+    }
+    SHORT scan = hkl ? VkKeyScanExW(L'v', hkl) : VkKeyScanW(L'v');
+    if (scan == -1) return 'V';
+    return (WORD)(scan & 0xFF);
+}
+
 int main(int argc, char* argv[]) {
     int use_shift = 0;
 
@@ -27,6 +41,8 @@ int main(int argc, char* argv[]) {
             use_shift = 1;
         }
     }
+
+    WORD v_vk = resolve_v_vk();
 
     int nInputs = use_shift ? 8 : 6;
     INPUT inputs[8];
@@ -47,12 +63,12 @@ int main(int argc, char* argv[]) {
 
     /* V down */
     inputs[idx].type = INPUT_KEYBOARD;
-    inputs[idx].ki.wVk = 'V';
+    inputs[idx].ki.wVk = v_vk;
     idx++;
 
     /* V up */
     inputs[idx].type = INPUT_KEYBOARD;
-    inputs[idx].ki.wVk = 'V';
+    inputs[idx].ki.wVk = v_vk;
     inputs[idx].ki.dwFlags = KEYEVENTF_KEYUP;
     idx++;
 

--- a/apps/electron/scripts/compile-native.js
+++ b/apps/electron/scripts/compile-native.js
@@ -73,7 +73,7 @@ function compileMacOS() {
     {
       name: "macos-fast-paste",
       src: "macos-fast-paste.swift",
-      frameworks: ["Cocoa"],
+      frameworks: ["Cocoa", "Carbon"],
     },
     {
       name: "macos-mic-listener",

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -943,8 +943,80 @@ async function getWindowsFrontmostApp(): Promise<string | null> {
   }
 }
 
-// -- Linux (X11): Get active window name + title via xdotool --
+// -- Linux: Get active window name + title (Wayland compositors + X11) --
 async function getLinuxFrontmostApp(): Promise<string | null> {
+  if (isWaylandSession()) {
+    return (
+      (await getSwayFrontmostApp()) ??
+      (await getGnomeFrontmostApp()) ??
+      (await getLinuxX11FrontmostApp())
+    );
+  }
+  return getLinuxX11FrontmostApp();
+}
+
+interface SwayNode {
+  focused?: boolean;
+  name?: string;
+  app_id?: string | null;
+  window_properties?: { class?: string };
+  nodes?: SwayNode[];
+  floating_nodes?: SwayNode[];
+}
+
+function findFocusedSwayNode(node: SwayNode): SwayNode | null {
+  if (node.focused) return node;
+  for (const child of [...(node.nodes ?? []), ...(node.floating_nodes ?? [])]) {
+    const hit = findFocusedSwayNode(child);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+async function getSwayFrontmostApp(): Promise<string | null> {
+  try {
+    const output = await execAsync("swaymsg", ["-t", "get_tree"], 2000);
+    const focused = findFocusedSwayNode(JSON.parse(output) as SwayNode);
+    if (!focused) return null;
+    return JSON.stringify({
+      app: focused.app_id ?? focused.window_properties?.class ?? "Unknown",
+      windowTitle: focused.name ?? "",
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function getGnomeFrontmostApp(): Promise<string | null> {
+  try {
+    const output = await execAsync(
+      "gdbus",
+      [
+        "call",
+        "--session",
+        "--dest",
+        "org.gnome.Shell",
+        "--object-path",
+        "/org/gnome/Shell/Introspect",
+        "--method",
+        "org.gnome.Shell.Introspect.GetWindows",
+      ],
+      2000,
+    );
+    for (const win of output.split(/uint64 \d+:/).slice(1)) {
+      if (!/'has-focus':\s*<true>/.test(win)) continue;
+      const app =
+        /'wm-class':\s*<'((?:[^'\\]|\\.)*)'>/.exec(win)?.[1] ?? "Unknown";
+      const title = /'title':\s*<'((?:[^'\\]|\\.)*)'>/.exec(win)?.[1] ?? "";
+      return JSON.stringify({ app, windowTitle: title });
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function getLinuxX11FrontmostApp(): Promise<string | null> {
   try {
     const windowTitle = await execAsync(
       "xdotool",

--- a/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
+++ b/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
@@ -1,11 +1,9 @@
+import { IS_MAC } from "@renderer/lib/platform";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 // ---------------------------------------------------------------------------
 // Platform detection
 // ---------------------------------------------------------------------------
-
-const IS_MAC =
-  typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
 
 // ---------------------------------------------------------------------------
 // Key symbol maps

--- a/apps/electron/src/renderer/src/lib/models.ts
+++ b/apps/electron/src/renderer/src/lib/models.ts
@@ -36,6 +36,8 @@ export interface WhisperModelDownloadState {
 }
 
 export interface WhisperStatus {
+  archSupported?: boolean;
+  archUnsupportedReason?: string | null;
   binaryAvailable: boolean;
   binaryDownloading: boolean;
   serverBinaryAvailable: boolean;

--- a/apps/electron/src/renderer/src/lib/platform.ts
+++ b/apps/electron/src/renderer/src/lib/platform.ts
@@ -1,0 +1,12 @@
+export const PLATFORM: string =
+  (typeof window !== "undefined" && window.api?.platform) ||
+  (typeof navigator !== "undefined" && navigator.userAgent.includes("Mac")
+    ? "darwin"
+    : "unknown");
+
+export const IS_MAC = PLATFORM === "darwin";
+export const IS_WINDOWS = PLATFORM === "win32";
+export const IS_LINUX = PLATFORM === "linux";
+
+export const MOD_LABEL = IS_MAC ? "⌘" : "Ctrl+";
+export const SEARCH_SHORTCUT_LABEL = IS_MAC ? "⌘ K" : "Ctrl+K";

--- a/apps/electron/src/renderer/src/onboarding.tsx
+++ b/apps/electron/src/renderer/src/onboarding.tsx
@@ -41,6 +41,7 @@ import {
   type WhisperStatus,
 } from "@renderer/lib/models";
 import { requestMicAccess, resolveMicStatus } from "@renderer/lib/permissions";
+import { IS_LINUX, IS_MAC, IS_WINDOWS, PLATFORM } from "@renderer/lib/platform";
 import { cn, ON_DEVICE_PHRASE } from "@renderer/lib/utils";
 import {
   ArrowRight,
@@ -64,15 +65,6 @@ import { getDefaultHotkey } from "../../shared/hotkey-defaults";
 import { SETTINGS_KEYS } from "../../shared/settings-keys";
 
 type Step = "permissions" | "cloud" | "language" | "tutorial";
-
-const PLATFORM =
-  (typeof window !== "undefined" && window.api?.platform) ||
-  (typeof navigator !== "undefined" && navigator.userAgent.includes("Mac")
-    ? "darwin"
-    : "unknown");
-const IS_MAC = PLATFORM === "darwin";
-const IS_WINDOWS = PLATFORM === "win32";
-const IS_LINUX = PLATFORM === "linux";
 
 const DEFAULT_HOTKEY =
   (typeof window !== "undefined" && window.api?.defaultHotkey) ||

--- a/apps/electron/src/renderer/src/pages/dictionary.tsx
+++ b/apps/electron/src/renderer/src/pages/dictionary.tsx
@@ -7,6 +7,7 @@ import { Button } from "@renderer/components/ui/button";
 import { Input } from "@renderer/components/ui/input";
 import { Textarea } from "@renderer/components/ui/textarea";
 import { getClient } from "@renderer/lib/api";
+import { SEARCH_SHORTCUT_LABEL } from "@renderer/lib/platform";
 import { cn } from "@renderer/lib/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -227,7 +228,7 @@ export default function DictionaryPage(): React.JSX.Element {
                   className="placeholder:text-muted-foreground/80 text-foreground flex-1 bg-transparent text-[13px] outline-none"
                 />
                 <span className="mono text-muted-foreground text-[10px]">
-                  ⌘ K
+                  {SEARCH_SHORTCUT_LABEL}
                 </span>
               </div>
               <div className="flex shrink-0 flex-wrap items-center gap-2.5">

--- a/apps/electron/src/renderer/src/pages/history.tsx
+++ b/apps/electron/src/renderer/src/pages/history.tsx
@@ -9,6 +9,7 @@ import {
   SheetTitle,
 } from "@renderer/components/ui/sheet";
 import { getClient } from "@renderer/lib/api";
+import { SEARCH_SHORTCUT_LABEL } from "@renderer/lib/platform";
 import { cn, ON_DEVICE_PHRASE } from "@renderer/lib/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -324,7 +325,7 @@ export default function HistoryPage(): React.JSX.Element {
                   className="placeholder:text-muted-foreground/80 text-foreground flex-1 bg-transparent text-[13px] outline-none"
                 />
                 <span className="mono text-muted-foreground text-[10px]">
-                  ⌘ K
+                  {SEARCH_SHORTCUT_LABEL}
                 </span>
               </div>
               <Button

--- a/apps/electron/src/renderer/src/pages/models/use-models.ts
+++ b/apps/electron/src/renderer/src/pages/models/use-models.ts
@@ -10,9 +10,9 @@ import type {
   VoiceItem,
   WhisperStatus,
 } from "@renderer/lib/models";
+import { IS_MAC } from "@renderer/lib/platform";
 import { useCallback, useEffect, useState } from "react";
 import { SETTINGS_KEYS } from "../../../../shared/settings-keys";
-
 import { DEFAULT_MLX_KEEP_ALIVE_MINUTES } from "./constants";
 import type { ApiKeyEntry, ConfiguredModel } from "./types";
 import {
@@ -20,9 +20,6 @@ import {
   clampMlxKeepAliveMinutes,
   groupByProvider,
 } from "./utils";
-
-const IS_MAC =
-  typeof navigator !== "undefined" && navigator.userAgent.includes("Mac");
 
 export interface LocalLlmState {
   url: string;

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -20,6 +20,7 @@ import {
 import { getApiBase, getClient } from "@renderer/lib/api";
 import { LANGUAGES } from "@renderer/lib/languages";
 import { requestMicAccess, resolveMicStatus } from "@renderer/lib/permissions";
+import { IS_LINUX, IS_MAC, IS_WINDOWS } from "@renderer/lib/platform";
 import { cn } from "@renderer/lib/utils";
 import {
   Check,
@@ -167,9 +168,9 @@ export default function SettingsPage(): React.JSX.Element {
   const accessibilityPollRef = useRef<ReturnType<typeof setInterval> | null>(
     null,
   );
-  const isMac = navigator.userAgent.includes("Mac");
-  const isLinux = window.api?.platform === "linux";
-  const isWindows = window.api?.platform === "win32";
+  const isMac = IS_MAC;
+  const isLinux = IS_LINUX;
+  const isWindows = IS_WINDOWS;
   const supportsBackgroundAudio = isMac || isLinux || isWindows;
   // macOS and Windows can deep-link to the OS mic privacy settings.
   const canOpenMicSettings = isMac || isWindows;

--- a/apps/electron/src/renderer/src/pages/vocabulary.tsx
+++ b/apps/electron/src/renderer/src/pages/vocabulary.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@renderer/components/ui/button";
 import { Input } from "@renderer/components/ui/input";
 import { getClient } from "@renderer/lib/api";
+import { SEARCH_SHORTCUT_LABEL } from "@renderer/lib/platform";
 import { cn } from "@renderer/lib/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -264,7 +265,7 @@ export default function VocabularyPage(): React.JSX.Element {
                   className="placeholder:text-muted-foreground/80 text-foreground min-w-0 flex-1 bg-transparent text-[13px] outline-none"
                 />
                 <span className="mono text-muted-foreground shrink-0 text-[10px]">
-                  {navigator.userAgent.includes("Mac") ? "⌘" : "Ctrl+"} K
+                  {SEARCH_SHORTCUT_LABEL}
                 </span>
               </div>
               <div className="flex shrink-0 flex-wrap items-center gap-2.5">

--- a/apps/electron/src/renderer/src/shell.tsx
+++ b/apps/electron/src/renderer/src/shell.tsx
@@ -3,6 +3,7 @@ import markLight from "@renderer/assets/mark-light.svg";
 import { CloudProfileButton } from "@renderer/components/cloud-profile";
 import { Badge } from "@renderer/components/ui/badge";
 import { LINKS } from "@renderer/lib/links";
+import { IS_MAC, MOD_LABEL } from "@renderer/lib/platform";
 import { cn } from "@renderer/lib/utils";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -129,7 +130,7 @@ function NavList({ items }: { items: NavItem[] }): React.JSX.Element {
                       : "text-muted-foreground/60",
                   )}
                 >
-                  {"⌘"}
+                  {MOD_LABEL}
                   {item.shortcut}
                 </span>
               </div>
@@ -191,7 +192,7 @@ export default function AppShell(): React.JSX.Element {
         <div
           className={cn(
             "flex items-center gap-2.5 px-3.5 pb-6",
-            isFullscreen ? "pt-4" : "pt-[44px]",
+            !IS_MAC || isFullscreen ? "pt-4" : "pt-[44px]",
           )}
         >
           <img

--- a/apps/electron/src/shared/hotkey-defaults.ts
+++ b/apps/electron/src/shared/hotkey-defaults.ts
@@ -2,8 +2,9 @@
  * Single source of truth for the default push-to-talk hotkey.
  *
  * - macOS: Fn (Globe) — dedicated dictation key, no modifier conflicts
- * - Windows: Control+Super — avoids Alt+Space window menu and common shortcuts
- * - Linux: Alt+Super — common dictation combo (e.g. pepper-x), avoids WM launcher binds
+ * - Windows/Linux: Control+Alt+Space — no Super key, so the OS launcher /
+ *   Start menu never fires alongside dictation, and the real key lets the
+ *   native listeners suppress the chord from reaching the focused app
  *
  * Imported by both the main process and the preload script (which exposes it
  * to the renderer as `window.api.defaultHotkey`).
@@ -12,11 +13,7 @@ export function getDefaultHotkey(platform: string = process.platform): string {
   switch (platform) {
     case "darwin":
       return "Fn";
-    case "win32":
-      return "Control+Super";
-    case "linux":
-      return "Alt+Super";
     default:
-      return "Control+Super";
+      return "Control+Alt+Space";
   }
 }

--- a/apps/server/src/lib/editor/context-match.ts
+++ b/apps/server/src/lib/editor/context-match.ts
@@ -1,0 +1,71 @@
+import { parseAppContextPayload } from "./app-context.js";
+
+const TITLE_SEPARATORS = /\s+[-|·—–/]\s+/;
+
+export interface MatchableContext {
+  full: string;
+  host: string;
+  segments: string[];
+}
+
+export function buildMatchableContext(
+  rawContext: string | null,
+): MatchableContext | null {
+  if (!rawContext) return null;
+
+  const ctx = parseAppContextPayload(rawContext);
+  if (!ctx) {
+    const raw = rawContext.trim().toLowerCase();
+    return raw ? { full: raw, host: "", segments: [raw] } : null;
+  }
+
+  const parts: string[] = [];
+  if (ctx.url) parts.push(ctx.url);
+  if (ctx.title) parts.push(ctx.title);
+  if (ctx.windowTitle) parts.push(ctx.windowTitle);
+  if (ctx.app) parts.push(ctx.app);
+  if (parts.length === 0) return null;
+
+  let host = "";
+  if (ctx.url) {
+    try {
+      host = new URL(ctx.url).hostname.toLowerCase();
+    } catch {
+      host = ctx.url.toLowerCase();
+    }
+  }
+
+  const segments = new Set<string>();
+  if (ctx.app) segments.add(ctx.app.trim().toLowerCase());
+  for (const title of [ctx.title, ctx.windowTitle]) {
+    if (!title) continue;
+    for (const segment of title.split(TITLE_SEPARATORS)) {
+      const trimmed = segment.trim().toLowerCase();
+      if (trimmed) segments.add(trimmed);
+    }
+  }
+
+  return {
+    full: parts.join(" ").toLowerCase(),
+    host,
+    segments: [...segments],
+  };
+}
+
+// Domain/phrase patterns match as substrings; bare words match only the app
+// name, a title segment, or the URL host — never prose inside a title.
+export function patternMatchesContext(
+  ctx: MatchableContext,
+  appPattern: string,
+): boolean {
+  for (const raw of appPattern.split("|")) {
+    const pattern = raw.trim().toLowerCase();
+    if (!pattern) continue;
+    if (pattern.includes(".") || pattern.includes(" ")) {
+      if (ctx.full.includes(pattern)) return true;
+    } else if (ctx.segments.includes(pattern) || ctx.host.includes(pattern)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/apps/server/src/lib/editor/rewrite-context.ts
+++ b/apps/server/src/lib/editor/rewrite-context.ts
@@ -1,5 +1,10 @@
 import type { DatabaseSync } from "node:sqlite";
 import { parseAppContextPayload } from "./app-context.js";
+import {
+  buildMatchableContext,
+  type MatchableContext,
+  patternMatchesContext,
+} from "./context-match.js";
 import type { RewriteRegisterMode } from "./prompts.js";
 
 interface FormatRuleRow {
@@ -24,47 +29,11 @@ const FORMAL_RULE_LABELS = new Set([
 
 const CASUAL_RULE_LABELS = new Set(["Discord", "Messaging", "X/Twitter"]);
 
-const FORMAL_FALLBACK_PATTERNS = [
-  "gmail",
-  "mail",
-  "outlook",
-  "yahoo",
-  "proton",
-  "slack",
-  "linkedin",
-  "docs.google.com",
-  "notion",
-  "github",
-  "gitlab",
-  "cursor",
-  "terminal",
-  "iterm",
-  "code",
-];
+const FORMAL_FALLBACK_PATTERN =
+  "gmail|mail|outlook|yahoo|proton mail|slack|linkedin|docs.google.com|notion|github|gitlab|cursor|terminal|iterm|code";
 
-const CASUAL_FALLBACK_PATTERNS = [
-  "discord",
-  "messages",
-  "whatsapp",
-  "telegram",
-  "twitter",
-  "x.com",
-];
-
-export function buildMatchContext(rawContext: string | null): string {
-  if (!rawContext) return "";
-
-  const ctx = parseAppContextPayload(rawContext);
-  // Fall back to the raw string when the payload isn't valid JSON.
-  if (!ctx) return rawContext;
-
-  const parts: string[] = [];
-  if (ctx.url) parts.push(ctx.url);
-  if (ctx.title) parts.push(ctx.title);
-  if (ctx.windowTitle) parts.push(ctx.windowTitle);
-  if (ctx.app) parts.push(ctx.app);
-  return parts.join(" ");
-}
+const CASUAL_FALLBACK_PATTERN =
+  "discord|messages|whatsapp|telegram|twitter|x.com";
 
 function inferRegisterModeFromLabel(
   label: string | undefined,
@@ -75,16 +44,11 @@ function inferRegisterModeFromLabel(
   return "neutral";
 }
 
-function inferRegisterModeFromMatchText(
-  matchText: string,
+function inferRegisterModeFromContext(
+  ctx: MatchableContext,
 ): RewriteRegisterMode {
-  const lower = matchText.toLowerCase();
-  if (FORMAL_FALLBACK_PATTERNS.some((pattern) => lower.includes(pattern))) {
-    return "formal";
-  }
-  if (CASUAL_FALLBACK_PATTERNS.some((pattern) => lower.includes(pattern))) {
-    return "casual";
-  }
+  if (patternMatchesContext(ctx, FORMAL_FALLBACK_PATTERN)) return "formal";
+  if (patternMatchesContext(ctx, CASUAL_FALLBACK_PATTERN)) return "casual";
   return "neutral";
 }
 
@@ -92,15 +56,10 @@ export function getRewritePromptContext(
   rawContext: string | null,
   db: DatabaseSync,
 ): RewritePromptContext {
-  if (!rawContext) {
+  const matchCtx = buildMatchableContext(rawContext);
+  if (!matchCtx) {
     return { contextHint: "", registerMode: "neutral" };
   }
-
-  const matchStr = buildMatchContext(rawContext);
-  if (!matchStr) {
-    return { contextHint: "", registerMode: "neutral" };
-  }
-  const matchStrLower = matchStr.toLowerCase();
 
   try {
     const rows = db
@@ -110,38 +69,31 @@ export function getRewritePromptContext(
       .all() as unknown as FormatRuleRow[];
 
     for (const row of rows) {
-      const patterns = row.app_pattern.split("|").map((p) => p.trim());
-      for (const pattern of patterns) {
-        if (pattern && matchStrLower.includes(pattern.toLowerCase())) {
-          const registerModeFromLabel = inferRegisterModeFromLabel(row.label);
-          return {
-            contextHint: row.instructions,
-            registerMode:
-              registerModeFromLabel === "neutral"
-                ? inferRegisterModeFromMatchText(matchStr)
-                : registerModeFromLabel,
-          };
-        }
+      if (patternMatchesContext(matchCtx, row.app_pattern)) {
+        const registerModeFromLabel = inferRegisterModeFromLabel(row.label);
+        return {
+          contextHint: row.instructions,
+          registerMode:
+            registerModeFromLabel === "neutral"
+              ? inferRegisterModeFromContext(matchCtx)
+              : registerModeFromLabel,
+        };
       }
     }
   } catch {
     // format_rules table may not exist yet
   }
 
-  try {
-    const ctx = JSON.parse(rawContext) as { app?: string };
-    if (ctx.app) {
-      return {
-        contextHint: `The user is dictating in ${ctx.app}.`,
-        registerMode: inferRegisterModeFromMatchText(matchStr),
-      };
-    }
-  } catch {
-    // not JSON
+  const ctx = parseAppContextPayload(rawContext);
+  if (ctx?.app) {
+    return {
+      contextHint: `The user is dictating in ${ctx.app}.`,
+      registerMode: inferRegisterModeFromContext(matchCtx),
+    };
   }
 
   return {
     contextHint: "",
-    registerMode: inferRegisterModeFromMatchText(matchStr),
+    registerMode: inferRegisterModeFromContext(matchCtx),
   };
 }

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -1,67 +1,87 @@
 import type { DatabaseSync } from "node:sqlite";
 
-const SCHEMA_VERSION = 10;
+const SCHEMA_VERSION = 11;
 
+// Patterns follow context-match.ts semantics: domain/phrase entries match as
+// substrings of url+title+app; bare words match the app name, a window-title
+// segment ("Inbox - Gmail" -> "gmail"), or the URL host. The bare words give
+// Windows/Linux parity, where context payloads carry no URL.
 const DEFAULT_FORMAT_RULES = [
   {
-    pattern: "mail.google.com|outlook|yahoo.com|proton",
+    pattern: "mail.google.com|yahoo.com|proton mail|gmail|outlook|mail",
     label: "Email",
     instructions:
       "If the transcript clearly dictates an email, preserve greeting/sign-off only if spoken, keep paragraph breaks clean, and do not invent a subject line.",
   },
   {
-    pattern: "slack.com|Slack",
+    pattern: "slack.com|slack",
     label: "Slack",
     instructions:
       "Keep the wording intact. Add only light punctuation and paragraph breaks.",
   },
   {
-    pattern: "discord.com|Discord",
+    pattern: "discord.com|discord",
     label: "Discord",
     instructions:
       "Keep the wording intact. Add only light punctuation and paragraph breaks.",
   },
   {
-    pattern: "github.com|GitLab",
+    pattern: "github.com|gitlab.com|github|gitlab",
     label: "Code Platform",
     instructions:
       "Keep technical wording exact. Preserve explicit markdown, code blocks, or lists only if they were clearly dictated.",
   },
   {
-    pattern: "docs.google.com|notion.so|Notion",
+    pattern: "docs.google.com|notion.so|google docs|notion",
     label: "Document",
     instructions:
       "Preserve paragraph breaks and headings only when they are already clearly implied by the transcript.",
   },
   {
-    pattern: "Code|Cursor|Terminal|iTerm",
+    pattern: "code|cursor|terminal|iterm",
     label: "Code Editor",
     instructions:
       "Keep technical terms exact. Do not rewrite for tone or style.",
   },
   {
-    pattern: "Messages|WhatsApp|Telegram",
+    pattern: "web.whatsapp.com|messages|whatsapp|telegram",
     label: "Messaging",
     instructions: "Keep the wording intact. Add only light punctuation.",
   },
   {
-    pattern: "x.com|twitter.com",
+    pattern: "x.com|twitter.com|twitter|x",
     label: "X/Twitter",
     instructions:
       "Keep the wording intact. Do not shorten or rewrite for length.",
   },
   {
-    pattern: "linkedin.com",
+    pattern: "linkedin.com|linkedin",
     label: "LinkedIn",
     instructions:
       "Keep the wording intact. Add only light punctuation and paragraph breaks.",
   },
   {
-    pattern: "chatgpt.com|claude.ai|perplexity",
+    pattern: "chatgpt.com|claude.ai|perplexity.ai|chatgpt|claude|perplexity",
     label: "AI Chat",
     instructions:
       "Keep the wording intact. Preserve explicit prompt structure only if it was clearly dictated.",
   },
+] as const;
+
+const V11_DEFAULT_PATTERN_UPDATES = [
+  {
+    label: "Email",
+    oldPattern: "mail.google.com|outlook|yahoo.com|proton",
+  },
+  { label: "Slack", oldPattern: "slack.com|Slack" },
+  { label: "Discord", oldPattern: "discord.com|Discord" },
+  { label: "Code Platform", oldPattern: "github.com|GitLab" },
+  { label: "Document", oldPattern: "docs.google.com|notion.so|Notion" },
+  { label: "Code Editor", oldPattern: "Code|Cursor|Terminal|iTerm" },
+  { label: "Messaging", oldPattern: "Messages|WhatsApp|Telegram" },
+  { label: "X/Twitter", oldPattern: "x.com|twitter.com" },
+  { label: "LinkedIn", oldPattern: "linkedin.com" },
+  { label: "AI Chat", oldPattern: "chatgpt.com|claude.ai|perplexity" },
 ] as const;
 
 const LEGACY_DEFAULT_FORMAT_RULES = [
@@ -314,6 +334,17 @@ function applyMigrations(db: DatabaseSync, currentVersion: number): void {
          SET model_name = replace(model_name, 'Freestyle Cloud', 'Freestyle Transcribe')
        WHERE provider = 'freestyle-cloud' AND model_name LIKE 'Freestyle Cloud%'`,
     );
+  }
+
+  if (currentVersion < 11) {
+    // Only untouched default rules migrate; user-edited patterns are left alone.
+    const updateStmt = db.prepare(
+      "UPDATE format_rules SET app_pattern = ?, updated_at = datetime('now') WHERE app_pattern = ? AND label = ? AND is_default = 1",
+    );
+    for (const { label, oldPattern } of V11_DEFAULT_PATTERN_UPDATES) {
+      const next = DEFAULT_FORMAT_RULES.find((r) => r.label === label);
+      if (next) updateStmt.run(next.pattern, oldPattern, label);
+    }
   }
 
   // Upsert schema version

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -3,7 +3,11 @@ import { collapseAsrLineBreaks } from "../../editor/model-hints.js";
 import { isServerBinaryAvailable } from "../../whisper/binary.js";
 import { WHISPER_PROVIDER_ID } from "../../whisper/constants.js";
 import { ensureBinariesDownloaded } from "../../whisper/models.js";
-import { ensureServerRunning, getServerPort } from "../../whisper/server.js";
+import {
+  ensureServerRunning,
+  getServerPort,
+  withServerUse,
+} from "../../whisper/server.js";
 import type {
   TranscribeOptions,
   TranscribeResult,
@@ -31,22 +35,24 @@ export class WhisperLocalTranscriptionProvider
       }
     }
 
-    // Restarts the server if it is not running or loaded a different model.
-    await ensureServerRunning(modelId);
-
-    const t0 = Date.now();
-    try {
-      return await transcribeViaServer(opts);
-    } catch (err) {
-      // The server may have crashed mid-request; restart it and retry once.
-      log.warn(
-        `inference failed, restarting server: ${err instanceof Error ? err.message : String(err)}`,
-      );
+    return withServerUse(async () => {
+      // Restarts the server if it is not running or loaded a different model.
       await ensureServerRunning(modelId);
-      return await transcribeViaServer(opts);
-    } finally {
-      log.debug(`server inference took ${Date.now() - t0}ms`);
-    }
+
+      const t0 = Date.now();
+      try {
+        return await transcribeViaServer(opts);
+      } catch (err) {
+        // The server may have crashed mid-request; restart it and retry once.
+        log.warn(
+          `inference failed, restarting server: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        await ensureServerRunning(modelId);
+        return await transcribeViaServer(opts);
+      } finally {
+        log.debug(`server inference took ${Date.now() - t0}ms`);
+      }
+    });
   }
 
   supportsStreaming(_modelId: string): boolean {

--- a/apps/server/src/lib/whisper/constants.ts
+++ b/apps/server/src/lib/whisper/constants.ts
@@ -138,15 +138,18 @@ export function getModelPath(model: WhisperModelDef): string {
   return join(getModelsDir(), model.fileName);
 }
 
+// Linux arm64 is served by the source build, which produces the same
+// binary names as x64. win32 stays x64-only: the prebuilt release zip has
+// no arm64 variant and there is no Windows source-build path.
 const BINARY_NAMES: Record<string, Record<string, string>> = {
   darwin: { arm64: "whisper-cli", x64: "whisper-cli" },
-  linux: { x64: "whisper-cli" },
+  linux: { x64: "whisper-cli", arm64: "whisper-cli" },
   win32: { x64: "whisper-cli.exe" },
 };
 
 const SERVER_NAMES: Record<string, Record<string, string>> = {
   darwin: { arm64: "whisper-server", x64: "whisper-server" },
-  linux: { x64: "whisper-server" },
+  linux: { x64: "whisper-server", arm64: "whisper-server" },
   win32: { x64: "whisper-server.exe" },
 };
 
@@ -160,6 +163,14 @@ export function getServerBinaryName(): string | null {
   const platform = process.platform;
   const arch = process.arch;
   return SERVER_NAMES[platform]?.[arch] ?? null;
+}
+
+export function isSupportedWhisperArch(): boolean {
+  return getServerBinaryName() !== null;
+}
+
+export function unsupportedArchMessage(): string {
+  return `Local Whisper transcription is not supported on ${process.platform}/${process.arch}. Choose a cloud model instead.`;
 }
 
 export function getResourcesDir(): string {

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import { execFile as execFileCallback } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
   copyFileSync,
@@ -13,7 +14,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import { join } from "node:path";
-import { Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
 import { createAppLogger } from "@freestyle-voice/utils";
@@ -219,14 +220,34 @@ export async function downloadModel(modelId: string): Promise<void> {
 
     // Stream straight to the models dir — going through the HF cache would
     // store every model twice on disk.
+    const expectedSha = await fetchExpectedSha256(
+      model.fileName,
+      controller.signal,
+    );
     const url = `https://huggingface.co/${WHISPER_REPO}/resolve/${WHISPER_REPO_REVISION}/${model.fileName}`;
     const res = await progressFetch(active, controller.signal)(url);
     if (!res.ok || !res.body) {
-      throw new Error(`Model download failed: HTTP ${res.status}`);
+      throw modelDownloadHttpError(res.status);
     }
     const total = Number(res.headers.get("content-length"));
     if (total > 0) active.bytesTotal = total;
-    await pipeline(webBodyToReadable(res.body), createWriteStream(tempPath));
+    const hash = createHash("sha256");
+    const hashThrough = new Transform({
+      transform(chunk, _enc, cb) {
+        hash.update(chunk);
+        cb(null, chunk);
+      },
+    });
+    await pipeline(
+      webBodyToReadable(res.body),
+      hashThrough,
+      createWriteStream(tempPath),
+    );
+    if (expectedSha && hash.digest("hex") !== expectedSha) {
+      throw new Error(
+        "Model download failed a checksum verification (corrupted transfer). Please try again.",
+      );
+    }
     renameSync(tempPath, destPath);
     activeDownloads.delete(modelId);
   } catch (err) {
@@ -288,6 +309,40 @@ export function getDownloadedModelPath(modelId: string): string | null {
   return getModelPath(model);
 }
 
+async function fetchExpectedSha256(
+  fileName: string,
+  signal: AbortSignal,
+): Promise<string | null> {
+  try {
+    const url = `https://huggingface.co/api/models/${WHISPER_REPO}/tree/${WHISPER_REPO_REVISION}`;
+    const res = await fetch(url, {
+      signal: AbortSignal.any([signal, AbortSignal.timeout(10_000)]),
+    });
+    if (!res.ok) return null;
+    const entries = (await res.json()) as {
+      path?: string;
+      lfs?: { oid?: string };
+    }[];
+    return entries.find((e) => e.path === fileName)?.lfs?.oid ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function modelDownloadHttpError(status: number): Error {
+  if (status === 404) {
+    return new Error(
+      "Model download failed because the file is no longer published on Hugging Face (HTTP 404). Try updating Freestyle to a newer version.",
+    );
+  }
+  if (status === 401 || status === 403) {
+    return new Error(
+      `Model download was rejected by Hugging Face (HTTP ${status}). Please try again in a few minutes.`,
+    );
+  }
+  return new Error(`Model download failed: HTTP ${status}`);
+}
+
 // ---------------------------------------------------------------------------
 // Binary acquisition
 // ---------------------------------------------------------------------------
@@ -333,6 +388,11 @@ async function buildFromSource(): Promise<void> {
     signal: AbortSignal.timeout(60_000),
   });
   if (!res.ok || !res.body) {
+    if (res.status === 404) {
+      throw new Error(
+        `whisper.cpp v${WHISPER_CPP_VERSION} source is no longer published on GitHub (HTTP 404). Try updating Freestyle to a newer version.`,
+      );
+    }
     throw new Error(
       `Failed to download whisper.cpp source: HTTP ${res.status}`,
     );
@@ -353,7 +413,7 @@ async function buildFromSource(): Promise<void> {
       "tar",
       ["xzf", tarPath, "-C", srcDir, "--strip-components=1"],
       {
-        timeout: 30_000,
+        timeout: 120_000,
       },
     );
   } catch {
@@ -373,11 +433,11 @@ async function buildFromSource(): Promise<void> {
     await execFile(
       "cmake",
       ["..", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_SHARED_LIBS=OFF"],
-      { cwd: buildDir, timeout: 60_000 },
+      { cwd: buildDir, timeout: 180_000 },
     );
     await execFile("cmake", ["--build", ".", "--config", "Release", "-j"], {
       cwd: buildDir,
-      timeout: 300_000,
+      timeout: 900_000,
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -450,20 +510,26 @@ async function downloadWindowsBinaries(): Promise<void> {
     signal: AbortSignal.timeout(120_000),
   });
   if (!res.ok || !res.body) {
+    if (res.status === 404) {
+      throw new Error(
+        `The whisper.cpp v${WHISPER_CPP_VERSION} Windows binaries are no longer published on GitHub (HTTP 404). Try updating Freestyle to a newer version.`,
+      );
+    }
     throw new Error(`Failed to download whisper binaries: HTTP ${res.status}`);
   }
 
   const fileStream = createWriteStream(tmpZip);
   await pipeline(webBodyToReadable(res.body), fileStream);
 
+  const psQuote = (p: string): string => `'${p.replace(/'/g, "''")}'`;
   try {
     await execFile(
       "powershell",
       [
         "-Command",
-        `Expand-Archive -Force -Path '${tmpZip}' -DestinationPath '${binDir}'`,
+        `Expand-Archive -Force -Path ${psQuote(tmpZip)} -DestinationPath ${psQuote(binDir)}`,
       ],
-      { timeout: 30_000 },
+      { timeout: 120_000 },
     );
   } catch {
     try {

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -29,7 +29,9 @@ import {
   getModelPath,
   getModelsDir,
   getWhisperModel,
+  isSupportedWhisperArch,
   LEGACY_WHISPER_MODELS,
+  unsupportedArchMessage,
   WHISPER_CPP_VERSION,
   WHISPER_MODELS,
   WHISPER_REPO,
@@ -354,6 +356,9 @@ export function isBinaryDownloading(): boolean {
 }
 
 export async function ensureBinariesDownloaded(): Promise<void> {
+  if (!isSupportedWhisperArch()) {
+    throw new Error(unsupportedArchMessage());
+  }
   const { isServerBinaryAvailable, resetBinaryCache } = await import(
     "./binary.js"
   );

--- a/apps/server/src/lib/whisper/server.ts
+++ b/apps/server/src/lib/whisper/server.ts
@@ -1,5 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { createServer } from "node:net";
 import { createAppLogger } from "@freestyle-voice/utils";
+import { getDb } from "../db.js";
 import {
   findWhisperServer,
   WIN_DLL_NOT_FOUND_EXIT,
@@ -14,6 +16,8 @@ const serverLog = createAppLogger("whisper-server");
 const MAX_RESTARTS = 3;
 const RESTART_COOLDOWN_MS = 3_000;
 const STABILITY_THRESHOLD_MS = 30_000;
+const DEFAULT_KEEP_ALIVE_MINUTES = 10;
+const MAX_KEEP_ALIVE_MINUTES = 10;
 
 let serverProcess: ChildProcess | null = null;
 let currentModelId: string | null = null;
@@ -23,6 +27,9 @@ let autoRestart = false;
 let restartCount = 0;
 let stabilityTimer: ReturnType<typeof setTimeout> | null = null;
 let serverFailed = false;
+let activePort = WHISPER_SERVER_PORT;
+let activeUses = 0;
+let unloadTimer: ReturnType<typeof setTimeout> | null = null;
 
 function stopServerOnExit(): void {
   const proc = serverProcess;
@@ -45,10 +52,73 @@ export function isServerFailed(): boolean {
 }
 
 export function getServerPort(): number {
-  return WHISPER_SERVER_PORT;
+  return activePort;
+}
+
+export function getWhisperKeepAliveMinutes(): number {
+  try {
+    const db = getDb();
+    const row = db
+      .prepare(
+        "SELECT value FROM settings WHERE key = 'whisper_keep_alive_minutes'",
+      )
+      .get() as { value: string } | undefined;
+    if (!row) return DEFAULT_KEEP_ALIVE_MINUTES;
+    const minutes = Number(row.value);
+    if (!Number.isFinite(minutes)) return DEFAULT_KEEP_ALIVE_MINUTES;
+    return Math.min(Math.max(Math.round(minutes), 0), MAX_KEEP_ALIVE_MINUTES);
+  } catch {
+    return DEFAULT_KEEP_ALIVE_MINUTES;
+  }
+}
+
+function clearUnloadTimer(): void {
+  if (!unloadTimer) return;
+  clearTimeout(unloadTimer);
+  unloadTimer = null;
+}
+
+function scheduleUnload(): void {
+  clearUnloadTimer();
+  if (!serverProcess) return;
+  if (activeUses > 0 || startPromise) return;
+  const delayMs = getWhisperKeepAliveMinutes() * 60_000;
+
+  if (delayMs <= 0) {
+    stopServer().catch((err: Error) => {
+      log.error(`Failed to unload server: ${err.message}`);
+    });
+    return;
+  }
+
+  unloadTimer = setTimeout(() => {
+    if (activeUses > 0) return;
+    log.info("Unloading idle whisper-server");
+    stopServer().catch((err: Error) => {
+      log.error(`Failed to unload idle server: ${err.message}`);
+    });
+  }, delayMs);
+  unloadTimer.unref?.();
+}
+
+export function applyWhisperRetentionPolicy(): void {
+  if (!serverProcess) return;
+  scheduleUnload();
+}
+
+export async function withServerUse<T>(fn: () => Promise<T>): Promise<T> {
+  activeUses++;
+  clearUnloadTimer();
+  try {
+    return await fn();
+  } finally {
+    activeUses--;
+    scheduleUnload();
+  }
 }
 
 export function startInBackground(modelId: string): void {
+  if (getWhisperKeepAliveMinutes() === 0) return;
   if (serverProcess && currentModelId === modelId && serverReady) return;
   if (startPromise && currentModelId === modelId) return;
 
@@ -58,11 +128,38 @@ export function startInBackground(modelId: string): void {
 
   ensureServerRunning(modelId)
     .then(() => {
-      log.info(`Server ready on port ${WHISPER_SERVER_PORT}`);
+      log.info(`Server ready on port ${activePort}`);
     })
     .catch((err) => {
       log.error(`Background server start failed: ${err.message}`);
     });
+}
+
+function isPortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.unref();
+    probe.once("error", () => resolve(false));
+    probe.listen({ port, host: "127.0.0.1" }, () => {
+      probe.close(() => resolve(true));
+    });
+  });
+}
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.unref();
+    probe.once("error", reject);
+    probe.listen({ port: 0, host: "127.0.0.1" }, () => {
+      const address = probe.address();
+      const port =
+        typeof address === "object" && address
+          ? address.port
+          : WHISPER_SERVER_PORT;
+      probe.close(() => resolve(port));
+    });
+  });
 }
 
 export async function ensureServerRunning(modelId: string): Promise<void> {
@@ -103,11 +200,20 @@ async function doStart(modelId: string): Promise<void> {
   currentModelId = modelId;
   serverReady = false;
 
+  if (await isPortFree(WHISPER_SERVER_PORT)) {
+    activePort = WHISPER_SERVER_PORT;
+  } else {
+    activePort = await findFreePort();
+    log.warn(
+      `Port ${WHISPER_SERVER_PORT} is in use by another process, using ${activePort}`,
+    );
+  }
+
   const args = [
     "--model",
     modelPath,
     "--port",
-    String(WHISPER_SERVER_PORT),
+    String(activePort),
     "--host",
     "127.0.0.1",
   ];
@@ -165,7 +271,7 @@ async function doStart(modelId: string): Promise<void> {
         return;
       }
       try {
-        const res = await fetch(`http://127.0.0.1:${WHISPER_SERVER_PORT}/`, {
+        const res = await fetch(`http://127.0.0.1:${activePort}/`, {
           signal: AbortSignal.timeout(1000),
         });
         if (res.ok || res.status === 404 || res.status === 405) {
@@ -214,6 +320,7 @@ async function doStart(modelId: string): Promise<void> {
   });
 
   startStabilityTimer();
+  scheduleUnload();
 }
 
 function scheduleRestart(modelId: string): void {
@@ -258,6 +365,7 @@ export async function stopServer(): Promise<void> {
   autoRestart = false;
   startPromise = null;
   clearStabilityTimer();
+  clearUnloadTimer();
   if (!serverProcess) return;
 
   const proc = serverProcess;
@@ -270,7 +378,7 @@ export async function stopServer(): Promise<void> {
     const killTimeout = setTimeout(() => {
       if (done) return;
       try {
-        proc.kill();
+        proc.kill(process.platform === "win32" ? undefined : "SIGKILL");
       } catch {}
       done = true;
       resolve();

--- a/apps/server/src/routes/formats.ts
+++ b/apps/server/src/routes/formats.ts
@@ -5,6 +5,10 @@ import {
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
+import {
+  buildMatchableContext,
+  patternMatchesContext,
+} from "../lib/editor/context-match.js";
 
 interface FormatRow {
   id: number;
@@ -75,8 +79,8 @@ const formats = new Hono()
   .get("/match", (c) => {
     const db = getDb();
     const context = c.req.query("context") ?? "";
-    if (!context) return c.json(null);
-    const contextLower = context.toLowerCase();
+    const matchCtx = buildMatchableContext(context || null);
+    if (!matchCtx) return c.json(null);
 
     const rows = db
       .prepare("SELECT * FROM format_rules ORDER BY is_default ASC, id DESC")
@@ -84,11 +88,8 @@ const formats = new Hono()
 
     // User rules (is_default=0) take priority over defaults (is_default=1)
     for (const row of rows) {
-      const patterns = row.app_pattern.split("|").map((p) => p.trim());
-      for (const pattern of patterns) {
-        if (pattern && contextLower.includes(pattern.toLowerCase())) {
-          return c.json(row);
-        }
+      if (patternMatchesContext(matchCtx, row.app_pattern)) {
+        return c.json(row);
       }
     }
 

--- a/apps/server/src/routes/settings.ts
+++ b/apps/server/src/routes/settings.ts
@@ -11,6 +11,7 @@ import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
 import { applyMlxAsrRetentionPolicy } from "../lib/mlx-asr/server.js";
 import { capture } from "../lib/posthog.js";
+import { applyWhisperRetentionPolicy } from "../lib/whisper/server.js";
 
 const settings = new Hono()
   .get("/", (c) => {
@@ -85,6 +86,9 @@ const settings = new Hono()
 
     if (key === "mlx_asr_keep_alive_minutes") {
       applyMlxAsrRetentionPolicy();
+    }
+    if (key === "whisper_keep_alive_minutes") {
+      applyWhisperRetentionPolicy();
     }
 
     // Don't capture internal/system keys

--- a/apps/server/src/routes/whisper.ts
+++ b/apps/server/src/routes/whisper.ts
@@ -8,7 +8,12 @@ import {
   isServerBinaryAvailable,
 } from "../lib/whisper/binary.js";
 
-import { getModelsDir, WHISPER_PROVIDER_ID } from "../lib/whisper/constants.js";
+import {
+  getModelsDir,
+  isSupportedWhisperArch,
+  unsupportedArchMessage,
+  WHISPER_PROVIDER_ID,
+} from "../lib/whisper/constants.js";
 import {
   cancelDownload,
   clearDownloadError,
@@ -31,6 +36,10 @@ const log = createAppLogger("whisper");
 const whisper = new Hono()
   .get("/status", (c) => {
     return c.json({
+      archSupported: isSupportedWhisperArch(),
+      archUnsupportedReason: isSupportedWhisperArch()
+        ? null
+        : unsupportedArchMessage(),
       binaryAvailable: isBinaryAvailable(),
       binaryDownloading: isBinaryDownloading(),
       serverBinaryAvailable: isServerBinaryAvailable(),

--- a/apps/server/tests/rewrite-context.test.ts
+++ b/apps/server/tests/rewrite-context.test.ts
@@ -56,4 +56,49 @@ describe("getRewritePromptContext", () => {
         .registerMode,
     ).toBe("casual");
   });
+
+  it("matches web apps from window-title segments when no URL is available", () => {
+    const gmail = getRewritePromptContext(
+      JSON.stringify({
+        app: "firefox",
+        windowTitle: "Inbox (2) - matthew@gmail.com - Gmail",
+      }),
+      makeDb(),
+    );
+    expect(gmail.registerMode).toBe("formal");
+    expect(gmail.contextHint).toContain("email");
+
+    const slack = getRewritePromptContext(
+      JSON.stringify({
+        app: "chromium",
+        windowTitle: "general (Channel) - Acme - Slack",
+      }),
+      makeDb(),
+    );
+    expect(slack.registerMode).toBe("formal");
+    expect(slack.contextHint).toContain("punctuation");
+  });
+
+  it("does not match bare-word patterns against prose inside titles", () => {
+    const ctx = getRewritePromptContext(
+      JSON.stringify({
+        app: "firefox",
+        windowTitle: "How to code in Rust - Mozilla Firefox",
+      }),
+      makeDb(),
+    );
+
+    expect(ctx.registerMode).toBe("neutral");
+    expect(ctx.contextHint).toBe("The user is dictating in firefox.");
+  });
+
+  it("matches app names for desktop apps", () => {
+    const ctx = getRewritePromptContext(
+      JSON.stringify({ app: "Code", windowTitle: "index.ts — freestyle" }),
+      makeDb(),
+    );
+
+    expect(ctx.contextHint).toContain("technical terms");
+    expect(ctx.registerMode).toBe("formal");
+  });
 });


### PR DESCRIPTION
1. 7ea76a9 — PR 7, whisper server lifecycle. Idle keep-alive
  unload (whisper_keep_alive_minutes, default 10 min, same
  pattern as MLX) so an idle server no longer holds ~GBs of model
  RAM until app exit; SIGKILL escalation when SIGTERM hangs; and
  port-conflict handling — 8178 is probed before spawning with
  fallback to an ephemeral port, so a foreign service can no
  longer satisfy the readiness check or receive /inference posts.
  2. 1132910 — PR 8, download integrity. Model downloads are
  hashed in-stream and compared against the Hugging Face LFS
  sha256 (best-effort); 404/403s get human messages on all three
  download paths; source-build timeouts relaxed for slow/ARM
  machines; PowerShell extract paths quoted.
  3. 5a14114 — PR 9, architecture policy (went with "reject
  explicitly" since you were away — easy to revisit). The real
  bug fixed: on ARM Linux the source build succeeded but the null
  binary-name lookup discarded it — arm64 names are now
  registered, so ARM Linux works via source build. win32-arm64
  fails setup with an explicit "not supported on win32/arm64"
  message, and /api/whisper/status now exposes
  archSupported/archUnsupportedReason.
  4. 78ddcfb — PR 10, context/formats parity (the big one).
  Wayland frontmost-app detection via swaymsg (sway/wlroots) and
  the GNOME Shell Introspect D-Bus call, with XWayland fallback.
  A new shared matcher: domain/phrase patterns stay substring,
  bare words match only app names, window-title segments, or the
  URL host — so "Inbox - Gmail" in a Linux browser title now
  triggers the Email rule, while "How to code in Rust" no longer
  triggers Code Editor. Default rules migrated to the new
  patterns via schema v11 (user-edited rules untouched). Four new
  tests cover the semantics.
  5. 0d3a544 — PR 11, layout-aware paste. All three platforms now
  resolve the V keycode from the active keyboard layout instead
  of hardcoding the QWERTY position: UCKeyTranslate on macOS,
  VkKeyScanExW against the focused window's layout on Windows,
  XKeysymToKeycode minus the evdev offset for Linux
  uinput/portal. I compiled the macOS binary and confirmed it
  resolves keycode 9 on US QWERTY; Dvorak/AZERTY paste should now
  work everywhere.
  6. e405888 — PR 12, renderer consistency. One lib/platform.ts
  module replaces five scattered detections (including the
  deprecated navigator.platform); Windows/Linux see Ctrl+ labels
  instead of ⌘ glyphs; mac traffic-light padding gated to darwin.
  7. ba2aa43 — PR 13, default hotkey → Ctrl+Alt+Space on
  Windows/Linux (the recommended option, since you were away).
  Docs table updated; existing users keep their saved hotkey.