### PR TITLE
feat: diff mode for AI-edited history entries

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -25,6 +25,7 @@
     "build:linux": "npm run compile:native && electron-vite build && electron-builder --linux --publish never",
     "download:whisper-cpp": "node scripts/download-whisper-cpp.mjs",
     "download:whisper-cpp:all": "node scripts/download-whisper-cpp.mjs --all",
+    "test": "vitest run",
     "test:e2e": "playwright test"
   },
   "dependencies": {
@@ -40,6 +41,7 @@
     "@tanstack/react-query": "^5.101.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "diff": "^8.0.4",
     "electron-updater": "^6.3.9",
     "freestyle-voice": "workspace:*",
     "hono": "^4.12.22",
@@ -78,6 +80,7 @@
     "react-dom": "^19.2.1",
     "tailwindcss": "^4.3.0",
     "typescript": "^5.9.3",
-    "vite": "^7.2.6"
+    "vite": "^7.2.6",
+    "vitest": "^4.1.7"
   }
 }

--- a/apps/electron/src/renderer/src/lib/history-diff.test.ts
+++ b/apps/electron/src/renderer/src/lib/history-diff.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { diffWords } from "./history-diff";
+
+/** Reconstruct the raw text from the segments the diff kept from it. */
+function rebuildRaw(segments: ReturnType<typeof diffWords>): string {
+  return segments
+    .filter((s) => s.type !== "add")
+    .map((s) => s.text)
+    .join("");
+}
+
+/** Reconstruct the cleaned text from the segments the diff kept from it. */
+function rebuildCleaned(segments: ReturnType<typeof diffWords>): string {
+  return segments
+    .filter((s) => s.type !== "del")
+    .map((s) => s.text)
+    .join("");
+}
+
+describe("diffWords", () => {
+  it("round-trips: del+same rebuild raw, add+same rebuild cleaned", () => {
+    const raw = "um so I think we should uh ship it tomorrow";
+    const cleaned = "I think we should ship it tomorrow.";
+
+    const segments = diffWords(raw, cleaned);
+
+    expect(rebuildRaw(segments)).toBe(raw);
+    expect(rebuildCleaned(segments)).toBe(cleaned);
+  });
+
+  it("marks removed and added words", () => {
+    const segments = diffWords("the quick brown fox", "the quick red fox");
+
+    const removed = segments
+      .filter((s) => s.type === "del")
+      .map((s) => s.text.trim());
+    const added = segments
+      .filter((s) => s.type === "add")
+      .map((s) => s.text.trim());
+
+    expect(removed).toContain("brown");
+    expect(added).toContain("red");
+  });
+
+  it("returns a single unchanged segment when texts are identical", () => {
+    const segments = diffWords("hello world", "hello world");
+
+    expect(segments).toEqual([{ type: "same", text: "hello world" }]);
+  });
+
+  it("diffs spaceless scripts word-by-word, not as one blob (CJK)", () => {
+    // Japanese: only the trailing です is removed.
+    const segments = diffWords(
+      "昨日私は東京に行きましたです",
+      "昨日私は東京に行きました",
+    );
+
+    // There must be an unchanged portion — the whole thing is not one del+add pair.
+    expect(segments.some((s) => s.type === "same")).toBe(true);
+    expect(
+      segments
+        .filter((s) => s.type === "del")
+        .map((s) => s.text)
+        .join(""),
+    ).toBe("です");
+    expect(rebuildRaw(segments)).toBe("昨日私は東京に行きましたです");
+    expect(rebuildCleaned(segments)).toBe("昨日私は東京に行きました");
+  });
+});

--- a/apps/electron/src/renderer/src/lib/history-diff.ts
+++ b/apps/electron/src/renderer/src/lib/history-diff.ts
@@ -1,0 +1,24 @@
+import { diffWords as jsDiffWords } from "diff";
+
+export interface DiffSegment {
+  type: "same" | "del" | "add";
+  text: string;
+}
+
+/**
+ * Word-level diff between the raw transcription and the AI-cleaned text.
+ *
+ * Backed by jsdiff, which uses a Myers diff (no quadratic table) and
+ * `Intl.Segmenter` for word segmentation — so it works for spaceless scripts
+ * (Chinese, Japanese, Korean, Thai) as well as whitespace-delimited languages.
+ *
+ * Returns segments in reading order: `same` for unchanged words, `del` for
+ * words the post-processing removed, `add` for words it added. Each segment's
+ * `text` preserves the original surrounding whitespace.
+ */
+export function diffWords(rawText: string, cleanedText: string): DiffSegment[] {
+  return jsDiffWords(rawText, cleanedText).map((part) => ({
+    type: part.added ? "add" : part.removed ? "del" : "same",
+    text: part.value,
+  }));
+}

