### PR TITLE
Remove asr biasing from the settings page. Modify the onboarding page

### DIFF
--- a/apps/electron/src/renderer/src/locales/de.json
+++ b/apps/electron/src/renderer/src/locales/de.json
@@ -141,9 +141,6 @@
       "outputModeDesc": "In die aktive App einfügen oder in die Zwischenablage kopieren.",
       "outputModePaste": "In App einfügen",
       "outputModeClipboard": "In Zwischenablage kopieren",
-      "transcriptionPrompt": "Transkriptions-Eingabe",
-      "transcriptionPromptDesc": "Fachbegriffe, Namen oder Jargon auflisten, um die Genauigkeit des Sprachmodells zu verbessern.",
-      "transcriptionPromptPlaceholder": "z.B. TypeScript, React, Kubernetes, JIRA…",
       "sound": "Klangfeedback",
       "soundDesc": "Sanfte Töne zu Beginn und Ende der Aufnahme.",
       "needsModifier": "Tastenkombinationen benötigen eine Modifikatortaste oder Maustaste"

--- a/apps/electron/src/renderer/src/locales/en.json
+++ b/apps/electron/src/renderer/src/locales/en.json
@@ -158,9 +158,6 @@
       "outputModeDesc": "Paste into the active app, or copy to clipboard.",
       "outputModePaste": "Paste into app",
       "outputModeClipboard": "Copy to clipboard",
-      "transcriptionPrompt": "Transcription prompt",
-      "transcriptionPromptDesc": "List domain terms, names, or jargon to nudge the speech model toward better accuracy.",
-      "transcriptionPromptPlaceholder": "e.g. TypeScript, React, Kubernetes, JIRA…",
       "sound": "Sound feedback",
       "soundDesc": "Soft chimes at the start and end of recording.",
       "needsModifier": "Hotkeys need a modifier or side mouse button"

--- a/apps/electron/src/renderer/src/locales/es.json
+++ b/apps/electron/src/renderer/src/locales/es.json
@@ -141,9 +141,6 @@
       "outputModeDesc": "Pegar en la app activa o copiar al portapapeles.",
       "outputModePaste": "Pegar en la app",
       "outputModeClipboard": "Copiar al portapapeles",
-      "transcriptionPrompt": "Indicación de transcripción",
-      "transcriptionPromptDesc": "Lista términos de dominio, nombres o jerga para mejorar la precisión del modelo de voz.",
-      "transcriptionPromptPlaceholder": "ej. TypeScript, React, Kubernetes, JIRA…",
       "sound": "Retroalimentación de sonido",
       "soundDesc": "Campanillas suaves al inicio y al final de la grabación.",
       "needsModifier": "Los atajos necesitan una tecla modificadora o botón lateral del ratón"

--- a/apps/electron/src/renderer/src/locales/fr.json
+++ b/apps/electron/src/renderer/src/locales/fr.json
@@ -141,9 +141,6 @@
       "outputModeDesc": "Coller dans l'app active ou copier dans le presse-papiers.",
       "outputModePaste": "Coller dans l'app",
       "outputModeClipboard": "Copier dans le presse-papiers",
-      "transcriptionPrompt": "Invite de transcription",
-      "transcriptionPromptDesc": "Listez des termes du domaine, noms ou jargon pour améliorer la précision du modèle vocal.",
-      "transcriptionPromptPlaceholder": "ex. TypeScript, React, Kubernetes, JIRA…",
       "sound": "Retour sonore",
       "soundDesc": "Carillons doux au début et à la fin de l'enregistrement.",
       "needsModifier": "Les raccourcis nécessitent une touche modificatrice ou un bouton latéral de souris"

--- a/apps/electron/src/renderer/src/locales/it.json
+++ b/apps/electron/src/renderer/src/locales/it.json
@@ -141,9 +141,6 @@
       "outputModeDesc": "Incolla nell'app attiva o copia negli appunti.",
       "outputModePaste": "Incolla nell'app",
       "outputModeClipboard": "Copia negli appunti",
