### PR TITLE
Users of an old Qwen3-ASR version must update to the newest one upon use.

### DIFF
--- a/apps/electron/src/renderer/src/components/voice-row.tsx
+++ b/apps/electron/src/renderer/src/components/voice-row.tsx
@@ -147,23 +147,21 @@ export function VoiceRow({
               <TooltipContent>Quality</TooltipContent>
             </Tooltip>
           )}
-          {local ? (
-            item.sizeBytes != null && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span>
-                    <StatPair
-                      icon={Download}
-                      label={formatBytes(item.sizeBytes)}
-                    />
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>Download size</TooltipContent>
-              </Tooltip>
-            )
-          ) : (
-            <>
-              {item.cost != null && (
+          {local
+            ? item.sizeBytes != null && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <StatPair
+                        icon={Download}
+                        label={formatBytes(item.sizeBytes)}
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>Download size</TooltipContent>
+                </Tooltip>
+              )
+            : item.cost != null && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span>
@@ -176,8 +174,6 @@ export function VoiceRow({
                   <TooltipContent>Estimated cost</TooltipContent>
                 </Tooltip>
               )}
-            </>
-          )}
         </div>
 
         {local && status === "error" && item.state?.error && (

--- a/apps/electron/src/renderer/src/pages/tone.tsx
+++ b/apps/electron/src/renderer/src/pages/tone.tsx
@@ -777,6 +777,7 @@ function CleanupTonePanel({
           {CLEANUP_OPTIONS.map((option, index) => {
             const selected = option.value === value;
             return (
+              // biome-ignore lint/a11y/useSemanticElements: roving-tabindex radiogroup on styled buttons; <input type="radio"> would need a full restyle of the card layout.
               <button
                 key={option.value}
                 type="button"
@@ -1082,6 +1083,7 @@ function SubsetTonePanel<T extends string>({
           {options.map((option, index) => {
             const selected = option.value === value;
             return (
+              // biome-ignore lint/a11y/useSemanticElements: roving-tabindex radiogroup on styled buttons; <input type="radio"> would need a full restyle of the card layout.
               <button
                 key={option.value}
                 type="button"

--- a/apps/server/scripts/tone-benchmark.ts
+++ b/apps/server/scripts/tone-benchmark.ts
@@ -281,7 +281,6 @@ function checkStructural(
   mode: string,
   tone: string,
   output: string,
-  expected: string,
 ): { ok: boolean; errors: string[] } {
   const errors: string[] = [];
   const trimmed = output.trim();
@@ -373,7 +372,7 @@ async function runCase(
     providerOptions: groqCleanupProviderOptions(MODEL_ID),
   });
   const output = sanitizeTranscriptText(result.text);
-  const { ok, errors } = checkStructural(mode, tone, output, testCase.expected);
+  const { ok, errors } = checkStructural(mode, tone, output);
   return {
     id: testCase.id,
     label: testCase.label,

--- a/apps/server/src/lib/mlx-asr/runtime.ts
+++ b/apps/server/src/lib/mlx-asr/runtime.ts
@@ -36,7 +36,7 @@ const DEFAULT_MLX_WORKER_LATEST_URL = `https://github.com/freestyle-voice/freest
 // Keep this in sync with scripts/build_mlx_asr_worker.sh so unchanged worker
 // builds don't force users to redownload identical archives on every app release.
 const MLX_WORKER_BUILD_SPEC =
-  "pyinstaller=6.20.0;mlx-audio=0.4.3;huggingface_hub=1.17.0;bundle=onedir";
+  "pyinstaller=6.20.0;mlx-audio=0.4.3;huggingface_hub=1.17.0;transformers>=5.7,<5.13;bundle=onedir";
 
 export interface MlxRuntimeDownloadStatus {
   available: boolean;

--- a/apps/server/tests/mlx-runtime.test.ts
+++ b/apps/server/tests/mlx-runtime.test.ts
@@ -111,7 +111,7 @@ function deriveBundledVersion(): string {
   );
   return createHash("sha256")
     .update(
-      "pyinstaller=6.20.0;mlx-audio=0.4.3;huggingface_hub=1.17.0;bundle=onedir",
+      "pyinstaller=6.20.0;mlx-audio=0.4.3;huggingface_hub=1.17.0;transformers>=5.7,<5.13;bundle=onedir",
     )
     .update("\0")
     .update(script)

--- a/packages/create-freestyle-plugin/src/index.ts
+++ b/packages/create-freestyle-plugin/src/index.ts
@@ -260,7 +260,7 @@ async function main(targetDir: string | undefined, options: Options) {
 
   // 9. Done!
   console.log();
-  console.log(pc.green(pc.bold("Done!") + " Your Freestyle plugin is ready."));
+  console.log(pc.green(`${pc.bold("Done!")} Your Freestyle plugin is ready.`));
   console.log();
 
   const resolvedTarget = path.resolve(target);

--- a/scripts/build_mlx_asr_worker.sh
+++ b/scripts/build_mlx_asr_worker.sh
@@ -15,6 +15,8 @@ HUGGINGFACE_HUB_VERSION="${HUGGINGFACE_HUB_VERSION:-1.17.0}"
 # "AttributeError: 'str' object has no attribute '__module__'" and the worker exits code 1.
 # Pin below 5.13 until mlx-lm's fix ships. Working band: transformers>=5.7,<5.13.
 # Refs: freestyle-voice/freestyle#403, ml-explore/mlx-lm#1458.
+# Any dependency change here must also update MLX_WORKER_BUILD_SPEC in
+# apps/server/src/lib/mlx-asr/runtime.ts, or installed workers never re-download.
 TRANSFORMERS_SPEC="${TRANSFORMERS_SPEC:->=5.7,<5.13}"
 
 if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then


### PR DESCRIPTION
# Overview 

In this PR, we make a change such that when you use Qwen3-ASR on the broken version of MLX, it automatically updates to the newest version.