### PR TITLE
Remove extra bottom spacing on the settings page 

### DIFF
--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -1312,7 +1312,7 @@ function NetworkPanel(): React.JSX.Element {
           )}
         />
       </Row>
-      <div className="border-border bg-secondary/40 text-muted-foreground mt-1 flex items-start gap-2.5 rounded-[10px] border px-3.5 py-3 text-[12px] leading-[1.55]">
+      <div className="border-border bg-secondary/40 text-muted-foreground mt-1 mb-4 flex items-start gap-2.5 rounded-[10px] border px-3.5 py-3 text-[12px] leading-[1.55]">
         <Info className="mt-px h-3.5 w-3.5 shrink-0 opacity-70" />
         <span>{t("settings.network.envNote")}</span>
       </div>

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -619,7 +619,7 @@ export default function SettingsPage(): React.JSX.Element {
     >
       <div className="h-7 shrink-0" />
       <div
-        className="responsive-page-scroll grid min-h-0 flex-1 grid-cols-1 grid-rows-[auto_minmax(0,1fr)] gap-x-10 gap-y-6 min-[900px]:grid-cols-[180px_minmax(0,1fr)]"
+        className="responsive-page-scroll grid min-h-0 flex-1 grid-cols-1 grid-rows-[auto_minmax(0,1fr)] gap-x-10 gap-y-6 !pb-0 min-[900px]:grid-cols-[180px_minmax(0,1fr)]"
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
         <div className="min-[900px]:col-span-2">


### PR DESCRIPTION
## What changed

This PR removes the extra blank space at the bottom of the Settings page.

The root cause was that the Settings page uses the shared `responsive-page-scroll` class on a grid wrapper rather than the actual scroll container. Since that shared class includes bottom padding, it created a fixed empty space below the page content.

Instead of changing the shared CSS, this PR overrides the bottom padding only for the Settings page so the layout matches the other pages while keeping the existing scrolling behavior unchanged.

## Where I checked

1) Settings page
2) History page
3) Models page

## Validation

Ran:

1) `pnpm biome check`
2) `pnpm --filter @freestyle-voice/electron typecheck:web`

Both passed.

## Screenshot 
<img width="1440" height="900" alt="Screenshot 2026-07-07 at 2 15 48 PM" src="https://github.com/user-attachments/assets/a751646d-48bb-4b39-87d4-a6441110bdfc" />



Closes #417