### PR TITLE
Enable Tone panel and switch cloud transcribe to v2

### DIFF
--- a/apps/electron/src/renderer/src/dashboard.tsx
+++ b/apps/electron/src/renderer/src/dashboard.tsx
@@ -19,7 +19,7 @@ import PluginPage from "@renderer/pages/plugins/plugin-page";
 import PluginsPage from "@renderer/pages/plugins/plugins";
 import SettingsPage from "@renderer/pages/settings";
 import TodayPage from "@renderer/pages/today";
-// import TonePage from "@renderer/pages/tone";
+import TonePage from "@renderer/pages/tone";
 import VocabularyPage from "@renderer/pages/vocabulary";
 import AppShell from "@renderer/shell";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -106,7 +106,7 @@ createRoot(document.getElementById("root")!).render(
                           path="/settings/formats"
                           element={<Navigate to="/settings" replace />}
                         />
-                        {/* <Route path="/settings/tone" element={<TonePage />} /> */}
+                        <Route path="/settings/tone" element={<TonePage />} />
                         <Route
                           path="/settings/history"
                           element={<HistoryPage />}

--- a/apps/electron/src/renderer/src/locales/en.json
+++ b/apps/electron/src/renderer/src/locales/en.json
@@ -317,7 +317,6 @@
   },
   "tone": {
     "title": "Tone",
-    "beta": "Beta",
     "subtitle": "How much Freestyle cleans up — and how it sounds in each app.",
     "loading": "Loading tone…",
     "disabledBanner": {

--- a/apps/electron/src/renderer/src/locales/template.json
+++ b/apps/electron/src/renderer/src/locales/template.json
@@ -318,7 +318,6 @@
   },
   "tone": {
     "title": "Tone",
-    "beta": "Beta",
     "subtitle": "How much Freestyle cleans up — and how it sounds in each app.",
     "loading": "Loading tone…",
     "disabledBanner": {

--- a/apps/electron/src/renderer/src/pages/models/index.tsx
+++ b/apps/electron/src/renderer/src/pages/models/index.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle,
   Key,
   Laptop,
+  Loader2,
   Pencil,
   Trash2,
   XCircle,
@@ -189,6 +190,7 @@ export default function ModelsPage(): React.JSX.Element {
         <KeysSection
           apiKeys={m.apiKeys}
           configured={m.configured}
+          deletingProviders={m.deletingProviders}
           showLocal={hasLocalVoice}
           onEdit={(provider) =>
             setModal({
@@ -358,12 +360,14 @@ function ModelsLoadingSkeleton(): React.JSX.Element {
 function KeysSection({
   apiKeys,
   configured,
+  deletingProviders,
   showLocal,
   onEdit,
   onDelete,
 }: {
   apiKeys: ApiKeyEntry[];
   configured: ConfiguredModel[];
+  deletingProviders: Set<string>;
   showLocal: boolean;
   onEdit: (provider: string) => void;
   onDelete: (provider: string) => void;
@@ -391,6 +395,7 @@ function KeysSection({
               configured.filter((c) => c.provider === entry.provider).length
             }
             first={i === 0}
+            deleting={deletingProviders.has(entry.provider)}
             onEdit={() => onEdit(entry.provider)}
             onDelete={() => onDelete(entry.provider)}
           />
@@ -422,12 +427,14 @@ function KeyRow({
   entry,
   count,
   first,
+  deleting,
   onEdit,
   onDelete,
 }: {
   entry: ApiKeyEntry;
   count: number;
   first: boolean;
+  deleting: boolean;
   onEdit: () => void;
   onDelete: () => void;
 }): React.JSX.Element {
@@ -470,13 +477,16 @@ function KeyRow({
       <div
         className={cn(
           "flex shrink-0 items-center gap-0.5 transition-opacity",
-          invalid ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+          invalid || deleting
+            ? "opacity-100"
+            : "opacity-0 group-hover:opacity-100",
         )}
       >
         <Button
           variant="ghost"
           size="icon-sm"
           onClick={onEdit}
+          disabled={deleting}
           className="text-muted-foreground hover:text-foreground"
           aria-label="Update API key"
           title="Update API key"
@@ -487,11 +497,12 @@ function KeyRow({
           variant="ghost"
           size="icon-sm"
           onClick={onDelete}
+          disabled={deleting}
           className="text-muted-foreground hover:text-destructive"
           aria-label="Delete provider"
           title="Delete provider"
         >
-          <Trash2 />
+          {deleting ? <Loader2 className="animate-spin" /> : <Trash2 />}
         </Button>
       </div>
     </div>

--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -75,6 +75,8 @@ interface Row {
   hasKey?: boolean;
   status?: WhisperModelDownloadState["status"];
   state?: WhisperModelDownloadState;
+  /** A delete request for this local model is in flight. */
+  deleting?: boolean;
   onSelect?: () => void;
   onDownload?: () => void;
   onCancel?: () => void;
@@ -122,6 +124,9 @@ function buildVoiceRows(m: UseModels, h: VoiceHandlers): Row[] {
         selected: it.selected && status === "ready",
         status,
         state: it.state,
+        deleting: defId
+          ? m.deletingKeys.has(`${it.localEngine ?? "whisper"}:${defId}`)
+          : false,
         onSelect: defId
           ? () => h.onPickLocalVoice(defId, it.name, it.localEngine)
           : undefined,
@@ -740,11 +745,16 @@ function ModelRow({
                     variant="ghost"
                     size="icon-sm"
                     onClick={row.onDelete}
+                    disabled={row.deleting}
                     className="text-muted-foreground hover:text-destructive"
                     aria-label="Remove downloaded model from disk"
                     title="Remove downloaded model from disk"
                   >
-                    <Trash2 />
+                    {row.deleting ? (
+                      <Loader2 className="animate-spin" />
+                    ) : (
+                      <Trash2 />
+                    )}
                   </Button>
                 )}
               </>

--- a/apps/electron/src/renderer/src/pages/models/pair-card.tsx
+++ b/apps/electron/src/renderer/src/pages/models/pair-card.tsx
@@ -33,6 +33,37 @@ export function PairCard({
   /** When set, shows a "Configure model warming" link by the voice button. */
   onConfigureWarming?: () => void;
 }): React.JSX.Element {
+  const warmingAccessory = onConfigureWarming ? (
+    <Button
+      variant="link"
+      size="sm"
+      onClick={onConfigureWarming}
+      className="ml-auto"
+    >
+      Configure model warming
+    </Button>
+  ) : undefined;
+
+  // Freestyle Transcribe handles both transcription and AI cleanup as one
+  // service, so collapse the pair into a single panel instead of showing an
+  // inert, duplicated "cleanup" side next to it.
+  if (cleanupIncluded) {
+    return (
+      <section className="border-border bg-card rounded-[14px] border p-6">
+        <PairSide
+          kicker="Transcription + AI cleanup"
+          modelName={voice?.model_name ?? "Freestyle Transcribe"}
+          providerName={undefined}
+          cta="Change"
+          primary
+          note="Transcription and AI cleanup handled by Freestyle Transcribe."
+          onChange={onChangeVoice}
+          accessory={warmingAccessory}
+        />
+      </section>
+    );
+  }
+
   return (
     <section className="border-border bg-card grid grid-cols-1 gap-6 rounded-[14px] border p-6 min-[820px]:grid-cols-2">
       <PairSide
@@ -42,44 +73,21 @@ export function PairCard({
         cta="Change"
         primary
         onChange={onChangeVoice}
-        accessory={
-          onConfigureWarming ? (
-            <Button
-              variant="link"
-              size="sm"
-              onClick={onConfigureWarming}
-              className="ml-auto"
-            >
-              Configure model warming
-            </Button>
-          ) : undefined
-        }
+        accessory={warmingAccessory}
       />
       <div className="border-border border-t pt-6 min-[820px]:border-l min-[820px]:border-t-0 min-[820px]:pl-6 min-[820px]:pt-0">
-        {cleanupIncluded ? (
-          <PairSide
-            kicker="AI cleanup · included"
-            modelName="Freestyle Transcribe"
-            providerName={undefined}
-            cta="Change"
-            disabled
-            note="Included with Freestyle Transcribe"
-            onChange={onChangeLlm}
-          />
-        ) : (
-          <PairSide
-            kicker="AI cleanup · optional"
-            modelName={llmCleanup ? llm?.model_name : undefined}
-            providerName={
-              llmCleanup && llm ? displayName(llm.provider) : undefined
-            }
-            cta={llm ? "Change" : "Pick a model"}
-            toggle={llmCleanup}
-            onToggle={onToggleCleanup}
-            onChange={onChangeLlm}
-            dimmed={!llmCleanup}
-          />
-        )}
+        <PairSide
+          kicker="AI cleanup · optional"
+          modelName={llmCleanup ? llm?.model_name : undefined}
+          providerName={
+            llmCleanup && llm ? displayName(llm.provider) : undefined
+          }
+          cta={llm ? "Change" : "Pick a model"}
+          toggle={llmCleanup}
+          onToggle={onToggleCleanup}
+          onChange={onChangeLlm}
+          dimmed={!llmCleanup}
+        />
       </div>
     </section>
   );
@@ -95,7 +103,6 @@ function PairSide({
   onToggle,
   onChange,
   dimmed,
-  disabled,
   note,
   accessory,
 }: {
@@ -108,8 +115,6 @@ function PairSide({
   onToggle?: (next: boolean) => void;
   onChange: () => void;
   dimmed?: boolean;
-  /** Disables the toggle and the change action (provider handles this itself). */
-  disabled?: boolean;
   /** Small caption shown under the model name. */
   note?: React.ReactNode;
   accessory?: React.ReactNode;
@@ -124,11 +129,7 @@ function PairSide({
       <div className="flex items-center justify-between">
         <Eyebrow text={kicker} accent={primary} mono={false} />
         {onToggle !== undefined && (
-          <Toggle
-            on={!!toggle}
-            onChange={(v) => onToggle(v)}
-            disabled={disabled}
-          />
+          <Toggle on={!!toggle} onChange={(v) => onToggle(v)} />
         )}
       </div>
       <div>
@@ -169,7 +170,6 @@ function PairSide({
           variant={primary ? "ink" : "outline"}
           size="sm"
           onClick={onChange}
-          disabled={disabled}
         >
           {cta}
         </Button>

--- a/apps/electron/src/renderer/src/pages/models/use-models.ts
+++ b/apps/electron/src/renderer/src/pages/models/use-models.ts
@@ -39,6 +39,11 @@ export interface UseModels {
   llmCleanup: boolean;
   mlxKeepAliveMinutes: number;
 
+  /** Local models with an in-flight delete, keyed `${engine ?? "whisper"}:${defId}`. */
+  deletingKeys: Set<string>;
+  /** Providers with an in-flight key/model delete. */
+  deletingProviders: Set<string>;
+
   // Derived
   keyProviders: Set<string>;
   defaultVoice: ConfiguredModel | undefined;
@@ -86,6 +91,13 @@ export function useModels(): UseModels {
   const [mlxStatus, setMlxStatus] = useState<MlxAsrStatus | null>(null);
   const [mlxKeepAliveMinutes, setMlxKeepAliveMinutes] = useState(
     DEFAULT_MLX_KEEP_ALIVE_MINUTES,
+  );
+
+  // In-flight deletes — drive spinners on the delete buttons since deletion has
+  // no server-reported status the way downloads do.
+  const [deletingKeys, setDeletingKeys] = useState<Set<string>>(new Set());
+  const [deletingProviders, setDeletingProviders] = useState<Set<string>>(
+    new Set(),
   );
 
   // Local LLM (Ollama / LM Studio) connection — simplified inline form state.
@@ -381,18 +393,28 @@ export function useModels(): UseModels {
 
   const deleteLocal = useCallback(
     async (defId: string, engine?: "whisper" | "mlx") => {
-      if (engine === "mlx") {
-        await getClient().api["mlx-asr"].models[":model"].$delete({
-          param: { model: defId },
+      const deletingKey = `${engine ?? "whisper"}:${defId}`;
+      setDeletingKeys((prev) => new Set(prev).add(deletingKey));
+      try {
+        if (engine === "mlx") {
+          await getClient().api["mlx-asr"].models[":model"].$delete({
+            param: { model: defId },
+          });
+          await loadMlxStatus();
+        } else {
+          await getClient().api.whisper.models[":model"].$delete({
+            param: { model: defId },
+          });
+          await loadWhisperStatus();
+        }
+        await loadData();
+      } finally {
+        setDeletingKeys((prev) => {
+          const next = new Set(prev);
+          next.delete(deletingKey);
+          return next;
         });
-        await loadMlxStatus();
-      } else {
-        await getClient().api.whisper.models[":model"].$delete({
-          param: { model: defId },
-        });
-        await loadWhisperStatus();
       }
-      await loadData();
     },
     [loadMlxStatus, loadWhisperStatus, loadData],
   );
@@ -458,17 +480,28 @@ export function useModels(): UseModels {
 
   const deleteProvider = useCallback(
     async (provider: string) => {
-      const client = getClient();
-      await client.api.keys[":provider"].$delete({ param: { provider } });
-      const providerModels = configured.filter((m) => m.provider === provider);
-      await Promise.all(
-        providerModels.map((m) =>
-          client.api.models.configured[":id"].$delete({
-            param: { id: String(m.id) },
-          }),
-        ),
-      );
-      await loadData();
+      setDeletingProviders((prev) => new Set(prev).add(provider));
+      try {
+        const client = getClient();
+        await client.api.keys[":provider"].$delete({ param: { provider } });
+        const providerModels = configured.filter(
+          (m) => m.provider === provider,
+        );
+        await Promise.all(
+          providerModels.map((m) =>
+            client.api.models.configured[":id"].$delete({
+              param: { id: String(m.id) },
+            }),
+          ),
+        );
+        await loadData();
+      } finally {
+        setDeletingProviders((prev) => {
+          const next = new Set(prev);
+          next.delete(provider);
+          return next;
+        });
+      }
     },
     [configured, loadData],
   );
@@ -544,6 +577,8 @@ export function useModels(): UseModels {
     mlxStatus,
     llmCleanup,
     mlxKeepAliveMinutes,
+    deletingKeys,
+    deletingProviders,
     keyProviders,
     defaultVoice,
     defaultLlm,

--- a/apps/electron/src/renderer/src/pages/tone.tsx
+++ b/apps/electron/src/renderer/src/pages/tone.tsx
@@ -499,11 +499,7 @@ export default function TonePage(): React.JSX.Element {
   return (
     <PageShell>
       <div className="mx-auto w-full max-w-[1060px]">
-        <PageHeader
-          title={t("tone.title")}
-          subtitle={t("tone.subtitle")}
-          badge={t("tone.beta")}
-        />
+        <PageHeader title={t("tone.title")} subtitle={t("tone.subtitle")} />
 
         {!llmCleanup ? (
           <CleanupDisabledBanner

--- a/apps/electron/src/renderer/src/pages/tone.tsx
+++ b/apps/electron/src/renderer/src/pages/tone.tsx
@@ -242,6 +242,9 @@ export default function TonePage(): React.JSX.Element {
   );
   const [assignments, setAssignments] = useState<CleanupAppAssignment[]>([]);
   const [hasCleanupModel, setHasCleanupModel] = useState(false);
+  // Freestyle Transcribe (cloud voice) always post-processes server-side, so
+  // cleanup is effectively on regardless of the llm_cleanup setting.
+  const [cloudVoiceActive, setCloudVoiceActive] = useState(false);
   const [usingCloud, setUsingCloud] = useState(false);
   const [activeTab, setActiveTab] = usePersistentState<ToneTab>(
     "tone.activeTab",
@@ -300,6 +303,14 @@ export default function TonePage(): React.JSX.Element {
         setHasCleanupModel(
           configured.some(
             (model) => model.type === "llm" && model.is_default === 1,
+          ),
+        );
+        setCloudVoiceActive(
+          configured.some(
+            (model) =>
+              model.type === "voice" &&
+              model.is_default === 1 &&
+              model.provider === FREESTYLE_CLOUD_PROVIDER,
           ),
         );
       }
@@ -501,7 +512,7 @@ export default function TonePage(): React.JSX.Element {
       <div className="mx-auto w-full max-w-[1060px]">
         <PageHeader title={t("tone.title")} subtitle={t("tone.subtitle")} />
 
-        {!llmCleanup ? (
+        {cloudVoiceActive ? null : !llmCleanup ? (
           <CleanupDisabledBanner
             signedIn={!!cloudAuth.user}
             busy={usingCloud}

--- a/apps/electron/src/renderer/src/shell.tsx
+++ b/apps/electron/src/renderer/src/shell.tsx
@@ -12,6 +12,7 @@ import {
   CircleHelp,
   Clock,
   Cpu,
+  FileText,
   Languages,
   Puzzle,
   Settings,
@@ -56,12 +57,12 @@ const STATIC_NAV: {
     shortcut: "4",
     labelKey: "shell.nav.vocabulary",
   },
-  // {
-  //   to: "/settings/tone",
-  //   icon: FileText,
-  //   shortcut: "5",
-  //   labelKey: "shell.nav.tone",
-  // },
+  {
+    to: "/settings/tone",
+    icon: FileText,
+    shortcut: "5",
+    labelKey: "shell.nav.tone",
+  },
   {
     to: "/settings/models",
     icon: Cpu,

--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -354,7 +354,7 @@ export async function transcribeWithFreestyleCloud(opts: {
     form.append("vocabulary", JSON.stringify(opts.vocabulary));
   }
 
-  return cloudJson<CloudTranscribeResult>("/v3/transcribe", opts.token, {
+  return cloudJson<CloudTranscribeResult>("/v2/transcribe", opts.token, {
     method: "POST",
     // Do not set content-type: fetch adds the multipart boundary itself.
     body: form,


### PR DESCRIPTION
## Summary

- Re-enable the **Tone** settings page: uncomment its route in `dashboard.tsx`, restore the sidebar nav entry in `shell.tsx` (re-adding the `FileText` import), and remove the **Beta** badge from the page header.
- Drop the now-unused `tone.beta` locale key from `en.json` and `template.json`.
- Point the Freestyle Cloud batch transcribe call at `/v2/transcribe` instead of `/v3/transcribe` in `freestyle-cloud.ts`.

## Notes

- The v3 route always post-processes and returns `cleaned` text. The consumer already falls back safely (`data.cleaned || data.raw || ""`), so if v2 omits server-side cleanup, transcription still works but the cloud-side cleanup step is skipped. Per request, only the route string was changed; the surrounding `v3`-referencing comments were left untouched.

## Verification

- `pnpm --filter electron run typecheck` — passes
- `tsc --noEmit` on the server package — passes