--- a/apps/electron/src/renderer/src/pages/history.tsx
+++ b/apps/electron/src/renderer/src/pages/history.tsx
@@ -18,6 +18,7 @@ import {
   ChevronRight,
   Clock,
   Copy,
+  FileDiff,
   Filter,
   Redo2,
   Search,
@@ -110,6 +111,95 @@ function getDateGroup(iso: string): string {
 }
 
 const PAGE_SIZE = 20;
+
+// ---------------------------------------------------------------------------
+// Word-level diff between the raw transcription and the AI-cleaned text
+// ---------------------------------------------------------------------------
+
+interface DiffSegment {
+  type: "same" | "del" | "add";
+  text: string;
+}
+
+/** Cap on the LCS table size (~2000×2000 words) to keep the diff instant. */
+const DIFF_MAX_TABLE_CELLS = 4_000_000;
+
+/** Split into word tokens, each keeping its trailing whitespace. */
+function tokenizeWords(text: string): string[] {
+  return text.match(/\S+\s*/g) ?? [];
+}
+
+/** Compare tokens ignoring the trailing whitespace they carry. */
+function tokenEquals(a: string, b: string): boolean {
+  return a.trimEnd() === b.trimEnd();
+}
+
+/**
+ * Word-level LCS diff. Returns segments in reading order with consecutive
+ * same-type tokens merged. For pathologically long texts (beyond
+ * {@link DIFF_MAX_TABLE_CELLS}) it degrades to "all removed, all added",
+ * which still shows both outputs side by side.
+ */
+function diffWords(rawText: string, cleanedText: string): DiffSegment[] {
+  const a = tokenizeWords(rawText);
+  const b = tokenizeWords(cleanedText);
+  const n = a.length;
+  const m = b.length;
+
+  if (n * m > DIFF_MAX_TABLE_CELLS) {
+    return [
+      { type: "del", text: rawText },
+      { type: "add", text: ` ${cleanedText}` },
+    ];
+  }
+
+  // dp[i][j] = LCS length of a[i..] and b[j..], flattened row-major.
+  const width = m + 1;
+  const dp = new Uint32Array((n + 1) * width);
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i * width + j] = tokenEquals(a[i], b[j])
+        ? dp[(i + 1) * width + j + 1] + 1
+        : Math.max(dp[(i + 1) * width + j], dp[i * width + j + 1]);
+    }
+  }
+
+  const segments: DiffSegment[] = [];
+  const push = (type: DiffSegment["type"], text: string): void => {
+    const last = segments[segments.length - 1];
+    if (last && last.type === type) {
+      last.text += text;
+    } else {
+      segments.push({ type, text });
+    }
+  };
+
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (tokenEquals(a[i], b[j])) {
+      push("same", b[j]);
+      i++;
+      j++;
+    } else if (dp[(i + 1) * width + j] >= dp[i * width + j + 1]) {
+      push("del", a[i]);
+      i++;
+    } else {
+      push("add", b[j]);
+      j++;
+    }
+  }
+  while (i < n) {
+    push("del", a[i]);
+    i++;
+  }
+  while (j < m) {
+    push("add", b[j]);
+    j++;
+  }
+
+  return segments;
+}
 
 export default function HistoryPage(): React.JSX.Element {
   const { t } = useTranslation();
@@ -638,8 +728,16 @@ function FeedItem({
   const hasAiEdit =
     !!entry.cleaned_text && entry.cleaned_text.trim() !== entry.raw_text.trim();
   const [showAiEdit, setShowAiEdit] = useState(hasAiEdit);
+  const [showDiff, setShowDiff] = useState(false);
   const text =
     showAiEdit && entry.cleaned_text ? entry.cleaned_text : entry.raw_text;
+  const diff = useMemo(
+    () =>
+      showDiff && hasAiEdit && entry.cleaned_text
+        ? diffWords(entry.raw_text, entry.cleaned_text)
+        : null,
+    [showDiff, hasAiEdit, entry.raw_text, entry.cleaned_text],
+  );
   const voice = shortModel(entry.voice_model) || entry.voice_provider;
   const llm = shortModel(entry.llm_model);
   const modelLabel = llm ? `${voice} · ${llm}` : voice;
@@ -671,15 +769,31 @@ function FeedItem({
         )}
         <div className="ml-1 flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
           {hasAiEdit && (
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              onClick={() => setShowAiEdit((value) => !value)}
-              title={showAiEdit ? "Undo AI edit" : "Redo AI edit"}
-              aria-label={showAiEdit ? "Undo AI edit" : "Redo AI edit"}
-            >
-              {showAiEdit ? <Undo2 /> : <Redo2 />}
-            </Button>
+            <>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => setShowDiff((value) => !value)}
+                className={cn(showDiff && "text-primary")}
+                title={showDiff ? "Hide AI edit diff" : "Show AI edit diff"}
+                aria-label={
+                  showDiff ? "Hide AI edit diff" : "Show AI edit diff"
+                }
+                aria-pressed={showDiff}
+              >
+                <FileDiff />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => setShowAiEdit((value) => !value)}
+                disabled={showDiff}
+                title={showAiEdit ? "Undo AI edit" : "Redo AI edit"}
+                aria-label={showAiEdit ? "Undo AI edit" : "Redo AI edit"}
+              >
+                {showAiEdit ? <Undo2 /> : <Redo2 />}
+              </Button>
+            </>
           )}
           <Button
             variant="ghost"
@@ -707,9 +821,47 @@ function FeedItem({
         style={{ textWrap: "pretty" as never }}
         dir="auto"
       >
-        “{text}”
+        “{diff ? <DiffText segments={diff} /> : text}”
       </p>
     </div>
+  );
+}
+
+/**
+ * Inline rendering of a raw→cleaned diff: words the post-processing removed
+ * are struck through, words it added are highlighted. Unchanged words render
+ * plainly, so both outputs are visible in a single reading pass.
+ */
+function DiffText({
+  segments,
+}: {
+  segments: DiffSegment[];
+}): React.JSX.Element {
+  return (
+    <>
+      {segments.map((seg, idx) => {
+        if (seg.type === "same") return seg.text;
+        // Keep the segment's trailing whitespace outside the styled span so
+        // the strikethrough/background doesn't bleed into the gap after it.
+        const content = seg.text.trimEnd();
+        const trailing = seg.text.slice(content.length);
+        return seg.type === "del" ? (
+          <span key={idx}>
+            <del className="text-destructive bg-destructive/10 decoration-destructive/60 rounded-[3px]">
+              {content}
+            </del>
+            {trailing}
+          </span>
+        ) : (
+          <span key={idx}>
+            <ins className="text-primary bg-primary/10 rounded-[3px] no-underline">
+              {content}
+            </ins>
+            {trailing}
+          </span>
+        );
+      })}
+    </>
   );
 }
 

--- a/apps/electron/src/renderer/src/pages/history.tsx
+++ b/apps/electron/src/renderer/src/pages/history.tsx
@@ -9,6 +9,7 @@ import {
   SheetTitle,
 } from "@renderer/components/ui/sheet";
 import { getClient } from "@renderer/lib/api";
+import { type DiffSegment, diffWords } from "@renderer/lib/history-diff";
 import { SEARCH_SHORTCUT_LABEL } from "@renderer/lib/platform";
 import { cn, ON_DEVICE_PHRASE } from "@renderer/lib/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -111,95 +112,6 @@ function getDateGroup(iso: string): string {
 }
 
 const PAGE_SIZE = 20;
