### PR TITLE
fix(plugins): replace plain text loading state with skeleton animations

### DIFF
--- a/apps/electron/src/renderer/src/locales/en.json
+++ b/apps/electron/src/renderer/src/locales/en.json
@@ -642,7 +642,6 @@
       "installed": "Installed",
       "browse": "Browse"
     },
-    "loading": "Loading plugins…",
     "emptyTitle": "No plugins yet",
     "empty": "Install a plugin to add features. Browse the available ones or add your own.",
     "missingBadge": "Missing",

--- a/apps/electron/src/renderer/src/locales/template.json
+++ b/apps/electron/src/renderer/src/locales/template.json
@@ -606,7 +606,6 @@
       "installed": "Installed",
       "browse": "Browse"
     },
-    "loading": "Loading plugins…",
     "emptyTitle": "No plugins yet",
     "empty": "Install a plugin to add features. Browse the available ones or add your own.",
     "missingBadge": "Missing",

--- a/apps/electron/src/renderer/src/pages/plugins/plugin-detail.tsx
+++ b/apps/electron/src/renderer/src/pages/plugins/plugin-detail.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router";
 import { pluginDisplayName, usePluginUpdates } from "./helpers";
 import { PluginReadme } from "./plugin-readme";
+import { PluginDetailSkeleton } from "./plugin-skeletons";
 
 const SKIP_UNINSTALL_CONFIRM_KEY = "plugins.skipUninstallConfirm";
 
