### PR TITLE
refactor(models): drive endpoint connect forms with react-hook-form

### DIFF
--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -1,3 +1,9 @@
+import type { EndpointConnectFormValues } from "@freestyle-voice/validations";
+import {
+  localLlmConnectFormSchema,
+  openaiSttConnectFormSchema,
+} from "@freestyle-voice/validations";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { Badge } from "@renderer/components/ui/badge";
 import { Button } from "@renderer/components/ui/button";
 import { Input } from "@renderer/components/ui/input";
@@ -30,7 +36,8 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { Controller, type Resolver, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {
   PICKER_MODAL_BODY,
@@ -45,7 +52,7 @@ import {
   TranscriptionPicker,
 } from "./transcription-picker";
 import type { ConfiguredModel } from "./types";
-import type { UseModels } from "./use-models";
+import type { EndpointConnectState, UseModels } from "./use-models";
 import { displayName } from "./utils";
 
 // ---------------------------------------------------------------------------
@@ -709,146 +716,148 @@ function ListEmptyState({
 }
 
 function LocalLlmConnect({ m }: { m: UseModels }): React.JSX.Element {
-  const [showKey, setShowKey] = useState(false);
-  const { localLlm } = m;
-
   return (
-    <div className="border-border border-b px-5 py-4">
-      <p className="text-muted-foreground mb-4 text-[13px] leading-relaxed">
-        Connect to Ollama, LM Studio, or another OpenAI-compatible server
-        running locally.
-      </p>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          void localLlm.test();
-        }}
-        className="space-y-3"
-      >
-        <div className="flex items-center gap-2">
-          <Input
-            type="text"
-            value={localLlm.url}
-            onChange={(e) => {
-              localLlm.setUrl(e.target.value);
-              localLlm.clearStatus();
-            }}
-            placeholder="http://localhost:11434"
-            className="min-w-0 flex-1"
-          />
-          <Button
-            type="submit"
-            variant="secondary"
-            size="sm"
-            disabled={localLlm.testing}
-            className="shrink-0"
-          >
-            {localLlm.testing ? (
-              <span className="flex items-center gap-1.5">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Testing…
-              </span>
-            ) : (
-              "Test"
-            )}
-          </Button>
-        </div>
-        <InputGroup>
-          <InputGroupInput
-            type={showKey ? "text" : "password"}
-            value={localLlm.apiKey}
-            onChange={(e) => localLlm.setApiKey(e.target.value)}
-            placeholder="API key (optional)"
-          />
-          <RevealToggle
-            revealed={showKey}
-            onToggle={() => setShowKey(!showKey)}
-            label="API key"
-          />
-        </InputGroup>
-        {localLlm.connected === true && (
-          <p className="text-primary text-[12px]">
-            Connected · {localLlm.models.length}{" "}
-            {localLlm.models.length === 1 ? "model" : "models"} found
-          </p>
-        )}
-        {localLlm.connected === false && localLlm.error && (
-          <p className="text-destructive text-[12px] leading-snug">
-            {localLlm.error}
-          </p>
-        )}
-      </form>
-    </div>
+    <EndpointConnectForm
+      connect={m.localLlm}
+      resolver={zodResolver(localLlmConnectFormSchema)}
+      description="Connect to Ollama, LM Studio, or another OpenAI-compatible server running locally."
+      urlPlaceholder="http://localhost:11434"
+    />
   );
 }
 
 function OpenaiSttConnect({ m }: { m: UseModels }): React.JSX.Element {
+  return (
+    <EndpointConnectForm
+      connect={m.openaiStt}
+      resolver={zodResolver(openaiSttConnectFormSchema)}
+      description="Point OpenAI transcription at a self-hosted or OpenAI-compatible server (vLLM, LiteLLM, LM Studio). Leave the URL empty to use OpenAI."
+      urlPlaceholder="https://example.com/v1"
+    />
+  );
+}
+
+/**
+ * Shared connect form for OpenAI-compatible endpoints (local LLM, custom STT).
+ * Drives a react-hook-form with inline validation from the shared schema; the
+ * Test button persists the values then probes the endpoint via the hook.
+ */
+function EndpointConnectForm({
+  connect,
+  resolver,
+  description,
+  urlPlaceholder,
+}: {
+  connect: EndpointConnectState;
+  resolver: Resolver<EndpointConnectFormValues>;
+  description: string;
+  urlPlaceholder: string;
+}): React.JSX.Element {
   const [showKey, setShowKey] = useState(false);
-  const { openaiStt } = m;
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<EndpointConnectFormValues>({
+    resolver,
+    defaultValues: { url: connect.initialUrl, apiKey: connect.initialApiKey },
+    mode: "onBlur",
+  });
+
+  // Seed the form once the persisted values resolve. react-hook-form owns the
+  // state afterwards, so later cache updates don't clobber in-progress edits.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current) return;
+    if (!connect.initialUrl && !connect.initialApiKey) return;
+    seededRef.current = true;
+    reset({ url: connect.initialUrl, apiKey: connect.initialApiKey });
+  }, [connect.initialUrl, connect.initialApiKey, reset]);
 
   return (
     <div className="border-border border-b px-5 py-4">
       <p className="text-muted-foreground mb-4 text-[13px] leading-relaxed">
-        Point OpenAI transcription at a self-hosted or OpenAI-compatible server
-        (vLLM, LiteLLM, LM Studio). Leave the URL empty to use OpenAI.
+        {description}
       </p>
       <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          void openaiStt.test();
-        }}
+        onSubmit={handleSubmit((values) => connect.test(values))}
         className="space-y-3"
       >
