### PR TITLE
feat(plugins): voice-commands plugin (LLM agent action routing)

### DIFF
--- a/plugins/voice-commands/README.md
+++ b/plugins/voice-commands/README.md
@@ -1,0 +1,31 @@
+# Voice Commands
+
+Turn spoken trigger phrases into actions. Define commands like _"post to Slack…"_
+or _"add a reminder…"_ and Voice Commands will detect them in your dictation and
+run the matching action instead of typing the text.
+
+## How it works
+
+1. **Prefilter** — a cheap, deterministic phrase match gates everything. If your
+   speech contains no trigger phrase, nothing else runs and the transcript is
+   dictated normally.
+2. **Agent** — when a trigger matches, a multi-step tool-calling agent (using the
+   LLM you've already configured for cleanup) decides whether it's really a
+   command and extracts the payload (the part of your speech that isn't the
+   trigger).
+3. **Action** — the command fires. The utterance is _consumed_: cleanup is
+   skipped and no text is delivered to the focused app.
+
+If no cleanup LLM is configured, detection falls back to a deterministic match
+(the longest matching trigger wins) so commands still work.
+
+## Action types
+
+- **Run Shortcut** _(macOS only)_ — run a macOS Shortcut by name; the payload is
+  piped to its input.
+- **Call webhook** — `POST` the payload as JSON, or `GET` it as a query param.
+- **Open URL / app** — open a URL or app scheme; `{{input}}` is substituted.
+- **Run script** — run a shell command; `{{input}}` is substituted and the
+  payload is also available as `$FREESTYLE_COMMAND_INPUT`.
+
+Shortcut commands are hidden on non-macOS hosts.

--- a/plugins/voice-commands/package.json
+++ b/plugins/voice-commands/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@freestyle-voice/commands",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "Turn spoken trigger phrases into actions — run macOS Shortcuts, call webhooks, open URLs, or execute scripts by voice.",
+  "license": "MIT",
+  "homepage": "https://github.com/freestyle-voice/freestyle/tree/main/plugins/voice-commands#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freestyle-voice/freestyle.git",
+    "directory": "plugins/voice-commands"
+  },
+  "keywords": [
+    "freestyle",
+    "freestyle-plugin",
+    "voice",
+    "dictation",
+    "commands",
+    "shortcuts",
+    "automation"
+  ],
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "freestyle": {
+    "icon": "Zap",
+    "contributes": {
+      "pages": [
+        {
+          "id": "voice-commands",
+          "title": "Voice Commands",
+          "entry": "dist/ui/index.html"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "build": "pkgroll --minify && vite build",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p ui/tsconfig.json",
+    "link": "node ../../scripts/link-plugin.mjs",
+    "unlink": "node ../../scripts/link-plugin.mjs --unlink"
+  },
+  "dependencies": {
+    "freestyle-voice": "workspace:*"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.101.2",
+    "@types/node": "^22.19.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^5.1.1",
+    "ai": "^6.0.191",
+    "hono": "^4.12.22",
+    "pkgroll": "^2.27.0",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1",
+    "react-hook-form": "^7.76.1",
+    "typescript": "^5.8.3",
+    "vite": "^7.3.3",
+    "zod": "^4.4.3"
+  }
+}

--- a/plugins/voice-commands/src/actions.ts
+++ b/plugins/voice-commands/src/actions.ts
@@ -1,0 +1,113 @@
+import { spawn } from "node:child_process";
+import process from "node:process";
+import type { PluginLogger } from "freestyle-voice";
+import type { CommandAction } from "./types.js";
+
+/** Whether macOS-only actions (Shortcuts) are available on this host. */
+export function isMacOS(): boolean {
+  return process.platform === "darwin";
+}
+
+const INPUT_PLACEHOLDER = /\{\{\s*input\s*\}\}/g;
+
+/**
+ * Spawn a child process and resolve with its stdout, rejecting on a non-zero
+ * exit. Input, when provided, is written to stdin. Never uses a shell unless
+ * `shell` is set, keeping argument passing injection-safe by default.
+ */
+function run(
+  command: string,
+  args: string[],
+  opts: { input?: string; shell?: boolean; env?: NodeJS.ProcessEnv } = {},
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      shell: opts.shell ?? false,
+      env: opts.env ?? process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (d) => {
+      stdout += d;
+    });
+    child.stderr?.on("data", (d) => {
+      stderr += d;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(stderr.trim() || `exited with code ${code}`));
+    });
+    if (opts.input !== undefined) child.stdin?.write(opts.input);
+    child.stdin?.end();
+  });
+}
+
+/** Open a URL or app scheme with the platform opener. */
+async function openUrl(url: string): Promise<string> {
+  if (process.platform === "darwin") return run("open", [url]);
+  if (process.platform === "win32") return run("cmd", ["/c", "start", "", url]);
+  return run("xdg-open", [url]);
+}
+
+/**
+ * Execute a command's action with the extracted `input`. Returns a short human
+ * description of what happened, which the agent surfaces back to the model.
+ * Throws on failure so the caller can report it.
+ */
+export async function runAction(
+  action: CommandAction,
+  input: string,
+  logger: PluginLogger,
+): Promise<string> {
+  logger.debug(`runAction type=${action.type} input="${input}"`);
+  switch (action.type) {
+    case "webhook": {
+      const method = action.method ?? "POST";
+      let url = action.url;
+      const init: RequestInit = { method, headers: { ...action.headers } };
+      if (method === "POST") {
+        (init.headers as Record<string, string>)["Content-Type"] ??=
+          "application/json";
+        init.body = JSON.stringify({ input });
+      } else {
+        const u = new URL(url);
+        u.searchParams.set("input", input);
+        url = u.toString();
+      }
+      const res = await fetch(url, init);
+      if (!res.ok) throw new Error(`webhook returned ${res.status}`);
+      logger.info(`webhook ${method} ${action.url} → ${res.status}`);
+      return `Called ${method} ${action.url} (${res.status}).`;
+    }
+
+    case "openUrl": {
+      const url = action.url.replace(
+        INPUT_PLACEHOLDER,
+        encodeURIComponent(input),
+      );
+      await openUrl(url);
+      logger.info(`opened ${url}`);
+      return `Opened ${url}.`;
+    }
+
+    case "shell": {
+      const command = action.command.replace(INPUT_PLACEHOLDER, input);
+      const out = await run(command, [], {
+        shell: true,
+        input,
+        env: { ...process.env, FREESTYLE_COMMAND_INPUT: input },
+      });
+      logger.info(`ran shell command`);
+      return out ? `Ran command:\n${out}` : "Ran command.";
+    }
+
+    case "shortcut": {
+      if (!isMacOS()) throw new Error("Shortcuts are only available on macOS.");
+      await run("shortcuts", ["run", action.name], { input });
+      logger.info(`ran shortcut "${action.name}"`);
+      return `Ran the "${action.name}" shortcut.`;
+    }
+  }
+}

