### PR TITLE
Change sidebar color and the scrolling of the right card

### DIFF
--- a/apps/electron/src/renderer/src/globals.css
+++ b/apps/electron/src/renderer/src/globals.css
@@ -92,7 +92,7 @@
   --glass-window-solid: #F4F0E4;
   --glass-window: #F4F0E4;
   --glass-sidebar-solid: #ECE7D6;
-  --glass-sidebar: rgba(236, 231, 214, 0.9);
+  --glass-sidebar: #ECE7D6;
   --glass-topbar-solid: #F4F0E4;
   --glass-topbar: rgba(244, 240, 228, 0.96);
   --glass-border: rgba(214, 205, 184, 0.72);
@@ -373,5 +373,14 @@
     .responsive-standalone-pad {
       padding-inline: 1rem;
     }
+  }
+
+  .no-scrollbar {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
   }
 }

--- a/apps/electron/src/renderer/src/pages/today.tsx
+++ b/apps/electron/src/renderer/src/pages/today.tsx
@@ -269,7 +269,7 @@ export default function TodayPage(): React.JSX.Element {
       </div>
 
       {/* Right rail — day summary */}
-      <aside className="border-border bg-sidebar mt-16 mr-4 mb-4 hidden w-[280px] shrink-0 flex-col gap-7 overflow-auto rounded-2xl border px-7 pt-7 pb-9 lg:flex">
+      <aside className="no-scrollbar border-border bg-sidebar mt-16 mr-4 mb-4 hidden w-[280px] shrink-0 flex-col gap-7 overflow-auto rounded-2xl border px-7 pt-7 pb-9 lg:flex">
         <section>
           <RailLabel>{t("today.inNumbers")}</RailLabel>
           <RailStat


### PR DESCRIPTION
# Overview

In light mode, the freestyle sidebar is corrected to a more appealing neutral color. We previously had transparent glass, but it was hard to read the sidebar. In this PR, we make the sidebar background color a lot more uniform. On the Today tab, in the right card, we also make the scroll bar invisible. 

<img width="1143" height="630" alt="Screenshot 2026-07-07 at 3 33 24 PM" src="https://github.com/user-attachments/assets/3b331b4e-3e8c-47da-b3f6-2e2d05904595" />
