### PR TITLE
fix(settings): reorder pill position options top-first

### DIFF
--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -608,13 +608,13 @@ export default function SettingsPage(): React.JSX.Element {
 
   const positionOptions = useMemo<SegmentOption[]>(() => {
     const opts: SegmentOption[] = [
+      { id: "top-center", label: t("settings.display.positionTopCenter") },
+      { id: "top-right", label: t("settings.display.positionTopRight") },
       {
         id: "bottom-center",
         label: t("settings.display.positionBottomCenter"),
       },
       { id: "bottom-right", label: t("settings.display.positionBottomRight") },
-      { id: "top-center", label: t("settings.display.positionTopCenter") },
-      { id: "top-right", label: t("settings.display.positionTopRight") },
     ];
     if (pillPosition === "custom")
       opts.push({ id: "custom", label: t("settings.display.positionCustom") });


### PR DESCRIPTION
## Summary

Reorders the pill position options in Settings → Display so the top positions come first:

1. Top Center
2. Top Right
3. Bottom Center
4. Bottom Right

Previously the order was bottom-first, which felt inconsistent with the natural top-to-bottom reading order.

## Changes

- `apps/electron/src/renderer/src/pages/settings.tsx`: reorder `positionOptions` array

## Testing

- No functional change; option IDs and labels are unchanged, only display order.