### PR TITLE
feat: add "Always on" option to MLX model warming (never unload)

### DIFF
--- a/apps/electron/src/renderer/src/pages/models/constants.ts
+++ b/apps/electron/src/renderer/src/pages/models/constants.ts
@@ -1,2 +1,4 @@
 export const DEFAULT_MLX_KEEP_ALIVE_MINUTES = 10;
 export const MAX_MLX_KEEP_ALIVE_MINUTES = 10;
+// Sentinel meaning "always on" (never unload the model). Stored as -1.
+export const MLX_KEEP_ALIVE_ALWAYS = -1;

--- a/apps/electron/src/renderer/src/pages/models/mlx-memory-section.tsx
+++ b/apps/electron/src/renderer/src/pages/models/mlx-memory-section.tsx
@@ -9,9 +9,12 @@ import {
 import { Slider } from "@renderer/components/ui/slider";
 import { Cpu } from "lucide-react";
 
-import { MAX_MLX_KEEP_ALIVE_MINUTES } from "./constants";
+import { MAX_MLX_KEEP_ALIVE_MINUTES, MLX_KEEP_ALIVE_ALWAYS } from "./constants";
 
 function mlxKeepAliveDescription(minutes: number): string {
+  if (minutes === MLX_KEEP_ALIVE_ALWAYS) {
+    return "Keep the model loaded in memory at all times, until you quit Freestyle. Fastest repeat use, uses the most RAM.";
+  }
   if (minutes === 0) {
     return "Unload the model from memory after each transcription. Uses less RAM, but the next dictation waits for a full reload.";
   }
@@ -36,6 +39,10 @@ export function MlxWarmingDialog({
   onChange: (minutes: number) => void;
   onClose: () => void;
 }): React.JSX.Element {
+  // The slider gets one extra step past the max minutes to represent "Always on".
+  const alwaysPos = MAX_MLX_KEEP_ALIVE_MINUTES + 1;
+  const sliderPos =
+    keepAliveMinutes === MLX_KEEP_ALIVE_ALWAYS ? alwaysPos : keepAliveMinutes;
   return (
     <Dialog open onOpenChange={(o) => !o && onClose()}>
       <DialogContent>
@@ -52,16 +59,20 @@ export function MlxWarmingDialog({
 
         <div>
           <Slider
-            value={[keepAliveMinutes]}
-            onValueChange={([v]) => onChange(v)}
+            value={[sliderPos]}
+            onValueChange={([v]) =>
+              onChange(
+                v > MAX_MLX_KEEP_ALIVE_MINUTES ? MLX_KEEP_ALIVE_ALWAYS : v,
+              )
+            }
             min={0}
-            max={MAX_MLX_KEEP_ALIVE_MINUTES}
+            max={alwaysPos}
             step={1}
-            aria-label="MLX ASR keep-alive minutes"
+            aria-label="MLX ASR keep-alive"
           />
           <div className="text-muted-foreground mt-2 flex justify-between text-[11px]">
             <span>Cold start (unload)</span>
-            <span>Keep warm 10 min</span>
+            <span>Always on</span>
           </div>
         </div>
 

--- a/apps/electron/src/renderer/src/pages/models/utils.ts
+++ b/apps/electron/src/renderer/src/pages/models/utils.ts
@@ -12,6 +12,7 @@ import {
 import {
   DEFAULT_MLX_KEEP_ALIVE_MINUTES,
   MAX_MLX_KEEP_ALIVE_MINUTES,
+  MLX_KEEP_ALIVE_ALWAYS,
 } from "./constants";
 import type { ConfiguredModel } from "./types";
 
@@ -21,6 +22,8 @@ export function displayName(providerId: string, fallback?: string): string {
 
 export function clampMlxKeepAliveMinutes(value: number): number {
   if (!Number.isFinite(value)) return DEFAULT_MLX_KEEP_ALIVE_MINUTES;
+  // Any negative value is the "always on" sentinel (never unload).
+  if (Math.round(value) < 0) return MLX_KEEP_ALIVE_ALWAYS;
   return Math.min(Math.max(Math.round(value), 0), MAX_MLX_KEEP_ALIVE_MINUTES);
 }
 

--- a/apps/server/src/lib/mlx-asr/server.ts
+++ b/apps/server/src/lib/mlx-asr/server.ts
@@ -25,6 +25,9 @@ const START_TIMEOUT_MS = 120_000;
 const TRANSCRIBE_TIMEOUT_MS = 300_000;
 const DEFAULT_KEEP_ALIVE_MINUTES = 10;
 const MAX_KEEP_ALIVE_MINUTES = 10;
+// Sentinel keep-alive value meaning "never unload" — the model stays resident
+// until the app quits. Stored as -1 in the settings table.
+const KEEP_ALIVE_ALWAYS = -1;
 
 interface WorkerResponse {
   id?: number;
@@ -99,6 +102,8 @@ export function getMlxAsrKeepAliveMinutes(): number {
     if (!row) return DEFAULT_KEEP_ALIVE_MINUTES;
     const minutes = Number(row.value);
     if (!Number.isFinite(minutes)) return DEFAULT_KEEP_ALIVE_MINUTES;
+    // Any negative value is the "always on" sentinel (never unload).
+    if (Math.round(minutes) < 0) return KEEP_ALIVE_ALWAYS;
     return Math.min(Math.max(Math.round(minutes), 0), MAX_KEEP_ALIVE_MINUTES);
   } catch {
     return DEFAULT_KEEP_ALIVE_MINUTES;
@@ -476,6 +481,12 @@ function scheduleUnload(): void {
   if (!workerProcess) return;
   if (pending.size > 0) return;
   const minutes = getMlxAsrKeepAliveMinutes();
+
+  if (minutes === KEEP_ALIVE_ALWAYS) {
+    // "Always on": keep the model resident indefinitely; never schedule unload.
+    return;
+  }
+
   const delayMs = minutes * 60_000;
 
   if (delayMs <= 0) {


### PR DESCRIPTION
### What

Adds an **"Always on"** position past the 10-minute maximum on the MLX model-warming slider, so the local `mlx-asr` model can stay resident until the app quits instead of unloading after at most 10 minutes.

### Why

For heavy dictation users, the model unloading after ≤10 min idle means a cold reload (~2–3s) on the next dictation. An always-resident option removes that at the cost of keeping the model in memory.

### How

Uses a sentinel keep-alive value of `-1` ("never unload"):

- **`server.ts`** — `getMlxAsrKeepAliveMinutes()` passes `-1` through instead of clamping to `0`; `scheduleUnload()` returns early without arming the unload timer when the value is `-1`.
- **UI** (`constants.ts` / `utils.ts` / `mlx-memory-section.tsx`) — the slider gains one step past `MAX` for "Always on", the clamp preserves the `-1` sentinel, and the description explains the behavior.

On app quit the worker is still stopped (existing `process.exit` handler), so "Always on" only affects idle retention, not shutdown.

### Validation

Built on macOS arm64 (`build:mac`), installed and run. Selecting "Always on" persists `-1`; the worker stayed resident for 36 minutes across a 12-minute idle gap with no unload (vs. the old cap where it would unload at 10 min). Finite values (0–10) behave exactly as before.