--- a/plugins/voice-commands/src/agent.ts
+++ b/plugins/voice-commands/src/agent.ts
@@ -1,0 +1,107 @@
+import { generateText, type LanguageModel, stepCountIs, tool } from "ai";
+import type { PluginLogger } from "freestyle-voice";
+import { z } from "zod";
+import type { VoiceCommand } from "./types.js";
+
+/** Outcome of a detection run: whether a command fired, and which. */
+export interface AgentResult {
+  fired: boolean;
+  command?: string;
+  detail?: string;
+}
+
+const SYSTEM_PROMPT = `You are the command router for a voice dictation app.
+The user just spoke an utterance that matched one or more command triggers.
+Decide whether the utterance is genuinely a request to run one of the available
+commands, or just ordinary dictation that happens to contain a trigger word.
+
+- If it clearly maps to a command, call that command's tool exactly once. Pass
+  the relevant payload from the utterance as "input" — strip the trigger/wake
+  words and keep only the meaningful content (e.g. the message body, the query,
+  the note text). If there is no payload, pass an empty string.
+- If it is ordinary dictation and NOT a command, do not call any tool and reply
+  with the single word: none.
+
+Never call more than one tool.`;
+
+/**
+ * Run the multi-step tool-calling agent over the candidate commands. Each
+ * command is exposed as a tool whose `execute` runs the real action. Returns
+ * whether a command fired. The model reuses the host's configured LLM.
+ */
+export async function runAgent(opts: {
+  model: LanguageModel;
+  transcript: string;
+  commands: VoiceCommand[];
+  execute: (command: VoiceCommand, input: string) => Promise<string>;
+  logger: PluginLogger;
+}): Promise<AgentResult> {
+  const { model, transcript, commands, execute, logger } = opts;
+
+  const result: AgentResult = { fired: false };
+
+  const tools = Object.fromEntries(
+    commands.map((command) => [
+      command.id,
+      tool({
+        description: `${command.name}. Triggers: ${command.triggers.join(
+          ", ",
+        )}. ${command.description}`.trim(),
+        inputSchema: z.object({
+          input: z
+            .string()
+            .describe(
+              "The payload extracted from the utterance (trigger words removed). Empty string if none.",
+            ),
+        }),
+        execute: async ({ input }) => {
+          logger.info(`agent chose "${command.name}" (input="${input}")`);
+          try {
+            const detail = await execute(command, input);
+            result.fired = true;
+            result.command = command.name;
+            result.detail = detail;
+            return detail;
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            logger.error(`command "${command.name}" failed: ${message}`);
+            // Report to the model, but still mark as fired so the utterance is
+            // consumed — the user issued a command; it just failed to execute.
+            result.fired = true;
+            result.command = command.name;
+            result.detail = `Failed: ${message}`;
+            return `The command failed: ${message}`;
+          }
+        },
+      }),
+    ]),
+  );
+
+  logger.debug(
+    `agent: calling model with ${commands.length} tool(s) [${commands
+      .map((c) => c.id)
+      .join(", ")}]`,
+  );
+
+  try {
+    const { steps, finishReason } = await generateText({
+      model,
+      tools,
+      stopWhen: stepCountIs(3),
+      system: SYSTEM_PROMPT,
+      prompt: `Utterance: "${transcript}"`,
+    });
+    logger.debug(
+      `agent: model finished (steps=${steps.length}, finishReason=${finishReason})`,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(`agent: model call failed: ${message}`);
+    if (err instanceof Error && err.stack) logger.debug(err.stack);
+    // Surface a clear, actionable message to the caller (the /test endpoint
+    // returns it to the UI; afterTranscribe logs and ignores it).
+    throw new Error(`LLM agent failed: ${message}`);
+  }
+
+  return result;
+}

--- a/plugins/voice-commands/src/api.ts
+++ b/plugins/voice-commands/src/api.ts
@@ -1,0 +1,122 @@
+import type { PluginLogger } from "freestyle-voice";
+import type { MiddlewareHandler } from "hono";
+import { z } from "zod";
+import { ROUTE_BASE } from "./constants.js";
+import type { CommandDraft, CommandStore } from "./store.js";
+
+const actionSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("webhook"),
+    url: z.string().min(1),
+    method: z.enum(["GET", "POST"]).default("POST"),
+    headers: z.record(z.string(), z.string()).optional(),
+  }),
+  z.object({ type: z.literal("openUrl"), url: z.string().min(1) }),
+  z.object({ type: z.literal("shell"), command: z.string().min(1) }),
+  z.object({ type: z.literal("shortcut"), name: z.string().min(1) }),
+]);
+
+const draftSchema = z.object({
+  name: z.string().min(1),
+  triggers: z.array(z.string().min(1)).min(1),
+  description: z.string().default(""),
+  action: actionSchema,
+  enabled: z.boolean().default(true),
+});
+
+export interface CommandsApiDeps {
+  store: CommandStore;
+  /** The host OS platform (`process.platform`), surfaced to the UI. */
+  platform: NodeJS.Platform;
+  /**
+   * Resolve the current plugin logger. A getter (not the logger itself) because
+   * the API is built when the plugin factory runs, before `setup` has handed us
+   * the real logger — the getter closes over the mutable reference.
+   */
+  getLogger: () => PluginLogger;
+}
+
+/**
+ * Build the Hono middleware exposing the voice-commands CRUD API plus a
+ * platform probe and a test runner. Mirrors the profanity-filter plugin: a
+ * single handler that owns everything under {@link ROUTE_BASE} and defers to
+ * `next()` for anything else.
+ */
+export function createCommandsApi(deps: CommandsApiDeps): MiddlewareHandler {
+  const { store, platform, getLogger } = deps;
+  const isMac = platform === "darwin";
+
+  return async (c, next) => {
+    const path = c.req.path;
+    if (!path.startsWith(ROUTE_BASE)) return next();
+
+    const sub = path.slice(ROUTE_BASE.length);
+    const method = c.req.method;
+    const log = getLogger();
+    log.debug(`api ${method} ${sub || "/"}`);
+
+    try {
+      // GET /platform — capability probe for the UI (hides macOS-only options).
+      if (sub === "/platform" && method === "GET") {
+        return c.json({ platform, isMac });
+      }
+
+      // GET /commands — list all commands.
+      if (sub === "/commands" && method === "GET") {
+        return c.json({ commands: store.list(), platform, isMac });
+      }
+
+      // POST /commands — create.
+      if (sub === "/commands" && method === "POST") {
+        const parsed = await parseDraft(c, isMac);
+        if ("error" in parsed) return c.json({ error: parsed.error }, 400);
+        const command = await store.create(parsed.draft);
+        log.info(`created command "${command.name}" (${command.id})`);
+        return c.json({ command }, 201);
+      }
+
+      // /commands/:id — update / delete.
+      const idMatch = sub.match(/^\/commands\/([^/]+)$/);
+      if (idMatch) {
+        const id = decodeURIComponent(idMatch[1]);
+        if (method === "PUT") {
+          const parsed = await parseDraft(c, isMac);
+          if ("error" in parsed) return c.json({ error: parsed.error }, 400);
+          const command = await store.update(id, parsed.draft);
+          if (!command) return c.json({ error: "command not found" }, 404);
+          log.info(`updated command "${command.name}" (${id})`);
+          return c.json({ command });
+        }
+        if (method === "DELETE") {
+          const ok = await store.remove(id);
+          if (!ok) return c.json({ error: "command not found" }, 404);
+          log.info(`deleted command ${id}`);
+          return c.json({ ok: true });
+        }
+      }
+
+      return next();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(`api ${method} ${sub || "/"} failed: ${message}`);
+      if (err instanceof Error && err.stack) log.debug(err.stack);
+      return c.json({ error: message }, 500);
+    }
+  };
+}
+
+/** Parse and validate a command draft from the request body. */
+async function parseDraft(
+  c: Parameters<MiddlewareHandler>[0],
+  isMac: boolean,
+): Promise<{ draft: CommandDraft } | { error: string }> {
+  const body = await c.req.json().catch(() => null);
+  const result = draftSchema.safeParse(body);
+  if (!result.success) {
+    return { error: result.error.issues[0]?.message ?? "invalid command" };
+  }
+  if (result.data.action.type === "shortcut" && !isMac) {
+    return { error: "Shortcuts are only available on macOS." };
+  }
+  return { draft: result.data };
+}