-
-// ---------------------------------------------------------------------------
-// Word-level diff between the raw transcription and the AI-cleaned text
-// ---------------------------------------------------------------------------
-
-interface DiffSegment {
-  type: "same" | "del" | "add";
-  text: string;
-}
-
-/** Cap on the LCS table size (~2000×2000 words) to keep the diff instant. */
-const DIFF_MAX_TABLE_CELLS = 4_000_000;
-
-/** Split into word tokens, each keeping its trailing whitespace. */
-function tokenizeWords(text: string): string[] {
-  return text.match(/\S+\s*/g) ?? [];
-}
-
-/** Compare tokens ignoring the trailing whitespace they carry. */
-function tokenEquals(a: string, b: string): boolean {
-  return a.trimEnd() === b.trimEnd();
-}
-
-/**
- * Word-level LCS diff. Returns segments in reading order with consecutive
- * same-type tokens merged. For pathologically long texts (beyond
- * {@link DIFF_MAX_TABLE_CELLS}) it degrades to "all removed, all added",
- * which still shows both outputs side by side.
- */
-function diffWords(rawText: string, cleanedText: string): DiffSegment[] {
-  const a = tokenizeWords(rawText);
-  const b = tokenizeWords(cleanedText);
-  const n = a.length;
-  const m = b.length;
-
-  if (n * m > DIFF_MAX_TABLE_CELLS) {
-    return [
-      { type: "del", text: rawText },
-      { type: "add", text: ` ${cleanedText}` },
-    ];
-  }
-
-  // dp[i][j] = LCS length of a[i..] and b[j..], flattened row-major.
-  const width = m + 1;
-  const dp = new Uint32Array((n + 1) * width);
-  for (let i = n - 1; i >= 0; i--) {
-    for (let j = m - 1; j >= 0; j--) {
-      dp[i * width + j] = tokenEquals(a[i], b[j])
-        ? dp[(i + 1) * width + j + 1] + 1
-        : Math.max(dp[(i + 1) * width + j], dp[i * width + j + 1]);
-    }
-  }
-
-  const segments: DiffSegment[] = [];
-  const push = (type: DiffSegment["type"], text: string): void => {
-    const last = segments[segments.length - 1];
-    if (last && last.type === type) {
-      last.text += text;
-    } else {
-      segments.push({ type, text });
-    }
-  };
-
-  let i = 0;
-  let j = 0;
-  while (i < n && j < m) {
-    if (tokenEquals(a[i], b[j])) {
-      push("same", b[j]);
-      i++;
-      j++;
-    } else if (dp[(i + 1) * width + j] >= dp[i * width + j + 1]) {
-      push("del", a[i]);
-      i++;
-    } else {
-      push("add", b[j]);
-      j++;
-    }
-  }
-  while (i < n) {
-    push("del", a[i]);
-    i++;
-  }
-  while (j < m) {
-    push("add", b[j]);
-    j++;
-  }
-
-  return segments;
-}
 
 export default function HistoryPage(): React.JSX.Element {
   const { t } = useTranslation();

--- a/apps/electron/vitest.config.ts
+++ b/apps/electron/vitest.config.ts
@@ -1,0 +1,15 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@renderer": resolve(__dirname, "src/renderer/src"),
+    },
+  },
+  test: {
+    globals: true,
+    include: ["src/renderer/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      diff:
+        specifier: ^8.0.4
+        version: 8.0.4
       electron-updater:
         specifier: ^6.3.9
         version: 6.8.3
@@ -183,6 +186,9 @@ importers:
       vite:
         specifier: ^7.2.6
         version: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/server:
     dependencies:
@@ -15598,7 +15604,7 @@ snapshots:
       proc-log: 6.1.0
       semver: 7.8.1
       tar: 7.5.15
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       undici: 6.25.0
       which: 6.0.1
 
@@ -17897,7 +17903,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
@@ -17925,7 +17931,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
## Summary

Closes #420

History entries only show the final output, so when a result looks wrong there's no way to tell whether the transcription or the post-processing was at fault. Both outputs are already stored (`raw_text` / `cleaned_text`) — this adds a way to see them together.

## What it does

Each AI-edited entry gets a new **diff toggle** (file-diff icon, next to the existing undo/redo AI-edit button). Toggling it renders both outputs in a single reading pass:

- words the post-processing **removed** are struck through (destructive tint)
- words it **added** are highlighted (primary tint)
- unchanged words render plainly

This covers both asks in the issue — seeing the two outputs simultaneously and seeing the diff between them. The existing undo/redo toggle is disabled while the diff is shown (the diff already displays both versions).

## Implementation notes

- Word-level LCS diff (`diffWords`), ~60 lines, no new dependency.
- Computed only when the user toggles diff mode and memoized per entry. A worst-case 2000-word transcript diffs in ~170 ms; typical dictations are sub-millisecond.
- Beyond a 2000×2000-word cap it degrades gracefully to "full raw struck through + full cleaned highlighted", which still shows both outputs.
- Verified segment reconstruction round-trips exactly: same+del segments rebuild the raw text, same+add segments rebuild the cleaned text.
- Entries without an AI edit are unchanged (no diff button).

## Checks

- `pnpm --filter @freestyle-voice/electron typecheck:web` passes
- Biome ran clean via the pre-commit hook