@@ -55,9 +56,7 @@ export default function PluginDetailPage(): React.JSX.Element {
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
         {loading ? (
-          <p className="text-muted-foreground py-10 text-center text-sm">
-            {t("plugins.loading")}
-          </p>
+          <PluginDetailSkeleton />
         ) : !plugin ? (
           <p className="text-muted-foreground py-10 text-center text-sm">
             {t("plugins.detail.notFound")}

--- a/apps/electron/src/renderer/src/pages/plugins/plugin-skeletons.tsx
+++ b/apps/electron/src/renderer/src/pages/plugins/plugin-skeletons.tsx
@@ -1,0 +1,100 @@
+import { cn } from "@renderer/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Skeleton loading — mirrors PluginCard / CatalogCard / Detail shape
+// ---------------------------------------------------------------------------
+
+function SkeletonLine({
+  className,
+}: {
+  className?: string;
+}): React.JSX.Element {
+  return (
+    <div
+      className={cn(
+        "bg-muted/60 relative overflow-hidden rounded-full",
+        "before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_1.4s_infinite] before:bg-gradient-to-r before:from-transparent before:via-white/10 before:to-transparent",
+        className,
+      )}
+    />
+  );
+}
+
+const SHIMMER_STYLE = `
+  @keyframes shimmer {
+    100% { transform: translateX(100%); }
+  }
+`;
+
+function PluginCardSkeleton(): React.JSX.Element {
+  return (
+    <div className="border-border bg-card flex w-full items-center gap-4 rounded-[14px] border p-5">
+      {/* Icon placeholder */}
+      <SkeletonLine className="size-11 shrink-0 rounded-[10px]" />
+
+      {/* Name + description */}
+      <div className="min-w-0 flex-1 space-y-2">
+        <div className="flex items-center gap-2">
+          <SkeletonLine className="h-4 w-36" />
+          <SkeletonLine className="h-3 w-10" />
+        </div>
+        <SkeletonLine className="h-3 w-full max-w-[260px]" />
+      </div>
+
+      {/* Action button placeholder */}
+      <SkeletonLine className="h-8 w-20 shrink-0 rounded-md" />
+    </div>
+  );
+}
+
+export function PluginsLoadingSkeleton(): React.JSX.Element {
+  return (
+    <div
+      className="flex flex-col gap-3"
+      role="status"
+      aria-label="Loading plugins"
+    >
+      <style>{SHIMMER_STYLE}</style>
+      {[0, 1, 2].map((i) => (
+        <PluginCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+export function PluginDetailSkeleton(): React.JSX.Element {
+  return (
+    <div role="status" aria-label="Loading plugin details">
+      <style>{SHIMMER_STYLE}</style>
+      {/* Header area */}
+      <div className="mb-7 flex items-end justify-between gap-4">
+        <div className="space-y-3">
+          <SkeletonLine className="h-10 w-64" />
+          <SkeletonLine className="h-4 w-96 max-w-full" />
+          <div className="flex items-center gap-2">
+            <SkeletonLine className="h-3 w-14" />
+            <SkeletonLine className="h-3 w-24" />
+            <SkeletonLine className="h-3 w-40" />
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-3">
+          <SkeletonLine className="h-8 w-20 rounded-md" />
+          <SkeletonLine className="h-5 w-10 rounded-full" />
+          <SkeletonLine className="h-8 w-24 rounded-md" />
+        </div>
+      </div>
+
+      <hr className="border-border" />
+
+      {/* Readme placeholder */}
+      <div className="mt-6 space-y-4">
+        <SkeletonLine className="h-5 w-48" />
+        <SkeletonLine className="h-3 w-full" />
+        <SkeletonLine className="h-3 w-full" />
+        <SkeletonLine className="h-3 w-3/4" />
+        <SkeletonLine className="h-3 w-full" />
+        <SkeletonLine className="h-3 w-5/6" />
+      </div>
+    </div>
+  );
+}

--- a/apps/electron/src/renderer/src/pages/plugins/plugins.tsx
+++ b/apps/electron/src/renderer/src/pages/plugins/plugins.tsx
@@ -29,6 +29,7 @@ import {
   resolvePluginIcon,
   usePluginUpdates,
 } from "./helpers";
+import { PluginsLoadingSkeleton } from "./plugin-skeletons";
 
 type Tab = "browse" | "installed";
 
@@ -160,11 +161,7 @@ function InstalledTab({
   );
 
   if (loading) {
-    return (
-      <p className="text-muted-foreground py-10 text-center text-sm">
-        {t("plugins.loading")}
-      </p>
-    );
+    return <PluginsLoadingSkeleton />;
   }
   if (plugins.length === 0) {
     return (
@@ -404,11 +401,7 @@ function BrowseTab({
     );
   }
   if (!catalog) {
-    return (
-      <p className="text-muted-foreground py-10 text-center text-sm">
-        {t("plugins.loading")}
-      </p>
-    );
+    return <PluginsLoadingSkeleton />;
   }
   if (filtered.length === 0) {
     return (

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -149,8 +149,6 @@ export default function SettingsPage(): React.JSX.Element {
   const [activeSection, setActiveSection] = useState<SettingsSectionId>(() =>
     parseSettingsSection(window.location.hash),
   );
-  const queryClient = useQueryClient();
-
   // Radix SelectItem cannot use an empty-string value, so the "system default"
   // microphone (stored as "") is represented by this sentinel at the Select
   // boundary only. Use an unlikely string to avoid colliding with a real


### PR DESCRIPTION
## Summary

Replace the plain "Loading plugins..." text on the plugins page with proper shimmer skeleton loading animations that mirror the actual card shapes.

### Before
Both the Browse and Installed tabs, plus the plugin detail page, showed a centered muted text paragraph while loading.

### After
- **Plugins list** (Browse + Installed tabs): 3 skeleton cards matching the `PluginCard`/`CatalogCard` layout — icon box, name/version bars, description bar, and action button placeholder.
- **Plugin detail page**: skeleton matching the detail header (title, description, metadata row, action buttons) + a separator + readme paragraph lines.

### Changes
- **New file**: `plugin-skeletons.tsx` — standalone skeleton components to avoid pulling `plugins.tsx` into the `plugin-detail` bundle (code-splitting friendly).
- **`plugins.tsx`**: `InstalledTab` and `BrowseTab` loading states now render `<PluginsLoadingSkeleton />`.
- **`plugin-detail.tsx`**: loading state now renders `<PluginDetailSkeleton />`.
- **i18n**: removed unused `plugins.loading` key from `en.json` and `template.json`.

### Pattern
Follows the same `SkeletonLine` + `@keyframes shimmer` pattern already used on the models page (`models/index.tsx`). Includes `role="status"` and `aria-label` for accessibility.