### PR TITLE
Add trailing white space to paste.

### DIFF
--- a/apps/electron/src/main/paste.ts
+++ b/apps/electron/src/main/paste.ts
@@ -528,6 +528,8 @@ async function doPasteIntoFocusedApp(
   log.debug(`pasting ${text?.length ?? 0} chars`);
   if (!text?.trim()) return;
 
+  text = `${text} `;
+
   const prior = snapshotClipboard();
   clipboard.writeText(text);
 

--- a/apps/electron/src/renderer/src/pages/models/transcription-picker.tsx
+++ b/apps/electron/src/renderer/src/pages/models/transcription-picker.tsx
@@ -17,7 +17,7 @@ export const FREESTYLE_CLOUD_TIER: AvailableModel = {
   provider_id: "freestyle-cloud",
   provider_name: "Freestyle Transcribe",
   model_id: "freestyle-cloud/stt",
-  model_name: "Freestyle Transcribe (Managed)",
+  model_name: "Freestyle Transcribe",
   type: "voice",
 };
 


### PR DESCRIPTION
# Overview 

In this PR, we add a trailing white space at the end of each sentence after paste. Allows the user to start a new sentence without having to manually hit the space bar. 