### PR TITLE
docs: refresh plugin system for the new pipeline API

### DIFF
--- a/apps/docs/first-plugin.mdx
+++ b/apps/docs/first-plugin.mdx
@@ -185,13 +185,13 @@ The word list itself isn't a static option — it's managed from the plugin's UI
 
 ## The API bridge
 
-Your UI page is sandboxed. It can't touch the filesystem or reach the local server directly. Instead, Freestyle injects `window.freestyle`, a small pre-authenticated bridge. It's the only privileged surface a page gets.
+Your UI page is served by the local server and confined to its own `/api/plugins/<slug>/…` namespace (plus `/api/health`) — it can't touch the filesystem or read settings, keys, or history. Freestyle injects `window.freestyle` as the privileged surface a page gets.
 
 It does three things:
 
-- **`api(path, init?)`** calls a server route. The bearer token and loopback origin are handled for you, so use it instead of `fetch`. It returns a `FreestyleResponse` (`ok`, `status`, `headers`, `json()` / `text()` / `arrayBuffer()`).
+- **`api(path, init?)`** calls a server route. Plugin UI is served same-origin with the server, so this is a thin wrapper over `fetch` and returns a **native `Response`** — call `res.ok`, `res.json()`, `res.text()` as usual.
 - **`invoke(channel, payload)`** runs a host action: `copy`, `toast`, or `navigate`.
-- **`serverUrl`** and **`token`** are there if you need the raw values.
+- **`serverUrl`** is the origin the page is served from, if you need the raw value.
 
 Always guard for the bridge first, since the page can be opened outside the host during development:
 
