### PR TITLE
fix: compound hotkey suppression blocks dictation activation

### DIFF
--- a/apps/electron/native/macos-key-listener.swift
+++ b/apps/electron/native/macos-key-listener.swift
@@ -406,12 +406,18 @@ let keyEventTap = CGEvent.tapCreate(
             return Unmanaged.passUnretained(event)
         }
 
-        // KEY_DOWN is emitted by the NSEvent global monitor above (avoids duplicate events).
         if type == .keyUp {
             emit("KEY_UP:\(name)")
         }
 
         if let suppressHotkey, eventMatchesSuppressibleHotkey(event, config: suppressHotkey) {
+            // Returning nil swallows this event before the NSEvent global monitor
+            // can observe it, so we must emit KEY_DOWN ourselves. For non-suppressed
+            // events the NSEvent monitor emits KEY_DOWN (no duplicate risk here
+            // because we only emit when suppressing).
+            if type == .keyDown {
+                emit("KEY_DOWN:\(name)")
+            }
             return nil
         }
 


### PR DESCRIPTION
## Problem

Compound hotkeys (e.g. `Option+V`, `Option+Space`) stopped triggering dictation after PR #346 added CGEvent tap suppression for dead-key prevention.

**Root cause:** The CGEvent tap uses `.headInsertEventTap` + `.defaultTap`, meaning it intercepts keyboard events *before* they propagate through the system. When a compound hotkey matches, the tap returns `nil` to suppress the keypress (preventing dead-key insertion in the foreground app). However, the `NSEvent.addGlobalMonitorForEvents(.keyDown)` monitor — which is responsible for emitting `KEY_DOWN:<name>` to the Electron process — observes events *after* they've passed through taps. Since the tap eats the event, the NSEvent monitor never sees it, and the `KEY_DOWN` is never emitted.

The result: the hotkey is correctly captured and suppressed (KeyCastr shows only the modifier, confirming the key is swallowed), but dictation never activates because the Electron process never receives the key-down event.

## Fix

Emit `KEY_DOWN:<name>` from the CGEvent tap callback *before* returning `nil` for suppressed events. For non-suppressed events, the NSEvent monitor continues to emit `KEY_DOWN` as before — no duplicate risk since the CGEvent tap only emits when it suppresses.

**Affected code path:** `apps/electron/native/macos-key-listener.swift` — the keyboard CGEvent tap callback.

**Not affected:** Globe/Fn hotkey (uses `flagsChanged` monitor, not key-down), right-modifier hotkeys (uses modifier state tracking), Windows/Linux (different native binaries).

## Testing

- Compound hotkeys (`Option+V`, `Alt+Space`, etc.) should now activate dictation
- The hotkey keystroke should still be suppressed from reaching the foreground app (no dead-key insertion)
- Globe/Fn and modifier-only hotkeys should continue to work as before
- `KEY_UP` is unaffected (always emitted by the CGEvent tap)