### PR TITLE
fix(server): keep Freestyle Cloud session alive before 7-day token expiry

### DIFF
--- a/apps/electron/src/renderer/src/components/session-expired-modal.tsx
+++ b/apps/electron/src/renderer/src/components/session-expired-modal.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@renderer/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@renderer/components/ui/dialog";
+import { useCloudAuth } from "@renderer/lib/auth-context";
+
+/**
+ * Prompts the user to sign in again after their Freestyle Cloud session has
+ * lapsed (e.g. the 7-day token expired while the app was closed, so the
+ * server-side keep-alive could not slide the window in time). Suppressed while
+ * a sign-in is already in flight.
+ */
+export function SessionExpiredModal(): React.JSX.Element | null {
+  const { sessionExpired, signingIn, signIn, dismissSessionExpired } =
+    useCloudAuth();
+  if (!sessionExpired || signingIn) return null;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) dismissSessionExpired();
+      }}
+    >
+      <DialogContent className="max-w-xs">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <DialogTitle className="text-[15px] font-semibold">
+            Session expired
+          </DialogTitle>
+          <DialogDescription className="text-muted-foreground text-[13px]">
+            Your Freestyle Cloud session has expired. Sign in again to keep
+            using cloud voice and cleanup.
+          </DialogDescription>
+
+          <Button
+            size="sm"
+            className="mt-1 w-full"
+            onClick={() => {
+              void signIn();
+            }}
+          >
+            Sign in again
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full"
+            onClick={() => dismissSessionExpired()}
+          >
+            Not now
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/electron/src/renderer/src/dashboard.tsx
+++ b/apps/electron/src/renderer/src/dashboard.tsx
@@ -3,6 +3,7 @@ import "./fonts.css";
 
 import { CloudSignInModal } from "@renderer/components/cloud-signin-modal";
 import { ErrorBoundary } from "@renderer/components/error-boundary";
+import { SessionExpiredModal } from "@renderer/components/session-expired-modal";
 import { TooltipProvider } from "@renderer/components/ui/tooltip";
 import i18n, { initI18n } from "@renderer/i18n";
 import { initApiBase } from "@renderer/lib/api";