-      "transcriptionPrompt": "Prompt di trascrizione",
-      "transcriptionPromptDesc": "Elenca termini specifici del dominio per aiutare la precisione del modello.",
-      "transcriptionPromptPlaceholder": "es. TypeScript, React, Kubernetes, JIRA...",
       "sound": "Feedback sonoro",
       "soundDesc": "Suoni leggeri all'inizio e alla fine della registrazione.",
       "needsModifier": "Le scorciatoie necessitano di un tasto modificatore"

--- a/apps/electron/src/renderer/src/locales/ja.json
+++ b/apps/electron/src/renderer/src/locales/ja.json
@@ -141,9 +141,6 @@
       "outputModeDesc": "アクティブなアプリに直接貼り付けるか、クリップボードにコピーします。",
       "outputModePaste": "アプリに貼り付け",
       "outputModeClipboard": "クリップボードにコピー",
-      "transcriptionPrompt": "文字起こしプロンプト",
-      "transcriptionPromptDesc": "専門用語、人名、業界用語などを指定することで、音声モデルの認識精度を向上させます。",
-      "transcriptionPromptPlaceholder": "例: TypeScript, React, Kubernetes, JIRA…",
       "sound": "サウンドフィードバック",
       "soundDesc": "録音の開始時と終了時に短いチャイム音を鳴らします。",
       "needsModifier": "ホットキーには修飾キーまたはマウスのサイドボタンが必要です"

--- a/apps/electron/src/renderer/src/locales/pt.json
+++ b/apps/electron/src/renderer/src/locales/pt.json
@@ -141,9 +141,6 @@
       "outputModeDesc": "Colar no aplicativo ativo ou copiar para a área de transferência.",
       "outputModePaste": "Colar no aplicativo",
       "outputModeClipboard": "Copiar para a área de transferência",
-      "transcriptionPrompt": "Prompt de transcrição",
-      "transcriptionPromptDesc": "Liste termos de domínio, nomes ou jargões para guiar o modelo de transcrição.",
-      "transcriptionPromptPlaceholder": "ex: TypeScript, React, Kubernetes, JIRA...",
       "sound": "Feedback sonoro",
       "soundDesc": "Sons suaves no início e fim da gravação.",
       "needsModifier": "Atalhos precisam de uma tecla modificadora"

--- a/apps/electron/src/renderer/src/locales/template.json
+++ b/apps/electron/src/renderer/src/locales/template.json
@@ -159,9 +159,6 @@
       "outputModeDesc": "Paste into the active app, or copy to clipboard.",
       "outputModePaste": "Paste into app",
       "outputModeClipboard": "Copy to clipboard",
-      "transcriptionPrompt": "Transcription prompt",
-      "transcriptionPromptDesc": "List domain terms, names, or jargon to nudge the speech model toward better accuracy.",
-      "transcriptionPromptPlaceholder": "e.g. TypeScript, React, Kubernetes, JIRA…",
       "sound": "Sound feedback",
       "soundDesc": "Soft chimes at the start and end of recording.",
       "needsModifier": "Hotkeys need a modifier or side mouse button"

