### PR TITLE
feat: send custom vocabulary to cloud v2 transcribe

### DIFF
--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -9,6 +9,7 @@ import { createAuthClient } from "better-auth/client";
 import { deviceAuthorizationClient } from "better-auth/client/plugins";
 import type { CloudUser } from "./sessions.js";
 import { CLOUD_TRANSCRIBE_TIMEOUT_MS } from "./streaming/types.js";
+import type { CloudVocabularyBias } from "./vocabulary.js";
 
 export const FREESTYLE_CLOUD_PROVIDER_ID = "freestyle-cloud";
 export const FREESTYLE_CLOUD_TRANSCRIBE_MODEL_ID = "freestyle-cloud/stt";
@@ -384,6 +385,8 @@ export async function transcribeWithFreestyleCloud(
     mode: "raw" | "combined";
     intensity?: string;
     customPrompt?: string | null;
+    /** Custom-vocabulary bias to steer recognition (independent of cleanup). */
+    vocabulary?: CloudVocabularyBias;
   } & CloudCleanupTones,
 ): Promise<CloudTranscribeResult> {
   const audio = opts.audio as Uint8Array<ArrayBuffer>;
@@ -395,6 +398,13 @@ export async function transcribeWithFreestyleCloud(
   form.append("audio", new Blob([audio], { type: "audio/wav" }), "audio.wav");
   if (opts.language) form.append("language", opts.language);
   if (opts.appContext) form.append("appContext", opts.appContext);
+  // Vocabulary bias applies to the recognizer regardless of cleanup mode.
+  if (
+    opts.vocabulary &&
+    (opts.vocabulary.terms?.length || opts.vocabulary.text)
+  ) {
+    form.append("vocabulary", JSON.stringify(opts.vocabulary));
+  }
   if (opts.mode === "raw") {
     form.append("skipPostProcess", "true");
   } else {

--- a/apps/server/src/lib/streaming/providers/freestyle-cloud.ts
+++ b/apps/server/src/lib/streaming/providers/freestyle-cloud.ts
@@ -3,6 +3,7 @@ import {
   FreestyleCloudAuthError,
   transcribeWithFreestyleCloud,
 } from "../../freestyle-cloud.js";
+import { getCloudVocabularyBias } from "../../vocabulary.js";
 import type {
   TranscribeOptions,
   TranscribeResult,
@@ -35,6 +36,7 @@ export class FreestyleCloudTranscriptionProvider
       audio: opts.audio,
       language: opts.language,
       mode: "raw",
+      vocabulary: getCloudVocabularyBias(),
     });
     return {
       text: data.raw || "",

--- a/apps/server/src/lib/vocabulary.ts
+++ b/apps/server/src/lib/vocabulary.ts
@@ -39,3 +39,29 @@ export function getTranscriptionContextPrompt(): string | undefined {
     return undefined;
   }
 }
+
+/**
+ * Raw custom-vocabulary bias forwarded to Freestyle Cloud's `/v2/transcribe`.
+ * The cloud assembles the recognizer prompt from these terms plus the optional
+ * context text, so the desktop sends the raw values rather than a formatted
+ * prompt. Shape mirrors the cloud's `{ terms?, text? }` contract.
+ */
+export interface CloudVocabularyBias {
+  terms?: string[];
+  text?: string;
+}
+
+/**
+ * Collect the user's vocabulary terms and transcription context prompt for the
+ * cloud batch transcription path. Returns `undefined` when there is nothing to
+ * send so callers can omit the field entirely.
+ */
+export function getCloudVocabularyBias(): CloudVocabularyBias | undefined {
+  const terms = loadVocabularyTerms();
+  const text = getTranscriptionContextPrompt();
+  if (terms.length === 0 && !text) return undefined;
+  return {
+    ...(terms.length > 0 ? { terms } : {}),
+    ...(text ? { text } : {}),
+  };
+}

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -30,6 +30,7 @@ import { invalidateSession } from "../lib/sessions.js";
 import { CloudAuthError } from "../lib/streaming/providers/freestyle-cloud.js";
 import { getProvider } from "../lib/streaming/registry.js";
 import { getApiKeyForProvider } from "../lib/streaming-stt.js";
+import { getCloudVocabularyBias } from "../lib/vocabulary.js";
 import { resolveAsrVocabularyBias } from "../lib/vocabulary-bias.js";
 
 const log = createAppLogger("transcribe");
@@ -151,6 +152,7 @@ const transcribeRoute = new Hono().post("/", async (c) => {
         language,
         appContext,
         mode: "combined",
+        vocabulary: getCloudVocabularyBias(),
         ...getEffectiveCleanupTones(),
         appAssignments: getCleanupAppAssignments(),
       });


### PR DESCRIPTION
## What

Sends the user's **custom vocabulary** to Freestyle Cloud's `/v2/transcribe` so the cloud can bias Whisper recognition toward the speaker's terms.

Companion to **freestyle-voice/cloud#35**, which adds the `vocabulary` field to the cloud v2 route.

## Changes

- `lib/vocabulary.ts`: new `getCloudVocabularyBias()` returning `{ terms?, text? }` (or `undefined`), built from `loadVocabularyTerms()` + the `transcription_prompt` setting. Shape mirrors the cloud contract, so the cloud assembles the recognizer prompt from raw values.
- `lib/freestyle-cloud.ts`: `transcribeWithFreestyleCloud` accepts an optional `vocabulary` and appends it (JSON) to the multipart form. Applied in **both** modes — biasing is independent of cleanup.
- Wired into both cloud call sites: the batch provider (`streaming/providers/freestyle-cloud.ts`, `mode: "raw"`) and the combined path (`routes/transcribe.ts`, `mode: "combined"`).

Dictionary is unchanged — it's applied locally to the cloud response and never sent.

## Compatibility

The `vocabulary` field is optional and ignored by older cloud server versions, so this can ship independently of the cloud PR. Biasing only takes effect once cloud#35 is deployed.

## Verification

- `biome check` clean
- `tsc --noEmit` clean (server)
- `vitest run` — 215 passed
- server build OK