@@ -84,6 +85,7 @@ function mount(): void {
                 <TooltipProvider>
                   <CloudAuthProvider>
                     <CloudSignInModal />
+                    <SessionExpiredModal />
                     <Suspense fallback={<RouteFallback />}>
                       <Routes>
                         <Route

--- a/apps/electron/src/renderer/src/lib/auth-context.tsx
+++ b/apps/electron/src/renderer/src/lib/auth-context.tsx
@@ -46,20 +46,27 @@ function useCloudAuthState(): UseCloudAuth {
   const signInAttemptRef = useRef(0);
 
   const refresh = useCallback(async (): Promise<CloudUser | null> => {
+    // `reached` distinguishes "server said not-authenticated" from "couldn't
+    // reach the server". A transient network/server blip must NOT be mistaken
+    // for an expired session, or it would spuriously pop the re-sign-in modal.
+    let reached = false;
     const user = await getClient()
       .api.auth.status.$get()
       .then(async (res) => {
         if (!res.ok) return null;
+        reached = true;
         const data = await res.json();
         return data.user ?? null;
       })
       .catch(() => null);
-    // Detect a session that lapsed while signed in (e.g. token expired). Only
-    // flag the transition from signed-in → signed-out, not a fresh cold start.
-    if (!user && wasSignedInRef.current) setSessionExpired(true);
-    if (user) setSessionExpired(false);
-    wasSignedInRef.current = !!user;
-    setUser(user);
+    if (reached) {
+      // Flag only the confirmed transition from signed-in → signed-out (e.g.
+      // the token expired), not a fresh cold start.
+      if (!user && wasSignedInRef.current) setSessionExpired(true);
+      if (user) setSessionExpired(false);
+      wasSignedInRef.current = !!user;
+      setUser(user);
+    }
     return user;
   }, []);
 

--- a/apps/electron/src/renderer/src/lib/auth-context.tsx
+++ b/apps/electron/src/renderer/src/lib/auth-context.tsx
@@ -16,6 +16,13 @@ export interface UseCloudAuth {
   /** Device user code, surfaced while a sign-in is pending. */
   userCode: string | null;
   error: string | null;
+  /**
+   * True when a previously signed-in session has lapsed (e.g. the token
+   * expired while the app was closed). Drives a re-sign-in prompt. Cleared
+   * once the user signs in again or explicitly dismisses it.
+   */
+  sessionExpired: boolean;
+  dismissSessionExpired: () => void;
   refresh: () => Promise<CloudUser | null>;
   signIn: () => Promise<CloudUser | null>;
   /** Abort an in-flight sign-in (driven from the pending modal). */
@@ -32,6 +39,8 @@ function useCloudAuthState(): UseCloudAuth {
   const [signingIn, setSigningIn] = useState(false);
   const [userCode, setUserCode] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [sessionExpired, setSessionExpired] = useState(false);
+  const wasSignedInRef = useRef(false);
   const cancelledRef = useRef(false);
   const signInPromiseRef = useRef<Promise<CloudUser | null> | null>(null);
   const signInAttemptRef = useRef(0);
@@ -45,8 +54,17 @@ function useCloudAuthState(): UseCloudAuth {
         return data.user ?? null;
       })
       .catch(() => null);
+    // Detect a session that lapsed while signed in (e.g. token expired). Only
+    // flag the transition from signed-in → signed-out, not a fresh cold start.
+    if (!user && wasSignedInRef.current) setSessionExpired(true);
+    if (user) setSessionExpired(false);
+    wasSignedInRef.current = !!user;
     setUser(user);
     return user;
+  }, []);
+
+  const dismissSessionExpired = useCallback((): void => {
+    setSessionExpired(false);
   }, []);
 
   useEffect(() => {
@@ -94,6 +112,8 @@ function useCloudAuthState(): UseCloudAuth {
         }
         const data = await tokenRes.json();
         if (attempt !== signInAttemptRef.current) return null;
+        wasSignedInRef.current = true;
+        setSessionExpired(false);
         setUser(data.user);
         return data.user;
       }
@@ -130,6 +150,8 @@ function useCloudAuthState(): UseCloudAuth {
     await getClient()
       .api.auth["sign-out"].$post()
       .catch(() => {});
+    wasSignedInRef.current = false;
+    setSessionExpired(false);
     setUser(null);
   }, []);
 
@@ -139,6 +161,8 @@ function useCloudAuthState(): UseCloudAuth {
     signingIn,
     userCode,
     error,
+    sessionExpired,
+    dismissSessionExpired,
     refresh,
     signIn,
     cancelSignIn,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -25,7 +25,10 @@ import {
   plugins,
 } from "./lib/plugins/index.js";
 import { captureException, shutdownPosthog } from "./lib/posthog.js";
-import { startSessionKeepAlive } from "./lib/session-keepalive.js";
+import {
+  startSessionKeepAlive,
+  stopSessionKeepAlive,
+} from "./lib/session-keepalive.js";
 import { trustedOriginMiddleware } from "./lib/trusted-origin.js";
 import routes from "./routes";
 
@@ -47,6 +50,7 @@ const TIMEOUT_PREFIXES = [
 ];
 
 async function shutdownServer(): Promise<void> {
+  stopSessionKeepAlive();
   await disposeServerPlugins().catch(() => {});
   await shutdownPosthog();
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -25,6 +25,7 @@ import {
   plugins,
 } from "./lib/plugins/index.js";
 import { captureException, shutdownPosthog } from "./lib/posthog.js";
+import { startSessionKeepAlive } from "./lib/session-keepalive.js";
 import { trustedOriginMiddleware } from "./lib/trusted-origin.js";
 import routes from "./routes";
 
@@ -209,6 +210,10 @@ export async function startServer(
   const app = createApp();
 
   startHistoryRetentionSweep();
+
+  // Keep the Freestyle Cloud session alive by sliding its expiry before the
+  // local token lapses (the cloud issues no refresh token). Fire-and-forget.
+  startSessionKeepAlive();
 
   return new Promise((resolve, reject) => {
     const wss = new WebSocketServer({ noServer: true });

--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -19,6 +19,17 @@ const DEFAULT_CLOUD_URL = "https://service.freestylevoice.com";
 const CLIENT_ID = "freestyle-desktop";
 const DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 
+/**
+ * The lifetime Freestyle Cloud grants a session token, in milliseconds (7 days).
+ *
+ * The cloud issues no refresh token; instead better-auth slides the expiry
+ * forward by this amount whenever the session is validated after its 24h
+ * `updateAge` window. We mirror that here when renewing locally: a successful
+ * `get-session` call means the cloud extended the window, so we recompute the
+ * local `expiresAt` from now. See `renewSession()`.
+ */
+export const SESSION_LIFETIME_MS = 7 * 24 * 60 * 60 * 1000;
+
 export class FreestyleCloudAuthError extends Error {
   constructor(message = "Freestyle Cloud sign-in required") {
     super(message);

--- a/apps/server/src/lib/session-keepalive.ts
+++ b/apps/server/src/lib/session-keepalive.ts
@@ -7,7 +7,6 @@ import {
 import { captureException } from "./posthog.js";
 import {
   getSession,
-  getSessionExpiry,
   invalidateSession,
   touchSessionExpiry,
 } from "./sessions.js";
@@ -34,20 +33,18 @@ export type RenewResult = "renewed" | "not-needed" | "no-session" | "expired";
  *   refresh). When false, renews only within {@link RENEW_THRESHOLD_MS}.
  */
 export async function renewSession(force = false): Promise<RenewResult> {
-  const expiry = getSessionExpiry();
-  if (!expiry) return "no-session";
+  const session = getSession();
+  if (!session) return "no-session";
 
   // No local expiry means the cloud never sent one — nothing to slide.
-  if (expiry.remainingMs === null) return "not-needed";
+  if (session.expiresAt == null) return "not-needed";
 
-  if (!force && expiry.remainingMs > RENEW_THRESHOLD_MS) return "not-needed";
-
-  const token = getSession()?.token;
-  if (!token) return "no-session";
+  const remainingMs = session.expiresAt - Date.now();
+  if (!force && remainingMs > RENEW_THRESHOLD_MS) return "not-needed";
 
   try {
     // Touching an authenticated endpoint slides the cloud session window.
-    await fetchCloudUser(token);
+    await fetchCloudUser(session.token);
     touchSessionExpiry(Date.now() + SESSION_LIFETIME_MS);
     return "renewed";
   } catch (err) {

--- a/apps/server/src/lib/session-keepalive.ts
+++ b/apps/server/src/lib/session-keepalive.ts
@@ -1,0 +1,91 @@
+import { createAppLogger } from "@freestyle-voice/utils";
+import {
+  FreestyleCloudAuthError,
+  fetchCloudUser,
+  SESSION_LIFETIME_MS,
+} from "./freestyle-cloud.js";
+import { captureException } from "./posthog.js";
+import {
+  getSession,
+  getSessionExpiry,
+  invalidateSession,
+  touchSessionExpiry,
+} from "./sessions.js";
+
+const log = createAppLogger("session-keepalive");
+
+/** How often the scheduler checks whether the token needs renewing (12h). */
+const KEEPALIVE_INTERVAL_MS = 12 * 60 * 60 * 1000;
+/** Renew once the token has less than this long remaining (2 days). */
+const RENEW_THRESHOLD_MS = 2 * 24 * 60 * 60 * 1000;
+
+export type RenewResult = "renewed" | "not-needed" | "no-session" | "expired";
+
+/**
+ * Keep the Freestyle Cloud session alive by exercising better-auth's sliding
+ * window before the local token expires.
+ *
+ * The cloud issues no refresh token, but validating the session after its 24h
+ * `updateAge` window extends `expiresAt` by another {@link SESSION_LIFETIME_MS}.
+ * A cheap authenticated `get-session` (via {@link fetchCloudUser}) triggers that
+ * slide; on success we mirror the new expiry locally.
+ *
+ * @param force - renew regardless of remaining time (used by tests / manual
+ *   refresh). When false, renews only within {@link RENEW_THRESHOLD_MS}.
+ */
+export async function renewSession(force = false): Promise<RenewResult> {
+  const expiry = getSessionExpiry();
+  if (!expiry) return "no-session";
+
+  // No local expiry means the cloud never sent one — nothing to slide.
+  if (expiry.remainingMs === null) return "not-needed";
+
+  if (!force && expiry.remainingMs > RENEW_THRESHOLD_MS) return "not-needed";
+
+  const token = getSession()?.token;
+  if (!token) return "no-session";
+
+  try {
+    // Touching an authenticated endpoint slides the cloud session window.
+    await fetchCloudUser(token);
+    touchSessionExpiry(Date.now() + SESSION_LIFETIME_MS);
+    return "renewed";
+  } catch (err) {
+    if (err instanceof FreestyleCloudAuthError) {
+      // The cloud already rejected the token; drop it so the UI can prompt
+      // a fresh sign-in rather than retrying a dead token forever.
+      invalidateSession();
+      return "expired";
+    }
+    // Transient network/cloud failure — keep the session and try again next
+    // tick. Never surface as an app defect.
+    log.warn(`session renewal failed: ${(err as Error).message}`);
+    return "not-needed";
+  }
+}
+
+let keepAliveTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Start the periodic keep-alive. Runs one check immediately (so a stale token
+ * is refreshed shortly after launch) then every {@link KEEPALIVE_INTERVAL_MS}.
+ * Idempotent and fire-and-forget: renewal errors never propagate.
+ */
+export function startSessionKeepAlive(): void {
+  if (keepAliveTimer) return;
+
+  const tick = (): void => {
+    void renewSession().catch((err) => captureException(err));
+  };
+
+  tick();
+  keepAliveTimer = setInterval(tick, KEEPALIVE_INTERVAL_MS);
+  keepAliveTimer.unref();
+}
+
+export function stopSessionKeepAlive(): void {
+  if (keepAliveTimer) {
+    clearInterval(keepAliveTimer);
+    keepAliveTimer = null;
+  }
+}

--- a/apps/server/src/lib/sessions.ts
+++ b/apps/server/src/lib/sessions.ts
@@ -74,6 +74,46 @@ export function getSessionToken(): string | null {
   return getSession()?.token ?? null;
 }
 
+export interface SessionExpiry {
+  /** Epoch ms when the token expires, or null if it never expires locally. */
+  expiresAt: number | null;
+  /** Ms remaining until expiry, or null when there is no expiry. */
+  remainingMs: number | null;
+}
+
+/**
+ * Report the current session's expiry without mutating it. Returns null when
+ * there is no (valid) session. Unlike {@link getSession}, this is purely
+ * informational — callers use it to decide whether to renew or warn the user.
+ * Note: {@link getSession} still invalidates an already-expired session, so a
+ * non-null result here always describes a live token.
+ */
+export function getSessionExpiry(): SessionExpiry | null {
+  const session = getSession();
+  if (!session) return null;
+  const expiresAt = session.expiresAt ?? null;
+  return {
+    expiresAt,
+    remainingMs: expiresAt === null ? null : expiresAt - Date.now(),
+  };
+}
+
+/**
+ * Update only the expiry timestamps of the stored session, leaving the token
+ * and user untouched. Used by the keep-alive scheduler after the cloud slides
+ * the session window forward. No-op when there is no session.
+ */
+export function touchSessionExpiry(expiresAt: number): void {
+  const session = getSession();
+  if (!session) return;
+  const now = Date.now();
+  getDb()
+    .prepare(
+      "UPDATE sessions SET expires_at = ?, issued_at = ?, updated_at = ? WHERE id = 1",
+    )
+    .run(expiresAt, now, now);
+}
+
 export function getSessionUser(): CloudUser | null {
   return getSession()?.user ?? null;
 }

--- a/apps/server/src/lib/sessions.ts
+++ b/apps/server/src/lib/sessions.ts
@@ -74,30 +74,6 @@ export function getSessionToken(): string | null {
   return getSession()?.token ?? null;
 }
 
-export interface SessionExpiry {
-  /** Epoch ms when the token expires, or null if it never expires locally. */
-  expiresAt: number | null;
-  /** Ms remaining until expiry, or null when there is no expiry. */
-  remainingMs: number | null;
-}
-
-/**
- * Report the current session's expiry without mutating it. Returns null when
- * there is no (valid) session. Unlike {@link getSession}, this is purely
- * informational — callers use it to decide whether to renew or warn the user.
- * Note: {@link getSession} still invalidates an already-expired session, so a
- * non-null result here always describes a live token.
- */
-export function getSessionExpiry(): SessionExpiry | null {
-  const session = getSession();
-  if (!session) return null;
-  const expiresAt = session.expiresAt ?? null;
-  return {
-    expiresAt,
-    remainingMs: expiresAt === null ? null : expiresAt - Date.now(),
-  };
-}
-
 /**
  * Update only the expiry timestamps of the stored session, leaving the token
  * and user untouched. Used by the keep-alive scheduler after the cloud slides

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -13,6 +13,7 @@ import { applyFreestyleCloudDefaults } from "../lib/freestyle-cloud-defaults.js"
 import { capture, identifyCloudUser } from "../lib/posthog.js";
 import {
   getSession,
+  getSessionExpiry,
   getSessionUser,
   invalidateSession,
   setSession,
@@ -28,7 +29,12 @@ const auth = new Hono()
   })
   .get("/status", (c) => {
     const user = getSessionUser();
-    return c.json({ authenticated: !!user, user });
+    const expiry = getSessionExpiry();
+    return c.json({
+      authenticated: !!user,
+      user,
+      expiresAt: expiry?.expiresAt ?? null,
+    });
   })
   .post("/device/code", async (c) => {
     const code = await requestDeviceCode();

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -13,7 +13,6 @@ import { applyFreestyleCloudDefaults } from "../lib/freestyle-cloud-defaults.js"
 import { capture, identifyCloudUser } from "../lib/posthog.js";
 import {
   getSession,
-  getSessionExpiry,
   getSessionUser,
   invalidateSession,
   setSession,
@@ -29,12 +28,7 @@ const auth = new Hono()
   })
   .get("/status", (c) => {
     const user = getSessionUser();
-    const expiry = getSessionExpiry();
-    return c.json({
-      authenticated: !!user,
-      user,
-      expiresAt: expiry?.expiresAt ?? null,
-    });
+    return c.json({ authenticated: !!user, user });
   })
   .post("/device/code", async (c) => {
     const code = await requestDeviceCode();

--- a/apps/server/tests/session-keepalive.test.ts
+++ b/apps/server/tests/session-keepalive.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  FreestyleCloudAuthError,
+  SESSION_LIFETIME_MS,
+} from "../src/lib/freestyle-cloud.js";
+import { renewSession } from "../src/lib/session-keepalive.js";
+import {
+  clearSession,
+  getSession,
+  getSessionExpiry,
+  setSession,
+} from "../src/lib/sessions.js";
+
+vi.mock("../src/lib/freestyle-cloud.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/lib/freestyle-cloud.js")>();
+  return {
+    ...actual,
+    fetchCloudUser: vi.fn(async () => ({
+      id: "user_1",
+      email: "user@example.com",
+      name: "User",
+      image: null,
+    })),
+  };
+});
+
+const cloud = await import("../src/lib/freestyle-cloud.js");
+
+const HOST = "https://service.freestylevoice.com";
+const USER = { id: "user_1", email: "user@example.com" };
+
+function signInWithRemaining(remainingMs: number): void {
+  setSession({
+    token: "token",
+    expiresAt: Date.now() + remainingMs,
+    issuedAt: Date.now(),
+    user: USER,
+    host: HOST,
+  });
+}
+
+afterEach(() => {
+  clearSession();
+  vi.clearAllMocks();
+});
+
+describe("renewSession", () => {
+  it("no-ops when there is no session", async () => {
+    await expect(renewSession()).resolves.toBe("no-session");
+    expect(cloud.fetchCloudUser).not.toHaveBeenCalled();
+  });
+
+  it("does not renew when plenty of time remains", async () => {
+    signInWithRemaining(5 * 24 * 60 * 60 * 1000); // 5 days
+    await expect(renewSession()).resolves.toBe("not-needed");
+    expect(cloud.fetchCloudUser).not.toHaveBeenCalled();
+  });
+
+  it("renews when within the 2-day threshold", async () => {
+    signInWithRemaining(24 * 60 * 60 * 1000); // 1 day
+    const before = getSessionExpiry()?.expiresAt ?? 0;
+
+    await expect(renewSession()).resolves.toBe("renewed");
+
+    expect(cloud.fetchCloudUser).toHaveBeenCalledTimes(1);
+    const after = getSessionExpiry()?.expiresAt ?? 0;
+    expect(after).toBeGreaterThan(before);
+    // New expiry should be ~one full lifetime out from now.
+    expect(after).toBeGreaterThan(Date.now() + SESSION_LIFETIME_MS - 5_000);
+  });
+
+  it("renews regardless of remaining time when forced", async () => {
+    signInWithRemaining(5 * 24 * 60 * 60 * 1000); // 5 days
+    await expect(renewSession(true)).resolves.toBe("renewed");
+    expect(cloud.fetchCloudUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the same token after renewal (no re-auth)", async () => {
+    signInWithRemaining(60 * 60 * 1000); // 1 hour
+    await renewSession();
+    expect(getSession()?.token).toBe("token");
+  });
+
+  it("invalidates the session when the cloud rejects the token (401)", async () => {
+    signInWithRemaining(60 * 60 * 1000); // 1 hour
+    vi.mocked(cloud.fetchCloudUser).mockRejectedValueOnce(
+      new FreestyleCloudAuthError(),
+    );
+
+    await expect(renewSession()).resolves.toBe("expired");
+    expect(getSession()).toBeNull();
+  });
+
+  it("keeps the session on a transient network failure", async () => {
+    signInWithRemaining(60 * 60 * 1000); // 1 hour
+    vi.mocked(cloud.fetchCloudUser).mockRejectedValueOnce(
+      new Error("fetch failed"),
+    );
+
+    await expect(renewSession()).resolves.toBe("not-needed");
+    // Session survives so the next tick can retry.
+    expect(getSession()?.token).toBe("token");
+  });
+
+  it("treats a session with no local expiry as not needing renewal", async () => {
+    setSession({ token: "token", user: USER, host: HOST });
+    await expect(renewSession()).resolves.toBe("not-needed");
+    expect(cloud.fetchCloudUser).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/tests/session-keepalive.test.ts
+++ b/apps/server/tests/session-keepalive.test.ts
@@ -4,12 +4,7 @@ import {
   SESSION_LIFETIME_MS,
 } from "../src/lib/freestyle-cloud.js";
 import { renewSession } from "../src/lib/session-keepalive.js";
-import {
-  clearSession,
-  getSession,
-  getSessionExpiry,
-  setSession,
-} from "../src/lib/sessions.js";
+import { clearSession, getSession, setSession } from "../src/lib/sessions.js";
 
 vi.mock("../src/lib/freestyle-cloud.js", async (importOriginal) => {
   const actual =
@@ -59,12 +54,12 @@ describe("renewSession", () => {
 
   it("renews when within the 2-day threshold", async () => {
     signInWithRemaining(24 * 60 * 60 * 1000); // 1 day
-    const before = getSessionExpiry()?.expiresAt ?? 0;
+    const before = getSession()?.expiresAt ?? 0;
 
     await expect(renewSession()).resolves.toBe("renewed");
 
     expect(cloud.fetchCloudUser).toHaveBeenCalledTimes(1);
-    const after = getSessionExpiry()?.expiresAt ?? 0;
+    const after = getSession()?.expiresAt ?? 0;
     expect(after).toBeGreaterThan(before);
     // New expiry should be ~one full lifetime out from now.
     expect(after).toBeGreaterThan(Date.now() + SESSION_LIFETIME_MS - 5_000);


### PR DESCRIPTION
## Problem

Freestyle Cloud session tokens expire **7 days** after issue. The cloud (better-auth) issues **no refresh token** and has **no refresh grant** — instead it slides a session's expiry forward by 7 days whenever the session is validated after its 24h `updateAge` window.

The desktop app never proactively touched an authenticated endpoint, so:

- An **active** user (transcribes at least weekly) kept their token alive only by accident, since each transcribe call slid the window.
- An **idle** user had their token silently deleted by `getSession()` at the 7-day mark (`sessions.ts` expiry check) and was forced into a full browser device-flow re-sign-in **with no warning**.

## Fix (desktop-only, no cloud changes)

Exercise the existing sliding window **before** the local token expires, and add a renderer safety net for the already-expired case.

### Server
- `freestyle-cloud.ts`: export `SESSION_LIFETIME_MS` (7d).
- `sessions.ts`: add `getSessionExpiry()` and `touchSessionExpiry()` — purely additive; `getSession()` behavior is unchanged.
- `session-keepalive.ts` (new):
  - `renewSession()` hits `/auth/get-session` (via `fetchCloudUser`) to slide the cloud window, then mirrors the new expiry locally with `touchSessionExpiry(now + SESSION_LIFETIME_MS)`. The **same token is kept** (no re-auth).
  - Invalidates the session on `401` (`FreestyleCloudAuthError`); keeps it on transient network failures so the next tick retries.
  - Scheduler runs once on startup + every **12h**, renewing only when **< 2 days** remain. Timer is `unref()`ed and fully try/caught — never blocks or crashes the app.
- `index.ts`: start the keep-alive in `startServer()` (fire-and-forget).
- `routes/auth.ts`: expose `expiresAt` on `GET /api/auth/status`.

### Renderer
- `auth-context.tsx`: detect the signed-in → signed-out transition and expose a `sessionExpired` flag (+ `dismissSessionExpired`).
- `session-expired-modal.tsx` (new): one-click "Sign in again" prompt wired to the existing device flow, mounted in `dashboard.tsx`.

## Scope note

This keeps the token alive indefinitely for anyone who opens the app at least once a week (well within the 7-day window). It **cannot** recover a token that already expired while the app was closed for >7 days — that path is handled by the new re-sign-in prompt. True offline refresh would require cloud-side changes (JWT + refresh grant) and was intentionally out of scope.

## Testing

- `tests/session-keepalive.test.ts` (new, 8 cases): no-session no-op, no-renew when plenty of time remains, renew within threshold, forced renew, token preserved after renewal, 401 → invalidate, transient failure → keep session, no-local-expiry no-op.
- Full server suite green: **294 tests passing**.
- `tsc --noEmit` clean for server; `typecheck:node` + `typecheck:web` clean for electron.
- Biome clean.