### PR TITLE
feat(plugins): give Freestyle Cloud users an LLM capability

### DIFF
--- a/apps/server/src/lib/llm/registry.ts
+++ b/apps/server/src/lib/llm/registry.ts
@@ -2,6 +2,10 @@ import type { GroqLanguageModelOptions } from "@ai-sdk/groq";
 import type { PostProcessParams } from "@freestyle-voice/stt";
 import type { LanguageModel } from "ai";
 import { getDb } from "../db.js";
+import {
+  FREESTYLE_CLOUD_PROVIDER_ID,
+  freestyleCloudUrl,
+} from "../freestyle-cloud.js";
 
 /** The provider-options shape accepted by the cleanup `generateText` call. */
 type CleanupProviderOptions = NonNullable<PostProcessParams["providerOptions"]>;
@@ -107,6 +111,23 @@ const PROVIDERS: LlmProvider[] = [
     createModel: async (modelId, apiKey) => {
       const { createMistral } = await import("@ai-sdk/mistral");
       return createMistral({ apiKey }).chat(modelId);
+    },
+  },
+  {
+    // Freestyle Cloud exposes an OpenAI-compatible chat-completions proxy at
+    // `/v2/llm`. This provider only powers the plugin LLM capability
+    // (`buildPluginLlm` → `api.llm`) — Freestyle Cloud *cleanup* takes the
+    // dedicated `postProcessWithFreestyleCloud` path and never reaches
+    // `createChatModel`. The `apiKey` handed in is the signed-in user's session
+    // token (resolved by `getApiKeyForProvider`), which the cloud verifies as
+    // `Authorization: Bearer <token>`.
+    providerId: FREESTYLE_CLOUD_PROVIDER_ID,
+    createModel: async (modelId, apiKey) => {
+      const { createOpenAI } = await import("@ai-sdk/openai");
+      return createOpenAI({
+        apiKey,
+        baseURL: `${freestyleCloudUrl()}/v2/llm`,
+      }).chat(modelId);
     },
   },
   {

--- a/apps/server/src/lib/providers.ts
+++ b/apps/server/src/lib/providers.ts
@@ -11,6 +11,7 @@ const PROVIDER_PREFIXED_CHAT_MODELS = new Set([
   "google",
   "mistral",
   "local-llm",
+  "freestyle-cloud",
 ]);
 
 function getChatModelId(providerId: string, modelId: string): string {

--- a/apps/server/tests/plugin-llm-cloud.test.ts
+++ b/apps/server/tests/plugin-llm-cloud.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { FREESTYLE_CLOUD_PROVIDER_ID } from "../src/lib/freestyle-cloud.js";
+import { applyFreestyleCloudDefaults } from "../src/lib/freestyle-cloud-defaults.js";
+import { getLlmProvider } from "../src/lib/llm/registry.js";
+import { buildPluginLlm } from "../src/lib/plugins/llm.js";
+import { createChatModel } from "../src/lib/providers.js";
+import { clearSession, setSession } from "../src/lib/sessions.js";
+
+function signIn(): void {
+  setSession({
+    token: "cloud-session-token",
+    user: { id: "user_1", email: "user@example.com" },
+    host: "https://service.freestylevoice.com",
+  });
+}
+
+describe("Freestyle Cloud LLM provider", () => {
+  afterEach(() => {
+    clearSession();
+  });
+
+  it("is registered in the LLM provider registry", () => {
+    expect(getLlmProvider(FREESTYLE_CLOUD_PROVIDER_ID)).not.toBeNull();
+  });
+
+  it("resolves an AI SDK model when signed in (no throw)", async () => {
+    signIn();
+    const model = await createChatModel(
+      FREESTYLE_CLOUD_PROVIDER_ID,
+      "freestyle-cloud/post-process",
+    );
+    expect(model).toBeDefined();
+  });
+
+  it("throws when signed out (no session token → no api key)", async () => {
+    clearSession();
+    await expect(
+      createChatModel(
+        FREESTYLE_CLOUD_PROVIDER_ID,
+        "freestyle-cloud/post-process",
+      ),
+    ).rejects.toThrow(/api key/i);
+  });
+
+  it("exposes api.llm for a signed-in Freestyle Cloud user", async () => {
+    applyFreestyleCloudDefaults();
+    signIn();
+
+    const llm = await buildPluginLlm();
+    expect(llm).toBeDefined();
+    expect(llm?.providerId).toBe(FREESTYLE_CLOUD_PROVIDER_ID);
+    expect(llm?.getModel()).toBeDefined();
+  });
+
+  it("returns no LLM capability when the cloud user is signed out", async () => {
+    applyFreestyleCloudDefaults();
+    clearSession();
+
+    const llm = await buildPluginLlm();
+    expect(llm).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Makes `api.llm` work for signed-in **Freestyle Cloud** users, so their plugins (e.g. the voice-commands agent) get an LLM without configuring their own provider or key.

This is the desktop half of the cloud LLM work; the cloud endpoint is freestyle-voice/cloud#65.

## The gap

Plugins receive their LLM through `api.llm`, built by `buildPluginLlm()` from the configured cleanup model. For a signed-in cloud user, `applyFreestyleCloudDefaults()` sets the default cleanup model to `freestyle-cloud/post-process`. But `freestyle-cloud` had **no entry in the LLM provider registry**, so `createChatModel("freestyle-cloud", …)` threw `Unsupported provider` → `buildPluginLlm()` returned `undefined`. Cloud users' plugins silently fell back to no-LLM behavior.

## Fix

Register a `freestyle-cloud` `LlmProvider` (`apps/server/src/lib/llm/registry.ts`) that points `@ai-sdk/openai` at the new OpenAI-compatible cloud endpoint:

```ts
createOpenAI({ apiKey /* session token */, baseURL: `${freestyleCloudUrl()}/v2/llm` }).chat(modelId)
```

`createChatModel` already resolves the API key for `freestyle-cloud` to the signed-in session token via `getApiKeyForProvider`, and returns `null` (→ throws → `api.llm` stays `undefined`) when signed out.

### No cleanup regression

Freestyle Cloud **cleanup** branches to `postProcessWithFreestyleCloud` in `post-process.ts:276` *before* `createChatModel` (only reached on the local/BYOK path at `:400`). This registry entry therefore affects **only** the plugin LLM capability, never cleanup.

Also adds `freestyle-cloud` to `PROVIDER_PREFIXED_CHAT_MODELS` so the `freestyle-cloud/` model-id prefix is stripped like the other prefixed providers.

## Tests

`apps/server/tests/plugin-llm-cloud.test.ts`:
- provider is registered
- `createChatModel` resolves a model when signed in / throws when signed out
- `buildPluginLlm()` yields a capability (providerId `freestyle-cloud`) for a signed-in cloud user, and `undefined` when signed out

## Verification

- server `vitest run` — 267 passed (37 files) ✓
- `tsc --noEmit` ✓
- `biome check` clean ✓

## Depends on

freestyle-voice/cloud#65 (the `/v2/llm` endpoint) for end-to-end function.