### PR TITLE
fix: pin transformers to <5.13 in mlx-asr worker build

### DIFF
--- a/scripts/build_mlx_asr_worker.sh
+++ b/scripts/build_mlx_asr_worker.sh
@@ -10,6 +10,12 @@ PYTHON_BIN="${PYTHON_BIN:-python3.12}"
 PYINSTALLER_VERSION="${PYINSTALLER_VERSION:-6.20.0}"
 MLX_AUDIO_VERSION="${MLX_AUDIO_VERSION:-0.4.3}"
 HUGGINGFACE_HUB_VERSION="${HUGGINGFACE_HUB_VERSION:-1.17.0}"
+# transformers 5.13.0 rewrote AutoTokenizer.register() to require a config class; mlx-lm still
+# registers with a string at import time, so any mlx-lm import raises
+# "AttributeError: 'str' object has no attribute '__module__'" and the worker exits code 1.
+# Pin below 5.13 until mlx-lm's fix ships. Working band: transformers>=5.7,<5.13.
+# Refs: freestyle-voice/freestyle#403, ml-explore/mlx-lm#1458.
+TRANSFORMERS_SPEC="${TRANSFORMERS_SPEC:->=5.7,<5.13}"
 
 if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
   echo "Python 3.12 is required to build the MLX ASR worker." >&2
@@ -22,6 +28,7 @@ fi
 "${VENV_DIR}/bin/python" -m pip install -U \
   "pyinstaller==${PYINSTALLER_VERSION}" \
   "mlx-audio==${MLX_AUDIO_VERSION}" \
+  "transformers${TRANSFORMERS_SPEC}" \
   "huggingface_hub[hf_xet]==${HUGGINGFACE_HUB_VERSION}"
 
 rm -rf "${ROOT_DIR}/build/mlx_asr_worker" "${DIST_DIR}/mlx_asr_worker"


### PR DESCRIPTION
### What

Pins `transformers` to `>=5.7,<5.13` when building the `mlx-asr` worker, so it stops resolving to the broken `5.13.0`.

### Why

Since `transformers 5.13.0` (released 2026-07-03), local transcription is 100% broken on 0.4.0–0.4.2. The worker exits immediately with `mlx-asr worker exited unexpectedly: exit code 1`. Root cause:

`transformers 5.13.0` rewrote `AutoTokenizer.register()` to require a config class, but `mlx-lm` still registers a tokenizer with a string at import time (`mlx_lm/tokenizer_utils.py`). So any `import mlx_lm` (pulled in via `mlx-audio`'s STT path) raises:

```
File "transformers/models/auto/auto_factory.py", line 680, in register
AttributeError: 'str' object has no attribute '__module__'
```

It fires at import, before any model loads, so it's model-independent (both `parakeet-tdt-0.6b-v3` and `Qwen3-ASR-0.6B-8bit` fail identically).

`build_mlx_asr_worker.sh` installs `mlx-audio` (which requires `transformers>=5.5.0`, no upper bound), so any worker built after 2026-07-03 froze the broken version. `0.3.4` (built 2026-07-02) shipped a working `transformers 5.12.x`, which is why it's the last working release.

Upstream tracking: ml-explore/mlx-lm#1458 (fix PRs not yet merged), so capping `transformers` is the reliable fix today.

### The change

One line added to the `pip install` in `scripts/build_mlx_asr_worker.sh`, plus a `TRANSFORMERS_SPEC` env override and an explanatory comment.

### Validation

Rebuilt the worker locally with this change on macOS arm64: `transformers` resolves to `5.12.1`, and the built worker loads a model and transcribes correctly (verified with both Parakeet and Qwen3-ASR under app 0.4.2).

Closes #403.