--- a/apps/electron/src/renderer/src/onboarding.tsx
+++ b/apps/electron/src/renderer/src/onboarding.tsx
@@ -48,11 +48,11 @@ import {
   Check,
   ChevronLeft,
   ClipboardPaste,
+  ExternalLink,
   HardDrive,
   Key,
   Keyboard,
   Loader2,
-  LogIn,
   Mic,
   Shield,
   X,
@@ -811,7 +811,6 @@ export default function OnboardingPage(): React.JSX.Element {
             draftKeys={draftKeys}
             captureHint={captureHint}
             modelReady={chosenReady}
-            modelName={chosen?.name}
             localModel={showLocalSetupPanel ? localSetupModel : undefined}
             onDownloadLocal={startLocalDownload}
             onRetryLocal={retryLocalDownload}
@@ -823,10 +822,6 @@ export default function OnboardingPage(): React.JSX.Element {
                   : "notReady"
                 : null
             }
-            onOpenSelector={() => {
-              capture("onboarding_model_selector_opened");
-              setShowSelector(true);
-            }}
             onStartRecording={() => {
               capture("onboarding_hotkey_change_started");
               startHotkeyRecording();
@@ -1146,24 +1141,30 @@ function CloudStep({
           <Check className="text-accent-foreground size-4 shrink-0" />
         </div>
       ) : (
-        <button
-          type="button"
-          onClick={onSignIn}
-          disabled={signingIn}
-          className="mt-6 flex w-full items-center justify-center gap-2.5 rounded-[11px] bg-primary px-5 py-3 text-[14px] font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-60"
-        >
-          {signingIn ? (
-            <>
-              <Loader2 className="size-4 animate-spin" />
-              Signing in…
-            </>
-          ) : (
-            <>
-              <LogIn className="size-[18px]" />
-              Sign in / Create account
-            </>
-          )}
-        </button>
+        <>
+          <p className="text-muted-foreground mt-3 max-w-[340px] text-[14px] leading-relaxed">
+            Do work 4X faster with voice. Sign in to get started.
+          </p>
+
+          <button
+            type="button"
+            onClick={onSignIn}
+            disabled={signingIn}
+            className="mt-7 flex w-full items-center justify-center gap-2.5 rounded-[11px] bg-primary px-5 py-3 text-[14px] font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-60"
+          >
+            {signingIn ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                Opening browser…
+              </>
+            ) : (
+              <>
+                Sign in via browser
+                <ExternalLink className="size-4 opacity-70" />
+              </>
+            )}
+          </button>
+        </>
       )}
 
       {error && (
@@ -1178,15 +1179,19 @@ function CloudStep({
           <ArrowRight data-icon="inline-end" />
         </Button>
       ) : (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onSkip}
-          disabled={signingIn}
-          className="text-muted-foreground mt-2 h-auto px-2 py-1 text-[12px]"
-        >
-          Skip for now
-        </Button>
+        // Skipping sign-in is a local-development affordance only — in
+        // production the browser sign-in is the sole way past this step.
+        import.meta.env.DEV && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onSkip}
+            disabled={signingIn}
+            className="text-muted-foreground mt-2 h-auto px-2 py-1 text-[12px]"
+          >
+            Skip for now (dev)
+          </Button>
+        )
       )}
     </div>
   );
@@ -1606,13 +1611,11 @@ function TutorialStep({
   draftKeys,
   captureHint,
   modelReady,
-  modelName,
   localModel,
   onDownloadLocal,
   onRetryLocal,
   canFinish,
   finishBlockedReason,
-  onOpenSelector,
   onStartRecording,
   onCancelRecording,
   onDictation,
@@ -1624,13 +1627,11 @@ function TutorialStep({
   draftKeys: string[];
   captureHint: string;
   modelReady: boolean;
-  modelName?: string;
   localModel: VoiceItem | undefined;
   onDownloadLocal: () => void;
   onRetryLocal: () => void;
   canFinish: boolean;
   finishBlockedReason: "downloading" | "notReady" | null;
-  onOpenSelector: () => void;
   onStartRecording: () => void;
   onCancelRecording: () => void;
   onDictation: () => void;
@@ -1651,19 +1652,6 @@ function TutorialStep({
         onDownload={onDownloadLocal}
         onRetry={onRetryLocal}
       />
-
-      {/* The model is visible and changeable here — where it can be tested. */}
-      <div className="mt-3 flex justify-center">
-        <Button
-          variant="link"
-          onClick={onOpenSelector}
-          className="mono text-muted-foreground hover:text-foreground h-auto p-0 text-[11px] underline underline-offset-[3px]"
-        >
-          {modelReady && modelName
-            ? t("onboarding.tutorial.usingModel", { name: modelName })
-            : t("onboarding.tutorial.chooseModel")}
-        </Button>
-      </div>
 
       {/* Hotkey rebind — a single minimal control */}
       <div className="mt-5 flex justify-center">

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -122,7 +122,6 @@ export default function SettingsPage(): React.JSX.Element {
   const [historyPaused, setHistoryPaused] = useState(false);
   const [audioPlaybackMode, setAudioPlaybackMode] =
     useState<AudioPlaybackMode>("off");
-  const [transcriptionPrompt, setTranscriptionPrompt] = useState("");
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null);
   const [updateDownloaded, setUpdateDownloaded] = useState(false);
   const [downloading, setDownloading] = useState(false);
@@ -401,15 +400,6 @@ export default function SettingsPage(): React.JSX.Element {
         setAudioPlaybackMode(legacyDuckData?.value === "true" ? "duck" : "off");
       } catch {}
     })();
-    getClient()
-      .api.settings[":key"].$get({
-        param: { key: SETTINGS_KEYS.transcriptionPrompt },
-      })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (data?.value) setTranscriptionPrompt(data.value);
-      })
-      .catch(() => {});
     // Auto-update setting
     window.api
       ?.getAutoUpdate()
@@ -880,30 +870,6 @@ export default function SettingsPage(): React.JSX.Element {
                   ]}
                   active={outputMode}
                   onSelect={handleOutputModeChange}
-                />
-              </Row>
-
-              <Row
-                label={t("settings.recording.transcriptionPrompt")}
-                desc={t("settings.recording.transcriptionPromptDesc")}
-              >
-                <Input
-                  id="settings-transcription-prompt"
-                  type="text"
-                  value={transcriptionPrompt}
-                  onChange={(e) => setTranscriptionPrompt(e.target.value)}
-                  onBlur={() => {
-                    getClient()
-                      .api.settings[":key"].$put({
-                        param: { key: SETTINGS_KEYS.transcriptionPrompt },
-                        json: { value: transcriptionPrompt },
-                      })
-                      .catch(() => {});
-                  }}
-                  placeholder={t(
-                    "settings.recording.transcriptionPromptPlaceholder",
-                  )}
-                  className="max-w-md"
                 />
               </Row>
 

--- a/apps/electron/src/shared/settings-keys.ts
+++ b/apps/electron/src/shared/settings-keys.ts
@@ -21,7 +21,6 @@ export const SETTINGS_KEYS = {
   outputMode: "output_mode",
   soundEnabled: "sound_enabled",
   theme: "theme",
-  transcriptionPrompt: "transcription_prompt",
 } as const;
 
 export type SettingsKey = (typeof SETTINGS_KEYS)[keyof typeof SETTINGS_KEYS];

--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -399,10 +399,7 @@ export async function transcribeWithFreestyleCloud(
   if (opts.language) form.append("language", opts.language);
   if (opts.appContext) form.append("appContext", opts.appContext);
   // Vocabulary bias applies to the recognizer regardless of cleanup mode.
-  if (
-    opts.vocabulary &&
-    (opts.vocabulary.terms?.length || opts.vocabulary.text)
-  ) {
+  if (opts.vocabulary?.terms.length) {
     form.append("vocabulary", JSON.stringify(opts.vocabulary));
   }
   if (opts.mode === "raw") {

--- a/apps/server/src/lib/vocabulary-bias.ts
+++ b/apps/server/src/lib/vocabulary-bias.ts
@@ -1,8 +1,5 @@
 import { stripProviderPrefix } from "./streaming/types.js";
-import {
-  getTranscriptionContextPrompt,
-  loadVocabularyTerms,
-} from "./vocabulary.js";
+import { loadVocabularyTerms } from "./vocabulary.js";
 
 /** ASR-only vocabulary bias (first recognition step). Not used in post-process. */
 export type AsrVocabularyBias =
@@ -35,37 +32,21 @@ function capTerms(terms: string[], max: number): string[] {
   return out;
 }
 
-function buildPromptText(
-  terms: string[],
-  contextPrompt?: string,
-): string | null {
-  const parts: string[] = [];
-  if (contextPrompt?.trim()) parts.push(contextPrompt.trim());
-
-  if (terms.length > 0) {
-    let list = terms.join(", ");
-    const prefix = parts.length > 0 ? " Terms: " : "Terms: ";
-    const budget = PROMPT_CHAR_BUDGET - parts.join(" ").length - prefix.length;
-    if (budget > 0 && list.length > budget) {
-      const trimmed: string[] = [];
-      let len = 0;
-      for (const t of terms) {
-        const next = trimmed.length === 0 ? t : `${trimmed.join(", ")}, ${t}`;
-        if (next.length > budget) break;
-        trimmed.push(t);
-        len = next.length;
-        void len;
-      }
-      list = trimmed.join(", ");
+function buildPromptText(terms: string[]): string | null {
+  if (terms.length === 0) return null;
+  let list = terms.join(", ");
+  const budget = PROMPT_CHAR_BUDGET - "Terms: ".length;
+  if (list.length > budget) {
+    const trimmed: string[] = [];
+    for (const t of terms) {
+      const next = trimmed.length === 0 ? t : `${trimmed.join(", ")}, ${t}`;
+      if (next.length > budget) break;
+      trimmed.push(t);
     }
-    if (list) {
-      parts.push(parts.length > 0 ? `Terms: ${list}.` : `Terms: ${list}.`);
-    }
+    list = trimmed.join(", ");
   }
-
-  const text = parts.join(" ").trim();
-  if (!text) return null;
-  return text.slice(0, PROMPT_CHAR_BUDGET);
+  if (!list) return null;
+  return `Terms: ${list}.`.slice(0, PROMPT_CHAR_BUDGET);
 }
 
 function expandNova2Keywords(terms: string[]): string[] {
@@ -116,11 +97,10 @@ export function buildAsrVocabularyBias(
   providerId: string,
   modelId: string,
   terms: string[],
-  contextPrompt?: string,
   streaming = false,
 ): AsrVocabularyBias | null {
   const capped = capTerms(terms, DEEPGRAM_KEYTERM_MAX);
-  if (capped.length === 0 && !contextPrompt?.trim()) return null;
+  if (capped.length === 0) return null;
 
   const short = stripProviderPrefix(modelId);
 
@@ -129,7 +109,7 @@ export function buildAsrVocabularyBias(
     case "groq":
     // whisper.cpp accepts the same OpenAI-style initial prompt (224-token budget).
     case "local-whisper": {
-      const text = buildPromptText(capped, contextPrompt);
+      const text = buildPromptText(capped);
       return text ? { kind: "prompt", text } : null;
     }
     case "deepgram": {
@@ -167,12 +147,10 @@ export function buildAsrVocabularyBias(
         : null;
     }
     case "local-mlx": {
-      const parts: string[] = [];
-      if (contextPrompt?.trim()) parts.push(contextPrompt.trim());
-      if (capped.length > 0) {
-        parts.push(`Technical terms: ${capped.join(", ")}`);
-      }
-      const text = parts.join(" ").trim().slice(0, PROMPT_CHAR_BUDGET);
+      const text = `Technical terms: ${capped.join(", ")}`.slice(
+        0,
+        PROMPT_CHAR_BUDGET,
+      );
       return text ? { kind: "prompt", text } : null;
     }
     default:
@@ -186,12 +164,5 @@ export function resolveAsrVocabularyBias(
   streaming = false,
 ): AsrVocabularyBias | null {
   const terms = loadVocabularyTerms();
-  const contextPrompt = getTranscriptionContextPrompt();
-  return buildAsrVocabularyBias(
-    providerId,
-    modelId,
-    terms,
-    contextPrompt,
-    streaming,
-  );
+  return buildAsrVocabularyBias(providerId, modelId, terms, streaming);
 }

--- a/apps/server/src/lib/vocabulary.ts
+++ b/apps/server/src/lib/vocabulary.ts
@@ -27,41 +27,23 @@ export function loadVocabularyTerms(): string[] {
   }
 }
 
-export function getTranscriptionContextPrompt(): string | undefined {
-  const db = getDb();
-  try {
-    const row = db
-      .prepare("SELECT value FROM settings WHERE key = 'transcription_prompt'")
-      .get() as { value: string } | undefined;
-    const value = row?.value?.trim();
-    return value || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 /**
  * Raw custom-vocabulary bias forwarded to Freestyle Cloud's `/v2/transcribe`.
- * The cloud assembles the recognizer prompt from these terms plus the optional
- * context text, so the desktop sends the raw values rather than a formatted
- * prompt. Shape mirrors the cloud's `{ terms?, text? }` contract.
+ * The cloud assembles the recognizer prompt from these terms, so the desktop
+ * sends the raw values rather than a formatted prompt. Shape mirrors the
+ * cloud's `{ terms }` contract.
  */
 export interface CloudVocabularyBias {
-  terms?: string[];
-  text?: string;
+  terms: string[];
 }
 
 /**
- * Collect the user's vocabulary terms and transcription context prompt for the
- * cloud batch transcription path. Returns `undefined` when there is nothing to
- * send so callers can omit the field entirely.
+ * Collect the user's vocabulary terms for the cloud batch transcription path.
+ * Returns `undefined` when there is nothing to send so callers can omit the
+ * field entirely.
  */
 export function getCloudVocabularyBias(): CloudVocabularyBias | undefined {
   const terms = loadVocabularyTerms();
-  const text = getTranscriptionContextPrompt();
-  if (terms.length === 0 && !text) return undefined;
-  return {
-    ...(terms.length > 0 ? { terms } : {}),
-    ...(text ? { text } : {}),
-  };
+  if (terms.length === 0) return undefined;
+  return { terms };
 }

--- a/apps/server/tests/vocabulary-bias.test.ts
+++ b/apps/server/tests/vocabulary-bias.test.ts
@@ -7,11 +7,9 @@ function terms(count: number, prefix = "term"): string[] {
 
 describe("buildAsrVocabularyBias", () => {
   describe("empty input", () => {
-    it("returns null when there are no terms and no context", () => {
+    it("returns null when there are no terms", () => {
       expect(buildAsrVocabularyBias("openai", "whisper-1", [])).toBeNull();
-      expect(
-        buildAsrVocabularyBias("deepgram", "nova-3", [], undefined, true),
-      ).toBeNull();
+      expect(buildAsrVocabularyBias("deepgram", "nova-3", [], true)).toBeNull();
     });
 
     it("returns null for unknown providers", () => {
@@ -35,30 +33,6 @@ describe("buildAsrVocabularyBias", () => {
         kind: "prompt",
         text: "Terms: TypeScript, Kubernetes.",
       });
-    });
-
-    it("includes context prompt with vocabulary terms", () => {
-      const bias = buildAsrVocabularyBias(
-        "openai",
-        "whisper-1",
-        ["Nguyen"],
-        "Medical dictation.",
-      );
-      expect(bias?.kind).toBe("prompt");
-      if (bias?.kind === "prompt") {
-        expect(bias.text).toContain("Medical dictation.");
-        expect(bias.text).toContain("Terms: Nguyen.");
-      }
-    });
-
-    it("returns context-only prompt when terms are empty", () => {
-      const bias = buildAsrVocabularyBias(
-        "openai",
-        "whisper-1",
-        [],
-        "Speak clearly.",
-      );
-      expect(bias).toEqual({ kind: "prompt", text: "Speak clearly." });
     });
 
     it("deduplicates terms case-insensitively", () => {
@@ -106,7 +80,6 @@ describe("buildAsrVocabularyBias", () => {
         "deepgram",
         "deepgram/nova-3",
         ["Freestyle", "Kubernetes"],
-        undefined,
         false,
       );
       expect(bias).toEqual({
@@ -120,7 +93,6 @@ describe("buildAsrVocabularyBias", () => {
         "deepgram",
         "nova-3-general",
         terms(40),
-        undefined,
         true,
       );
       expect(bias?.kind).toBe("deepgram-keyterms");
@@ -134,7 +106,6 @@ describe("buildAsrVocabularyBias", () => {
         "deepgram",
         "nova-3",
         terms(150),
-        undefined,
         false,
       );
       expect(bias?.kind).toBe("deepgram-keyterms");
@@ -148,7 +119,6 @@ describe("buildAsrVocabularyBias", () => {
         "deepgram",
         "nova-2",
         ["account number", "TypeScript"],
-        undefined,
         false,
       );
       expect(bias).toEqual({
@@ -162,18 +132,6 @@ describe("buildAsrVocabularyBias", () => {
         buildAsrVocabularyBias("deepgram", "whisper-large", ["Freestyle"]),
       ).toBeNull();
     });
-
-    it("ignores context prompt without terms", () => {
-      expect(
-        buildAsrVocabularyBias(
-          "deepgram",
-          "nova-3",
-          [],
-          "Medical dictation.",
-          false,
-        ),
-      ).toBeNull();
-    });
   });
 
   describe("elevenlabs", () => {
@@ -182,7 +140,6 @@ describe("buildAsrVocabularyBias", () => {
         "elevenlabs",
         "scribe_v2",
         ["Freestyle", "Nguyen"],
-        undefined,
         false,
       );
       expect(bias).toEqual({
@@ -202,7 +159,6 @@ describe("buildAsrVocabularyBias", () => {
         "elevenlabs",
         "scribe_v2_realtime",
         terms(60),
-        undefined,
         true,
       );
       expect(bias?.kind).toBe("elevenlabs-keyterms");
@@ -216,7 +172,6 @@ describe("buildAsrVocabularyBias", () => {
         "elevenlabs",
         "scribe_v2_realtime",
         ["abcdefghijklmnopqrstuvwxyz"],
-        undefined,
         true,
       );
       expect(bias).toEqual({
@@ -231,7 +186,6 @@ describe("buildAsrVocabularyBias", () => {
         "elevenlabs",
         "scribe_v2",
         [longTerm],
-        undefined,
         false,
       );
       expect(bias).toEqual({
@@ -252,35 +206,11 @@ describe("buildAsrVocabularyBias", () => {
         text: "Technical terms: TypeScript, Kubernetes",
       });
     });
-
-    it("includes context prompt for mlx", () => {
-      const bias = buildAsrVocabularyBias(
-        "local-mlx",
-        "qwen",
-        ["Nguyen"],
-        "Medical dictation.",
-      );
-      expect(bias?.kind).toBe("prompt");
-      if (bias?.kind === "prompt") {
-        expect(bias.text).toContain("Medical dictation.");
-        expect(bias.text).toContain("Technical terms: Nguyen");
-      }
-    });
-
-    it("returns context-only mlx prompt when terms are empty", () => {
-      const bias = buildAsrVocabularyBias(
-        "local-mlx",
-        "qwen",
-        [],
-        "Speak clearly.",
-      );
-      expect(bias).toEqual({ kind: "prompt", text: "Speak clearly." });
-    });
   });
 });
 
 describe("resolveAsrVocabularyBias", () => {
-  it("loads terms and settings from the database", async () => {
+  it("loads terms from the database", async () => {
     const { getDb } = await import("../src/lib/db.js");
     const { resolveAsrVocabularyBias } = await import(
       "../src/lib/vocabulary-bias.js"
@@ -291,14 +221,10 @@ describe("resolveAsrVocabularyBias", () => {
       "Freestyle",
       null,
     );
-    db.prepare(
-      "INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-    ).run("transcription_prompt", "Dictation context.");
 
     const bias = resolveAsrVocabularyBias("openai", "whisper-1", false);
     expect(bias?.kind).toBe("prompt");
     if (bias?.kind === "prompt") {
-      expect(bias.text).toContain("Dictation context.");
       expect(bias.text).toContain("Freestyle");
     }
   });


### PR DESCRIPTION
# Overview 

A couple of fast changes bundled into this PR:
1. The skip option has been removed from the onboarding page in production. It is still available in local development mode. 
2. The testing page is now using Freestyle Transcribe Cloud by default. 
3. Remove the ASR biasing feature in the settings page; it's a bit confusing there. 