--- a/plugins/voice-commands/src/constants.ts
+++ b/plugins/voice-commands/src/constants.ts
@@ -1,0 +1,5 @@
+/** The npm package / plugin name. */
+export const PLUGIN_NAME = "@freestyle-voice/commands";
+
+/** Base path for this plugin's HTTP API, derived from its slug. */
+export const ROUTE_BASE = "/api/plugins/freestyle-voice-commands";

--- a/plugins/voice-commands/src/defaults.ts
+++ b/plugins/voice-commands/src/defaults.ts
@@ -1,0 +1,55 @@
+import type { CommandDraft } from "./store.js";
+
+/**
+ * Commands seeded on first run so the plugin is useful out of the box. All use
+ * the cross-platform `openUrl` action (no config, no keys, no shell) and pick
+ * multi-word trigger phrases that are unlikely to collide with ordinary
+ * dictation. Users can edit, disable, or delete them freely — they are only
+ * seeded once, when no commands have ever been saved.
+ */
+export const DEFAULT_COMMANDS: CommandDraft[] = [
+  {
+    name: "Web search",
+    triggers: ["search the web for", "search the internet for"],
+    description:
+      "Open a web search for the spoken query. The payload is the search terms.",
+    action: {
+      type: "openUrl",
+      url: "https://www.google.com/search?q={{input}}",
+    },
+    enabled: true,
+  },
+  {
+    name: "YouTube search",
+    triggers: ["search youtube for", "find on youtube"],
+    description:
+      "Open a YouTube search for the spoken query. The payload is the search terms.",
+    action: {
+      type: "openUrl",
+      url: "https://www.youtube.com/results?search_query={{input}}",
+    },
+    enabled: true,
+  },
+  {
+    name: "Maps directions",
+    triggers: ["get directions to", "navigate to"],
+    description:
+      "Open Google Maps for the spoken place or address. The payload is the destination.",
+    action: {
+      type: "openUrl",
+      url: "https://www.google.com/maps/search/{{input}}",
+    },
+    enabled: true,
+  },
+  {
+    name: "Wikipedia lookup",
+    triggers: ["look up on wikipedia", "search wikipedia for"],
+    description:
+      "Open a Wikipedia search for the spoken topic. The payload is the topic.",
+    action: {
+      type: "openUrl",
+      url: "https://en.wikipedia.org/wiki/Special:Search?search={{input}}",
+    },
+    enabled: true,
+  },
+];

