### PR TITLE
feat: auto-delete transcription history after a configurable period

### DIFF
--- a/apps/electron/src/renderer/src/locales/en.json
+++ b/apps/electron/src/renderer/src/locales/en.json
@@ -187,6 +187,13 @@
     "data": {
       "pauseHistory": "Pause history",
       "pauseHistoryDesc": "Stop saving new transcription sessions to history until you turn this off.",
+      "autoDelete": "Auto-delete history",
+      "autoDeleteDesc": "Automatically delete saved sessions older than the selected period. Runs once a day.",
+      "autoDeleteNever": "Never",
+      "autoDelete7": "After 7 days",
+      "autoDelete30": "After 30 days",
+      "autoDeleteCustom": "Custom",
+      "autoDeleteDays": "days",
       "history": "Transcription history",
       "historyDesc": "Permanently delete every saved session — this can't be undone.",
       "clearHistory": "Clear history",

--- a/apps/electron/src/renderer/src/locales/template.json
+++ b/apps/electron/src/renderer/src/locales/template.json
@@ -188,6 +188,13 @@
     "data": {
       "pauseHistory": "Pause history",
       "pauseHistoryDesc": "Stop saving new transcription sessions to history until you turn this off.",
+      "autoDelete": "Auto-delete history",
+      "autoDeleteDesc": "Automatically delete saved sessions older than the selected period. Runs once a day.",
+      "autoDeleteNever": "Never",
+      "autoDelete7": "After 7 days",
+      "autoDelete30": "After 30 days",
+      "autoDeleteCustom": "Custom",
+      "autoDeleteDays": "days",
       "history": "Transcription history",
       "historyDesc": "Permanently delete every saved session — this can't be undone.",
       "clearHistory": "Clear history",

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -1,6 +1,8 @@
 import {
+  HISTORY_RETENTION_DAYS_MAX,
   type NetworkSettingsForm,
   networkSettingsFormSchema,
+  parseRetentionDays,
 } from "@freestyle-voice/validations";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { KeyComboDisplay } from "@renderer/components/key-combo";
@@ -122,6 +124,10 @@ export default function SettingsPage(): React.JSX.Element {
   const [pillPosition, setPillPosition] = useState("bottom-center");
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [historyPaused, setHistoryPaused] = useState(false);
+  const [historyRetention, setHistoryRetention] = useState<
+    "never" | "7" | "30" | "custom"
+  >("never");
+  const [customRetentionDays, setCustomRetentionDays] = useState("90");
   const [audioPlaybackMode, setAudioPlaybackMode] =
     useState<AudioPlaybackMode>("off");
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null);
@@ -160,6 +166,16 @@ export default function SettingsPage(): React.JSX.Element {
         label:
           t(`settings.recording.transcriptionLanguages.${l.id}`) || l.label,
       })),
+    ],
+    [t],
+  );
+
+  const retentionOptions = useMemo(
+    () => [
+      { value: "never", label: t("settings.data.autoDeleteNever") },
+      { value: "7", label: t("settings.data.autoDelete7") },
+      { value: "30", label: t("settings.data.autoDelete30") },
+      { value: "custom", label: t("settings.data.autoDeleteCustom") },
     ],
     [t],
   );
@@ -310,6 +326,18 @@ export default function SettingsPage(): React.JSX.Element {
     if (s[SETTINGS_KEYS.outputMode]) setOutputMode(s[SETTINGS_KEYS.outputMode]);
     if (s[SETTINGS_KEYS.soundEnabled] === "false") setSoundEnabled(false);
     if (s[SETTINGS_KEYS.historyPaused] === "true") setHistoryPaused(true);
+
+    const retentionDays = parseRetentionDays(
+      s[SETTINGS_KEYS.historyRetentionDays],
+    );
+    if (retentionDays !== null) {
+      if (retentionDays === 7 || retentionDays === 30) {
+        setHistoryRetention(String(retentionDays) as "7" | "30");
+      } else {
+        setHistoryRetention("custom");
+        setCustomRetentionDays(String(retentionDays));
+      }
+    }
 
     // Audio playback mode with legacy fallback chain (new key → paused → duck).
     if (s.audio_playback_mode) {
@@ -507,6 +535,47 @@ export default function SettingsPage(): React.JSX.Element {
       })
       .catch(() => {});
   }, []);