@@ -206,7 +206,7 @@ const res = await bridge.api("/api/plugins/freestyle-voice-profanity-filter/repl
 if (!res.ok) throw new Error(`server returned ${res.status}`);
 const data = await res.json();
 
-// POST works too. Send a Blob or ArrayBuffer, not FormData.
+// POST works too — it's a normal fetch, so any body type is fine.
 await bridge.api("/api/transcribe", {
   method: "POST",
   headers: { "content-type": "audio/wav" },

--- a/apps/docs/how-plugins-work.mdx
+++ b/apps/docs/how-plugins-work.mdx
@@ -25,12 +25,15 @@ User presses hotkey
 [APP]    Capture audio  ......... event: recordingStarted
         |
         v
-[SERVER] Speech-to-text -> raw transcript
+[SERVER] Speech-to-text
+        |                  |-- beforeTranscribe  (preprocess audio, pick model, or consume)
+        |                  v
+        |                 raw transcript
         |                  |-- afterTranscribe   (rewrite, or consume as an action)
         |                  +-- event: transcribed
         v
 [SERVER] AI cleanup (optional)
-        |                  |-- beforeCleanup     (shape the prompt + register)
+        |                  |-- beforeCleanup     (shape the prompt + destination tone)
         |                  |-- dictionary + LLM rewrite
         |                  |-- afterCleanup      (rewrite the final text)
         |                  +-- event: cleaned
@@ -41,6 +44,8 @@ User presses hotkey
         v
 Text appears in your focused app
 ```
+
+Every mutating hook also receives an `api` argument: `api.control` cancels or consumes the run (`consume()` skips the rest of the pipeline and delivers nothing — how a voice command "eats" an utterance), and `api.llm` exposes the host's configured LLM to server hooks. See the [SDK reference](/sdk-reference#hookapi).
 
 Building a plugin allows you to modify what happens at each step of Freestyle's dictation pipeline. The SDK offers hooks like `afterTranscribe` and `beforeOutput` that lets you control the inputs and the outputs at each step of the pipeline. In those hooks you can write functions that can do anything as long as it runs properly in a node environment.
 
@@ -64,6 +69,10 @@ Most people manage these in **Settings → Plugins**.
 
 - Each plugin's settings live under `plugin:<name>:<key>`, isolated from other plugins.
 - A throwing hook is caught and reported. It won't break the pipeline.
-- UI pages run in a sandboxed `freestyle-plugin://` origin with no direct filesystem or network access. They reach the server only through `window.freestyle`.
+- UI pages are served by the local server at `/api/plugins/<slug>/ui/*` and confined by the host to their own `/api/plugins/<slug>/…` namespace (plus `/api/health`) — no filesystem access, and no reach into settings, keys, or history. They call the server through `window.freestyle`.
+
+## Plugin pages in the app
+
+A plugin that ships a UI page (via `contributes.pages` in its manifest) appears automatically as an item in the app's sidebar, under the built-in sections. Enabling or disabling the plugin adds or removes its nav entry.
 
 Next: [build your first plugin](/first-plugin).

--- a/apps/docs/plugins/audio-transcription.mdx
+++ b/apps/docs/plugins/audio-transcription.mdx
@@ -17,7 +17,7 @@ Or install from **Settings → Plugins** inside the app.
 
 <Steps>
   <Step title="Open the plugin page">
-    Go to **Plugins → Audio Transcription → Open**.
+    Once the plugin is enabled, open **Audio Transcription** from the app sidebar.
   </Step>
   <Step title="Drop your files">
     Drop one or more audio files onto the page, or click to choose from your filesystem.

--- a/apps/docs/plugins/profanity-filter.mdx
+++ b/apps/docs/plugins/profanity-filter.mdx
@@ -32,7 +32,7 @@ Identity-based slurs are intentionally **not** included — this is a playful fi
 
 ## UI page
 
-The plugin adds a **Profanity Filter** page inside the app (accessible from **Plugins → Profanity Filter → Open**). It's a full editor for the word list, so you don't need to touch config or restart the app to change what gets swapped. The page lets you:
+The plugin adds a **Profanity Filter** page to the app sidebar (shown once the plugin is enabled). It's a full editor for the word list, so you don't need to touch config or restart the app to change what gets swapped. The page lets you:
 
 - **Add** a word or phrase with one or more replacements (repeats cycle through them)
 - **Edit** the replacements for any existing word inline

--- a/apps/docs/plugins/voice-commands.mdx
+++ b/apps/docs/plugins/voice-commands.mdx
@@ -23,11 +23,11 @@ Detection runs on the server's `afterTranscribe` hook, in three stages:
 
 1. **Prefilter** — a cheap, deterministic phrase match gates everything. If your speech contains no trigger phrase, nothing else runs and the transcript is dictated normally. No LLM call, no added latency.
 2. **Agent** — when a trigger matches, a multi-step tool-calling agent (using the LLM you've already configured for cleanup) decides whether it's really a command and extracts the payload — the part of your speech that isn't the trigger words.
-3. **Action** — the command fires. The utterance is _consumed_: cleanup is skipped and no text is delivered to the focused app.
+3. **Action** — the command fires and the utterance is _consumed_ (via `api.control.consume()`): the rest of the pipeline is skipped and no text is delivered to the focused app.
 
-<Note>If no cleanup LLM is configured, detection falls back to a deterministic match (the longest matching trigger wins) so commands still work — just without the smarter intent check and payload extraction.</Note>
+<Note>If no LLM is available, detection falls back to a deterministic match (the longest matching trigger wins) so commands still work — just without the smarter intent check and payload extraction.</Note>
 
-The plugin reuses your configured cleanup model and API keys through the SDK's [`PluginLlm`](/sdk-reference#pluginllm) capability, so there's no separate provider or key to set up.
+The plugin reuses your configured model and keys through the SDK's [`api.llm`](/sdk-reference#pluginllm) capability, so there's no separate provider or key to set up. **Signed-in Freestyle Cloud users get this too** — the agent runs on Freestyle Cloud's managed LLM, with no local model required.
 
 ## Action types
 
@@ -42,11 +42,10 @@ The plugin reuses your configured cleanup model and API keys through the SDK's [
 
 ## UI page
 
-The plugin adds a **Voice Commands** page inside the app (accessible from **Plugins → Voice Commands → Open**). From there you can:
+The plugin adds a **Voice Commands** page to the app sidebar (shown once the plugin is enabled). From there you can:
 
 - **Add** a command with a name, one or more trigger phrases, a description, and an action.
 - **Edit** or **delete** existing commands, and **enable/disable** them without deleting.
-- **Try a phrase** — type an utterance to run the real detection pipeline and see whether (and which) command fires.
 
 The **description** you give each command matters: it's used as the tool description the agent reads to decide when to run the command and what payload to extract. A clear description like _"Posts the dictated message to the team Slack channel"_ works better than a terse one.
 

--- a/apps/docs/sdk-reference.mdx
+++ b/apps/docs/sdk-reference.mdx
@@ -9,7 +9,8 @@ Import everything from `freestyle-voice`.
 import {
   transform, OutputMode, FreestyleEventType, PipelineStage,
   type Plugin, type PluginContext, type PluginOptions,
-  type FreestyleEvent, type AppContext, type Register,
+  type FreestyleEvent, type AppContext, type HookApi,
+  type PluginLlm, type CleanupToneDestination,
 } from "freestyle-voice";
 ```
 
@@ -30,20 +31,28 @@ interface Plugin {
 
 ## Hooks
 
-Each hook is optional. Mutating hooks get a read-only `input` and an `output` you change in place. They chain across plugins in order.
+Each hook is optional. Mutating hooks receive three arguments: a read-only `input`, an `output` you change in place, and a [`HookApi`](#hookapi) (`api`) for cancellation/suppression control and — on server hooks — the host's LLM. They chain across plugins in resolved order (`enforce: "pre"` → none → `"post"`, then load order).
 
 | Hook | Runs | Do |
 | --- | --- | --- |
 | `setup(ctx)` | on load | read settings, init state |
 | `dispose()` | on unload | clean up |
-| `afterTranscribe(input, output)` | after speech-to-text [server] | rewrite `output.text`, or set `output.consumed = true` |
-| `beforeCleanup(input, output)` | building the AI prompt [server] | push to `output.system`, set `output.register` |
-| `afterCleanup(input, output)` | after cleanup + dictionary [server] | rewrite `output.text` |
-| `beforeOutput(input, output)` | before delivery [app] | rewrite `output.text`, set `output.mode` |
+| `beforeTranscribe(input, output, api)` | before speech-to-text [server] | preprocess `output.audio`, override `output.providerId`/`modelId`/`language`/`bias`, or `api.control.consume()` to skip STT |
+| `afterTranscribe(input, output, api)` | after speech-to-text [server] | rewrite `output.text`, or `api.control.consume()` to skip cleanup + delivery |
+| `beforeCleanup(input, output, api)` | building the AI prompt [server] | push to `output.system`, set `output.destination`, `output.prompt`, or `output.skip` |
+| `afterCleanup(input, output, api)` | after cleanup + dictionary [server] | rewrite `output.text` |
+| `beforeOutput(input, output, api)` | before delivery [app] | rewrite `output.text`, set `output.mode` (no `api.llm` here) |
 | `event({ event })` | throughout [both] | observe only, no mutation |
 | `config(existing)` | boot [server] | return partial config to deep-merge |
 
-Hook inputs: `afterTranscribe` gets `{ providerId, modelId, appContext? }`, `beforeCleanup` gets `{ text, appContext?, inferredRegister }`, `afterCleanup` and `beforeOutput` get `{ appContext? }`. `Register` is `"formal" | "casual" | "neutral"`.
+Hook inputs:
+
+- `beforeTranscribe` → `{ providerId, modelId, audioDurationMs, appContext? }`
+- `afterTranscribe` → `{ providerId, modelId, appContext? }`
+- `beforeCleanup` → `{ text, appContext?, destination }`
+- `afterCleanup` and `beforeOutput` → `{ appContext? }`
+
+`beforeCleanup`'s `destination` is a `CleanupToneDestination` — `"overall" | "personal" | "work" | "email"` — the tone bucket the host inferred; set `output.destination` to override it.
 
 ```ts
 beforeOutput(input, output) {
@@ -56,16 +65,45 @@ beforeOutput(input, output) {
 
 ### Consuming an utterance
 
-`afterTranscribe` can do more than rewrite text — set `output.consumed = true` to signal that the plugin handled the utterance entirely (for example, it triggered a voice command). The host then **skips LLM cleanup and delivers nothing** to the focused app: the dictation is treated as an action, not text to type.
+A plugin can handle an utterance entirely instead of dictating it — for example, a voice command that ran an action. Call `api.control.consume()` from a server hook (typically `afterTranscribe`): the host **skips every remaining stage and delivers nothing** to the focused app.
 
 ```ts
-afterTranscribe(input, output) {
+afterTranscribe(input, output, api) {
   if (isCommand(output.text)) {
     runCommand(output.text);
-    output.consumed = true; // no cleanup, no output
+    api.control.consume("ran a voice command"); // no cleanup, no output
   }
 }
 ```
+
+<Note>`api.control.consume()` replaces the old `output.consumed` flag. It is unambiguous (a genuinely empty transcript is different from a consumed one) and preserves the raw text for logging.</Note>
+
+## HookApi
+
+The third argument to every mutating hook. Built once per dictation and threaded through every stage, so `control` and `llm` are consistent across the whole run.
+
+```ts
+interface HookApi {
+  control: PipelineControl;  // cancellation + suppression for this dictation
+  signal: AbortSignal;       // alias for control.signal
+  llm?: PluginLlm;           // [server hooks only] the host's LLM, when configured
+}
+
+class PipelineControl {
+  readonly state: "running" | "consumed" | "aborted";
+  readonly reason: string | undefined;
+  readonly signal: AbortSignal;
+  stopPropagation(): void;   // stop later plugins for THIS hook only
+  consume(reason?: string): void; // handled: skip the rest of the pipeline, deliver nothing
+  abort(reason?: string): void;   // hard-stop: deliver nothing, emit a pipelineError event
+}
+```
+
+- **`stopPropagation()`** — stop running the remaining plugins for the *current hook only*; later hooks still run.
+- **`consume(reason?)`** — the utterance is handled (e.g. a voice command). Every remaining stage is skipped and no output is delivered.
+- **`abort(reason?)`** — unrecoverable failure: nothing is delivered and the host emits a `pipelineError` event. Aborting also fires `control.signal`, so pass `api.signal` to cancellable work (e.g. `api.llm.generateText({ signal: api.signal })`).
+
+The host checks `control.state` between stages. `llm` is present only on server hooks (`beforeTranscribe`, `afterTranscribe`, `beforeCleanup`, `afterCleanup`) and only when an LLM is configured — never on `beforeOutput`. Always guard with `if (api.llm)`.
 
 ## PluginContext
 
@@ -79,7 +117,6 @@ interface PluginContext {
   logger: PluginLogger;        // debug / info / warn / error
   settings: SettingsReader;    // read-only settings access
   storage: PluginStorage;      // read/write per-plugin key-value storage
-  llm?: PluginLlm;             // [server] the host's configured LLM, when available
 }
 
 interface SettingsReader {
@@ -88,38 +125,53 @@ interface SettingsReader {
 }
 ```
 
+<Note>The LLM capability moved off `PluginContext`. It is now on the per-hook [`HookApi`](#hookapi) as `api.llm`, so it can reflect the model configured for each dictation.</Note>
+
 <Note>Settings are read-only. Pass runtime config through factory `options` and read it back with `getOwn`. For state your plugin needs to write, use `storage`.</Note>
 
 ## PluginLlm
 
-Access to the host's configured language model, so server-side plugins can run their own LLM calls (classification, tool-calling agents, and so on) **reusing the user's default cleanup model and stored API keys** — no separate provider or key configuration required.
+Access to the host's configured language model, so server-side plugins can run their own LLM calls (classification, tool-calling agents, and so on) **reusing the user's configured cleanup model and stored keys** — no separate provider or key configuration required. Reached through [`api.llm`](#hookapi) on any server hook.
 
 ```ts
 interface PluginLlm {
-  getModel(): unknown;         // an AI SDK LanguageModel — cast at the call site
-  readonly providerId: string; // e.g. "openai", "groq"
+  readonly providerId: string; // e.g. "openai", "groq", "freestyle-cloud"
   readonly modelId: string;
+  getModel(): unknown;         // an AI SDK LanguageModel — cast at the call site
+  generateText(opts: {         // convenience wrapper over the host's generateText
+    prompt: string;
+    system?: string;
+    signal?: AbortSignal;
+  }): Promise<{ text: string; usage?: { inputTokens: number; outputTokens: number } }>;
 }
 ```
 
-`llm` is present **only in the server process** (`mode: "server"`) and **only when the user has a default LLM model configured**, so always guard with `if (ctx.llm)`. Capture it in `setup` and use it from your hooks:
+`api.llm` is present **only on server hooks** and **only when a model is configured**, so always guard with `if (api.llm)`. Read it fresh in each hook — don't capture it in `setup` (it's built per-dictation):
 
 ```ts
 import { generateText, type LanguageModel } from "ai";
 
-let model: LanguageModel | null = null;
+async afterTranscribe(input, output, api) {
+  if (!api.llm) return; // no model configured — leave the transcript as-is
+  const model = api.llm.getModel() as LanguageModel;
+  const { text } = await generateText({ model, prompt: output.text, abortSignal: api.signal });
+  output.text = text;
+}
+```
 
-setup(ctx) {
-  if (ctx.llm) model = ctx.llm.getModel() as LanguageModel;
-},
-async afterTranscribe(input, output) {
-  if (!model) return;
-  const { text } = await generateText({ model, prompt: output.text });
+For a simple one-shot call you can skip the AI SDK entirely and use the wrapper:
+
+```ts
+async afterTranscribe(input, output, api) {
+  if (!api.llm) return;
+  const { text } = await api.llm.generateText({ prompt: output.text, signal: api.signal });
   output.text = text;
 }
 ```
 
 `getModel()` is typed `unknown` in the SDK to avoid a hard dependency on the `ai` package — cast the result to `LanguageModel` (from `ai`) at the call site. Bundle `ai` in your plugin's `devDependencies`; installed plugins don't get a transitive `npm install`.
+
+<Note>**Freestyle Cloud.** Signed-in Freestyle Cloud users get `api.llm` too — it routes to Freestyle Cloud's managed LLM endpoint, so plugins work without the user configuring their own provider or key. Plugins never see credentials either way: the host resolves the provider, model, and key and hands back only the capability.</Note>
 
 ## PluginStorage
 
@@ -205,24 +257,13 @@ function transform(
 
 ## The UI bridge
 
-Plugin pages are sandboxed: no filesystem, no direct network. Freestyle injects `window.freestyle` as the one privileged surface. Use it to call the server and trigger host actions. See [a worked example](/first-plugin#the-api-bridge) in the first-plugin guide.
+Freestyle injects `window.freestyle` into plugin pages as the one privileged surface: a helper to call the local server API and to trigger a small set of host actions. See [a worked example](/first-plugin#the-api-bridge) in the first-plugin guide.
 
 ```ts
 interface FreestyleBridge {
-  readonly serverUrl: string;  // e.g. http://127.0.0.1:4649
-  readonly token?: string;     // bearer token, when configured
-  api(path: string, init?: RequestInit): Promise<FreestyleResponse>;
+  readonly serverUrl: string;  // origin the page is served from (location.origin)
+  api(path: string, init?: RequestInit): Promise<Response>;
   invoke<C extends keyof HostActions>(channel: C, payload: HostActions[C]): Promise<void>;
-}
-
-interface FreestyleResponse {
-  readonly ok: boolean;
-  readonly status: number;
-  readonly statusText: string;
-  readonly headers: Record<string, string>;
-  json<T = unknown>(): Promise<T>;
-  text(): Promise<string>;
-  arrayBuffer(): Promise<ArrayBuffer>;
 }
 
 interface HostActions {
@@ -232,12 +273,14 @@ interface HostActions {
 }
 ```
 
-**`api(path, init?)`** appends `path` to `serverUrl`, attaches the token, and proxies the request through the host, so it resolves a `FreestyleResponse` rather than a native `Response`. Use it instead of `fetch`.
+**`api(path, init?)`** resolves `path` against `serverUrl` and returns a **native `Response`**. Plugin UI is now served same-origin with the server, so this is a thin wrapper over `fetch` (no proxying, no manual token) — call `res.json()` / `res.text()` as usual.
 
 ```ts
 const res = await window.freestyle.api("/api/plugins/my-plugin/data");
 if (res.ok) console.log(await res.json());
 ```
+
+<Note>Plugin pages may only reach their own `/api/plugins/<slug>/…` namespace plus `/api/health` — the host confines them by the request `Referer`. They cannot read settings, keys, or history.</Note>
 
 **`invoke(channel, payload)`** asks the host to do something:
 


### PR DESCRIPTION
## What

The plugin docs still described the **pre-#462** pipeline (2-arg hooks, `output.consumed`, `PluginContext.llm`, the old proxied bridge). This brings `apps/docs` current with the plugin-pipeline overhaul (#462, #463) and the new cloud LLM capability (#476 / freestyle-voice/cloud#65).

## Changes

**`sdk-reference.mdx`**
- Hooks now take a third `api` (`HookApi`) argument. New **HookApi** section documents `api.control` (`consume` / `abort` / `stopPropagation` / `state` / `signal`) and `api.llm`.
- `output.consumed` → `api.control.consume()`.
- LLM capability moved off `PluginContext` onto `api.llm`; documents the `generateText` wrapper and notes signed-in **Freestyle Cloud** users get `api.llm` via the managed cloud endpoint.
- Added the missing `beforeTranscribe` hook; corrected `beforeCleanup` (`destination` tone, not "register") in the hooks table.
- UI bridge `api()` returns a **native same-origin `Response`** (no proxy, no bearer token, no `FreestyleResponse`); pages served at `/api/plugins/<slug>/ui/*` and confined to their own API namespace.

**`how-plugins-work.mdx`**
- Pipeline diagram gains `beforeTranscribe`; `beforeCleanup` note fixed; added an `api` blurb.
- Sandboxing section updated (same-origin serving, not `freestyle-plugin://`); added a note that plugin pages appear as sidebar items.

**Plugin pages**
- `voice-commands.mdx`: new-API wording (`api.control.consume()`, `api.llm`), Freestyle Cloud note, dropped the non-existent "Try a phrase" tester and the removed "→ Open" button.
- `profanity-filter.mdx` / `audio-transcription.mdx`: dropped "→ Open" (pages are sidebar items now).

## Verification

- `docs.json` valid JSON; `<Note>`/`<Warning>` tags balanced; internal anchors (`#hookapi`, `#pluginllm`, `#the-ui-bridge`) resolve.
- `apps/docs` is excluded from turbo/knip/CI build checks (Mintlify project), so there's no automated gate; changes are content-only.

## Related

- #476 — desktop `freestyle-cloud` LLM provider
- #477 — voice-commands plugin (new API)
- freestyle-voice/cloud#65 — `/v2/llm` cloud endpoint