### PR TITLE
fix: preserve right-side modifier-only hotkeys (RightCommand etc.)

### DIFF
--- a/apps/electron/src/main/hotkey-recorder.ts
+++ b/apps/electron/src/main/hotkey-recorder.ts
@@ -38,15 +38,6 @@ const MAC_RIGHT_MOD_KEYS: Record<string, string> = {
   rightshift: "RightShift",
 };
 
-const RIGHT_MODIFIER_KEYS: Record<string, string> = {
-  RightOption: "Alt",
-  RightAlt: "Alt",
-  RightCommand: "Command",
-  RightControl: "Control",
-  RightShift: "Shift",
-  RightSuper: "Super",
-};
-
 const MAC_FLAG_MODIFIERS: Record<string, string> = {
   control: "Control",
   option: "Alt",
@@ -245,8 +236,7 @@ export class HotkeyRecorder {
     if (line.startsWith("RIGHT_MOD_DOWN:")) {
       const modName = line.slice("RIGHT_MOD_DOWN:".length);
       const key = MAC_RIGHT_MOD_KEYS[modName.toLowerCase()] ?? modName;
-      const modifier = RIGHT_MODIFIER_KEYS[key] ?? key;
-      this.sendModifiers([...this.pendingModifiers, modifier]);
+      this.sendModifiers([...this.pendingModifiers, key]);
       return;
     }
 

--- a/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
+++ b/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
@@ -40,6 +40,31 @@ const KEY_SYMBOLS: Record<string, string> = {
   Fn: "\uD83C\uDF10",
   MouseButton4: "Mouse 4",
   MouseButton5: "Mouse 5",
+  RightAlt: "Right Alt",
+  RightOption: "Right Alt",
+  RightControl: "Right Ctrl",
+  RightShift: "Right Shift",
+  RightSuper: "Right Super",
+  RightCommand: "Right Super",
+};
+
+/** Side-specific right-modifier symbols shown on macOS (falls back to KEY_SYMBOLS elsewhere). */
+const MAC_RIGHT_MOD_SYMBOLS: Record<string, string> = {
+  RightControl: "Right \u2303",
+  RightCommand: "Right \u2318",
+  RightAlt: "Right \u2325",
+  RightOption: "Right \u2325",
+  RightShift: "Right \u21E7",
+};
+
+/** Maps a side-specific modifier token to the generic token it collapses to for display/merging. */
+const RIGHT_MODIFIER_TO_GENERIC: Record<string, string> = {
+  RightAlt: "Alt",
+  RightOption: "Alt",
+  RightCommand: "Command",
+  RightControl: "Control",
+  RightShift: "Shift",
+  RightSuper: "Super",
 };
 
 // ---------------------------------------------------------------------------
@@ -198,9 +223,87 @@ export function acceleratorToCombo(accel: string): HotkeyCombo {
 
 export function keyDisplayLabel(key: string): string {
   if (IS_MAC && MAC_MOD_SYMBOLS[key]) return MAC_MOD_SYMBOLS[key];
+  if (IS_MAC && MAC_RIGHT_MOD_SYMBOLS[key]) return MAC_RIGHT_MOD_SYMBOLS[key];
   if (!IS_MAC && OTHER_MOD_LABELS[key]) return OTHER_MOD_LABELS[key];
   if (KEY_SYMBOLS[key]) return KEY_SYMBOLS[key];
   return key;
+}
+
+// ---------------------------------------------------------------------------
+// Right-modifier latch — tracks whether the in-progress draft combo is a
+// solo right-side modifier press, so it can be saved as the side-specific
+// accelerator (e.g. "RightCommand") instead of the generic one ("Command").
+// ---------------------------------------------------------------------------
+
+/** Normalized description of a single modifiers-update event, from either the
+ *  native listener or the DOM keydown handler. */
+export interface RightModifierUpdateEvent {
+  /** The side-specific token this update represents a lone press of, or null. */
+  rightToken: string | null;
+  /** Total modifier count carried by this update. */
+  modifierCount: number;
+  /** This update's modifiers after mapping side-specific tokens to generic. */
+  genericModifiers: string[];
+  /** True only when the update definitively identifies a left-side key (e.g. DOM `MetaLeft`). */
+  explicitLeft?: boolean;
+}
+
+/** Maps DOM `KeyboardEvent.code` to the side-specific token it represents (macOS only). */
+function domRightModifierToken(e: KeyboardEvent): string | null {
+  if (!IS_MAC) return null;
+  switch (e.code) {
+    case "MetaRight":
+      return "RightCommand";
+    case "AltRight":
+      return "RightOption";
+    case "ControlRight":
+      return "RightControl";
+    case "ShiftRight":
+      return "RightShift";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Decides the next right-modifier latch value given the previous latch, the
+ * draft combo before this update was applied, and a normalized description
+ * of the update. Idempotent for duplicate delivery of the same right
+ * modifier (native + DOM both fire when the settings window is focused).
+ */
+export function nextRightModifierLatch(
+  previousLatch: string | null,
+  draftBeforeUpdate: HotkeyCombo,
+  event: RightModifierUpdateEvent,
+): string | null {
+  const draftEmpty =
+    draftBeforeUpdate.modifiers.length === 0 && draftBeforeUpdate.key === null;
+
+  if (event.rightToken && event.modifierCount === 1) {
+    if (draftEmpty || event.rightToken === previousLatch) {
+      return event.rightToken;
+    }
+  }
+
+  if (event.rightToken && event.rightToken === previousLatch) {
+    return previousLatch;
+  }
+
+  // A same-callback trailing generic update (e.g. the Swift binary's
+  // RIGHT_MOD_DOWN:RightCommand is unconditionally followed by FLAGS:command
+  // from the same flagsChanged invocation) or a duplicate generic delivery
+  // consistent with the latched key keeps the latch. Only a definitively
+  // left-side DOM event, a chord, or an inconsistent modifier clears it.
+  if (
+    previousLatch &&
+    !event.explicitLeft &&
+    event.modifierCount === 1 &&
+    event.genericModifiers[0] === RIGHT_MODIFIER_TO_GENERIC[previousLatch]
+  ) {
+    return previousLatch;
+  }
+
+  return null;
 }
 
 export function comboDisplayKeys(combo: HotkeyCombo): string[] {
@@ -246,6 +349,9 @@ export function useHotkeyRecorder(
   const recordingActiveRef = useRef(false);
   const draftComboRef = useRef<HotkeyCombo>(EMPTY_COMBO);
   const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Solo right-modifier latch: set when the draft is exactly one modifier
+  // produced solely by a right-side key press. See nextRightModifierLatch.
+  const rightModifierLatchRef = useRef<string | null>(null);
 
   const updateDraftCombo = useCallback(
     (updater: (combo: HotkeyCombo) => HotkeyCombo) => {
@@ -277,6 +383,7 @@ export function useHotkeyRecorder(
     setState("recording");
     draftComboRef.current = EMPTY_COMBO;
     setDraftCombo(EMPTY_COMBO);
+    rightModifierLatchRef.current = null;
     setInvalidReleaseNotice(false);
     window.api?.startHotkeyRecording();
   }, []);
@@ -287,23 +394,33 @@ export function useHotkeyRecorder(
     setState("idle");
     draftComboRef.current = EMPTY_COMBO;
     setDraftCombo(EMPTY_COMBO);
+    rightModifierLatchRef.current = null;
     setInvalidReleaseNotice(false);
     window.api?.stopHotkeyRecording();
   }, [clearWarningTimer]);
 
   const completeRecording = useCallback(() => {
-    const accel = comboToAccelerator(draftComboRef.current);
+    const draft = draftComboRef.current;
+    let accel = comboToAccelerator(draft);
+    const latch = rightModifierLatchRef.current;
+    if (
+      accel &&
+      latch &&
+      draft.key === null &&
+      draft.modifiers.length === 1 &&
+      RIGHT_MODIFIER_TO_GENERIC[latch] === draft.modifiers[0]
+    ) {
+      accel = latch;
+    }
     if (!accel) {
-      if (
-        draftComboRef.current.key ||
-        draftComboRef.current.modifiers.length > 0
-      ) {
+      if (draft.key || draft.modifiers.length > 0) {
         showInvalidReleaseNotice();
         window.api?.stopHotkeyRecording();
         recordingActiveRef.current = false;
         setState("idle");
         draftComboRef.current = EMPTY_COMBO;
         setDraftCombo(EMPTY_COMBO);
+        rightModifierLatchRef.current = null;
       }
       return;
     }
@@ -318,6 +435,7 @@ export function useHotkeyRecorder(
     setState("idle");
     draftComboRef.current = EMPTY_COMBO;
     setDraftCombo(EMPTY_COMBO);
+    rightModifierLatchRef.current = null;
     setInvalidReleaseNotice(false);
   }, [clearWarningTimer, showInvalidReleaseNotice]);
 
@@ -333,13 +451,31 @@ export function useHotkeyRecorder(
     if (state !== "recording" || !window.api) return;
 
     const removeModifiers = window.api.onHotkeyRecordModifiers((modifiers) => {
+      const rightToken =
+        modifiers.length === 1 && RIGHT_MODIFIER_TO_GENERIC[modifiers[0]]
+          ? modifiers[0]
+          : null;
+      const genericModifiers = modifiers.map(
+        (m) => RIGHT_MODIFIER_TO_GENERIC[m] ?? m,
+      );
+      rightModifierLatchRef.current = nextRightModifierLatch(
+        rightModifierLatchRef.current,
+        draftComboRef.current,
+        {
+          rightToken,
+          modifierCount: modifiers.length,
+          genericModifiers,
+          explicitLeft: false,
+        },
+      );
       updateDraftCombo((combo) => ({
         ...combo,
-        modifiers: mergeModifiers(combo.modifiers, modifiers),
+        modifiers: mergeModifiers(combo.modifiers, genericModifiers),
       }));
     });
 
     const removeCaptured = window.api.onHotkeyRecordCaptured((combo) => {
+      rightModifierLatchRef.current = null;
       updateDraftCombo((current) => normalizeCapturedCombo(current, combo));
     });
 
@@ -353,6 +489,7 @@ export function useHotkeyRecorder(
       setState("idle");
       draftComboRef.current = EMPTY_COMBO;
       setDraftCombo(EMPTY_COMBO);
+      rightModifierLatchRef.current = null;
       setInvalidReleaseNotice(false);
     });
 
@@ -379,6 +516,22 @@ export function useHotkeyRecorder(
       const modifiers = modifiersFromEvent(e);
 
       if (isDomModifierKey(e)) {
+        const rightToken = domRightModifierToken(e);
+        // isDomModifierKey(e) is true here, so this is equivalent to the full
+        // `isDomModifierKey(e) && domRightModifierToken(e) === null` check:
+        // a DOM modifier keydown whose e.code definitively identifies the
+        // left key (e.g. MetaLeft) is the only source that can assert "left".
+        const explicitLeft = rightToken === null;
+        rightModifierLatchRef.current = nextRightModifierLatch(
+          rightModifierLatchRef.current,
+          draftComboRef.current,
+          {
+            rightToken,
+            modifierCount: modifiers.length,
+            genericModifiers: modifiers,
+            explicitLeft,
+          },
+        );
         updateDraftCombo((combo) => ({
           ...combo,
           modifiers: mergeModifiers(combo.modifiers, modifiers),
@@ -389,6 +542,7 @@ export function useHotkeyRecorder(
       const key = domKeyFromEvent(e);
       if (!key) return;
 
+      rightModifierLatchRef.current = null;
       updateDraftCombo((combo) => ({
         modifiers: mergeModifiers(combo.modifiers, modifiers),
         key,

--- a/apps/electron/tests/key-listener.test.ts
+++ b/apps/electron/tests/key-listener.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { HotkeyRecorder } from "../src/main/hotkey-recorder";
 import { NativeKeyListener } from "../src/main/key-listener";
+import {
+  comboToAccelerator,
+  isValidHotkeyCombo,
+  nextRightModifierLatch,
+} from "../src/renderer/src/hooks/use-hotkey-recorder";
 
 type LineHandler = {
   handleLine(line: string): void;
@@ -104,4 +109,188 @@ test("hotkey recorder preserves modifiers emitted with Fn chord lines", () => {
   recorder.handleLine("FN_DOWN:control,option,shift,command");
 
   expect(modifiers).toEqual([["Control", "Alt", "Shift", "Command", "Fn"]]);
+});
+
+test("hotkey recorder preserves the side-specific token for a right modifier press", () => {
+  const modifiers: string[][] = [];
+  const recorder = new HotkeyRecorder({
+    onModifiers: (nextModifiers) => modifiers.push(nextModifiers),
+    onCaptured: () => {},
+    onCancel: () => {},
+  }) as unknown as LineHandler;
+
+  recorder.handleLine("RIGHT_MOD_DOWN:RightCommand");
+
+  expect(modifiers).toEqual([["RightCommand"]]);
+});
+
+test("NativeKeyListener with hotkey RightCommand ignores the generic FLAGS event", async () => {
+  const events: string[] = [];
+  const listener = new NativeKeyListener({
+    hotkey: "RightCommand",
+    onKeyDown: () => events.push("down"),
+    onKeyUp: () => events.push("up"),
+  }) as unknown as LineHandler;
+
+  listener.handleLine("FLAGS:command");
+  expect(events).toEqual([]);
+
+  listener.handleLine("RIGHT_MOD_DOWN:RightCommand");
+  expect(events).toEqual(["down"]);
+
+  listener.handleLine("RIGHT_MOD_UP:RightCommand");
+  expect(events).toEqual(["down", "up"]);
+
+  // Self-generated paste synthesizes a generic Command flag; must not re-fire.
+  listener.handleLine("FLAGS:command");
+  expect(events).toEqual(["down", "up"]);
+});
+
+test("NativeKeyListener with hotkey Command still fires on the generic FLAGS event (regression)", () => {
+  const events: string[] = [];
+  const listener = new NativeKeyListener({
+    hotkey: "Command",
+    onKeyDown: () => events.push("down"),
+    onKeyUp: () => events.push("up"),
+  }) as unknown as LineHandler;
+
+  listener.handleLine("FLAGS:command");
+  expect(events).toEqual(["down"]);
+});
+
+test("comboToAccelerator serializes a bare side-specific modifier combo", () => {
+  expect(comboToAccelerator({ modifiers: [], key: "RightCommand" })).toBe(
+    "RightCommand",
+  );
+});
+
+test("isValidHotkeyCombo accepts a bare side-specific modifier combo", () => {
+  expect(isValidHotkeyCombo({ modifiers: [], key: "RightCommand" })).toBe(true);
+});
+
+test("nextRightModifierLatch latches a lone right modifier on an empty draft", () => {
+  const latch = nextRightModifierLatch(
+    null,
+    { modifiers: [], key: null },
+    {
+      rightToken: "RightCommand",
+      modifierCount: 1,
+      genericModifiers: ["Command"],
+    },
+  );
+  expect(latch).toBe("RightCommand");
+});
+
+test("nextRightModifierLatch clears when a second modifier joins the chord", () => {
+  const latch = nextRightModifierLatch(
+    "RightCommand",
+    { modifiers: ["Command"], key: null },
+    {
+      rightToken: null,
+      modifierCount: 2,
+      genericModifiers: ["Command", "Shift"],
+    },
+  );
+  expect(latch).toBeNull();
+});
+
+test("nextRightModifierLatch clears on a generic (non-right) modifier update", () => {
+  const latch = nextRightModifierLatch(
+    null,
+    { modifiers: [], key: null },
+    { rightToken: null, modifierCount: 1, genericModifiers: ["Shift"] },
+  );
+  expect(latch).toBeNull();
+});
+
+test("nextRightModifierLatch survives a duplicate delivery of the same right modifier", () => {
+  // Native RIGHT_MOD_DOWN already latched and merged "Command" into the draft;
+  // the DOM listener then fires for the same physical key press.
+  const latch = nextRightModifierLatch(
+    "RightCommand",
+    { modifiers: ["Command"], key: null },
+    {
+      rightToken: "RightCommand",
+      modifierCount: 1,
+      genericModifiers: ["Command"],
+    },
+  );
+  expect(latch).toBe("RightCommand");
+});
+
+test("nextRightModifierLatch does not latch a right modifier when the draft is not empty", () => {
+  const latch = nextRightModifierLatch(
+    null,
+    { modifiers: ["Shift"], key: null },
+    {
+      rightToken: "RightCommand",
+      modifierCount: 1,
+      genericModifiers: ["Command"],
+    },
+  );
+  expect(latch).toBeNull();
+});
+
+test("nextRightModifierLatch survives the native RIGHT_MOD_DOWN followed by its trailing generic FLAGS emission", () => {
+  // macos-key-listener.swift emits RIGHT_MOD_DOWN:RightCommand then FLAGS:command
+  // from the SAME flagsChanged callback (rightModifiers loop runs before the
+  // flags-diff block unconditionally calls emitFlags). The trailing generic
+  // update must not clear the latch it just set.
+  let latch = nextRightModifierLatch(
+    null,
+    { modifiers: [], key: null },
+    {
+      rightToken: "RightCommand",
+      modifierCount: 1,
+      genericModifiers: ["Command"],
+    },
+  );
+  expect(latch).toBe("RightCommand");
+
+  latch = nextRightModifierLatch(
+    latch,
+    { modifiers: ["Command"], key: null },
+    { rightToken: null, modifierCount: 1, genericModifiers: ["Command"] },
+  );
+  expect(latch).toBe("RightCommand");
+});
+
+test("nextRightModifierLatch clears when the DOM event explicitly identifies a left-side key", () => {
+  const latch = nextRightModifierLatch(
+    "RightCommand",
+    { modifiers: ["Command"], key: null },
+    {
+      rightToken: null,
+      modifierCount: 1,
+      genericModifiers: ["Command"],
+      explicitLeft: true,
+    },
+  );
+  expect(latch).toBeNull();
+});
+
+test("nextRightModifierLatch clears when a chord forms even if it maps back through the latched generic key", () => {
+  const latch = nextRightModifierLatch(
+    "RightCommand",
+    { modifiers: ["Command"], key: null },
+    {
+      rightToken: null,
+      modifierCount: 2,
+      genericModifiers: ["Command", "Shift"],
+    },
+  );
+  expect(latch).toBeNull();
+});
+
+test("nextRightModifierLatch does not latch when a right token arrives after a left modifier is already in the draft", () => {
+  const latch = nextRightModifierLatch(
+    null,
+    { modifiers: ["Command"], key: null },
+    {
+      rightToken: "RightCommand",
+      modifierCount: 1,
+      genericModifiers: ["Command"],
+    },
+  );
+  expect(latch).toBeNull();
 });


### PR DESCRIPTION
Fixes #448.

## What

Recording a right-side modifier (e.g. right ⌘) as a modifier-only push-to-talk hotkey now saves the side-specific accelerator (`RightCommand`) instead of silently collapsing to the generic category (`Command`).

With generic `Command` stored, the matcher fires on **either** ⌘ key, and — worse — on the app's own synthetic Cmd+V paste (`macos-fast-paste` posts V with `maskCommand`; the key listener's CGEvent tap emits `FLAGS:command` for it), so recording ghost-restarts right after every hold-release. Full diagnosis in #448.

The runtime already supports side-specific accelerators end-to-end (`NativeKeyListener` matching, `isValidAccelerator`, `normalizeAccelerator`, `isValidHotkeyCombo`); only the recording path lost the information — in two places (`hotkey-recorder.ts` `RIGHT_MODIFIER_KEYS` collapse, and the renderer hook's generic-only `orderModifiers`).

## How

Chord behavior is deliberately unchanged — right-⌘+Space still records as `Command+Space`, matching current matcher semantics. Only a **solo** right-modifier capture becomes side-specific:

- **`hotkey-recorder.ts` (main):** forward the side-specific token (`RightCommand`) to the renderer instead of pre-collapsing it.
- **`use-hotkey-recorder.ts` (renderer):** modifiers stay generic for display/merging, but a small latch (`nextRightModifierLatch`, pure + exported for tests) tracks "this draft is exactly one modifier, produced solely by a right-side key." On completion, a latched solo-modifier combo saves the side-specific accelerator.
  - The latch survives the trailing `FLAGS:command` the Swift binary emits from the same `flagsChanged` callback as `RIGHT_MOD_DOWN:RightCommand`, and the duplicate DOM delivery when the settings window is focused.
  - It clears on chords, on a captured non-modifier key, and on a definitively left-side DOM modifier press (`e.code === "MetaLeft"` etc.) — so pressing left ⌘ still records generic `Command`.
  - Display labels added so saved side-specific hotkeys render as `Right ⌘` / `Right ⌥` / … (mac) and `Right Alt` / `Right Super` / … (elsewhere) instead of raw `RightCommand`.

## Tests

`apps/electron/tests/key-listener.test.ts`: 20 passed (6 existing + 14 new), covering:

- `NativeKeyListener` with `RightCommand`: `FLAGS:command` alone (left ⌘ **or** the synthetic paste) never fires; `RIGHT_MOD_DOWN/UP` drives hold-to-talk correctly.
- `NativeKeyListener` with generic `Command`: existing behavior unchanged.
- `HotkeyRecorder`: `RIGHT_MOD_DOWN:RightCommand` now reaches the renderer side-specific.
- `nextRightModifierLatch`: realistic native event sequence (incl. the trailing `FLAGS:command`), DOM left-clear, chord-clear, and the ambiguous left-then-right case (stays generic).
- Pure helpers: `comboToAccelerator` / `isValidHotkeyCombo` with side-specific values.

Happy to split or adjust if you'd prefer a different approach (e.g. first-class right-modifier tokens in chords too). A separate follow-up could harden the listener against the app's own synthetic paste events (tagging them with a `CGEventSource` user-data marker) so even deliberately-generic `Command` hotkeys can't self-trigger — say the word and I'll send it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
