### PR TITLE
feat(models): support custom OpenAI-compatible STT endpoints

### DIFF
--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -328,6 +328,7 @@ export function ModelList({
     : 0;
 
   const showLocalLlmForm = type === "llm" && localOnly;
+  const showOpenaiSttForm = type === "voice" && cloudOnly;
 
   const scopedTitle =
     type === "voice"
@@ -417,6 +418,7 @@ export function ModelList({
 
       <div className="min-h-0 flex-1 overflow-y-auto">
         {showLocalLlmForm && <LocalLlmConnect m={m} />}
+        {showOpenaiSttForm && <OpenaiSttConnect m={m} />}
         {visible.length === 0 ? (
           <ListEmptyState
             type={type}
@@ -773,6 +775,80 @@ function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
         {localLlm.connected === false && localLlm.error && (
           <p className="text-destructive text-[12px] leading-snug">
             {localLlm.error}
+          </p>
+        )}
+      </form>
+    </div>
+  );
+}
+
+function OpenaiSttConnect({ m }: { m: UseModels }): React.JSX.Element {
+  const [showKey, setShowKey] = useState(false);
+  const { openaiStt } = m;
+
+  return (
+    <div className="border-border border-b px-5 py-4">
+      <p className="text-muted-foreground mb-4 text-[13px] leading-relaxed">
+        Point OpenAI transcription at a self-hosted or OpenAI-compatible server
+        (vLLM, LiteLLM, LM Studio). Leave the URL empty to use OpenAI.
+      </p>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void openaiStt.test();
+        }}
+        className="space-y-3"
+      >
+        <div className="flex items-center gap-2">
+          <Input
+            type="text"
+            value={openaiStt.url}
+            onChange={(e) => {
+              openaiStt.setUrl(e.target.value);
+              openaiStt.clearStatus();
+            }}
+            placeholder="https://example.com/v1"
+            className="min-w-0 flex-1"
+          />
+          <Button
+            type="submit"
+            variant="secondary"
+            size="sm"
+            disabled={openaiStt.testing}
+            className="shrink-0"
+          >
+            {openaiStt.testing ? (
+              <span className="flex items-center gap-1.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Testing…
+              </span>
+            ) : (
+              "Test"
+            )}
+          </Button>
+        </div>
+        <InputGroup>
+          <InputGroupInput
+            type={showKey ? "text" : "password"}
+            value={openaiStt.apiKey}
+            onChange={(e) => openaiStt.setApiKey(e.target.value)}
+            placeholder="API key (optional)"
+          />
+          <RevealToggle
+            revealed={showKey}
+            onToggle={() => setShowKey(!showKey)}
+            label="API key"
+          />
+        </InputGroup>
+        {openaiStt.connected === true && (
+          <p className="text-primary text-[12px]">
+            Connected · {openaiStt.models.length}{" "}
+            {openaiStt.models.length === 1 ? "model" : "models"} found
+          </p>
+        )}
+        {openaiStt.connected === false && openaiStt.error && (
+          <p className="text-destructive text-[12px] leading-snug">
+            {openaiStt.error}
           </p>
         )}
       </form>

--- a/apps/electron/src/renderer/src/pages/models/use-models.ts
+++ b/apps/electron/src/renderer/src/pages/models/use-models.ts
@@ -57,6 +57,19 @@ export interface LocalLlmState {
   clearStatus: () => void;
 }
 
+export interface OpenaiSttState {
+  url: string;
+  setUrl: (v: string) => void;
+  apiKey: string;
+  setApiKey: (v: string) => void;
+  testing: boolean;
+  connected: boolean | null;
+  error: string | null;
+  models: string[];
+  test: () => Promise<void>;
+  clearStatus: () => void;
+}
+
 export interface UseModels {
   loading: boolean;
   available: AvailableModel[];
@@ -85,6 +98,7 @@ export interface UseModels {
   >;
 
   localLlm: LocalLlmState;
+  openaiStt: OpenaiSttState;
 
   // Actions — each refetches as needed
   configureModel: (
@@ -212,6 +226,14 @@ export function useModels(): UseModels {
   const [localError, setLocalError] = useState<string | null>(null);
   const [localModels, setLocalModels] = useState<string[]>([]);
 
+  // Custom OpenAI-compatible STT endpoint — same inline form pattern as local LLM.
+  const [sttUrl, setSttUrl] = useState("");
+  const [sttApiKey, setSttApiKey] = useState("");
+  const [sttTesting, setSttTesting] = useState(false);
+  const [sttConnected, setSttConnected] = useState<boolean | null>(null);
+  const [sttError, setSttError] = useState<string | null>(null);
+  const [sttModels, setSttModels] = useState<string[]>([]);
+
   // Seed editable state from persisted settings once, when the settings query
   // first resolves. Mutations update this local state directly, so we don't
   // re-seed on later invalidations (which would clobber in-progress edits).
@@ -231,6 +253,8 @@ export function useModels(): UseModels {
     if (url) setLocalUrl(url);
     const key = s[SETTINGS_KEYS.localLlmApiKey];
     if (key) setLocalApiKey(key);
+    setSttUrl(s[SETTINGS_KEYS.openaiSttBaseUrl] ?? "");
+    setSttApiKey(s[SETTINGS_KEYS.openaiSttApiKey] ?? "");
     const rawMinutes = s[SETTINGS_KEYS.mlxAsrKeepAliveMinutes];
     if (rawMinutes) {
       const minutes = Number(rawMinutes);
@@ -632,6 +656,78 @@ export function useModels(): UseModels {
     }
   }, [localUrl, localApiKey, loadData]);
 
+  // -------------------------------------------------------------------------
+  // Custom OpenAI-compatible STT endpoint test
+  // -------------------------------------------------------------------------
+
+  const clearSttStatus = useCallback(() => {
+    setSttConnected(null);
+    setSttError(null);
+  }, []);
+
+  const testOpenaiStt = useCallback(async () => {
+    setSttTesting(true);
+    setSttConnected(null);
+    setSttError(null);
+    try {
+      const url = sttUrl.replace(/\/+$/, "");
+      const key = sttApiKey.trim();
+      const client = getClient();
+      await Promise.all([
+        url
+          ? client.api.settings[":key"].$put({
+              param: { key: SETTINGS_KEYS.openaiSttBaseUrl },
+              json: { value: url },
+            })
+          : client.api.settings[":key"].$delete({
+              param: { key: SETTINGS_KEYS.openaiSttBaseUrl },
+            }),
+        key
+          ? client.api.settings[":key"].$put({
+              param: { key: SETTINGS_KEYS.openaiSttApiKey },
+              json: { value: key },
+            })
+          : client.api.settings[":key"].$delete({
+              param: { key: SETTINGS_KEYS.openaiSttApiKey },
+            }),
+      ]);
+
+      if (!url) {
+        setSttConnected(null);
+        await loadData();
+        return;
+      }
+
+      const res = await client.api.settings["openai-stt"].test.$post({
+        json: { url, api_key: key || undefined },
+      });
+
+      if (res.ok) {
+        const result = await res.json();
+        if ("ok" in result && result.ok) {
+          setSttConnected(true);
+          setSttModels(result.models ?? []);
+          await loadData();
+          return;
+        }
+        setSttConnected(false);
+        setSttError(
+          "error" in result && typeof result.error === "string"
+            ? result.error
+            : "Connection failed",
+        );
+        return;
+      }
+      setSttConnected(false);
+      setSttError(`HTTP ${res.status}`);
+    } catch (err) {
+      setSttConnected(false);
+      setSttError(err instanceof Error ? err.message : "Connection failed");
+    } finally {
+      setSttTesting(false);
+    }
+  }, [sttUrl, sttApiKey, loadData]);
+
   return {
     loading,
     available,
@@ -660,6 +756,18 @@ export function useModels(): UseModels {
       models: localModels,
       test: testLocalLlm,
       clearStatus: clearLocalStatus,
+    },
+    openaiStt: {
+      url: sttUrl,
+      setUrl: setSttUrl,
+      apiKey: sttApiKey,
+      setApiKey: setSttApiKey,
+      testing: sttTesting,
+      connected: sttConnected,
+      error: sttError,
+      models: sttModels,
+      test: testOpenaiStt,
+      clearStatus: clearSttStatus,
     },
     configureModel,
     saveKey,

--- a/apps/electron/src/shared/settings-keys.ts
+++ b/apps/electron/src/shared/settings-keys.ts
@@ -19,6 +19,8 @@ export const SETTINGS_KEYS = {
   mlxAsrKeepAliveMinutes: "mlx_asr_keep_alive_minutes",
   networkCaCertPath: "network_ca_cert_path",
   networkProxyUrl: "network_proxy_url",
+  openaiSttApiKey: "openai_stt_api_key",
+  openaiSttBaseUrl: "openai_stt_base_url",
   outputMode: "output_mode",
   soundEnabled: "sound_enabled",
   theme: "theme",

--- a/apps/server/src/lib/streaming/providers/openai.ts
+++ b/apps/server/src/lib/streaming/providers/openai.ts
@@ -1,6 +1,8 @@
 import { Buffer } from "node:buffer";
 import { createOpenAI } from "@ai-sdk/openai";
+import { sanitizeSttBaseUrl } from "@freestyle-voice/validations";
 import WebSocket from "ws";
+import { readSetting } from "../../db.js";
 import { createPcmUpsampler } from "../pcm.js";
 import type {
   StreamingSessionOptions,
@@ -21,7 +23,18 @@ export class OpenAITranscriptionProvider implements TranscriptionProvider {
   readonly providerId = "openai";
 
   async transcribe(opts: TranscribeOptions): Promise<TranscribeResult> {
-    return transcribeWithAiSdk(opts, createOpenAI, this.providerId);
+    const baseUrl = sanitizeSttBaseUrl(
+      readSetting("openai_stt_base_url") ?? "",
+    );
+    if (!baseUrl) {
+      return transcribeWithAiSdk(opts, createOpenAI, this.providerId);
+    }
+
+    const apiKey = readSetting("openai_stt_api_key") ?? "";
+    const createOpenAIWithBaseUrl = () =>
+      createOpenAI({ apiKey, baseURL: baseUrl });
+
+    return transcribeWithAiSdk(opts, createOpenAIWithBaseUrl, this.providerId);
   }
 
   supportsStreaming(modelId: string): boolean {

--- a/apps/server/src/routes/settings.ts
+++ b/apps/server/src/routes/settings.ts
@@ -10,6 +10,8 @@ import {
   disabledPluginsSettingSchema,
   historyRetentionDaysSettingSchema,
   localLlmConfigSchema,
+  openaiSttBaseUrlSchema,
+  openaiSttConfigSchema,
   pluginsSettingSchema,
   proxyUrlSettingSchema,
   settingValueSchema,
@@ -125,6 +127,17 @@ const settings = new Hono()
       if (!parsed.success) {
         return c.json({ error: "Invalid disabled_plugins setting" }, 400);
       }
+    } else if (key === "openai_stt_base_url") {
+      const parsed = openaiSttBaseUrlSchema.safeParse(body.value);
+      if (!parsed.success) {
+        return c.json(
+          {
+            error:
+              parsed.error.issues[0]?.message ?? "Invalid OpenAI STT base URL",
+          },
+          400,
+        );
+      }
     } else if (key === PROXY_URL_SETTING) {
       const parsed = proxyUrlSettingSchema.safeParse(body.value);
       if (!parsed.success) {
@@ -193,6 +206,47 @@ const settings = new Hono()
   .post(
     "/local-llm/test",
     zValidator("json", localLlmConfigSchema),
+    async (c) => {
+      const body = c.req.valid("json");
+      const url = body.url.replace(/\/+$/, "").replace(/\/v1$/, "");
+
+      try {
+        const res = await fetch(`${url}/v1/models`, {
+          headers: {
+            ...(body.api_key
+              ? { Authorization: `Bearer ${body.api_key}` }
+              : {}),
+          },
+          signal: AbortSignal.timeout(5000),
+        });
+
+        if (!res.ok) {
+          return c.json(
+            { error: `Server returned ${res.status}: ${res.statusText}` },
+            502,
+          );
+        }
+
+        const data = (await res.json()) as {
+          data?: { id: string }[];
+        };
+
+        let models: string[] = [];
+        if (data.data && Array.isArray(data.data)) {
+          models = data.data.map((m) => m.id);
+        }
+
+        return c.json({ ok: true, models });
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to connect";
+        return c.json({ error: message }, 502);
+      }
+    },
+  )
+  .post(
+    "/openai-stt/test",
+    zValidator("json", openaiSttConfigSchema),
     async (c) => {
       const body = c.req.valid("json");
       const url = body.url.replace(/\/+$/, "").replace(/\/v1$/, "");

--- a/apps/server/tests/openai-stt-base-url.test.ts
+++ b/apps/server/tests/openai-stt-base-url.test.ts
@@ -1,0 +1,148 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SETTINGS_KEYS } from "../../electron/src/shared/settings-keys.js";
+import createApp from "../src/index.js";
+import { getDb } from "../src/lib/db.js";
+
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: vi.fn(() => ({
+    transcription: vi.fn((id: string) => ({ id })),
+  })),
+}));
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    experimental_transcribe: vi.fn(async () => ({
+      text: "mock transcript",
+      segments: undefined,
+      durationInSeconds: undefined,
+    })),
+  };
+});
+
+const { OpenAITranscriptionProvider } = await import(
+  "../src/lib/streaming/providers/openai.js"
+);
+
+const opts = {
+  audio: new Uint8Array([1, 2, 3, 4]),
+  model: "whisper-1",
+  apiKey: "cloud-openai-key",
+};
+
+function createOpenAICallConfig(): unknown {
+  return vi.mocked(createOpenAI).mock.calls[0]?.[0];
+}
+
+function setSetting(key: string, value: string): void {
+  getDb()
+    .prepare("INSERT INTO settings (key, value) VALUES (?, ?)")
+    .run(key, value);
+}
+
+describe("OpenAI STT custom endpoint provider", () => {
+  beforeEach(() => {
+    getDb()
+      .prepare("DELETE FROM settings WHERE key IN (?, ?)")
+      .run(SETTINGS_KEYS.openaiSttBaseUrl, SETTINGS_KEYS.openaiSttApiKey);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the default provider config when no base URL is set", async () => {
+    const provider = new OpenAITranscriptionProvider();
+
+    const result = await provider.transcribe(opts);
+
+    expect(result.text).toBe("mock transcript");
+    expect(createOpenAICallConfig()).toEqual({ apiKey: "cloud-openai-key" });
+  });
+
+  it("uses the default provider config when the base URL is empty", async () => {
+    setSetting(SETTINGS_KEYS.openaiSttBaseUrl, "");
+    const provider = new OpenAITranscriptionProvider();
+
+    await provider.transcribe(opts);
+
+    expect(createOpenAICallConfig()).toEqual({ apiKey: "cloud-openai-key" });
+  });
+
+  it("forwards the verbatim base URL and STT key when configured", async () => {
+    setSetting(SETTINGS_KEYS.openaiSttBaseUrl, "https://example.com/v1");
+    setSetting(SETTINGS_KEYS.openaiSttApiKey, "stt-endpoint-key");
+    const provider = new OpenAITranscriptionProvider();
+
+    await provider.transcribe(opts);
+
+    expect(createOpenAICallConfig()).toEqual({
+      apiKey: "stt-endpoint-key",
+      baseURL: "https://example.com/v1",
+    });
+  });
+
+  it("trims whitespace and trailing slashes but does not append /v1", async () => {
+    setSetting(SETTINGS_KEYS.openaiSttBaseUrl, "  http://localhost:10095/  ");
+    const provider = new OpenAITranscriptionProvider();
+
+    await provider.transcribe(opts);
+
+    expect(createOpenAICallConfig()).toEqual({
+      apiKey: "",
+      baseURL: "http://localhost:10095",
+    });
+  });
+});
+
+describe("POST /api/settings/openai-stt/test", () => {
+  const app = createApp();
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function post(body: unknown) {
+    return app.request("/api/settings/openai-stt/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("probes <url>/v1/models and returns discovered models", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: "whisper-1" }] }), {
+        status: 200,
+      }),
+    );
+
+    const res = await post({ url: "https://example.com", api_key: "k" });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, models: ["whisper-1"] });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/v1/models",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer k" },
+      }),
+    );
+  });
+
+  it("returns 502 when the endpoint responds with an error status", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 401, statusText: "Unauthorized" }),
+    );
+
+    const res = await post({ url: "https://example.com" });
+
+    expect(res.status).toBe(502);
+  });
+
+  it("rejects an invalid URL with a 400", async () => {
+    const res = await post({ url: "not-a-url" });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/validations/src/index.ts
+++ b/packages/validations/src/index.ts
@@ -7,6 +7,7 @@ export * from "./dictionary.js";
 export * from "./export.js";
 export * from "./local-llm.js";
 export * from "./models.js";
+export * from "./openai-stt.js";
 export * from "./plugins.js";
 export * from "./post-process.js";
 export * from "./query.js";

--- a/packages/validations/src/openai-stt.ts
+++ b/packages/validations/src/openai-stt.ts
@@ -1,0 +1,32 @@
+import { z } from "zod/v3";
+
+export const openaiSttConfigSchema = z.object({
+  url: z.string().min(1, "Endpoint URL is required").url("Must be a valid URL"),
+  api_key: z.string().optional(),
+});
+
+export type OpenaiSttConfigInput = z.infer<typeof openaiSttConfigSchema>;
+
+export const openaiSttBaseUrlSchema = z
+  .string()
+  .max(2048)
+  .refine(
+    (value) => {
+      if (value.trim() === "") return true;
+      try {
+        const url = new URL(value.trim());
+        return url.protocol === "http:" || url.protocol === "https:";
+      } catch {
+        return false;
+      }
+    },
+    {
+      message:
+        "OpenAI STT base URL must be a valid http:// or https:// URL (or empty to disable)",
+    },
+  );
+
+export function sanitizeSttBaseUrl(input: string): string | undefined {
+  const trimmed = input.trim().replace(/\/+$/, "");
+  return trimmed === "" ? undefined : trimmed;
+}


### PR DESCRIPTION
## Summary

Adds support for pointing OpenAI speech-to-text at a self-hosted or OpenAI-compatible endpoint (vLLM, LiteLLM, LM Studio, etc.). This is a reworked take on #441 that follows the existing **on-device cleanup (local LLM)** flow as closely as possible.

Closes #415. Reworks the approach from #441.

## Design

A custom STT endpoint is treated as a **self-contained connection** — a URL plus its own API key — exactly like `local_llm_url` / `local_llm_api_key`:

- When `openai_stt_base_url` is set, transcription runs against that endpoint using `openai_stt_api_key`.
- When it's empty/unset, behavior is unchanged: default OpenAI endpoint with the existing OpenAI key.
- **No fallback** between the STT key and the cloud OpenAI key — either you're on a custom endpoint (with its own creds) or on stock OpenAI.

## What changed

- **Settings**: `openai_stt_base_url` + `openai_stt_api_key` keys, with a relaxed http/https validation schema (mirrors `proxyUrlSettingSchema`).
- **Backend**: `OpenAITranscriptionProvider.transcribe` reads the setting and, when present, builds the client with the custom `baseURL` + STT key.
- **URL handling**: stored **verbatim** (trim + trailing-slash only, no `/v1` rewrite), so gateways that don't use a `/v1` suffix work.
- **UI**: `OpenaiSttConnect` reuses the `LocalLlmConnect` pattern — URL field, password key field, and a **Test** button that probes `<url>/v1/models`. Shown at the top of the cloud voice list.
- **Tests**: provider behavior (default / empty / custom / verbatim URL + STT key) and the new `POST /api/settings/openai-stt/test` endpoint.

## Differences vs #441

- Adds a **Test-connection button** (#441 was save-only).
- Simpler validation (drops the strict query/hash rejection + throwing normalizer; `normalizeOpenAISttBaseUrl` → `sanitizeSttBaseUrl`, trim-only).
- UI rendered unconditionally at the top of the cloud list instead of injected mid-list after the first OpenAI row.
- Separate STT API key so self-hosted gateways with their own credentials work at runtime.

## Testing

- `pnpm --filter @freestyle-voice/server exec vitest run` — full server suite green (269 tests, incl. 7 new).
- `pnpm --filter @freestyle-voice/electron typecheck` — clean (node + web).
- Server `tsc` build, validations pkgroll build, Biome, and Knip all clean.