### PR TITLE
fix(server): retry stale-socket resets on Freestyle Cloud calls

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -504,6 +504,9 @@
 <!-- lore:019ef818-39a8-7346-bc15-eb0a35dd54c3 -->
 * **Never commit real API keys or secrets**: Never commit real keys or secrets to the repository. \`.dev.vars\` is gitignored. For deployed Cloudflare Workers, use \`wrangler secret put \<KEY\_NAME>\`. This is an absolute directive stated across 6+ sessions.
 
+<!-- lore:019f2e5c-a885-7fca-91fc-0096ea48dd38 -->
+* **Never let analytics/error-reporting calls throw or block execution**: The user consistently requires that all PostHog calls (\`capture\`, \`captureException\`, etc.) are fire-and-forget and wrapped in try/catch so they can never throw or block the primary execution path. Additionally, transient infrastructure errors (network faults, 5xx cloud responses, ECONNRESET, etc.) must never be reported to error tracking as app defects — gate \`captureException\` calls with classification logic (e.g., \`isTransientCloudError\`) to distinguish real bugs from external failures. The codebase comment 'Never let analytics errors affect the app' is the canonical expression of this rule. Apply it everywhere: route handlers, pipeline catch blocks, crash handlers, and any new error reporting site.
+
 <!-- lore:019f2428-af1c-7937-be28-d999a8d126e9 -->
 * **Plugins never manage their own credentials — always route through host LLM endpoint**: User directive: plugins must never manage their own API keys or credentials. LLM access in plugins routes exclusively through the host's configured provider via \`PluginLlm\` on \`PluginContext\`. Always guard with \`if (ctx.llm)\` before use — the capability is optional and only present in server mode when the host has a default LLM configured. This was established during voice-commands plugin implementation.
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import { WebSocketServer } from "ws";
+import { isTransientCloudError } from "./lib/freestyle-cloud.js";
 import { reconcileUnsupportedMlxVoiceDefault } from "./lib/mlx-asr/reconcile.js";
 import {
   activateManagedMlxRuntimeForAppVersion,
@@ -62,7 +63,12 @@ function createApp(pluginMiddleware: MiddlewareHandler[] = []) {
         if (origin) res.headers.set("Access-Control-Allow-Origin", origin);
         return res;
       }
-      captureException(err);
+      // Transient network faults (e.g. `fetch failed` / ECONNRESET when calling
+      // Freestyle Cloud) and upstream 5xx responses aren't app defects. Every
+      // route already guards its own reporting; guard here too so anything that
+      // escapes to this catch-all still gets a graceful 500 without polluting
+      // error tracking with outages outside our control.
+      if (!isTransientCloudError(err)) captureException(err);
       return c.json({ error: "Internal server error" }, 500);
     })
     .get("/", (c) => c.text("Freestyle API"))

--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -48,6 +48,111 @@ export class FreestyleCloudUsageError extends Error {
   }
 }
 
+/**
+ * Thrown when Freestyle Cloud returns a non-OK response that isn't an auth
+ * (401) or usage (429) failure. Carries the HTTP status so callers can tell an
+ * upstream server fault (5xx) apart from a genuine app defect and avoid
+ * reporting transient outages to error tracking.
+ */
+export class FreestyleCloudRequestError extends Error {
+  constructor(
+    readonly status: number,
+    readonly detail = "",
+  ) {
+    super(
+      `Freestyle Cloud request failed (${status})${detail ? `: ${detail}` : ""}`,
+    );
+    this.name = "FreestyleCloudRequestError";
+  }
+}
+
+const TRANSIENT_NETWORK_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EPIPE",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+]);
+
+/**
+ * True when a request failed for reasons outside the desktop app's control:
+ * transient network faults (connection resets, DNS hiccups, timeouts) or an
+ * upstream 5xx response. `fetch` (undici) surfaces socket errors as a
+ * `TypeError: fetch failed` with the real cause on `.cause`, and timeouts as an
+ * abort — so we walk the cause chain looking for a known network code or abort.
+ * These should be surfaced to the user but never captured as app defects.
+ */
+export function isTransientCloudError(err: unknown): boolean {
+  if (err instanceof FreestyleCloudRequestError) return err.status >= 500;
+
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const e = current as {
+      name?: unknown;
+      code?: unknown;
+      cause?: unknown;
+    };
+    if (typeof e.code === "string" && TRANSIENT_NETWORK_CODES.has(e.code)) {
+      return true;
+    }
+    if (e.name === "TimeoutError" || e.name === "AbortError") return true;
+    current = e.cause;
+  }
+  return false;
+}
+
+/**
+ * Connection-level faults where the request never reached the server, so
+ * retrying a non-idempotent POST is safe. This is deliberately narrower than
+ * {@link TRANSIENT_NETWORK_CODES}: it excludes response-phase timeouts
+ * (`UND_ERR_HEADERS_TIMEOUT`/`UND_ERR_BODY_TIMEOUT`) and generic aborts, where
+ * the request may already be processing server-side and a retry could double
+ * up (e.g. double-charge a transcribe).
+ */
+const RETRIABLE_CONNECTION_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EPIPE",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/**
+ * True when a request threw before reaching the server on a reused connection.
+ * The dominant case is a stale keep-alive socket: undici pools a connection
+ * that an idle timeout or NAT/middlebox silently dropped, then the first write
+ * on resume gets an RST — surfaced as `TypeError: fetch failed` with
+ * `code === "ECONNRESET"` on the cause chain. Since the request never landed,
+ * a single retry on a fresh socket recovers it safely.
+ */
+function isRetriableConnectionError(err: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string" && RETRIABLE_CONNECTION_CODES.has(code)) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/** One extra attempt after the initial request (2 total). */
+const CLOUD_FETCH_ATTEMPTS = 2;
+/** Brief pause before retrying so we don't tight-loop on a refused connection. */
+const CLOUD_RETRY_DELAY_MS = 150;
+
 export interface DeviceCodeResult {
   device_code: string;
   user_code: string;
@@ -194,14 +299,35 @@ async function cloudJson<T>(
   token: string,
   init: RequestInit,
 ): Promise<T> {
-  const res = await fetch(`${freestyleCloudUrl()}${path}`, {
-    ...init,
-    headers: {
-      ...(init.headers ?? {}),
-      authorization: `Bearer ${token}`,
-    },
-    signal: init.signal ?? AbortSignal.timeout(CLOUD_TRANSCRIBE_TIMEOUT_MS),
-  });
+  const url = `${freestyleCloudUrl()}${path}`;
+  let res: Response | undefined;
+  for (let attempt = 0; attempt < CLOUD_FETCH_ATTEMPTS; attempt++) {
+    try {
+      res = await fetch(url, {
+        ...init,
+        headers: {
+          ...(init.headers ?? {}),
+          authorization: `Bearer ${token}`,
+        },
+        // A fresh per-attempt timeout when the caller didn't supply a signal,
+        // so a retry isn't handicapped by the first attempt's elapsed clock.
+        signal: init.signal ?? AbortSignal.timeout(CLOUD_TRANSCRIBE_TIMEOUT_MS),
+      });
+      break;
+    } catch (err) {
+      // Retry once on a stale-socket reset (request never reached the server).
+      // Anything else — including response-phase timeouts — propagates as-is.
+      if (
+        attempt === CLOUD_FETCH_ATTEMPTS - 1 ||
+        !isRetriableConnectionError(err)
+      ) {
+        throw err;
+      }
+      await new Promise((r) => setTimeout(r, CLOUD_RETRY_DELAY_MS));
+    }
+  }
+  // Unreachable: the loop either assigns `res` or throws on the final attempt.
+  if (!res) throw new Error("Freestyle Cloud request produced no response");
   if (res.status === 401) throw new FreestyleCloudAuthError();
   if (res.status === 429) {
     const resetsAt = await res
@@ -216,9 +342,7 @@ async function cloudJson<T>(
   }
   if (!res.ok) {
     const detail = await res.text().catch(() => "");
-    throw new Error(
-      `Freestyle Cloud request failed (${res.status})${detail ? `: ${detail}` : ""}`,
-    );
+    throw new FreestyleCloudRequestError(res.status, detail);
   }
   return (await res.json()) as T;
 }

--- a/apps/server/src/lib/post-process.ts
+++ b/apps/server/src/lib/post-process.ts
@@ -27,6 +27,7 @@ import { getRewritePromptContext } from "./editor/rewrite-context.js";
 import {
   FREESTYLE_CLOUD_PROVIDER_ID,
   FreestyleCloudAuthError,
+  isTransientCloudError,
   postProcessWithFreestyleCloud,
 } from "./freestyle-cloud.js";
 import {
@@ -263,7 +264,8 @@ export async function postProcess(
         cleanedText = sanitizeTranscriptText(result.cleaned);
       } catch (err) {
         if (err instanceof FreestyleCloudAuthError) throw err;
-        captureException(err);
+        // Transient network faults / upstream 5xx aren't app defects.
+        if (!isTransientCloudError(err)) captureException(err);
         capture("post process failed", {
           provider: llm.provider,
           model: llm.model_id,
@@ -336,7 +338,7 @@ export async function postProcess(
         llmModel = llm.model_id;
         cleanedText = sanitizeTranscriptText(result.text);
       } catch (err) {
-        captureException(err);
+        if (!isTransientCloudError(err)) captureException(err);
         void plugins().emit({
           type: FreestyleEventType.PipelineError,
           stage: PipelineStage.Cleanup,

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -6,6 +6,7 @@ import {
   FREESTYLE_CLOUD_PROVIDER_ID,
   FreestyleCloudAuthError,
   FreestyleCloudUsageError,
+  isTransientCloudError,
   transcribeWithFreestyleCloud,
 } from "../lib/freestyle-cloud.js";
 import { saveProcessedHistory, saveRawHistory } from "../lib/history-store.js";
@@ -219,7 +220,11 @@ const transcribeRoute = new Hono().post("/", async (c) => {
       if (err instanceof FreestyleCloudUsageError) {
         return c.json({ error: "usage_exceeded", resetsAt: err.resetsAt }, 429);
       }
-      captureException(err, { provider: voiceProvider, model: voiceModel });
+      // Transient network faults / upstream 5xx aren't app defects — surface
+      // them to the user but don't report them to error tracking.
+      if (!isTransientCloudError(err)) {
+        captureException(err, { provider: voiceProvider, model: voiceModel });
+      }
       return c.json(
         {
           error: "Transcription failed",
@@ -269,10 +274,12 @@ const transcribeRoute = new Hono().post("/", async (c) => {
       invalidateSession();
       return c.json({ error: "cloud_auth_required" }, 401);
     }
-    captureException(err, {
-      provider: defaults.voice.provider,
-      model: defaults.voice.model_id,
-    });
+    if (!isTransientCloudError(err)) {
+      captureException(err, {
+        provider: defaults.voice.provider,
+        model: defaults.voice.model_id,
+      });
+    }
     void plugins().emit({
       type: FreestyleEventType.PipelineError,
       stage: PipelineStage.Transcribe,


### PR DESCRIPTION
## Problem

Users intermittently lose a dictation with `TypeError: fetch failed` / `Error: read ECONNRESET` thrown from `cloudJson` in `apps/server/src/lib/freestyle-cloud.ts`. Error tracking: [PostHog issue](https://us.posthog.com/error_tracking/019f2e43-ae1f-7571-9dc5-1c95b6227936).

## Root cause

Dictation calls to Freestyle Cloud are bursty with long idle gaps. undici keeps idle sockets pooled, but a NAT/middlebox (the failing session's ISP path was Optimum) or the CF edge can **silently drop an idle flow without sending a FIN**. undici never learns the socket is dead, reuses it on the next dictation, and the first write gets an `RST` back → `ECONNRESET`. Because a POST is non-idempotent, undici does **not** auto-retry, so the error surfaces to the app and the request is lost.

This matches production: the Worker logged **only 200s** with no failed transcribe attempt — the failed request never reached Cloudflare because it died on the client's reused socket.

### Reproduced deterministically

A local server that silently drops an idle flow then RSTs on resume makes undici reuse the stale pooled socket and throw `ECONNRESET` with no auto-retry. A single retry on a fresh socket recovers cleanly, and the RST'd write never reaches the server (no duplicate processing).

## Fix

1. **Retry once on connection-level faults** in `cloudJson` (covers transcribe, post-process, and usage — all cloud calls route through it). A reset means the request never reached the server, so retrying a POST is safe. The retriable set (`RETRIABLE_CONNECTION_CODES`) is deliberately **narrower** than the transient-classification set: it excludes response-phase timeouts (`UND_ERR_HEADERS_TIMEOUT`/`UND_ERR_BODY_TIMEOUT`) and generic aborts where the request may already be processing server-side — so a transcribe can't be double-charged.
2. **Stop reporting transient failures as app defects.** `cloudJson` now throws a typed `FreestyleCloudRequestError` (carrying HTTP status); `isTransientCloudError` classifies network faults and upstream 5xx, and `captureException` is gated on it across `transcribe.ts`, `post-process.ts`, and the app-level `onError` in `index.ts`.

### Why no keep-alive tuning

Lowering undici's `keepAliveMaxTimeout` to shrink the stale-socket window would force a fresh TLS handshake on nearly every dictation (gaps are typically minutes), adding constant latency to avoid a rare reset. The retry handles the reset cheaply — only paying an extra round-trip when a reset actually occurs — so it's the more targeted fix.

## Verification

- `tsc --noEmit`: clean
- `biome check`: clean
- `vitest run`: **216 passed** (23 files)
- `pnpm build`: succeeds
- Deterministic repro confirms transparent recovery with no duplicate server processing

## User-facing behavior

Transient failures still return the same 500/429/fallback responses and still fire `capture()` analytics + logs — only `captureException` (error tracking) is gated, plus dictations now transparently recover from stale-socket resets.