### PR TITLE
NORMALIZE UI LABEL TYPOGRAPHY 

### DIFF
--- a/apps/electron/src/renderer/src/components/tone-previews/app-assignments.tsx
+++ b/apps/electron/src/renderer/src/components/tone-previews/app-assignments.tsx
@@ -222,7 +222,7 @@ export function AppAssignments({
           {items.length > 0 ? (
             <section className="space-y-2.5">
               <div className="flex items-center justify-between gap-3">
-                <span className="mono text-muted-foreground text-[10px] uppercase tracking-[0.14em]">
+                <span className="text-muted-foreground text-[11px] font-semibold">
                   {t("tone.apps.currentRoutes")}
                 </span>
               </div>
@@ -240,7 +240,7 @@ export function AppAssignments({
 
           <section className="space-y-3">
             <div className="flex items-center justify-between gap-3">
-              <span className="mono text-muted-foreground text-[10px] uppercase tracking-[0.14em]">
+              <span className="text-muted-foreground text-[11px] font-semibold">
                 {t("tone.apps.openApps")}
               </span>
               <Button
@@ -323,7 +323,7 @@ export function AppAssignments({
           <section className="space-y-3 border-t border-border/70 pt-5">
             <div className="flex items-center gap-2">
               <Globe className="text-muted-foreground size-4" />
-              <span className="mono text-muted-foreground text-[10px] uppercase tracking-[0.14em]">
+              <span className="text-muted-foreground text-[11px] font-semibold">
                 {t("tone.apps.websiteLabel")}
               </span>
             </div>

--- a/apps/electron/src/renderer/src/components/tone-previews/email-preview.tsx
+++ b/apps/electron/src/renderer/src/components/tone-previews/email-preview.tsx
@@ -49,13 +49,13 @@ export function EmailPreview({
       <div className="bg-background/75 border-border/80 border-b px-3 py-2.5">
         <div className="grid gap-1">
           <div className="flex items-center gap-2">
-            <span className="mono text-muted-foreground text-[9px] uppercase tracking-[0.16em]">
+            <span className="text-muted-foreground text-[10.5px] font-medium">
               To
             </span>
             <span className="text-foreground text-[12px]">{to}</span>
           </div>
           <div className="flex items-center gap-2">
-            <span className="mono text-muted-foreground text-[9px] uppercase tracking-[0.16em]">
+            <span className="text-muted-foreground text-[10.5px] font-medium">
               Subject
             </span>
             <span className="text-foreground text-[12px]">{subject}</span>

--- a/apps/electron/src/renderer/src/components/tone-previews/work-chat-preview.tsx
+++ b/apps/electron/src/renderer/src/components/tone-previews/work-chat-preview.tsx
@@ -34,7 +34,7 @@ export function WorkChatPreview({
             <span className="text-foreground text-[13px] font-semibold">
               {sender}
             </span>
-            <span className="mono text-muted-foreground text-[9px] uppercase tracking-[0.16em]">
+            <span className="text-muted-foreground text-[10.5px] font-medium">
               {time}
             </span>
           </div>

--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -307,10 +307,7 @@ export function ModelList({
         ) : (
           <Sparkles className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
         )}
-        <span
-          className="mono text-foreground shrink-0 text-[11px] uppercase"
-          style={{ letterSpacing: "0.14em" }}
-        >
+        <span className="text-foreground shrink-0 text-[12px] font-semibold">
           {type === "voice" ? "All voice models" : "Cleanup model"}
         </span>
         <InputGroup className="ml-3 h-9 flex-1 rounded-md">
@@ -445,10 +442,7 @@ function VoiceTiers({
     <>
       <header className="border-border flex shrink-0 items-center gap-3 border-b px-5 py-3.5">
         <Mic className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-        <span
-          className="mono text-foreground flex-1 text-[11px] uppercase"
-          style={{ letterSpacing: "0.14em" }}
-        >
+        <span className="text-foreground flex-1 text-[12px] font-semibold">
           How should Freestyle transcribe?
         </span>
         <Button
@@ -566,8 +560,7 @@ function TierCard({
         {badge && !selected && (
           <Badge
             variant="secondary"
-            className="mono ml-auto text-[9px] uppercase"
-            style={{ letterSpacing: "0.1em" }}
+            className="ml-auto text-[10px] font-semibold"
           >
             {badge}
           </Badge>
@@ -713,8 +706,7 @@ function ModelRow({
           {row.recommended && !row.selected && (
             <Badge
               variant="secondary"
-              className="mono shrink-0 text-[9px] uppercase"
-              style={{ letterSpacing: "0.1em" }}
+              className="shrink-0 text-[10px] font-semibold"
             >
               Recommended
             </Badge>
@@ -733,11 +725,8 @@ function ModelRow({
 
       <div className="flex shrink-0 items-center gap-1.5 justify-self-end">
         {row.selected ? (
-          <span
-            className="mono text-primary"
-            style={{ fontSize: 10, letterSpacing: "0.14em" }}
-          >
-            SELECTED
+          <span className="text-primary text-[11px] font-semibold">
+            Selected
           </span>
         ) : local ? (
           <>
@@ -857,10 +846,7 @@ function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
     <div className="border-border border-b">
       <div className="flex items-center gap-2 px-5 pb-2 pt-3">
         <Laptop className="text-primary h-3 w-3" />
-        <span
-          className="mono text-foreground text-[10px] uppercase"
-          style={{ letterSpacing: "0.14em" }}
-        >
+        <span className="text-foreground text-[11px] font-semibold">
           On-device
         </span>
         <span className="text-muted-foreground text-[11.5px]">

--- a/apps/electron/src/renderer/src/pages/models/model-modal.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-modal.tsx
@@ -231,10 +231,7 @@ function KeyStep({
           </div>
         )}
         <div className="flex items-center justify-between">
-          <p
-            className="mono text-muted-foreground text-[10px] uppercase"
-            style={{ letterSpacing: "0.14em" }}
-          >
+          <p className="text-muted-foreground text-[11px] font-medium">
             Stored in keychain · never logged
           </p>
           {PROVIDER_KEY_URLS[provider] && (

--- a/apps/electron/src/renderer/src/pages/models/page-chrome.tsx
+++ b/apps/electron/src/renderer/src/pages/models/page-chrome.tsx
@@ -54,13 +54,13 @@ export function PageHeader({
 }
 
 // ---------------------------------------------------------------------------
-// Eyebrow — small uppercase label shared across sections
+// Eyebrow — small section label shared across settings pages
 // ---------------------------------------------------------------------------
 
 export function Eyebrow({
   text,
   accent,
-  mono = true,
+  mono = false,
 }: {
   text: string;
   accent?: boolean;
@@ -69,11 +69,10 @@ export function Eyebrow({
   return (
     <span
       className={cn(
-        "text-[10px] uppercase",
-        mono ? "mono" : "font-semibold",
+        "text-[11px] font-semibold",
+        mono && "mono",
         accent ? "text-primary" : "text-muted-foreground",
       )}
-      style={{ letterSpacing: "0.14em" }}
     >
       {text}
     </span>

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -1203,7 +1203,7 @@ function CopyButton({
       type="button"
       onClick={() => copy(value)}
       className={cn(
-        "mono text-muted-foreground hover:text-foreground inline-flex shrink-0 items-center gap-1 text-[10.5px] font-medium tracking-[0.08em] uppercase transition-colors",
+        "text-muted-foreground hover:text-foreground inline-flex shrink-0 items-center gap-1 text-[11px] font-medium transition-colors",
         className,
       )}
     >
@@ -1249,7 +1249,7 @@ function CopyField({
 }): React.JSX.Element {
   return (
     <div className="border-border bg-secondary/45 flex min-w-0 items-center gap-3 rounded-[10px] border px-3 py-2.5">
-      <div className="mono text-muted-foreground hidden shrink-0 text-[10.5px] tracking-[0.14em] uppercase min-[760px]:block">
+      <div className="text-muted-foreground hidden shrink-0 text-[11px] font-medium min-[760px]:block">
         {label}
       </div>
       <div className="bg-background/45 border-border flex min-w-0 flex-1 items-center rounded-md border px-3 py-2">
@@ -1275,7 +1275,7 @@ function CodeBlock({
     <div className="border-border bg-secondary/45 overflow-hidden rounded-[12px] border">
       <div className="flex items-start justify-between gap-3 border-b border-border/70 px-3 py-2.5">
         <div className="min-w-0">
-          <div className="mono text-muted-foreground text-[10.5px] tracking-[0.14em] uppercase">
+          <div className="text-muted-foreground text-[11px] font-medium">
             {label}
           </div>
           {note && (
@@ -1342,7 +1342,7 @@ function McpConnect(): React.JSX.Element {
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-3 min-[760px]:flex-row min-[760px]:items-start min-[760px]:justify-between">
           <div className="min-w-0">
-            <div className="mono text-primary text-[10px] uppercase tracking-[0.16em]">
+            <div className="text-primary text-[11px] font-semibold">
               Connect an MCP client
             </div>
             <p className="text-muted-foreground mt-1.5 max-w-[620px] text-[12.5px] leading-relaxed">

--- a/apps/electron/src/renderer/src/pages/today.tsx
+++ b/apps/electron/src/renderer/src/pages/today.tsx
@@ -67,12 +67,54 @@ function formatMinutes(totalSec: number): string {
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
+const MODEL_LABEL_OVERRIDES: Record<string, string> = {
+  api: "API",
+  asr: "ASR",
+  deepgram: "Deepgram",
+  elevenlabs: "ElevenLabs",
+  "freestyle-cloud": "Freestyle Cloud",
+  "freestyle-cloud/stt": "Freestyle Cloud / STT",
+  "freestyle-cloud/post-process": "Freestyle Cloud / Post-process",
+  gpt: "GPT",
+  groq: "Groq",
+  llm: "LLM",
+  mlx: "MLX",
+  openai: "OpenAI",
+  stt: "STT",
+  "post-process": "Post-process",
+  soniox: "Soniox",
+};
+
+function titleizeModelPart(part: string): string {
+  const normalized = part.trim();
+  const override = MODEL_LABEL_OVERRIDES[normalized.toLowerCase()];
+  if (override) return override;
+  if (!normalized) return normalized;
+  return normalized
+    .split("-")
+    .map((token) => {
+      const tokenOverride = MODEL_LABEL_OVERRIDES[token.toLowerCase()];
+      if (tokenOverride) return tokenOverride;
+      if (/^[A-Z0-9]+$/.test(token)) return token;
+      return `${token.charAt(0).toUpperCase()}${token.slice(1)}`;
+    })
+    .join(" ");
+}
+
+function formatModelIdForDisplay(modelId: string): string {
+  const normalized = modelId.trim();
+  const override = MODEL_LABEL_OVERRIDES[normalized.toLowerCase()];
+  if (override) return override;
+  return normalized.split("/").map(titleizeModelPart).join(" / ");
+}
+
 function formatModelLabel(entry: HistoryEntry): string {
   const voice = entry.voice_model || entry.voice_provider;
+  const voiceLabel = formatModelIdForDisplay(voice);
   if (entry.llm_model) {
-    return `${voice} · ${entry.llm_model}`;
+    return `${voiceLabel} · ${formatModelIdForDisplay(entry.llm_model)}`;
   }
-  return voice;
+  return voiceLabel;
 }
 
 // Build a 24-bin (per-hour) histogram of word activity for today.

--- a/apps/electron/src/renderer/src/pages/today.tsx
+++ b/apps/electron/src/renderer/src/pages/today.tsx
@@ -265,7 +265,7 @@ export default function TodayPage(): React.JSX.Element {
               <span className="serif-italic text-foreground text-[26px] leading-none min-w-[70px]">
                 {cloudUsage.remaining.toLocaleString()}
               </span>
-              <span className="mono text-muted-foreground text-[10px] leading-snug tracking-[0.12em] uppercase">
+              <span className="text-muted-foreground text-[11px] font-medium leading-snug">
                 credits left
               </span>
             </div>
@@ -330,7 +330,7 @@ function TimelineNode({ entry }: { entry: HistoryEntry }): React.JSX.Element {
 
       <div className="border-border bg-card rounded-[11px] border px-[18px] py-[14px]">
         <div className="mb-2 flex items-center gap-2.5">
-          <span className="mono text-primary text-[10.5px] font-semibold tracking-[0.14em] uppercase">
+          <span className="text-primary text-[11.5px] font-semibold">
             {formatModelLabel(entry)}
           </span>
           <span className="flex-1" />
@@ -368,7 +368,7 @@ function RailLabel({
   children: React.ReactNode;
 }): React.JSX.Element {
   return (
-    <div className="mono text-muted-foreground mb-3 text-[10px] tracking-[0.18em] uppercase">
+    <div className="text-muted-foreground mb-3 text-[11px] font-semibold">
       {children}
     </div>
   );
@@ -397,7 +397,7 @@ function RailStat({
       >
         {n}
       </span>
-      <span className="mono text-muted-foreground text-[10px] leading-snug tracking-[0.12em] uppercase">
+      <span className="text-muted-foreground text-[11px] font-medium leading-snug">
         {l}
       </span>
     </div>
@@ -408,7 +408,7 @@ function UsageBar({ label, pct }: UsageBucket): React.JSX.Element {
   return (
     <div className="mb-3">
       <div className="flex items-center justify-between mb-1">
-        <span className="mono text-foreground text-[10.5px] tracking-[0.1em] uppercase">
+        <span className="text-foreground text-[11.5px] font-medium">
           {label}
         </span>
         <span className="mono text-muted-foreground text-[10.5px]">{pct}%</span>


### PR DESCRIPTION
## What changed

This PR updates the UI labels across the Electron app to make the typography more consistent with the design direction discussed in #405.

Most of the changes replace uppercase mono labels with the default UI typography where they are meant to be read as labels rather than technical identifiers.

I also cleaned up the Today page model labels so provider names are displayed in a more readable format (for example, "Freestyle Cloud / STT" instead of raw model IDs).

## Where I checked

1) Today
2) Models
3) Tone


## Validation

ran:

`pnpm biome check`
`pnpm --filter @freestyle-voice/electron typecheck:web`

Both  passed 


## ScreenShots 

1) Today Page SS : <img width="1440" height="900" alt="Screenshot 2026-07-07 at 12 36 26 AM" src="https://github.com/user-attachments/assets/f01d9156-0300-4e18-8289-da700b243ea2" />
2) Models Page SS <img width="1440" height="900" alt="Screenshot 2026-07-07 at 12 43 27 AM" src="https://github.com/user-attachments/assets/cf94cf59-fc1c-4357-8e29-443ba3e9ab6a" />
3) Tone Page SS <img width="1440" height="900" alt="Screenshot 2026-07-07 at 12 44 05 AM" src="https://github.com/user-attachments/assets/c84109e8-5a02-43f7-9017-46785a406917" />


Closes #405