### PR TITLE
feat(mobile): add Sign in with Apple button

### DIFF
--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -1,6 +1,12 @@
 import { useRouter } from "expo-router";
 import { useCallback, useState } from "react";
-import { ActivityIndicator, Pressable, StyleSheet, View } from "react-native";
+import {
+  ActivityIndicator,
+  Platform,
+  Pressable,
+  StyleSheet,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { ThemedText } from "@/components/themed-text";
@@ -8,6 +14,19 @@ import { ThemedView } from "@/components/themed-view";
 import { Fonts, Radius, Spacing } from "@/constants/theme";
 import { type SocialProvider, useAuth } from "@/hooks/use-auth";
 import { useTheme } from "@/hooks/use-theme";
+
+const PROVIDER_LABELS: Record<SocialProvider, string> = {
+  apple: "Continue with Apple",
+  google: "Continue with Google",
+  github: "Continue with GitHub",
+};
+
+// Present providers in the order each platform's users expect: Apple first on
+// iOS, Google first on Android. GitHub always trails.
+const PROVIDER_ORDER: SocialProvider[] = Platform.select({
+  ios: ["apple", "google", "github"],
+  default: ["google", "apple", "github"],
+});
 
 export default function SignInScreen() {
   const router = useRouter();
@@ -58,27 +77,16 @@ export default function SignInScreen() {
             </ThemedText>
           ) : null}
 
-          <ProviderButton
-            label="Continue with Google"
-            onPress={() => handleSignIn("google")}
-            loading={pending === "google"}
-            disabled={pending !== null}
-            variant="primary"
-          />
-          <ProviderButton
-            label="Continue with GitHub"
-            onPress={() => handleSignIn("github")}
-            loading={pending === "github"}
-            disabled={pending !== null}
-            variant="outline"
-          />
-          <ProviderButton
-            label="Continue with Apple"
-            onPress={() => handleSignIn("apple")}
-            loading={pending === "apple"}
-            disabled={pending !== null}
-            variant="outline"
-          />
+          {PROVIDER_ORDER.map((provider, index) => (
+            <ProviderButton
+              key={provider}
+              label={PROVIDER_LABELS[provider]}
+              onPress={() => handleSignIn(provider)}
+              loading={pending === provider}
+              disabled={pending !== null}
+              variant={index === 0 ? "primary" : "outline"}
+            />
+          ))}
 
           <ThemedText themeColor="mutedForeground" style={styles.legal}>
             We only use your account to sync credits and preferences.

--- a/apps/mobile/src/app/sign-in.tsx
+++ b/apps/mobile/src/app/sign-in.tsx
@@ -72,6 +72,13 @@ export default function SignInScreen() {
             disabled={pending !== null}
             variant="outline"
           />
+          <ProviderButton
+            label="Continue with Apple"
+            onPress={() => handleSignIn("apple")}
+            loading={pending === "apple"}
+            disabled={pending !== null}
+            variant="outline"
+          />
 
           <ThemedText themeColor="mutedForeground" style={styles.legal}>
             We only use your account to sync credits and preferences.

--- a/apps/mobile/src/hooks/use-auth.tsx
+++ b/apps/mobile/src/hooks/use-auth.tsx
@@ -10,7 +10,7 @@ import { authClient } from "@/lib/cloud/auth-client";
 import { type CloudUser, signOutCloud } from "@/lib/cloud/session";
 import { clearKeyboardSession } from "@/lib/keyboard-bridge";
 
-export type SocialProvider = "google" | "github";
+export type SocialProvider = "google" | "github" | "apple";
 
 interface AuthState {
   user: CloudUser | null;


### PR DESCRIPTION
## Summary

Adds a **Sign in with Apple** option to the mobile app's sign-in screen, alongside the existing Google and GitHub buttons.

- Extend `SocialProvider` with `"apple"` (`apps/mobile/src/hooks/use-auth.tsx`)
- Add a "Continue with Apple" `ProviderButton` on the sign-in screen (`apps/mobile/src/app/sign-in.tsx`)

The button flows through the existing better-auth `authClient.signIn.social({ provider: "apple" })` path — no auth-client changes were needed. This also helps satisfy Apple's App Store requirement to offer Sign in with Apple when other third-party social logins are present.

## Backend dependency

The Apple provider (client ID / secret / callback config) must be registered in `socialProviders` on the **Freestyle Cloud** better-auth backend (`https://service.freestylevoice.com/auth`) for sign-in to complete. That change lives in the separate cloud repo, not here. Apple Team ID reference: `X87V5R2F7D` (`apps/mobile/eas.json`).

## Verification

- `pnpm --filter @freestyle-voice/mobile typecheck` — passes
- `pnpm --filter @freestyle-voice/mobile lint` (biome) — passes