-        <div className="flex items-center gap-2">
-          <Input
-            type="text"
-            value={openaiStt.url}
-            onChange={(e) => {
-              openaiStt.setUrl(e.target.value);
-              openaiStt.clearStatus();
-            }}
-            placeholder="https://example.com/v1"
-            className="min-w-0 flex-1"
-          />
-          <Button
-            type="submit"
-            variant="secondary"
-            size="sm"
-            disabled={openaiStt.testing}
-            className="shrink-0"
-          >
-            {openaiStt.testing ? (
-              <span className="flex items-center gap-1.5">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Testing…
-              </span>
-            ) : (
-              "Test"
-            )}
-          </Button>
-        </div>
-        <InputGroup>
-          <InputGroupInput
-            type={showKey ? "text" : "password"}
-            value={openaiStt.apiKey}
-            onChange={(e) => openaiStt.setApiKey(e.target.value)}
-            placeholder="API key (optional)"
-          />
-          <RevealToggle
-            revealed={showKey}
-            onToggle={() => setShowKey(!showKey)}
-            label="API key"
-          />
-        </InputGroup>
-        {openaiStt.connected === true && (
-          <p className="text-primary text-[12px]">
-            Connected · {openaiStt.models.length}{" "}
-            {openaiStt.models.length === 1 ? "model" : "models"} found
+        <Controller
+          control={control}
+          name="url"
+          render={({ field }) => (
+            <div className="flex items-center gap-2">
+              <Input
+                type="text"
+                name={field.name}
+                ref={field.ref}
+                value={field.value}
+                onChange={(e) => {
+                  field.onChange(e);
+                  connect.clearStatus();
+                }}
+                onBlur={field.onBlur}
+                placeholder={urlPlaceholder}
+                aria-invalid={errors.url ? true : undefined}
+                className="min-w-0 flex-1"
+              />
+              <Button
+                type="submit"
+                variant="secondary"
+                size="sm"
+                disabled={connect.testing}
+                className="shrink-0"
+              >
+                {connect.testing ? (
+                  <span className="flex items-center gap-1.5">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    Testing…
+                  </span>
+                ) : (
+                  "Test"
+                )}
+              </Button>
+            </div>
+          )}
+        />
+        {errors.url && (
+          <p className="text-destructive text-[12px] leading-snug">
+            {errors.url.message}
           </p>
         )}
-        {openaiStt.connected === false && openaiStt.error && (
+        <Controller
+          control={control}
+          name="apiKey"
+          render={({ field }) => (
+            <InputGroup>
+              <InputGroupInput
+                type={showKey ? "text" : "password"}
+                name={field.name}
+                ref={field.ref}
+                value={field.value}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+                placeholder="API key (optional)"
+              />
+              <RevealToggle
+                revealed={showKey}
+                onToggle={() => setShowKey(!showKey)}
+                label="API key"
+              />
+            </InputGroup>
+          )}
+        />
+        {connect.connected === true && (
+          <p className="text-primary text-[12px]">
+            Connected · {connect.models.length}{" "}
+            {connect.models.length === 1 ? "model" : "models"} found
+          </p>
+        )}
+        {connect.connected === false && connect.error && (
           <p className="text-destructive text-[12px] leading-snug">
-            {openaiStt.error}
+            {connect.error}
           </p>
         )}
       </form>

--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -36,7 +36,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { Controller, type Resolver, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {
@@ -757,23 +757,12 @@ function EndpointConnectForm({
   const {
     control,
     handleSubmit,
-    reset,
     formState: { errors },
   } = useForm<EndpointConnectFormValues>({
     resolver,
     defaultValues: { url: connect.initialUrl, apiKey: connect.initialApiKey },
     mode: "onBlur",
   });
-
-  // Seed the form once the persisted values resolve. react-hook-form owns the
-  // state afterwards, so later cache updates don't clobber in-progress edits.
-  const seededRef = useRef(false);
-  useEffect(() => {
-    if (seededRef.current) return;
-    if (!connect.initialUrl && !connect.initialApiKey) return;
-    seededRef.current = true;
-    reset({ url: connect.initialUrl, apiKey: connect.initialApiKey });
-  }, [connect.initialUrl, connect.initialApiKey, reset]);
 
   return (
     <div className="border-border border-b px-5 py-4">

--- a/apps/electron/src/renderer/src/pages/models/use-endpoint-connect.ts
+++ b/apps/electron/src/renderer/src/pages/models/use-endpoint-connect.ts
@@ -1,0 +1,190 @@
+import { getClient } from "@renderer/lib/api";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { SettingsKey } from "../../../../shared/settings-keys";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface EndpointTestValues {
+  url: string;
+  apiKey: string;
+}
+
+/**
+ * Connection state for an OpenAI-compatible endpoint (local LLM or custom
+ * STT). The form fields themselves live in react-hook-form inside the connect
+ * component; this hook owns the persisted seed values and the async test that
+ * saves the settings then probes the endpoint.
+ */
+export interface EndpointConnectState {
+  /** Persisted URL, used to seed the form once settings resolve. */
+  initialUrl: string;
+  /** Persisted API key, used to seed the form once settings resolve. */
+  initialApiKey: string;
+  testing: boolean;
+  connected: boolean | null;
+  error: string | null;
+  models: string[];
+  test: (values: EndpointTestValues) => Promise<void>;
+  clearStatus: () => void;
+}
+
+/** Static configuration for an endpoint — invariant across renders. */
+export interface EndpointConnectConfig {
+  /** Setting key for the URL (e.g. `SETTINGS_KEYS.localLlmUrl`). */
+  urlKey: SettingsKey;
+  /** Setting key for the API key (e.g. `SETTINGS_KEYS.localLlmApiKey`). */
+  apiKeyKey: SettingsKey;
+  /** Default URL shown when no persisted value exists. */
+  defaultUrl: string;
+  /** When true, an empty URL clears the setting and skips probing. */
+  clearUrlWhenEmpty: boolean;
+  /** Issue the typed test-endpoint call for this particular provider. */
+  probe: (
+    client: ReturnType<typeof getClient>,
+    body: { url: string; api_key: string | undefined },
+  ) => Promise<Response>;
+}
+
+// ---------------------------------------------------------------------------
+// Shared test runner (pure function, no hooks)
+// ---------------------------------------------------------------------------
+
+interface TestStatus {
+  setTesting: (v: boolean) => void;
+  setConnected: (v: boolean | null) => void;
+  setError: (v: string | null) => void;
+  setModels: (v: string[]) => void;
+}
+
+async function runEndpointTest(
+  values: EndpointTestValues,
+  config: EndpointConnectConfig,
+  status: TestStatus,
+  onDone: () => Promise<void>,
+): Promise<void> {
+  status.setTesting(true);
+  status.setConnected(null);
+  status.setError(null);
+  try {
+    const url = values.url.replace(/\/+$/, "");
+    const key = values.apiKey.trim();
+    const client = getClient();
+
+    const saveUrl =
+      url || !config.clearUrlWhenEmpty
+        ? client.api.settings[":key"].$put({
+            param: { key: config.urlKey },
+            json: { value: url },
+          })
+        : client.api.settings[":key"].$delete({
+            param: { key: config.urlKey },
+          });
+    const saveKey = key
+      ? client.api.settings[":key"].$put({
+          param: { key: config.apiKeyKey },
+          json: { value: key },
+        })
+      : client.api.settings[":key"].$delete({
+          param: { key: config.apiKeyKey },
+        });
+    await Promise.all([saveUrl, saveKey]);
+
+    if (config.clearUrlWhenEmpty && !url) {
+      status.setConnected(null);
+      await onDone();
+      return;
+    }
+
+    const res = await config.probe(client, { url, api_key: key || undefined });
+    if (res.ok) {
+      const result = (await res.json()) as {
+        ok?: boolean;
+        models?: string[];
+        error?: string;
+      };
+      if (result.ok) {
+        status.setConnected(true);
+        status.setModels(result.models ?? []);
+        await onDone();
+        return;
+      }
+      status.setConnected(false);
+      status.setError(
+        typeof result.error === "string" ? result.error : "Connection failed",
+      );
+      return;
+    }
+    status.setConnected(false);
+    status.setError(`HTTP ${res.status}`);
+  } catch (err) {
+    status.setConnected(false);
+    status.setError(err instanceof Error ? err.message : "Connection failed");
+  } finally {
+    status.setTesting(false);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages a single OpenAI-compatible endpoint connection. Called once per
+ * endpoint (local LLM, custom STT) inside `useModels`.
+ *
+ * @param config  Static description of the endpoint (keys, default URL, probe).
+ * @param settingsData  The resolved settings record from the shared query.
+ * @param onDone  Called after a successful save/test (typically `loadData`).
+ */
+export function useEndpointConnect(
+  config: EndpointConnectConfig,
+  settingsData: Record<string, string> | undefined,
+  onDone: () => Promise<void>,
+): EndpointConnectState {
+  const [initialUrl, setInitialUrl] = useState(config.defaultUrl);
+  const [initialApiKey, setInitialApiKey] = useState("");
+  const [testing, setTesting] = useState(false);
+  const [connected, setConnected] = useState<boolean | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [models, setModels] = useState<string[]>([]);
+
+  // Seed from persisted settings once.
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (seeded.current || !settingsData) return;
+    seeded.current = true;
+    const url = settingsData[config.urlKey];
+    if (url !== undefined) setInitialUrl(url);
+    const key = settingsData[config.apiKeyKey];
+    if (key !== undefined) setInitialApiKey(key);
+  }, [settingsData, config.urlKey, config.apiKeyKey]);
+
+  const clearStatus = useCallback(() => {
+    setConnected(null);
+    setError(null);
+  }, []);
+
+  const test = useCallback(
+    (values: EndpointTestValues) =>
+      runEndpointTest(
+        values,
+        config,
+        { setTesting, setConnected, setError, setModels },
+        onDone,
+      ),
+    [config, onDone],
+  );
+
+  return {
+    initialUrl,
+    initialApiKey,
+    testing,
+    connected,
+    error,
+    models,
+    test,
+    clearStatus,
+  };
+}

--- a/apps/electron/src/renderer/src/pages/models/use-endpoint-connect.ts
+++ b/apps/electron/src/renderer/src/pages/models/use-endpoint-connect.ts
@@ -56,6 +56,8 @@ interface TestStatus {
   setConnected: (v: boolean | null) => void;
   setError: (v: string | null) => void;
   setModels: (v: string[]) => void;
+  setInitialUrl: (v: string) => void;
+  setInitialApiKey: (v: string) => void;
 }
 
 async function runEndpointTest(
@@ -90,6 +92,10 @@ async function runEndpointTest(
           param: { key: config.apiKeyKey },
         });
     await Promise.all([saveUrl, saveKey]);
+
+    // Keep seed values in sync so the form re-seeds correctly on remount.
+    status.setInitialUrl(url);
+    status.setInitialApiKey(key);
 
     if (config.clearUrlWhenEmpty && !url) {
       status.setConnected(null);
@@ -150,15 +156,16 @@ export function useEndpointConnect(
   const [error, setError] = useState<string | null>(null);
   const [models, setModels] = useState<string[]>([]);
 
-  // Seed from persisted settings once.
+  // Seed from persisted settings once, matching the original truthiness guards
+  // in useModels (an empty string does not override the default).
   const seeded = useRef(false);
   useEffect(() => {
     if (seeded.current || !settingsData) return;
     seeded.current = true;
     const url = settingsData[config.urlKey];
-    if (url !== undefined) setInitialUrl(url);
+    if (url) setInitialUrl(url);
     const key = settingsData[config.apiKeyKey];
-    if (key !== undefined) setInitialApiKey(key);
+    if (key) setInitialApiKey(key);
   }, [settingsData, config.urlKey, config.apiKeyKey]);
 
   const clearStatus = useCallback(() => {
@@ -171,7 +178,14 @@ export function useEndpointConnect(
       runEndpointTest(
         values,
         config,
-        { setTesting, setConnected, setError, setModels },
+        {
+          setTesting,
+          setConnected,
+          setError,
+          setModels,
+          setInitialUrl,
+          setInitialApiKey,
+        },
         onDone,
       ),
     [config, onDone],

--- a/apps/electron/src/renderer/src/pages/models/use-models.ts
+++ b/apps/electron/src/renderer/src/pages/models/use-models.ts
@@ -44,29 +44,22 @@ function hasActiveDownload(
   );
 }
 
-export interface LocalLlmState {
-  url: string;
-  setUrl: (v: string) => void;
-  apiKey: string;
-  setApiKey: (v: string) => void;
+/**
+ * Connection state for an OpenAI-compatible endpoint (local LLM or custom
+ * STT). The form fields themselves live in react-hook-form inside the connect
+ * component; the hook owns the persisted seed values and the async test that
+ * saves the settings then probes the endpoint.
+ */
+export interface EndpointConnectState {
+  /** Persisted URL, used to seed the form once settings resolve. */
+  initialUrl: string;
+  /** Persisted API key, used to seed the form once settings resolve. */
+  initialApiKey: string;
   testing: boolean;
   connected: boolean | null;
   error: string | null;
   models: string[];
-  test: () => Promise<void>;
-  clearStatus: () => void;
-}
-
-export interface OpenaiSttState {
-  url: string;
-  setUrl: (v: string) => void;
-  apiKey: string;
-  setApiKey: (v: string) => void;
-  testing: boolean;
-  connected: boolean | null;
-  error: string | null;
-  models: string[];
-  test: () => Promise<void>;
+  test: (values: { url: string; apiKey: string }) => Promise<void>;
   clearStatus: () => void;
 }
 
@@ -97,8 +90,8 @@ export interface UseModels {
     { providerName: string; models: AvailableModel[] }
   >;
 
-  localLlm: LocalLlmState;
-  openaiStt: OpenaiSttState;
+  localLlm: EndpointConnectState;
+  openaiStt: EndpointConnectState;
 
   // Actions — each refetches as needed
   configureModel: (
@@ -218,17 +211,21 @@ export function useModels(): UseModels {
     new Set(),
   );
 
-  // Local LLM (Ollama / LM Studio) connection — simplified inline form state.
-  const [localUrl, setLocalUrl] = useState("http://localhost:11434");
-  const [localApiKey, setLocalApiKey] = useState("");
+  // Local LLM (Ollama / LM Studio) connection. The editable url/key fields live
+  // in the connect component's react-hook-form; the hook keeps the persisted
+  // seed values plus the transient connection status.
+  const [localInitialUrl, setLocalInitialUrl] = useState(
+    "http://localhost:11434",
+  );
+  const [localInitialApiKey, setLocalInitialApiKey] = useState("");
   const [localTesting, setLocalTesting] = useState(false);
   const [localConnected, setLocalConnected] = useState<boolean | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
   const [localModels, setLocalModels] = useState<string[]>([]);
 
-  // Custom OpenAI-compatible STT endpoint — same inline form pattern as local LLM.
-  const [sttUrl, setSttUrl] = useState("");
-  const [sttApiKey, setSttApiKey] = useState("");
+  // Custom OpenAI-compatible STT endpoint — same connection pattern as local LLM.
+  const [sttInitialUrl, setSttInitialUrl] = useState("");
+  const [sttInitialApiKey, setSttInitialApiKey] = useState("");
   const [sttTesting, setSttTesting] = useState(false);
   const [sttConnected, setSttConnected] = useState<boolean | null>(null);
   const [sttError, setSttError] = useState<string | null>(null);
@@ -250,11 +247,11 @@ export function useModels(): UseModels {
     const cleanup = s[SETTINGS_KEYS.llmCleanup];
     if (cleanup) setLlmCleanup(cleanup === "true");
     const url = s[SETTINGS_KEYS.localLlmUrl];
-    if (url) setLocalUrl(url);
+    if (url) setLocalInitialUrl(url);
     const key = s[SETTINGS_KEYS.localLlmApiKey];
-    if (key) setLocalApiKey(key);
-    setSttUrl(s[SETTINGS_KEYS.openaiSttBaseUrl] ?? "");
-    setSttApiKey(s[SETTINGS_KEYS.openaiSttApiKey] ?? "");
+    if (key) setLocalInitialApiKey(key);
+    setSttInitialUrl(s[SETTINGS_KEYS.openaiSttBaseUrl] ?? "");
+    setSttInitialApiKey(s[SETTINGS_KEYS.openaiSttApiKey] ?? "");
     const rawMinutes = s[SETTINGS_KEYS.mlxAsrKeepAliveMinutes];
     if (rawMinutes) {
       const minutes = Number(rawMinutes);
@@ -603,58 +600,61 @@ export function useModels(): UseModels {
     setLocalError(null);
   }, []);
 
-  const testLocalLlm = useCallback(async () => {
-    setLocalTesting(true);
-    setLocalConnected(null);
-    setLocalError(null);
-    try {
-      const url = localUrl.replace(/\/+$/, "");
-      const key = localApiKey.trim();
-      const client = getClient();
-      await Promise.all([
-        client.api.settings[":key"].$put({
-          param: { key: SETTINGS_KEYS.localLlmUrl },
-          json: { value: url },
-        }),
-        key
-          ? client.api.settings[":key"].$put({
-              param: { key: SETTINGS_KEYS.localLlmApiKey },
-              json: { value: key },
-            })
-          : client.api.settings[":key"].$delete({
-              param: { key: SETTINGS_KEYS.localLlmApiKey },
-            }),
-      ]);
+  const testLocalLlm = useCallback(
+    async (values: { url: string; apiKey: string }) => {
+      setLocalTesting(true);
+      setLocalConnected(null);
+      setLocalError(null);
+      try {
+        const url = values.url.replace(/\/+$/, "");
+        const key = values.apiKey.trim();
+        const client = getClient();
+        await Promise.all([
+          client.api.settings[":key"].$put({
+            param: { key: SETTINGS_KEYS.localLlmUrl },
+            json: { value: url },
+          }),
+          key
+            ? client.api.settings[":key"].$put({
+                param: { key: SETTINGS_KEYS.localLlmApiKey },
+                json: { value: key },
+              })
+            : client.api.settings[":key"].$delete({
+                param: { key: SETTINGS_KEYS.localLlmApiKey },
+              }),
+        ]);
 
-      const res = await client.api.settings["local-llm"].test.$post({
-        json: { url, api_key: key || undefined },
-      });
+        const res = await client.api.settings["local-llm"].test.$post({
+          json: { url, api_key: key || undefined },
+        });
 
-      if (res.ok) {
-        const result = await res.json();
-        if ("ok" in result && result.ok) {
-          setLocalConnected(true);
-          setLocalModels(result.models ?? []);
-          await loadData();
+        if (res.ok) {
+          const result = await res.json();
+          if ("ok" in result && result.ok) {
+            setLocalConnected(true);
+            setLocalModels(result.models ?? []);
+            await loadData();
+            return;
+          }
+          setLocalConnected(false);
+          setLocalError(
+            "error" in result && typeof result.error === "string"
+              ? result.error
+              : "Connection failed",
+          );
           return;
         }
         setLocalConnected(false);
-        setLocalError(
-          "error" in result && typeof result.error === "string"
-            ? result.error
-            : "Connection failed",
-        );
-        return;
+        setLocalError(`HTTP ${res.status}`);
+      } catch (err) {
+        setLocalConnected(false);
+        setLocalError(err instanceof Error ? err.message : "Connection failed");
+      } finally {
+        setLocalTesting(false);
       }
-      setLocalConnected(false);
-      setLocalError(`HTTP ${res.status}`);
-    } catch (err) {
-      setLocalConnected(false);
-      setLocalError(err instanceof Error ? err.message : "Connection failed");
-    } finally {
-      setLocalTesting(false);
-    }
-  }, [localUrl, localApiKey, loadData]);
+    },
+    [loadData],
+  );
 
   // -------------------------------------------------------------------------
   // Custom OpenAI-compatible STT endpoint test
@@ -665,68 +665,71 @@ export function useModels(): UseModels {
     setSttError(null);
   }, []);
 
-  const testOpenaiStt = useCallback(async () => {
-    setSttTesting(true);
-    setSttConnected(null);
-    setSttError(null);
-    try {
-      const url = sttUrl.replace(/\/+$/, "");
-      const key = sttApiKey.trim();
-      const client = getClient();
-      await Promise.all([
-        url
-          ? client.api.settings[":key"].$put({
-              param: { key: SETTINGS_KEYS.openaiSttBaseUrl },
-              json: { value: url },
-            })
-          : client.api.settings[":key"].$delete({
-              param: { key: SETTINGS_KEYS.openaiSttBaseUrl },
-            }),
-        key
-          ? client.api.settings[":key"].$put({
-              param: { key: SETTINGS_KEYS.openaiSttApiKey },
-              json: { value: key },
-            })
-          : client.api.settings[":key"].$delete({
-              param: { key: SETTINGS_KEYS.openaiSttApiKey },
-            }),
-      ]);
+  const testOpenaiStt = useCallback(
+    async (values: { url: string; apiKey: string }) => {
+      setSttTesting(true);
+      setSttConnected(null);
+      setSttError(null);
+      try {
+        const url = values.url.replace(/\/+$/, "");
+        const key = values.apiKey.trim();
+        const client = getClient();
+        await Promise.all([
+          url
+            ? client.api.settings[":key"].$put({
+                param: { key: SETTINGS_KEYS.openaiSttBaseUrl },
+                json: { value: url },
+              })
+            : client.api.settings[":key"].$delete({
+                param: { key: SETTINGS_KEYS.openaiSttBaseUrl },
+              }),
+          key
+            ? client.api.settings[":key"].$put({
+                param: { key: SETTINGS_KEYS.openaiSttApiKey },
+                json: { value: key },
+              })
+            : client.api.settings[":key"].$delete({
+                param: { key: SETTINGS_KEYS.openaiSttApiKey },
+              }),
+        ]);
 
-      if (!url) {
-        setSttConnected(null);
-        await loadData();
-        return;
-      }
-
-      const res = await client.api.settings["openai-stt"].test.$post({
-        json: { url, api_key: key || undefined },
-      });
-
-      if (res.ok) {
-        const result = await res.json();
-        if ("ok" in result && result.ok) {
-          setSttConnected(true);
-          setSttModels(result.models ?? []);
+        if (!url) {
+          setSttConnected(null);
           await loadData();
           return;
         }
+
+        const res = await client.api.settings["openai-stt"].test.$post({
+          json: { url, api_key: key || undefined },
+        });
+
+        if (res.ok) {
+          const result = await res.json();
+          if ("ok" in result && result.ok) {
+            setSttConnected(true);
+            setSttModels(result.models ?? []);
+            await loadData();
+            return;
+          }
+          setSttConnected(false);
+          setSttError(
+            "error" in result && typeof result.error === "string"
+              ? result.error
+              : "Connection failed",
+          );
+          return;
+        }
         setSttConnected(false);
-        setSttError(
-          "error" in result && typeof result.error === "string"
-            ? result.error
-            : "Connection failed",
-        );
-        return;
+        setSttError(`HTTP ${res.status}`);
+      } catch (err) {
+        setSttConnected(false);
+        setSttError(err instanceof Error ? err.message : "Connection failed");
+      } finally {
+        setSttTesting(false);
       }
-      setSttConnected(false);
-      setSttError(`HTTP ${res.status}`);
-    } catch (err) {
-      setSttConnected(false);
-      setSttError(err instanceof Error ? err.message : "Connection failed");
-    } finally {
-      setSttTesting(false);
-    }
-  }, [sttUrl, sttApiKey, loadData]);
+    },
+    [loadData],
+  );
 
   return {
     loading,
@@ -746,10 +749,8 @@ export function useModels(): UseModels {
     voiceItems,
     llmModelsByProvider,
     localLlm: {
-      url: localUrl,
-      setUrl: setLocalUrl,
-      apiKey: localApiKey,
-      setApiKey: setLocalApiKey,
+      initialUrl: localInitialUrl,
+      initialApiKey: localInitialApiKey,
       testing: localTesting,
       connected: localConnected,
       error: localError,
@@ -758,10 +759,8 @@ export function useModels(): UseModels {
       clearStatus: clearLocalStatus,
     },
     openaiStt: {
-      url: sttUrl,
-      setUrl: setSttUrl,
-      apiKey: sttApiKey,
-      setApiKey: setSttApiKey,
+      initialUrl: sttInitialUrl,
+      initialApiKey: sttInitialApiKey,
       testing: sttTesting,
       connected: sttConnected,
       error: sttError,

--- a/apps/electron/src/renderer/src/pages/models/use-models.ts
+++ b/apps/electron/src/renderer/src/pages/models/use-models.ts
@@ -12,11 +12,18 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SETTINGS_KEYS } from "../../../../shared/settings-keys";
 import { DEFAULT_MLX_KEEP_ALIVE_MINUTES } from "./constants";
 import type { ApiKeyEntry, ConfiguredModel } from "./types";
+import type {
+  EndpointConnectConfig,
+  EndpointConnectState,
+} from "./use-endpoint-connect";
+import { useEndpointConnect } from "./use-endpoint-connect";
 import {
   buildSettingsVoiceItems,
   clampMlxKeepAliveMinutes,
   groupByProvider,
 } from "./utils";
+
+export type { EndpointConnectState } from "./use-endpoint-connect";
 
 // Query keys for the models page. `["models", ...]` is a family so a single
 // invalidate refreshes both available + configured.
@@ -42,125 +49,6 @@ function hasActiveDownload(
   return !!models?.some(
     (m) => m.status === "downloading" || m.status === "verifying",
   );
-}
-
-interface EndpointTestValues {
-  url: string;
-  apiKey: string;
-}
-
-/** The subset of a connect endpoint's state setters {@link runEndpointTest} drives. */
-interface EndpointTestStatus {
-  setTesting: (v: boolean) => void;
-  setConnected: (v: boolean | null) => void;
-  setError: (v: string | null) => void;
-  setModels: (v: string[]) => void;
-}
-
-interface EndpointTestConfig {
-  urlKey: string;
-  apiKey: string;
-  /** When true, an empty URL clears the setting and skips the connectivity probe. */
-  clearUrlWhenEmpty: boolean;
-  probe: (
-    client: ReturnType<typeof getClient>,
-    body: { url: string; api_key: string | undefined },
-  ) => Promise<Response>;
-  status: EndpointTestStatus;
-  onDone: () => Promise<void>;
-}
-
-/**
- * Persist an endpoint's URL + API key, then probe it for connectivity. Shared
- * by the local-LLM and custom-STT connect forms, which differ only in their
- * setting keys, probe endpoint, and whether an empty URL clears the setting.
- */
-async function runEndpointTest(
-  values: EndpointTestValues,
-  {
-    urlKey,
-    apiKey: apiKeyKey,
-    clearUrlWhenEmpty,
-    probe,
-    status,
-    onDone,
-  }: EndpointTestConfig,
-): Promise<void> {
-  status.setTesting(true);
-  status.setConnected(null);
-  status.setError(null);
-  try {
-    const url = values.url.replace(/\/+$/, "");
-    const key = values.apiKey.trim();
-    const client = getClient();
-
-    const saveUrl =
-      url || !clearUrlWhenEmpty
-        ? client.api.settings[":key"].$put({
-            param: { key: urlKey },
-            json: { value: url },
-          })
-        : client.api.settings[":key"].$delete({ param: { key: urlKey } });
-    const saveKey = key
-      ? client.api.settings[":key"].$put({
-          param: { key: apiKeyKey },
-          json: { value: key },
-        })
-      : client.api.settings[":key"].$delete({ param: { key: apiKeyKey } });
-    await Promise.all([saveUrl, saveKey]);
-
-    if (clearUrlWhenEmpty && !url) {
-      status.setConnected(null);
-      await onDone();
-      return;
-    }
-
-    const res = await probe(client, { url, api_key: key || undefined });
-    if (res.ok) {
-      const result = (await res.json()) as {
-        ok?: boolean;
-        models?: string[];
-        error?: string;
-      };
-      if (result.ok) {
-        status.setConnected(true);
-        status.setModels(result.models ?? []);
-        await onDone();
-        return;
-      }
-      status.setConnected(false);
-      status.setError(
-        typeof result.error === "string" ? result.error : "Connection failed",
-      );
-      return;
-    }
-    status.setConnected(false);
-    status.setError(`HTTP ${res.status}`);
-  } catch (err) {
-    status.setConnected(false);
-    status.setError(err instanceof Error ? err.message : "Connection failed");
-  } finally {
-    status.setTesting(false);
-  }
-}
-
-/**
- * Connection state for an OpenAI-compatible endpoint (local LLM or custom
- * STT). The form fields themselves live in react-hook-form inside the connect
- * component; the hook owns the persisted seed values and the async test that
- * saves the settings then probes the endpoint.
- */
-export interface EndpointConnectState {
-  /** Persisted URL, used to seed the form once settings resolve. */
-  initialUrl: string;
-  /** Persisted API key, used to seed the form once settings resolve. */
-  initialApiKey: string;
-  testing: boolean;
-  connected: boolean | null;
-  error: string | null;
-  models: string[];
-  test: (values: EndpointTestValues) => Promise<void>;
-  clearStatus: () => void;
 }
 
 export interface UseModels {
@@ -214,6 +102,29 @@ export interface UseModels {
   deleteProvider: (provider: string) => Promise<void>;
   reload: () => Promise<void>;
 }
+
+// ---------------------------------------------------------------------------
+// Endpoint connect configs — static, defined once at module level so the
+// probe callback references are stable across renders.
+// ---------------------------------------------------------------------------
+
+const LOCAL_LLM_CONFIG: EndpointConnectConfig = {
+  urlKey: SETTINGS_KEYS.localLlmUrl,
+  apiKeyKey: SETTINGS_KEYS.localLlmApiKey,
+  defaultUrl: "http://localhost:11434",
+  clearUrlWhenEmpty: false,
+  probe: (client, body) =>
+    client.api.settings["local-llm"].test.$post({ json: body }),
+};
+
+const OPENAI_STT_CONFIG: EndpointConnectConfig = {
+  urlKey: SETTINGS_KEYS.openaiSttBaseUrl,
+  apiKeyKey: SETTINGS_KEYS.openaiSttApiKey,
+  defaultUrl: "",
+  clearUrlWhenEmpty: true,
+  probe: (client, body) =>
+    client.api.settings["openai-stt"].test.$post({ json: body }),
+};
 
 export function useModels(): UseModels {
   const queryClient = useQueryClient();
@@ -311,26 +222,6 @@ export function useModels(): UseModels {
     new Set(),
   );
 
-  // Local LLM (Ollama / LM Studio) connection. The editable url/key fields live
-  // in the connect component's react-hook-form; the hook keeps the persisted
-  // seed values plus the transient connection status.
-  const [localInitialUrl, setLocalInitialUrl] = useState(
-    "http://localhost:11434",
-  );
-  const [localInitialApiKey, setLocalInitialApiKey] = useState("");
-  const [localTesting, setLocalTesting] = useState(false);
-  const [localConnected, setLocalConnected] = useState<boolean | null>(null);
-  const [localError, setLocalError] = useState<string | null>(null);
-  const [localModels, setLocalModels] = useState<string[]>([]);
-
-  // Custom OpenAI-compatible STT endpoint — same connection pattern as local LLM.
-  const [sttInitialUrl, setSttInitialUrl] = useState("");
-  const [sttInitialApiKey, setSttInitialApiKey] = useState("");
-  const [sttTesting, setSttTesting] = useState(false);
-  const [sttConnected, setSttConnected] = useState<boolean | null>(null);
-  const [sttError, setSttError] = useState<string | null>(null);
-  const [sttModels, setSttModels] = useState<string[]>([]);
-
   // Seed editable state from persisted settings once, when the settings query
   // first resolves. Mutations update this local state directly, so we don't
   // re-seed on later invalidations (which would clobber in-progress edits).
@@ -346,12 +237,6 @@ export function useModels(): UseModels {
     setSettingsSeeded(true);
     const cleanup = s[SETTINGS_KEYS.llmCleanup];
     if (cleanup) setLlmCleanup(cleanup === "true");
-    const url = s[SETTINGS_KEYS.localLlmUrl];
-    if (url) setLocalInitialUrl(url);
-    const key = s[SETTINGS_KEYS.localLlmApiKey];
-    if (key) setLocalInitialApiKey(key);
-    setSttInitialUrl(s[SETTINGS_KEYS.openaiSttBaseUrl] ?? "");
-    setSttInitialApiKey(s[SETTINGS_KEYS.openaiSttApiKey] ?? "");
     const rawMinutes = s[SETTINGS_KEYS.mlxAsrKeepAliveMinutes];
     if (rawMinutes) {
       const minutes = Number(rawMinutes);
@@ -384,6 +269,21 @@ export function useModels(): UseModels {
     ]);
   }, [queryClient]);
   const loadData = reload;
+
+  // -------------------------------------------------------------------------
+  // Endpoint connections (local LLM + custom STT)
+  // -------------------------------------------------------------------------
+
+  const localLlm = useEndpointConnect(
+    LOCAL_LLM_CONFIG,
+    settingsQuery.data,
+    loadData,
+  );
+  const openaiStt = useEndpointConnect(
+    OPENAI_STT_CONFIG,
+    settingsQuery.data,
+    loadData,
+  );
 
   const loadWhisperStatus = useCallback(
     () => queryClient.invalidateQueries({ queryKey: MODELS_KEYS.whisper }),
@@ -691,64 +591,6 @@ export function useModels(): UseModels {
     [configured, loadData],
   );
 
-  // -------------------------------------------------------------------------
-  // Local LLM connection test
-  // -------------------------------------------------------------------------
-
-  const clearLocalStatus = useCallback(() => {
-    setLocalConnected(null);
-    setLocalError(null);
-  }, []);
-
-  const testLocalLlm = useCallback(
-    (values: EndpointTestValues) =>
-      runEndpointTest(values, {
-        urlKey: SETTINGS_KEYS.localLlmUrl,
-        apiKey: SETTINGS_KEYS.localLlmApiKey,
-        // Local LLM always persists the URL; the connect form requires it.
-        clearUrlWhenEmpty: false,
-        probe: (client, body) =>
-          client.api.settings["local-llm"].test.$post({ json: body }),
-        status: {
-          setTesting: setLocalTesting,
-          setConnected: setLocalConnected,
-          setError: setLocalError,
-          setModels: setLocalModels,
-        },
-        onDone: loadData,
-      }),
-    [loadData],
-  );
-
-  // -------------------------------------------------------------------------
-  // Custom OpenAI-compatible STT endpoint test
-  // -------------------------------------------------------------------------
-
-  const clearSttStatus = useCallback(() => {
-    setSttConnected(null);
-    setSttError(null);
-  }, []);
-
-  const testOpenaiStt = useCallback(
-    (values: EndpointTestValues) =>
-      runEndpointTest(values, {
-        urlKey: SETTINGS_KEYS.openaiSttBaseUrl,
-        apiKey: SETTINGS_KEYS.openaiSttApiKey,
-        // Empty URL disables the custom endpoint, so clear it and skip probing.
-        clearUrlWhenEmpty: true,
-        probe: (client, body) =>
-          client.api.settings["openai-stt"].test.$post({ json: body }),
-        status: {
-          setTesting: setSttTesting,
-          setConnected: setSttConnected,
-          setError: setSttError,
-          setModels: setSttModels,
-        },
-        onDone: loadData,
-      }),
-    [loadData],
-  );
-
   return {
     loading,
     available,
@@ -766,26 +608,8 @@ export function useModels(): UseModels {
     defaultLlm,
     voiceItems,
     llmModelsByProvider,
-    localLlm: {
-      initialUrl: localInitialUrl,
-      initialApiKey: localInitialApiKey,
-      testing: localTesting,
-      connected: localConnected,
-      error: localError,
-      models: localModels,
-      test: testLocalLlm,
-      clearStatus: clearLocalStatus,
-    },
-    openaiStt: {
-      initialUrl: sttInitialUrl,
-      initialApiKey: sttInitialApiKey,
-      testing: sttTesting,
-      connected: sttConnected,
-      error: sttError,
-      models: sttModels,
-      test: testOpenaiStt,
-      clearStatus: clearSttStatus,
-    },
+    localLlm,
+    openaiStt,
     configureModel,
     saveKey,
     selectLocalVoice,

--- a/apps/electron/src/renderer/src/pages/models/use-models.ts
+++ b/apps/electron/src/renderer/src/pages/models/use-models.ts
@@ -44,6 +44,106 @@ function hasActiveDownload(
   );
 }
 
+interface EndpointTestValues {
+  url: string;
+  apiKey: string;
+}
+
+/** The subset of a connect endpoint's state setters {@link runEndpointTest} drives. */
+interface EndpointTestStatus {
+  setTesting: (v: boolean) => void;
+  setConnected: (v: boolean | null) => void;
+  setError: (v: string | null) => void;
+  setModels: (v: string[]) => void;
+}
+
+interface EndpointTestConfig {
+  urlKey: string;
+  apiKey: string;
+  /** When true, an empty URL clears the setting and skips the connectivity probe. */
+  clearUrlWhenEmpty: boolean;
+  probe: (
+    client: ReturnType<typeof getClient>,
+    body: { url: string; api_key: string | undefined },
+  ) => Promise<Response>;
+  status: EndpointTestStatus;
+  onDone: () => Promise<void>;
+}
+
+/**
+ * Persist an endpoint's URL + API key, then probe it for connectivity. Shared
+ * by the local-LLM and custom-STT connect forms, which differ only in their
+ * setting keys, probe endpoint, and whether an empty URL clears the setting.
+ */
+async function runEndpointTest(
+  values: EndpointTestValues,
+  {
+    urlKey,
+    apiKey: apiKeyKey,
+    clearUrlWhenEmpty,
+    probe,
+    status,
+    onDone,
+  }: EndpointTestConfig,
+): Promise<void> {
+  status.setTesting(true);
+  status.setConnected(null);
+  status.setError(null);
+  try {
+    const url = values.url.replace(/\/+$/, "");
+    const key = values.apiKey.trim();
+    const client = getClient();
+
+    const saveUrl =
+      url || !clearUrlWhenEmpty
+        ? client.api.settings[":key"].$put({
+            param: { key: urlKey },
+            json: { value: url },
+          })
+        : client.api.settings[":key"].$delete({ param: { key: urlKey } });
+    const saveKey = key
+      ? client.api.settings[":key"].$put({
+          param: { key: apiKeyKey },
+          json: { value: key },
+        })
+      : client.api.settings[":key"].$delete({ param: { key: apiKeyKey } });
+    await Promise.all([saveUrl, saveKey]);
+
+    if (clearUrlWhenEmpty && !url) {
+      status.setConnected(null);
+      await onDone();
+      return;
+    }
+
+    const res = await probe(client, { url, api_key: key || undefined });
+    if (res.ok) {
+      const result = (await res.json()) as {
+        ok?: boolean;
+        models?: string[];
+        error?: string;
+      };
+      if (result.ok) {
+        status.setConnected(true);
+        status.setModels(result.models ?? []);
+        await onDone();
+        return;
+      }
+      status.setConnected(false);
+      status.setError(
+        typeof result.error === "string" ? result.error : "Connection failed",
+      );
+      return;
+    }
+    status.setConnected(false);
+    status.setError(`HTTP ${res.status}`);
+  } catch (err) {
+    status.setConnected(false);
+    status.setError(err instanceof Error ? err.message : "Connection failed");
+  } finally {
+    status.setTesting(false);
+  }
+}
+
 /**
  * Connection state for an OpenAI-compatible endpoint (local LLM or custom
  * STT). The form fields themselves live in react-hook-form inside the connect
@@ -59,7 +159,7 @@ export interface EndpointConnectState {
   connected: boolean | null;
   error: string | null;
   models: string[];
-  test: (values: { url: string; apiKey: string }) => Promise<void>;
+  test: (values: EndpointTestValues) => Promise<void>;
   clearStatus: () => void;
 }
 
@@ -601,58 +701,22 @@ export function useModels(): UseModels {
   }, []);
 
   const testLocalLlm = useCallback(
-    async (values: { url: string; apiKey: string }) => {
-      setLocalTesting(true);
-      setLocalConnected(null);
-      setLocalError(null);
-      try {
-        const url = values.url.replace(/\/+$/, "");
-        const key = values.apiKey.trim();
-        const client = getClient();
-        await Promise.all([
-          client.api.settings[":key"].$put({
-            param: { key: SETTINGS_KEYS.localLlmUrl },
-            json: { value: url },
-          }),
-          key
-            ? client.api.settings[":key"].$put({
-                param: { key: SETTINGS_KEYS.localLlmApiKey },
-                json: { value: key },
-              })
-            : client.api.settings[":key"].$delete({
-                param: { key: SETTINGS_KEYS.localLlmApiKey },
-              }),
-        ]);
-
-        const res = await client.api.settings["local-llm"].test.$post({
-          json: { url, api_key: key || undefined },
-        });
-
-        if (res.ok) {
-          const result = await res.json();
-          if ("ok" in result && result.ok) {
-            setLocalConnected(true);
-            setLocalModels(result.models ?? []);
-            await loadData();
-            return;
-          }
-          setLocalConnected(false);
-          setLocalError(
-            "error" in result && typeof result.error === "string"
-              ? result.error
-              : "Connection failed",
-          );
-          return;
-        }
-        setLocalConnected(false);
-        setLocalError(`HTTP ${res.status}`);
-      } catch (err) {
-        setLocalConnected(false);
-        setLocalError(err instanceof Error ? err.message : "Connection failed");
-      } finally {
-        setLocalTesting(false);
-      }
-    },
+    (values: EndpointTestValues) =>
+      runEndpointTest(values, {
+        urlKey: SETTINGS_KEYS.localLlmUrl,
+        apiKey: SETTINGS_KEYS.localLlmApiKey,
+        // Local LLM always persists the URL; the connect form requires it.
+        clearUrlWhenEmpty: false,
+        probe: (client, body) =>
+          client.api.settings["local-llm"].test.$post({ json: body }),
+        status: {
+          setTesting: setLocalTesting,
+          setConnected: setLocalConnected,
+          setError: setLocalError,
+          setModels: setLocalModels,
+        },
+        onDone: loadData,
+      }),
     [loadData],
   );
 
@@ -666,68 +730,22 @@ export function useModels(): UseModels {
   }, []);
 
   const testOpenaiStt = useCallback(
-    async (values: { url: string; apiKey: string }) => {
-      setSttTesting(true);
-      setSttConnected(null);
-      setSttError(null);
-      try {
-        const url = values.url.replace(/\/+$/, "");
-        const key = values.apiKey.trim();
-        const client = getClient();
-        await Promise.all([
-          url
-            ? client.api.settings[":key"].$put({
-                param: { key: SETTINGS_KEYS.openaiSttBaseUrl },
-                json: { value: url },
-              })
-            : client.api.settings[":key"].$delete({
-                param: { key: SETTINGS_KEYS.openaiSttBaseUrl },
-              }),
-          key
-            ? client.api.settings[":key"].$put({
-                param: { key: SETTINGS_KEYS.openaiSttApiKey },
-                json: { value: key },
-              })
-            : client.api.settings[":key"].$delete({
-                param: { key: SETTINGS_KEYS.openaiSttApiKey },
-              }),
-        ]);
-
-        if (!url) {
-          setSttConnected(null);
-          await loadData();
-          return;
-        }
-
-        const res = await client.api.settings["openai-stt"].test.$post({
-          json: { url, api_key: key || undefined },
-        });
-
-        if (res.ok) {
-          const result = await res.json();
-          if ("ok" in result && result.ok) {
-            setSttConnected(true);
-            setSttModels(result.models ?? []);
-            await loadData();
-            return;
-          }
-          setSttConnected(false);
-          setSttError(
-            "error" in result && typeof result.error === "string"
-              ? result.error
-              : "Connection failed",
-          );
-          return;
-        }
-        setSttConnected(false);
-        setSttError(`HTTP ${res.status}`);
-      } catch (err) {
-        setSttConnected(false);
-        setSttError(err instanceof Error ? err.message : "Connection failed");
-      } finally {
-        setSttTesting(false);
-      }
-    },
+    (values: EndpointTestValues) =>
+      runEndpointTest(values, {
+        urlKey: SETTINGS_KEYS.openaiSttBaseUrl,
+        apiKey: SETTINGS_KEYS.openaiSttApiKey,
+        // Empty URL disables the custom endpoint, so clear it and skip probing.
+        clearUrlWhenEmpty: true,
+        probe: (client, body) =>
+          client.api.settings["openai-stt"].test.$post({ json: body }),
+        status: {
+          setTesting: setSttTesting,
+          setConnected: setSttConnected,
+          setError: setSttError,
+          setModels: setSttModels,
+        },
+        onDone: loadData,
+      }),
     [loadData],
   );
 

--- a/packages/validations/src/local-llm.ts
+++ b/packages/validations/src/local-llm.ts
@@ -6,3 +6,15 @@ export const localLlmConfigSchema = z.object({
 });
 
 export type LocalLlmConfigInput = z.infer<typeof localLlmConfigSchema>;
+
+/**
+ * Shape for the local LLM connect form in the Models page. Drives a
+ * react-hook-form with inline validation matching the `/local-llm/test`
+ * endpoint's expectations.
+ */
+export const localLlmConnectFormSchema = z.object({
+  url: z.string().min(1, "Endpoint URL is required").url("Must be a valid URL"),
+  apiKey: z.string().max(2048),
+});
+
+export type LocalLlmConnectForm = z.infer<typeof localLlmConnectFormSchema>;

--- a/packages/validations/src/openai-stt.ts
+++ b/packages/validations/src/openai-stt.ts
@@ -30,3 +30,18 @@ export function sanitizeSttBaseUrl(input: string): string | undefined {
   const trimmed = input.trim().replace(/\/+$/, "");
   return trimmed === "" ? undefined : trimmed;
 }
+
+/**
+ * Shape for the STT connect form in the Models page. The URL may be empty
+ * (disables the custom endpoint), so it uses the same relaxed schema the
+ * server enforces on `PUT /settings/openai_stt_base_url`.
+ */
+export const openaiSttConnectFormSchema = z.object({
+  url: openaiSttBaseUrlSchema,
+  apiKey: z.string().max(2048),
+});
+
+export type OpenaiSttConnectForm = z.infer<typeof openaiSttConnectFormSchema>;
+
+/** Shared shape for both endpoint connect forms (local LLM + custom STT). */
+export type EndpointConnectFormValues = { url: string; apiKey: string };


### PR DESCRIPTION
## Summary

Follow-up to #479 (now merged). Converts the Models-page connect forms (local LLM + custom STT) from manual `useState` to **react-hook-form + zodResolver**, matching the Network settings form in `settings.tsx`.

## Why

After #479, the models page was the only place using hand-rolled `useState` for these forms while the rest of the app (`settings.tsx`, `onboarding.tsx`, `dictionary.tsx`, `vocabulary.tsx`) uses react-hook-form. This aligns the pattern and adds inline, schema-driven validation.

## What changed

- **Shared component**: extracted `EndpointConnectForm`, used by both `LocalLlmConnect` and `OpenaiSttConnect`, so the two forms share one implementation (mirrors how `NetworkField` is shared in `settings.tsx`).
- **Validation**: added `localLlmConnectFormSchema` / `openaiSttConnectFormSchema` (+ `EndpointConnectFormValues`) in `@freestyle-voice/validations`, reusing the same URL rules the server enforces.
- **Hook API**: `useModels` no longer owns the editable `url`/`apiKey` fields. It exposes `EndpointConnectState` — persisted `initialUrl`/`initialApiKey` seeds plus the async `test({ url, apiKey })` action and connection status. The form state lives in RHF.
- **Behavior preserved**: Test button still persists settings then probes `<url>/v1/models`; empty STT URL still clears the setting; local-LLM default `http://localhost:11434` still shown.

## Testing

- `pnpm --filter @freestyle-voice/electron typecheck` — clean (node + web).
- `pnpm --filter @freestyle-voice/server exec vitest run` — server suite unaffected, still green.
- Validations pkgroll build, Biome, and Knip all clean.