### PR TITLE
ci: enforce conventional commit PR titles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+  Thanks for contributing! A few quick reminders before you submit.
+
+  PR title must follow Conventional Commits, e.g.:
+    fix: prevent duplicate settings requests
+    feat(plugins): add update checks
+  Allowed types: feat, fix, docs, chore, refactor, test, ci, build, perf, style, revert
+  It's used for the squash commit and the release changelog. A CI check enforces this.
+-->
+
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
+- [ ] Ran `pnpm biome check .` (lint + formatting)
+- [ ] Ran `pnpm --filter @freestyle-voice/electron typecheck:web` (if touching the app)

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,39 @@
+# Validates that PR titles follow Conventional Commits.
+# PR titles drive squash-merge commits and the release changelog,
+# so they must be well-formed. See CONTRIBUTING.md.
+
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            ci
+            build
+            perf
+            style
+            revert
+          requireScope: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,29 @@ fix: resolve a bug
 chore: maintenance task
 ```
 
+## Pull request titles
+
+PR titles must follow the [Conventional Commits](https://www.conventionalcommits.org/) format. We squash-merge PRs and use the PR title for the squash commit and the release changelog, so a clean title matters.
+
+```
+type(scope): short imperative summary
+```
+
+The scope is optional. Allowed types:
+
+`feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `revert`
+
+Examples:
+
+```
+fix: prevent duplicate settings requests
+feat(plugins): add update checks
+docs: clarify local development setup
+refactor(server): simplify plugin loading
+```
+
+A CI check validates PR titles automatically. If it fails, edit your PR title to match the format above — no need to open a new PR.
+
 ## Freestyle Cloud backend (managed STT)
 
 Only needed if you're working on the **Freestyle Cloud** transcription provider. It's a separate Cloudflare Worker (the `cloud` repository) that exposes the `/v1/transcribe` endpoint, and the desktop app calls it when "Freestyle Cloud" is the selected voice model.


### PR DESCRIPTION
## Summary

Contributor PR titles don't follow any standard, which pollutes squash-merge commits and the Craft release changelog. This adds enforcement plus documentation.

Three parts:

1. **`.github/workflows/pr-title.yml`** (new) — a `PR Title` workflow using [`amannn/action-semantic-pull-request@v6`](https://github.com/amannn/action-semantic-pull-request) that validates PR titles against Conventional Commits. Runs on `pull_request_target` (fork-safe, read-only metadata) with `requireScope: false`.
2. **`CONTRIBUTING.md`** — new `## Pull request titles` section documenting the `type(scope): summary` format, allowed types, and examples.
3. **`.github/PULL_REQUEST_TEMPLATE.md`** (new) — title reminder + checklist.

Allowed types: `feat, fix, docs, chore, refactor, test, ci, build, perf, style, revert`.

## Why `pull_request_target`

The action only reads PR metadata (the title) and never checks out contributor code, so `pull_request_target` is safe and is the documented trigger for fork-based contributor PRs.

## Follow-up (manual, not in this PR)

Make the `PR Title / Validate PR title` check **required** in branch protection for `main` so malformed titles actually block merge.

## Test plan

- YAML validated; workflow references the action and `pull_request_target` trigger.
- The workflow itself will run on this PR once merged to `main` (per `pull_request_target` semantics, config must be on the default branch to take effect).