### PR TITLE
fix: update cloud plugins endpoint URL

### DIFF
--- a/apps/docs/api-reference.mdx
+++ b/apps/docs/api-reference.mdx
@@ -115,7 +115,7 @@ Output formatting rules matched by the app you're typing in.
 | Method | Path | Description |
 | --- | --- | --- |
 | `POST` | `/api/plugins/reload` | Reload server-side plugin registry. Re-reads settings and re-runs `setup()`. |
-| `GET` | `/api/plugins/catalog` | Return the built-in plugin catalog. |
+| `GET` | `/api/plugins/catalog` | Return the plugin catalog from the cloud registry. |
 | `POST` | `/api/plugins/install` | Install a plugin from npm. Body: `{ npmName, version? }`. Downloads, stages atomically, adds specifier, and reloads. |
 | `POST` | `/api/plugins/uninstall` | Uninstall a plugin. Body: `{ specifier }`. Removes package and specifier. |
 | `POST` | `/api/plugins/check-updates` | Check for updates against npm. Body: `{ plugins: [{ name, currentVersion }] }`. |

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -48,7 +48,7 @@ const plugins = new Hono()
     // The cloud registry is the sole source of truth for the plugin catalog,
     // so new plugins can be listed without a desktop release.
     try {
-      const res = await fetch(`${freestyleCloudUrl()}/plugins/catalog`, {
+      const res = await fetch(`${freestyleCloudUrl()}/plugins`, {
         signal: AbortSignal.timeout(5_000),
       });
       if (!res.ok) {


### PR DESCRIPTION
## Summary

Update the upstream cloud plugins catalog URL from `/plugins/catalog` to `/plugins`.

The cloud server simplified the plugin catalog endpoint in [cloud PR #55](https://github.com/freestyle-voice/cloud/pull/55) — replacing the static array with a D1-backed CRUD resource at `GET /plugins` (was `GET /plugins/catalog`).

### Changes

- **`apps/server/src/routes/plugins.ts:51`** — update `fetch()` URL from `${freestyleCloudUrl()}/plugins/catalog` to `${freestyleCloudUrl()}/plugins`
- **`apps/docs/api-reference.mdx:118`** — clarify description to 'cloud registry'

The desktop's own local route stays at `/api/plugins/catalog` (preserving the hono RPC client contract with the Electron renderer).