### PR TITLE
fix(ui): match filter button height with searchbar in history page

### DIFF
--- a/apps/electron/src/renderer/src/pages/history.tsx
+++ b/apps/electron/src/renderer/src/pages/history.tsx
@@ -332,7 +332,7 @@ export default function HistoryPage(): React.JSX.Element {
                 variant="outline"
                 onClick={() => setFilterOpen(true)}
                 className={cn(
-                  "text-muted-foreground",
+                  "text-muted-foreground h-auto self-stretch",
                   filterCount > 0 && "border-primary text-primary bg-primary/5",
                 )}
               >


### PR DESCRIPTION
## Summary

Fixes #418

On the history page, the Filters button was visibly shorter than the searchbar next to it. The `Button` component applies a fixed default height (`h-8`), while the searchbar's height comes from its own padding, so the two never lined up.

## Change

- Let the filter button stretch to the height of the search & filter row (`h-auto self-stretch`), so it always matches the searchbar exactly, even if the searchbar's padding or font size changes later.

One-line change in `apps/electron/src/renderer/src/pages/history.tsx`.

## Checks

- `pnpm biome check` passes on the changed file (pre-commit hook ran clean)
- `pnpm --filter @freestyle-voice/electron typecheck:web` passes