--- a/plugins/voice-commands/src/index.ts
+++ b/plugins/voice-commands/src/index.ts
@@ -1,0 +1,173 @@
+import process from "node:process";
+import type { LanguageModel } from "ai";
+import type { Plugin, PluginLlm, PluginLogger } from "freestyle-voice";
+import { runAction } from "./actions.js";
+import { runAgent } from "./agent.js";
+import { createCommandsApi } from "./api.js";
+import { PLUGIN_NAME } from "./constants.js";
+import { matchCommands, normalize, stripTrigger } from "./prefilter.js";
+import { CommandStore } from "./store.js";
+import type { DetectionResult, VoiceCommand } from "./types.js";
+
+/**
+ * Voice Commands — turn spoken trigger phrases into actions. A cheap
+ * deterministic prefilter gates a multi-step tool-calling agent (reusing the
+ * host's configured LLM); when a command fires, the utterance is `consumed` so
+ * the host skips cleanup and delivers no text.
+ */
+export default function voiceCommands(): Plugin {
+  const store = new CommandStore();
+  // Starts as a no-op logger and is replaced with the host logger in `setup`;
+  // the API and hooks read it lazily so early calls never hit a null.
+  let logger: PluginLogger = nullLogger;
+
+  /** Execute a single command's action with the extracted input. */
+  const execute = (command: VoiceCommand, input: string): Promise<string> => {
+    logger.info(`executing "${command.name}" action=${command.action.type}`);
+    return runAction(command.action, input, logger);
+  };
+
+  /**
+   * The full detection pipeline: prefilter, then either the multi-step LLM
+   * agent (when the host exposes one via `api.llm`) or a deterministic fallback
+   * when no model is available. The LLM is passed in per-dictation rather than
+   * captured at setup — the host builds it fresh for each pipeline run and
+   * hands it to the hook on `api.llm`.
+   */
+  async function detect(
+    text: string,
+    llm: PluginLlm | null,
+  ): Promise<DetectionResult> {
+    const matched = matchCommands(text, store.list());
+    const names = matched.map((c) => c.name);
+    logger.debug(
+      `prefilter: ${matched.length}/${store.list().length} command(s) matched${
+        names.length ? ` [${names.join(", ")}]` : ""
+      }`,
+    );
+    if (matched.length === 0) {
+      return { matched: names, fired: false, llm: Boolean(llm) };
+    }
+
+    if (llm) {
+      try {
+        // Resolve the model lazily here so a misconfigured/unsupported provider
+        // throws inside this try and degrades to the deterministic path rather
+        // than aborting detection entirely.
+        const model = llm.getModel() as LanguageModel;
+        logger.info(
+          `running agent (model=${llm.providerId}/${llm.modelId}) over ${matched.length} candidate(s)`,
+        );
+        const result = await runAgent({
+          model,
+          transcript: text,
+          commands: matched,
+          execute,
+          logger,
+        });
+        logger.info(
+          result.fired
+            ? `agent fired "${result.command}"`
+            : "agent decided: not a command",
+        );
+        return { matched: names, llm: true, ...result };
+      } catch (err) {
+        // The LLM was advertised but is unusable (bad key, unsupported model,
+        // network failure). Don't drop the command — fall through to the
+        // deterministic match so a clear trigger phrase still fires.
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(
+          `LLM agent unavailable (${message}) — using deterministic fallback`,
+        );
+      }
+    }
+
+    // No usable LLM — fall back to firing the best deterministic match.
+    const command = pickBestMatch(text, matched);
+    const input = stripTrigger(text, command);
+    logger.info(`deterministic fallback firing "${command.name}"`);
+    try {
+      const detail = await execute(command, input);
+      return {
+        matched: names,
+        fired: true,
+        command: command.name,
+        detail,
+        llm: false,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`command "${command.name}" failed: ${message}`);
+      return {
+        matched: names,
+        fired: true,
+        command: command.name,
+        detail: `Failed: ${message}`,
+        llm: false,
+      };
+    }
+  }
+
+  const middleware = createCommandsApi({
+    store,
+    platform: process.platform,
+    getLogger: () => logger,
+  });
+
+  return {
+    name: PLUGIN_NAME,
+    middleware: [middleware],
+
+    async setup(ctx) {
+      logger = ctx.logger;
+      await store.load(ctx.storage);
+      logger.info(
+        `voice-commands ready on ${ctx.mode} (${store.list().length} commands)`,
+      );
+    },
+
+    async afterTranscribe(_input, output, api) {
+      const text = output.text?.trim();
+      if (!text) return;
+      try {
+        const result = await detect(text, api.llm ?? null);
+        if (result.fired) {
+          logger.info(`voice command consumed utterance: ${result.command}`);
+          // Mark the utterance handled: the host skips cleanup and delivers no
+          // text (the command already ran the action).
+          api.control.consume(`voice command: ${result.command}`);
+        }
+      } catch (err) {
+        // Never let a detection failure break the dictation pipeline — log it
+        // and fall through so the raw transcript is delivered as normal text.
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error(`afterTranscribe detection failed: ${message}`);
+        if (err instanceof Error && err.stack) logger.debug(err.stack);
+      }
+    },
+  };
+}
+
+/** Choose the candidate whose longest trigger phrase appears in the text. */
+function pickBestMatch(text: string, matched: VoiceCommand[]): VoiceCommand {
+  const hay = normalize(text);
+  let best = matched[0];
+  let bestLen = 0;
+  for (const cmd of matched) {
+    for (const trigger of cmd.triggers) {
+      const needle = normalize(trigger);
+      if (needle && hay.includes(needle) && needle.length > bestLen) {
+        bestLen = needle.length;
+        best = cmd;
+      }
+    }
+  }
+  return best;
+}
+
+const nullLogger: PluginLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};

--- a/plugins/voice-commands/src/prefilter.ts
+++ b/plugins/voice-commands/src/prefilter.ts
@@ -1,0 +1,60 @@
+import type { VoiceCommand } from "./types.js";
+
+/**
+ * Normalise text for cheap phrase matching: lower-case, strip punctuation, and
+ * collapse whitespace. Unicode-aware so accented trigger words still match.
+ */
+export function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * The cheap deterministic gate that runs before any LLM call. Returns the
+ * enabled commands whose trigger phrases appear in the transcript. An empty
+ * result means "definitely not a command" — the agent is skipped entirely.
+ */
+export function matchCommands(
+  text: string,
+  commands: VoiceCommand[],
+): VoiceCommand[] {
+  const hay = normalize(text);
+  if (!hay) return [];
+  return commands.filter(
+    (cmd) =>
+      cmd.enabled &&
+      cmd.triggers.some((t) => {
+        const needle = normalize(t);
+        return needle.length > 0 && hay.includes(needle);
+      }),
+  );
+}
+
+/**
+ * Best-effort extraction of the command "payload" for the LLM-less fallback
+ * path: strip the first matching trigger phrase from the original transcript
+ * and return the remainder (original casing preserved).
+ */
+export function stripTrigger(text: string, command: VoiceCommand): string {
+  const normalizedTriggers = command.triggers
+    .map((t) => normalize(t))
+    .filter(Boolean)
+    // Longest first so "open the pod bay doors" wins over "open".
+    .sort((a, b) => b.length - a.length);
+
+  for (const needle of normalizedTriggers) {
+    // Build a case-insensitive, whitespace-tolerant regex from the trigger.
+    const pattern = needle
+      .split(" ")
+      .map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+      .join("\\s+");
+    const re = new RegExp(pattern, "i");
+    if (re.test(text)) {
+      return text.replace(re, " ").replace(/\s+/g, " ").trim();
+    }
+  }
+  return text.trim();
+}

