### PR TITLE
fix(stt): send vocabulary bias to Freestyle Cloud streaming

### DIFF
--- a/apps/server/src/lib/streaming/providers/freestyle-cloud.ts
+++ b/apps/server/src/lib/streaming/providers/freestyle-cloud.ts
@@ -5,6 +5,7 @@ import {
   freestyleCloudStreamWsUrl,
   transcribeWithFreestyleCloud,
 } from "../../freestyle-cloud.js";
+import { sonioxContextFromBias } from "../transcribe-bias.js";
 import type {
   StreamingSessionOptions,
   StreamSession,
@@ -67,7 +68,7 @@ export class FreestyleCloudTranscriptionProvider
   }
 
   openStreamingSession(opts: StreamingSessionOptions): StreamSession {
-    const { apiKey, model, language, cleanup, callbacks } = opts;
+    const { apiKey, model, language, cleanup, callbacks, bias } = opts;
 
     if (!apiKey) {
       throw new FreestyleCloudAuthError();
@@ -80,6 +81,11 @@ export class FreestyleCloudTranscriptionProvider
       },
     });
 
+    // Vocabulary bias for the Soniox upstream. The cloud DO transcribes via
+    // Soniox, so we forward the same `context` object (custom terms + optional
+    // background text) that the local BYOK Soniox provider sends directly.
+    const vocabulary = sonioxContextFromBias(bias);
+
     // The DO applies cleanup preferences on `start`. Mirror the batch
     // `/v2/transcribe` payload: send `skipPostProcess` plus intensity, custom
     // prompt, and destination-aware tones so the cloud cleans (or skips) and
@@ -89,6 +95,7 @@ export class FreestyleCloudTranscriptionProvider
       type: "start" as const,
       language: language || undefined,
       skipPostProcess: cleanup?.skipPostProcess ?? false,
+      ...(vocabulary ? { vocabulary } : {}),
       ...(cleanup && !cleanup.skipPostProcess
         ? {
             intensity: cleanup.intensity,

--- a/apps/server/src/lib/vocabulary-bias.ts
+++ b/apps/server/src/lib/vocabulary-bias.ts
@@ -1,3 +1,4 @@
+import { FREESTYLE_CLOUD_PROVIDER_ID } from "./freestyle-cloud.js";
 import { stripProviderPrefix } from "./streaming/types.js";
 import {
   getTranscriptionContextPrompt,
@@ -179,7 +180,10 @@ export function buildAsrVocabularyBias(
       const text = parts.join(" ").trim().slice(0, PROMPT_CHAR_BUDGET);
       return text ? { kind: "prompt", text } : null;
     }
-    case "soniox": {
+    // Freestyle Cloud transcribes via a Soniox upstream inside the DO, so it
+    // uses the same context-based vocabulary bias as direct (BYOK) Soniox.
+    case "soniox":
+    case FREESTYLE_CLOUD_PROVIDER_ID: {
       const terms = capTerms(capped, SONIOX_TERM_MAX);
       const text = contextPrompt?.trim().slice(0, SONIOX_CONTEXT_TEXT_MAX);
       if (terms.length === 0 && !text) return null;

--- a/apps/server/tests/vocabulary-bias.test.ts
+++ b/apps/server/tests/vocabulary-bias.test.ts
@@ -321,6 +321,38 @@ describe("buildAsrVocabularyBias", () => {
       ).toBeNull();
     });
   });
+
+  describe("freestyle-cloud", () => {
+    // The cloud provider transcribes via a Soniox upstream, so it must produce
+    // the same soniox-context bias as direct Soniox — otherwise vocabulary
+    // never reaches the cloud DO.
+    it("maps vocabulary terms and prompt to soniox-context", () => {
+      const bias = buildAsrVocabularyBias(
+        "freestyle-cloud",
+        "freestyle-cloud/stt",
+        ["Freestyle", "Kubernetes"],
+        "Medical dictation about diabetes care.",
+        true,
+      );
+      expect(bias).toEqual({
+        kind: "soniox-context",
+        terms: ["Freestyle", "Kubernetes"],
+        text: "Medical dictation about diabetes care.",
+      });
+    });
+
+    it("returns null when there is nothing to send", () => {
+      expect(
+        buildAsrVocabularyBias(
+          "freestyle-cloud",
+          "freestyle-cloud/stt",
+          [],
+          undefined,
+          true,
+        ),
+      ).toBeNull();
+    });
+  });
 });
 
 describe("sonioxContextFromBias", () => {


### PR DESCRIPTION
Vocabulary worked for BYOK Soniox but not for Freestyle Cloud, which also transcribes via Soniox. buildAsrVocabularyBias had no freestyle-cloud case (so the bias was never built), and the cloud provider's start message never forwarded it.

- vocabulary-bias: freestyle-cloud shares the soniox branch, producing a soniox-context bias
- providers/freestyle-cloud: forward the context object as `vocabulary` in the start message (also carried on reset)

Pairs with the freestyle-cloud repo change that receives the field and sets Soniox's session `context`.