+
+  const saveHistoryRetention = useCallback((days: string) => {
+    getClient()
+      .api.settings[":key"].$put({
+        param: { key: SETTINGS_KEYS.historyRetentionDays },
+        json: { value: days },
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleHistoryRetentionChange = useCallback(
+    (value: string) => {
+      const preset = value as "never" | "7" | "30" | "custom";
+      setHistoryRetention(preset);
+      if (preset === "never") {
+        saveHistoryRetention("");
+      } else if (preset === "custom") {
+        if (parseRetentionDays(customRetentionDays) !== null) {
+          saveHistoryRetention(customRetentionDays);
+        }
+      } else {
+        saveHistoryRetention(preset);
+      }
+    },
+    [customRetentionDays, saveHistoryRetention],
+  );
+
+  const handleCustomRetentionDaysChange = useCallback(
+    (raw: string) => {
+      const digits = raw.replace(/\D/g, "").slice(0, 4);
+      const clamped =
+        digits === ""
+          ? ""
+          : String(Math.min(Number(digits), HISTORY_RETENTION_DAYS_MAX));
+      setCustomRetentionDays(clamped);
+      if (parseRetentionDays(clamped) !== null) {
+        saveHistoryRetention(clamped);
+      }
+    },
+    [saveHistoryRetention],
+  );
 
   const handleAudioPlaybackModeChange = useCallback((value: string) => {
     const mode = normalizeAudioPlaybackMode(value);
@@ -962,6 +1031,47 @@ export default function SettingsPage(): React.JSX.Element {
                   checked={historyPaused}
                   onCheckedChange={handleHistoryPausedToggle}
                 />
+              </Row>
+              <Row
+                label={t("settings.data.autoDelete")}
+                desc={t("settings.data.autoDeleteDesc")}
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <Select
+                    value={historyRetention}
+                    onValueChange={handleHistoryRetentionChange}
+                  >
+                    <SelectTrigger
+                      id="settings-history-retention"
+                      className="w-36"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {retentionOptions.map((o) => (
+                        <SelectItem key={o.value} value={o.value}>
+                          {o.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {historyRetention === "custom" && (
+                    <>
+                      <Input
+                        inputMode="numeric"
+                        value={customRetentionDays}
+                        onChange={(e) =>
+                          handleCustomRetentionDaysChange(e.target.value)
+                        }
+                        className="w-16 text-center"
+                        aria-label={t("settings.data.autoDeleteDays")}
+                      />
+                      <span className="text-muted-foreground text-xs">
+                        {t("settings.data.autoDeleteDays")}
+                      </span>
+                    </>
+                  )}
+                </div>
               </Row>
               <Row
                 label={t("settings.data.history")}

--- a/apps/electron/src/shared/settings-keys.ts
+++ b/apps/electron/src/shared/settings-keys.ts
@@ -10,6 +10,7 @@ export const SETTINGS_KEYS = {
   hotkey: "hotkey",
   hotkeyMode: "hotkey_mode",
   historyPaused: "history_paused",
+  historyRetentionDays: "history_retention_days",
   language: "language",
   llmCleanup: "llm_cleanup",
   localLlmApiKey: "local_llm_api_key",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,6 +8,7 @@ import { logger } from "hono/logger";
 import { requestId } from "hono/request-id";
 import { timeout } from "hono/timeout";
 import { isTransientCloudError } from "./lib/freestyle-cloud.js";
+import { startHistoryRetentionSweep } from "./lib/history-store.js";
 import { reconcileUnsupportedMlxVoiceDefault } from "./lib/mlx-asr/reconcile.js";
 import {
   activateManagedMlxRuntimeForAppVersion,
@@ -146,6 +147,8 @@ export async function startServer(
 
   const pluginMiddleware = plugins().collectMiddleware();
   const app = createApp(pluginMiddleware);
+
+  startHistoryRetentionSweep();
 
   return new Promise((resolve, reject) => {
     const server = serve(

--- a/apps/server/src/lib/history-store.ts
+++ b/apps/server/src/lib/history-store.ts
@@ -1,6 +1,11 @@
+import { parseRetentionDays } from "@freestyle-voice/validations";
 import { getDb, readSetting } from "./db.js";
+import { capture, captureException } from "./posthog.js";
 
 export const HISTORY_PAUSED_SETTING_KEY = "history_paused";
+export const HISTORY_RETENTION_SETTING_KEY = "history_retention_days";
+
+const RETENTION_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 export interface RawHistoryEntry {
   rawText: string;
@@ -21,6 +26,55 @@ export interface ProcessedHistoryEntry extends RawHistoryEntry {
 
 export function isHistoryPaused(): boolean {
   return readSetting(HISTORY_PAUSED_SETTING_KEY) === "true";
+}
+
+export function getHistoryRetentionDays(): number | null {
+  return parseRetentionDays(readSetting(HISTORY_RETENTION_SETTING_KEY));
+}
+
+export function purgeExpiredHistory(): number {
+  const days = getHistoryRetentionDays();
+  if (days === null) return 0;
+
+  const result = getDb()
+    .prepare(
+      "DELETE FROM transcription_history WHERE created_at < datetime('now', ?)",
+    )
+    .run(`-${days} days`);
+
+  const deleted = Number(result.changes);
+  if (deleted > 0) {
+    capture("history expired entries purged", {
+      deleted_count: deleted,
+      retention_days: days,
+    });
+  }
+  return deleted;
+}
+
+let retentionSweepTimer: NodeJS.Timeout | null = null;
+
+export function startHistoryRetentionSweep(): void {
+  if (retentionSweepTimer) return;
+
+  const sweep = (): void => {
+    try {
+      purgeExpiredHistory();
+    } catch (err) {
+      captureException(err);
+    }
+  };
+
+  sweep();
+  retentionSweepTimer = setInterval(sweep, RETENTION_SWEEP_INTERVAL_MS);
+  retentionSweepTimer.unref();
+}
+
+export function stopHistoryRetentionSweep(): void {
+  if (retentionSweepTimer) {
+    clearInterval(retentionSweepTimer);
+    retentionSweepTimer = null;
+  }
 }
 
 export function saveRawHistory(entry: RawHistoryEntry): boolean {

--- a/apps/server/src/routes/settings.ts
+++ b/apps/server/src/routes/settings.ts
@@ -8,6 +8,7 @@ import {
   cleanupPersonalToneSchema,
   cleanupWorkToneSchema,
   disabledPluginsSettingSchema,
+  historyRetentionDaysSettingSchema,
   localLlmConfigSchema,
   pluginsSettingSchema,
   proxyUrlSettingSchema,
@@ -16,6 +17,10 @@ import {
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
+import {
+  HISTORY_RETENTION_SETTING_KEY,
+  purgeExpiredHistory,
+} from "../lib/history-store.js";
 import { applyMlxAsrRetentionPolicy } from "../lib/mlx-asr/server.js";
 import {
   CA_CERT_PATH_SETTING,
@@ -133,6 +138,17 @@ const settings = new Hono()
       if (!parsed.success) {
         return c.json({ error: "Invalid CA certificate path" }, 400);
       }
+    } else if (key === HISTORY_RETENTION_SETTING_KEY) {
+      const parsed = historyRetentionDaysSettingSchema.safeParse(body.value);
+      if (!parsed.success) {
+        return c.json(
+          {
+            error:
+              parsed.error.issues[0]?.message ?? "Invalid history retention",
+          },
+          400,
+        );
+      }
     }
 
     db.prepare(
@@ -145,6 +161,9 @@ const settings = new Hono()
     }
     if (key === "whisper_keep_alive_minutes") {
       applyWhisperRetentionPolicy();
+    }
+    if (key === HISTORY_RETENTION_SETTING_KEY) {
+      purgeExpiredHistory();
     }
     // Re-install the global dispatcher so proxy/CA changes take effect for the
     // next download without an app restart.

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -1,10 +1,15 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import createApp from "../src/index.js";
 import { getDb } from "../src/lib/db.js";
 import {
+  getHistoryRetentionDays,
   HISTORY_PAUSED_SETTING_KEY,
+  HISTORY_RETENTION_SETTING_KEY,
   isHistoryPaused,
+  purgeExpiredHistory,
   saveRawHistory,
+  startHistoryRetentionSweep,
+  stopHistoryRetentionSweep,
 } from "../src/lib/history-store.js";
 
 const app = createApp();
@@ -671,5 +676,115 @@ describe("History", () => {
     );
     const statsInvalid = await statsInvalidRes.json();
     expect(statsInvalid.total_sessions).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// History retention (auto-delete)
+// ---------------------------------------------------------------------------
+
+describe("History retention", () => {
+  function insertEntry(rawText: string, ageModifier: string): void {
+    getDb()
+      .prepare(
+        `INSERT INTO transcription_history
+           (raw_text, voice_provider, voice_model, duration_ms, audio_duration_ms, created_at)
+           VALUES (?, 'voice', 'model', 1000, 1000, datetime('now', ?))`,
+      )
+      .run(rawText, ageModifier);
+  }
+
+  function historyTexts(): string[] {
+    return (
+      getDb().prepare("SELECT raw_text FROM transcription_history").all() as {
+        raw_text: string;
+      }[]
+    ).map((r) => r.raw_text);
+  }
+
+  beforeEach(() => {
+    const db = getDb();
+    db.exec("DELETE FROM transcription_history");
+    db.prepare("DELETE FROM settings WHERE key = ?").run(
+      HISTORY_RETENTION_SETTING_KEY,
+    );
+  });
+
+  afterEach(() => {
+    stopHistoryRetentionSweep();
+  });
+
+  it("purgeExpiredHistory is a no-op when retention is not configured", () => {
+    insertEntry("Ancient text", "-400 days");
+    expect(getHistoryRetentionDays()).toBe(null);
+    expect(purgeExpiredHistory()).toBe(0);
+    expect(historyTexts()).toEqual(["Ancient text"]);
+  });
+
+  it("purgeExpiredHistory deletes only entries older than the window", async () => {
+    await json(
+      `/api/settings/${HISTORY_RETENTION_SETTING_KEY}`,
+      { value: "30" },
+      "PUT",
+    );
+    expect(getHistoryRetentionDays()).toBe(30);
+
+    insertEntry("Old text", "-40 days");
+    insertEntry("Recent text", "-5 days");
+    insertEntry("Fresh text", "-1 hours");
+
+    expect(purgeExpiredHistory()).toBe(1);
+    expect(historyTexts().sort()).toEqual(["Fresh text", "Recent text"]);
+
+    expect(purgeExpiredHistory()).toBe(0);
+  });
+
+  it("startHistoryRetentionSweep runs an immediate purge and is idempotent", async () => {
+    await json(
+      `/api/settings/${HISTORY_RETENTION_SETTING_KEY}`,
+      { value: "30" },
+      "PUT",
+    );
+    insertEntry("Old text", "-40 days");
+    insertEntry("Fresh text", "-1 hours");
+
+    startHistoryRetentionSweep();
+    startHistoryRetentionSweep();
+
+    expect(historyTexts()).toEqual(["Fresh text"]);
+  });
+
+  it("writing the retention setting purges expired entries immediately", async () => {
+    insertEntry("Old text", "-40 days");
+    insertEntry("Fresh text", "-1 hours");
+
+    const res = await json(
+      `/api/settings/${HISTORY_RETENTION_SETTING_KEY}`,
+      { value: "7" },
+      "PUT",
+    );
+    expect(res.status).toBe(200);
+    expect(historyTexts()).toEqual(["Fresh text"]);
+  });
+
+  it("empty value disables auto-deletion", async () => {
+    const res = await json(
+      `/api/settings/${HISTORY_RETENTION_SETTING_KEY}`,
+      { value: "" },
+      "PUT",
+    );
+    expect(res.status).toBe(200);
+    expect(getHistoryRetentionDays()).toBe(null);
+  });
+
+  it("rejects malformed retention values", async () => {
+    for (const value of ["abc", "0", "-5", "1.5", "7 days", "99999"]) {
+      const res = await json(
+        `/api/settings/${HISTORY_RETENTION_SETTING_KEY}`,
+        { value },
+        "PUT",
+      );
+      expect(res.status, `value: ${value}`).toBe(400);
+    }
   });
 });

--- a/packages/validations/src/settings.ts
+++ b/packages/validations/src/settings.ts
@@ -70,6 +70,28 @@ export const proxyUrlSettingSchema = z
 /** Filesystem path to a custom CA certificate bundle. Empty string clears it. */
 export const caCertPathSettingSchema = z.string().max(4096);
 
+export const HISTORY_RETENTION_DAYS_MAX = 3650;
+
+export function parseRetentionDays(
+  value: string | null | undefined,
+): number | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const days = Number(trimmed);
+  if (days < 1 || days > HISTORY_RETENTION_DAYS_MAX) return null;
+  return days;
+}
+
+export const historyRetentionDaysSettingSchema = z
+  .string()
+  .refine(
+    (value) => value.trim() === "" || parseRetentionDays(value) !== null,
+    {
+      message: `Retention must be a whole number of days between 1 and ${HISTORY_RETENTION_DAYS_MAX} (or empty to disable)`,
+    },
+  );
+
 /**
  * Combined shape for the Network settings form. The renderer drives a
  * react-hook-form with this schema so its inline validation matches exactly


### PR DESCRIPTION
## Summary

Closes #421

Adds a scheduling system that automatically deletes old transcription history, so users no longer have to choose between pausing history and manually clearing it.


## How it works

- **New setting** `history_retention_days` — configured from **Settings → Data → Auto-delete history** with the options suggested in the issue: **Never / After 7 days / After 30 days / Custom** (custom takes a number of days).
- **Daily sweep** — the server runs a purge once every 24 hours (not every minute, per the issue), plus once at server start so a restart never postpones an overdue cleanup. The timer is `unref()`'d so it can't keep the process alive during shutdown.
- **Immediate effect** — writing the setting also purges expired entries right away (mirroring the existing `applyMlxAsrRetentionPolicy` pattern), so picking "7 days" cleans up old sessions without waiting for the next sweep.
- **Validation** — value must be a whole number of days between 1 and 3650; empty string disables auto-deletion. Enforced server-side in `PUT /api/settings/:key` via a new schema in `@freestyle-voice/validations`, consistent with the other constrained settings keys.

## Tests

- 5 new tests in `apps/server/tests/api.test.ts` covering: no-op when unconfigured, purging only entries older than the window, immediate purge on setting write, empty-value disable, and rejection of malformed values (`abc`, `0`, `-5`, `1.5`, `7 days`, out-of-range).

## Checks

- `vitest run tests/api.test.ts` — 53/53 pass (the 3 `mlx-runtime` failures in the full suite are pre-existing on `main` in my Windows environment and unrelated)
- `tsc --noEmit` (server) and `pnpm --filter @freestyle-voice/electron typecheck:web` pass
- Biome ran clean via the pre-commit hook
- New UI strings added to `en.json` and `template.json` (other locales fall back to English)