--- a/plugins/voice-commands/src/store.ts
+++ b/plugins/voice-commands/src/store.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from "node:crypto";
+import type { PluginStorage } from "freestyle-voice";
+import { DEFAULT_COMMANDS } from "./defaults.js";
+import type { CommandAction, VoiceCommand } from "./types.js";
+
+const STORAGE_KEY = "commands";
+const SEEDED_KEY = "seeded";
+
+export interface CommandDraft {
+  name: string;
+  triggers: string[];
+  description: string;
+  action: CommandAction;
+  enabled: boolean;
+}
+
+/**
+ * In-memory, storage-backed collection of voice commands. Seeded from
+ * {@link PluginStorage} on `load` and persisted on every mutation, so the
+ * server-side detection path and the UI CRUD API share one source of truth.
+ */
+export class CommandStore {
+  private commands: VoiceCommand[] = [];
+  private storage: PluginStorage | null = null;
+
+  async load(storage: PluginStorage): Promise<void> {
+    this.storage = storage;
+    const stored = await storage.get<VoiceCommand[]>(STORAGE_KEY);
+    const seeded = (await storage.get<boolean>(SEEDED_KEY)) === true;
+    // Once we've seeded, honour whatever the user has now — including an empty
+    // list they cleared out — so deleted defaults never come back. We must key
+    // off an explicit marker, not "is `stored` an array?", because an empty
+    // array is ambiguous: it could mean "user deleted everything" or "an older
+    // build left a stale []" — only the marker tells them apart.
+    if (seeded) {
+      this.commands = Array.isArray(stored) ? stored : [];
+      return;
+    }
+    // First run (or a stale empty list from before seeding existed): seed the
+    // starter commands so the plugin works out of the box, then mark it done.
+    this.commands = DEFAULT_COMMANDS.map((draft) => ({
+      id: randomUUID(),
+      ...draft,
+    }));
+    await this.persist();
+    await storage.set(SEEDED_KEY, true);
+  }
+
+  list(): VoiceCommand[] {
+    return this.commands;
+  }
+
+  get(id: string): VoiceCommand | undefined {
+    return this.commands.find((c) => c.id === id);
+  }
+
+  async create(draft: CommandDraft): Promise<VoiceCommand> {
+    const command: VoiceCommand = { id: randomUUID(), ...draft };
+    this.commands.push(command);
+    await this.persist();
+    return command;
+  }
+
+  async update(id: string, draft: CommandDraft): Promise<VoiceCommand | null> {
+    const index = this.commands.findIndex((c) => c.id === id);
+    if (index === -1) return null;
+    const updated: VoiceCommand = { id, ...draft };
+    this.commands[index] = updated;
+    await this.persist();
+    return updated;
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const before = this.commands.length;
+    this.commands = this.commands.filter((c) => c.id !== id);
+    if (this.commands.length === before) return false;
+    await this.persist();
+    return true;
+  }
+
+  private async persist(): Promise<void> {
+    if (this.storage) await this.storage.set(STORAGE_KEY, this.commands);
+  }
+}

--- a/plugins/voice-commands/src/types.ts
+++ b/plugins/voice-commands/src/types.ts
@@ -1,0 +1,70 @@
+/** The kinds of actions a voice command can trigger. */
+export type ActionType = "shortcut" | "webhook" | "openUrl" | "shell";
+
+/** Call an HTTP endpoint. The extracted input is sent as JSON (POST) or query (GET). */
+export interface WebhookAction {
+  type: "webhook";
+  url: string;
+  method: "GET" | "POST";
+  headers?: Record<string, string>;
+}
+
+/** Open a URL (or app URL scheme) with the host OS opener. `{{input}}` is substituted. */
+export interface OpenUrlAction {
+  type: "openUrl";
+  url: string;
+}
+
+/**
+ * Run a shell command. `{{input}}` is substituted into the command string and
+ * the raw input is also exposed as the `FREESTYLE_COMMAND_INPUT` env var.
+ */
+export interface ShellAction {
+  type: "shell";
+  command: string;
+}
+
+/**
+ * Run a macOS Shortcut by name (macOS only). The extracted input is piped to
+ * the shortcut on stdin. Hidden/inert on non-macOS hosts.
+ */
+export interface ShortcutAction {
+  type: "shortcut";
+  name: string;
+}
+
+export type CommandAction =
+  | WebhookAction
+  | OpenUrlAction
+  | ShellAction
+  | ShortcutAction;
+
+/** Outcome of running the detection pipeline over an utterance. */
+export interface DetectionResult {
+  /** Names of the commands whose triggers matched the prefilter. */
+  matched: string[];
+  /** Whether a command actually fired (action executed). */
+  fired: boolean;
+  /** The command that fired, if any. */
+  command?: string;
+  /** Human-readable detail of what happened (or the failure message). */
+  detail?: string;
+  /** Whether the LLM agent path ran (vs the deterministic fallback). */
+  llm: boolean;
+}
+
+/** A user-defined voice command: trigger phrases → an action. */
+export interface VoiceCommand {
+  /** Stable id (generated on create). */
+  id: string;
+  /** Human-readable label shown in the UI. */
+  name: string;
+  /** Phrases that gate the command. Any match makes it a candidate for the agent. */
+  triggers: string[];
+  /** Natural-language description of when to run this — used as the LLM tool description. */
+  description: string;
+  /** What to do when this command fires. */
+  action: CommandAction;
+  /** Whether the command participates in matching. */
+  enabled: boolean;
+}

--- a/plugins/voice-commands/tsconfig.json
+++ b/plugins/voice-commands/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "declaration": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["./src/**/*"]
+}

--- a/plugins/voice-commands/ui/index.html
+++ b/plugins/voice-commands/ui/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' http://127.0.0.1:*; script-src 'self'"
+    />
+    <title>Voice Commands</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,300..700&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/main.tsx"></script>
+  </body>
+</html>

--- a/plugins/voice-commands/ui/src/App.tsx
+++ b/plugins/voice-commands/ui/src/App.tsx
@@ -1,0 +1,456 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { FreestyleBridge } from "freestyle-voice";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import type {
+  ActionType,
+  CommandAction,
+  VoiceCommand,
+} from "../../src/types.js";
+
+const ROUTE = "/api/plugins/freestyle-voice-commands";
+
+interface CommandsResponse {
+  commands: VoiceCommand[];
+  platform: string;
+  isMac: boolean;
+}
+
+const ACTION_LABELS: Record<ActionType, string> = {
+  shortcut: "Run Shortcut",
+  webhook: "Call webhook",
+  openUrl: "Open URL / app",
+  shell: "Run script",
+};
+
+// ---------------------------------------------------------------------------
+// Bridge helpers
+// ---------------------------------------------------------------------------
+
+function getBridge(): FreestyleBridge {
+  const b = window.freestyle;
+  if (!b) throw new Error("Host bridge unavailable.");
+  return b;
+}
+
+async function fetchCommands(): Promise<CommandsResponse> {
+  const res = await getBridge().api(`${ROUTE}/commands`);
+  if (!res.ok) throw new Error(`server returned ${res.status}`);
+  return (await res.json()) as CommandsResponse;
+}
+
+async function sendCommand(
+  method: "POST" | "PUT" | "DELETE",
+  path: string,
+  body?: unknown,
+): Promise<void> {
+  const res = await getBridge().api(path, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : {},
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  if (!res.ok) {
+    const err = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(err.error ?? `server returned ${res.status}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Components
+// ---------------------------------------------------------------------------
+
+function BackButton() {
+  return (
+    <button
+      type="button"
+      className="back-btn"
+      onClick={() => window.freestyle?.invoke("navigate", { to: "/plugins" })}
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="m15 18-6-6 6-6" />
+      </svg>
+      Plugins
+    </button>
+  );
+}
+
+interface FormValues {
+  name: string;
+  triggers: string;
+  description: string;
+  actionType: ActionType;
+  webhookUrl: string;
+  webhookMethod: "GET" | "POST";
+  openUrlValue: string;
+  shellCommand: string;
+  shortcutName: string;
+}
+
+function toDefaults(command?: VoiceCommand): FormValues {
+  const action = command?.action;
+  return {
+    name: command?.name ?? "",
+    triggers: command?.triggers.join(", ") ?? "",
+    description: command?.description ?? "",
+    actionType: action?.type ?? "webhook",
+    webhookUrl: action?.type === "webhook" ? action.url : "",
+    webhookMethod: action?.type === "webhook" ? action.method : "POST",
+    openUrlValue: action?.type === "openUrl" ? action.url : "",
+    shellCommand: action?.type === "shell" ? action.command : "",
+    shortcutName: action?.type === "shortcut" ? action.name : "",
+  };
+}
+
+function buildAction(values: FormValues): CommandAction {
+  switch (values.actionType) {
+    case "webhook":
+      return {
+        type: "webhook",
+        url: values.webhookUrl.trim(),
+        method: values.webhookMethod,
+      };
+    case "openUrl":
+      return { type: "openUrl", url: values.openUrlValue.trim() };
+    case "shell":
+      return { type: "shell", command: values.shellCommand.trim() };
+    case "shortcut":
+      return { type: "shortcut", name: values.shortcutName.trim() };
+  }
+}
+
+function CommandForm({
+  isMac,
+  editing,
+  onDone,
+}: {
+  isMac: boolean;
+  editing?: VoiceCommand;
+  onDone: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { register, handleSubmit, watch, reset } = useForm<FormValues>({
+    defaultValues: toDefaults(editing),
+  });
+  const actionType = watch("actionType");
+
+  const mutation = useMutation({
+    mutationFn: async (values: FormValues) => {
+      const triggers = values.triggers
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (triggers.length === 0)
+        throw new Error("At least one trigger phrase is required");
+      const draft = {
+        name: values.name.trim(),
+        triggers,
+        description: values.description.trim(),
+        action: buildAction(values),
+        enabled: editing?.enabled ?? true,
+      };
+      if (editing) {
+        await sendCommand("PUT", `${ROUTE}/commands/${editing.id}`, draft);
+      } else {
+        await sendCommand("POST", `${ROUTE}/commands`, draft);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["commands"] });
+      reset(toDefaults());
+      onDone();
+    },
+  });
+
+  const onSubmit = handleSubmit((values) => mutation.mutate(values));
+
+  // macOS-only: hide the Shortcut option entirely on other platforms.
+  const actionTypes: ActionType[] = isMac
+    ? ["shortcut", "webhook", "openUrl", "shell"]
+    : ["webhook", "openUrl", "shell"];
+
+  return (
+    <form className="card form" onSubmit={onSubmit}>
+      <h2>{editing ? "Edit command" : "New command"}</h2>
+
+      <label className="field">
+        <span className="field-label">Name</span>
+        <input
+          className="input"
+          placeholder="Send a Slack message"
+          {...register("name", { required: true })}
+        />
+      </label>
+
+      <label className="field">
+        <span className="field-label">Trigger phrases</span>
+        <input
+          className="input"
+          placeholder="post to slack, message the team"
+          {...register("triggers", { required: true })}
+        />
+        <span className="hint">
+          Comma-separated. Any match arms the command.
+        </span>
+      </label>
+
+      <label className="field">
+        <span className="field-label">Description</span>
+        <input
+          className="input"
+          placeholder="Posts the dictated message to the team Slack channel."
+          {...register("description")}
+        />
+        <span className="hint">
+          Tells the assistant when to run this and what payload to extract.
+        </span>
+      </label>
+
+      <label className="field">
+        <span className="field-label">Action</span>
+        <select className="input" {...register("actionType")}>
+          {actionTypes.map((t) => (
+            <option key={t} value={t}>
+              {ACTION_LABELS[t]}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {actionType === "webhook" && (
+        <div className="field-row">
+          <label className="field field-grow">
+            <span className="field-label">URL</span>
+            <input
+              className="input"
+              placeholder="https://example.com/hook"
+              {...register("webhookUrl", { required: true })}
+            />
+          </label>
+          <label className="field">
+            <span className="field-label">Method</span>
+            <select className="input" {...register("webhookMethod")}>
+              <option value="POST">POST</option>
+              <option value="GET">GET</option>
+            </select>
+          </label>
+        </div>
+      )}
+
+      {actionType === "openUrl" && (
+        <label className="field">
+          <span className="field-label">URL or app scheme</span>
+          <input
+            className="input"
+            placeholder="https://google.com/search?q={{input}}"
+            {...register("openUrlValue", { required: true })}
+          />
+          <span className="hint">
+            {"{{input}}"} is replaced with the spoken payload.
+          </span>
+        </label>
+      )}
+
+      {actionType === "shell" && (
+        <label className="field">
+          <span className="field-label">Command</span>
+          <input
+            className="input mono"
+            placeholder='echo "{{input}}" >> ~/notes.txt'
+            {...register("shellCommand", { required: true })}
+          />
+          <span className="hint">
+            {"{{input}}"} and the $FREESTYLE_COMMAND_INPUT env var carry the
+            payload.
+          </span>
+        </label>
+      )}
+
+      {actionType === "shortcut" && isMac && (
+        <label className="field">
+          <span className="field-label">Shortcut name</span>
+          <input
+            className="input"
+            placeholder="Add to Reminders"
+            {...register("shortcutName", { required: true })}
+          />
+          <span className="hint">
+            The payload is piped to the shortcut's input. macOS only.
+          </span>
+        </label>
+      )}
+
+      {mutation.error ? (
+        <p className="error-text">{mutation.error.message}</p>
+      ) : null}
+
+      <div className="form-actions">
+        <button type="button" className="ghost-btn" onClick={onDone}>
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className="primary-btn"
+          disabled={mutation.isPending}
+        >
+          {mutation.isPending
+            ? "Saving…"
+            : editing
+              ? "Save changes"
+              : "Add command"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function CommandRow({
+  command,
+  onEdit,
+}: {
+  command: VoiceCommand;
+  onEdit: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const deleteMutation = useMutation({
+    mutationFn: () => sendCommand("DELETE", `${ROUTE}/commands/${command.id}`),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["commands"] }),
+  });
+
+  const toggleMutation = useMutation({
+    mutationFn: () =>
+      sendCommand("PUT", `${ROUTE}/commands/${command.id}`, {
+        name: command.name,
+        triggers: command.triggers,
+        description: command.description,
+        action: command.action,
+        enabled: !command.enabled,
+      }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["commands"] }),
+  });
+
+  return (
+    <li className={`command-row${command.enabled ? "" : " disabled"}`}>
+      <div className="command-main">
+        <span className="command-name">{command.name}</span>
+        <span className="command-triggers">
+          {command.triggers.map((t) => (
+            <span key={t} className="trigger-chip">
+              {t}
+            </span>
+          ))}
+        </span>
+      </div>
+      <span className="action-badge">{ACTION_LABELS[command.action.type]}</span>
+      <div className="row-actions">
+        <button type="button" className="row-btn" onClick={onEdit}>
+          Edit
+        </button>
+        <button
+          type="button"
+          className="row-btn"
+          onClick={() => toggleMutation.mutate()}
+          disabled={toggleMutation.isPending}
+        >
+          {command.enabled ? "Disable" : "Enable"}
+        </button>
+        <button
+          type="button"
+          className="row-btn delete-btn"
+          onClick={() => deleteMutation.mutate()}
+          disabled={deleteMutation.isPending}
+        >
+          Delete
+        </button>
+      </div>
+    </li>
+  );
+}
+
+export function App() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["commands"],
+    queryFn: fetchCommands,
+  });
+  const [editing, setEditing] = useState<VoiceCommand | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const isMac = data?.isMac ?? false;
+  const showForm = creating || editing !== null;
+
+  return (
+    <main className="page">
+      <BackButton />
+      <header className="head-row">
+        <h1 className="page-title">Voice Commands</h1>
+        {!showForm && (
+          <button
+            type="button"
+            className="primary-btn"
+            onClick={() => {
+              setEditing(null);
+              setCreating(true);
+            }}
+          >
+            New command
+          </button>
+        )}
+      </header>
+
+      {isLoading && <p className="muted">Loading…</p>}
+
+      {error && (
+        <section className="card error">
+          <p>
+            Couldn't load commands:{" "}
+            {error instanceof Error ? error.message : String(error)}
+          </p>
+        </section>
+      )}
+
+      {showForm && (
+        <CommandForm
+          isMac={isMac}
+          editing={editing ?? undefined}
+          onDone={() => {
+            setCreating(false);
+            setEditing(null);
+          }}
+        />
+      )}
+
+      {data &&
+        !showForm &&
+        (data.commands.length === 0 ? (
+          <section className="card">
+            <p className="muted">
+              No commands yet. Create one to turn a spoken phrase into an
+              action.
+            </p>
+          </section>
+        ) : (
+          <ul className="command-list">
+            {data.commands.map((command) => (
+              <CommandRow
+                key={command.id}
+                command={command}
+                onEdit={() => {
+                  setCreating(false);
+                  setEditing(command);
+                }}
+              />
+            ))}
+          </ul>
+        ))}
+    </main>
+  );
+}

--- a/plugins/voice-commands/ui/src/main.tsx
+++ b/plugins/voice-commands/ui/src/main.tsx
@@ -1,0 +1,22 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+import "./styles.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: 1, staleTime: 60_000 },
+  },
+});
+
+const root = document.getElementById("root");
+if (!root) throw new Error("missing #root");
+
+createRoot(root).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/plugins/voice-commands/ui/src/styles.css
+++ b/plugins/voice-commands/ui/src/styles.css
@@ -1,0 +1,362 @@
+:root {
+  /* Host injects the real Freestyle tokens; these are fallbacks. */
+  --background: #f4f0e4;
+  --foreground: #16140f;
+  --card: #fbf8ee;
+  --primary: #6b8f12;
+  --primary-foreground: #fbf8ee;
+  --muted-foreground: #7b7461;
+  --border: #d6cdb8;
+  --destructive: #dd6e4e;
+  --accent: #6b8f12;
+  --accent-foreground: #16140f;
+  --input: #ebe6d4;
+  --ring: #6b8f12;
+  --radius: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: "DM Sans", system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.page {
+  padding: 0 3rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+@media (max-width: 1080px) {
+  .page {
+    padding: 0 2rem 2rem;
+  }
+}
+
+@media (max-width: 820px) {
+  .page {
+    padding: 0 1rem 1.5rem;
+  }
+}
+
+/* ---- Back button ---- */
+
+.back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: max-content;
+  padding: 4px 10px 4px 6px;
+  margin: 0 0 -4px -6px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.back-btn:hover {
+  color: var(--foreground);
+  background: color-mix(in srgb, currentColor 8%, transparent);
+}
+
+/* ---- Header ---- */
+
+.head-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.page-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.muted {
+  color: var(--muted-foreground);
+  font-size: 13px;
+}
+
+h2 {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 500;
+}
+
+p {
+  margin: 0 0 8px;
+  line-height: 1.5;
+}
+
+/* ---- Buttons ---- */
+
+.primary-btn {
+  padding: 8px 18px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border: none;
+  border-radius: 8px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: opacity 0.15s ease;
+}
+
+.primary-btn:hover {
+  opacity: 0.9;
+}
+
+.primary-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.ghost-btn {
+  padding: 8px 16px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.ghost-btn:hover {
+  color: var(--foreground);
+  border-color: var(--muted-foreground);
+}
+
+/* ---- Cards ---- */
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius, 14px);
+  padding: 20px 22px;
+}
+
+.card.error {
+  border-color: var(--destructive);
+  color: var(--destructive);
+}
+
+/* ---- Form ---- */
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.field-grow {
+  flex: 1;
+  min-width: 0;
+}
+
+.field-row {
+  display: flex;
+  gap: 10px;
+  align-items: flex-end;
+}
+
+.field-label {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted-foreground);
+}
+
+.input {
+  width: 100%;
+  font: inherit;
+  font-size: 13px;
+  color: inherit;
+  background: var(--input, color-mix(in srgb, currentColor 5%, transparent));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 11px;
+}
+
+.input.mono {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 12px;
+}
+
+.input:focus {
+  outline: 2px solid var(--ring, var(--accent));
+  outline-offset: 1px;
+}
+
+.input::placeholder {
+  color: var(--muted-foreground);
+  opacity: 0.7;
+}
+
+.hint {
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+
+.error-text {
+  margin: 0;
+  font-size: 12px;
+  color: var(--destructive);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+/* ---- Command list ---- */
+
+.command-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.command-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius, 14px);
+}
+
+.command-row.disabled {
+  opacity: 0.55;
+}
+
+.command-main {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+
+.command-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.command-triggers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.trigger-chip {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 11px;
+  padding: 2px 7px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--border) 35%, transparent);
+  color: var(--muted-foreground);
+}
+
+.action-badge {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent-foreground, var(--foreground));
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.row-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.row-btn {
+  padding: 4px 10px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.row-btn:hover {
+  color: var(--foreground);
+  border-color: var(--border);
+  background: var(--card);
+}
+
+.row-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.delete-btn:hover {
+  color: var(--destructive);
+  border-color: color-mix(in srgb, var(--destructive) 40%, transparent);
+  background: color-mix(in srgb, var(--destructive) 6%, transparent);
+}
+
+/* ---- Test result ---- */
+
+.test-result {
+  margin-top: 12px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--border) 15%, transparent);
+  font-size: 13px;
+}
+
+.test-result.fired {
+  border-color: color-mix(in srgb, var(--primary) 45%, transparent);
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+}
+
+.test-result p {
+  margin: 0 0 4px;
+}
+
+.test-result p:last-child {
+  margin-bottom: 0;
+}

--- a/plugins/voice-commands/ui/tsconfig.json
+++ b/plugins/voice-commands/ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "types": ["react", "react-dom", "vite/client"]
+  },
+  "include": ["./src/**/*", "./vite-env.d.ts", "../src/types.ts"]
+}

--- a/plugins/voice-commands/ui/vite-env.d.ts
+++ b/plugins/voice-commands/ui/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/plugins/voice-commands/vite.config.ts
+++ b/plugins/voice-commands/vite.config.ts
@@ -1,0 +1,16 @@
+import { resolve } from "node:path";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  root: resolve(__dirname, "ui"),
+  base: "./",
+  plugins: [react()],
+  build: {
+    outDir: resolve(__dirname, "dist/ui"),
+    emptyOutDir: true,
+    rollupOptions: {
+      input: resolve(__dirname, "ui/index.html"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,6 +484,55 @@ importers:
         specifier: ^7.3.3
         version: 7.3.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
 
+  plugins/voice-commands:
+    dependencies:
+      freestyle-voice:
+        specifier: workspace:*
+        version: link:../../packages/sdk
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.101.2
+        version: 5.101.2(react@19.2.6)
+      '@types/node':
+        specifier: ^22.19.1
+        version: 22.19.19
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.1
+        version: 5.2.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      ai:
+        specifier: ^6.0.191
+        version: 6.0.191(zod@4.4.3)
+      hono:
+        specifier: ^4.12.22
+        version: 4.12.22
+      pkgroll:
+        specifier: ^2.27.0
+        version: 2.27.0(typescript@5.9.3)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      react:
+        specifier: ^19.2.1
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.6(react@19.2.6)
+      react-hook-form:
+        specifier: ^7.76.1
+        version: 7.76.1(react@19.2.6)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.3
+        version: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+
 packages:
 
   7zip-bin@5.2.0:
@@ -12043,7 +12092,7 @@ snapshots:
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 22.19.19
 
   '@types/stats.js@0.17.4': {}
 


### PR DESCRIPTION
## What

Adds the **`@freestyle-voice/commands`** plugin: turn spoken trigger phrases into actions — run macOS Shortcuts, call webhooks, open URLs/apps, or execute scripts by voice.

Say _"post to Slack that I'll be five minutes late"_ and, instead of typing the words, Freestyle runs the matching action.

## Supersedes #379

#379 introduced this plugin **plus** two SDK/server seams. The `#462` plugin-pipeline overhaul has since landed those capabilities in a better form, so this PR keeps only the plugin and rebuilds it against the current SDK. #379 will be closed in favor of this.

| #379 (old) | current SDK (this PR) |
|---|---|
| `afterTranscribe` `output.consumed = true` | `api.control.consume(reason)` |
| `PluginContext.llm` (captured in `setup`) | `api.llm` (built per-dictation, passed to the hook) |
| bridge `res.json<T>()` | native same-origin `Response` → `res.json()` |

Because the LLM now flows through `api.llm`, the agent also works for **Freestyle Cloud** users once #476 (the `freestyle-cloud` LLM provider) and freestyle-voice/cloud#65 (the `/v2/llm` endpoint) land.

## How it works

1. **Prefilter** — a cheap deterministic phrase match gates everything. No trigger → the transcript is dictated normally.
2. **Agent** — on a match, a multi-step tool-calling agent (`api.llm`) decides whether it's really a command and extracts the payload. Falls back to a deterministic longest-trigger match when no LLM is available.
3. **Action** — the command fires and the utterance is consumed via `api.control.consume()` (cleanup skipped, no text delivered).

### Action types
- **Run Shortcut** *(macOS only, hidden elsewhere)* — runs a macOS Shortcut by name; payload piped to stdin.
- **Call webhook** — `POST` payload as JSON, or `GET` as a query param.
- **Open URL / app** — opens a URL or app scheme; `{{input}}` substituted.
- **Run script** — runs a shell command; `{{input}}` substituted and payload also in `$FREESTYLE_COMMAND_INPUT`.

CRUD + a platform probe are exposed via plugin middleware; a React UI manages commands.

## Notes

- Bundles `ai` + `zod` in `devDependencies` (installed plugins get no transitive `npm install`); the host-created model is passed to the plugin's bundled `generateText` — both are AI SDK v6, so the model spec object is compatible across copies.
- Must still be added to the `plugins` allowlist (enabled in the UI) for the server to run it, like every plugin.
- Known follow-up: `ROUTE_BASE` / UI `ROUTE` hardcode the production slug; dev-linking under a `-dev` slug would 404 the settings page (documented gotcha). Not addressed here to keep this focused on the API migration.

## Verification

- `@freestyle-voice/commands` typecheck (server + UI) ✓
- full build (`pkgroll --minify && vite build`) ✓
- `biome check` clean ✓