### PR TITLE
feat: make streaming audio always-on

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1775,10 +1775,6 @@ app.whenReady().then(async () => {
     mainWindow?.webContents.send("settings:audio-ducking-changed", enabled);
   });
 
-  ipcMain.on("settings:streaming-audio-changed", (_event, enabled: boolean) => {
-    mainWindow?.webContents.send("settings:streaming-audio-changed", enabled);
-  });
-
   ipcMain.on("settings:audio-playback-mode-changed", (_event, mode: string) => {
     mainWindow?.webContents.send("settings:audio-playback-mode-changed", mode);
   });

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -103,10 +103,6 @@ declare global {
       onAudioDuckingChanged: (
         callback: (enabled: boolean) => void,
       ) => () => void;
-      sendStreamingAudioChanged: (enabled: boolean) => void;
-      onStreamingAudioChanged: (
-        callback: (enabled: boolean) => void,
-      ) => () => void;
       sendAudioPlaybackModeChanged: (mode: AudioPlaybackMode) => void;
       onAudioPlaybackModeChanged: (
         callback: (mode: AudioPlaybackMode) => void,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -210,16 +210,6 @@ const api = {
     return () =>
       ipcRenderer.removeListener("settings:audio-ducking-changed", handler);
   },
-  sendStreamingAudioChanged: (enabled: boolean): void =>
-    ipcRenderer.send("settings:streaming-audio-changed", enabled),
-  onStreamingAudioChanged: (
-    callback: (enabled: boolean) => void,
-  ): (() => void) => {
-    const handler = (_: unknown, enabled: boolean): void => callback(enabled);
-    ipcRenderer.on("settings:streaming-audio-changed", handler);
-    return () =>
-      ipcRenderer.removeListener("settings:streaming-audio-changed", handler);
-  },
   sendAudioPlaybackModeChanged: (mode: AudioPlaybackMode): void =>
     ipcRenderer.send("settings:audio-playback-mode-changed", mode),
   onAudioPlaybackModeChanged: (

--- a/apps/electron/src/renderer/src/locales/en.json
+++ b/apps/electron/src/renderer/src/locales/en.json
@@ -108,8 +108,7 @@
       "permissions": "Permissions",
       "data": "Data",
       "billing": "Usage and Billing",
-      "network": "Network",
-      "experimental": "Experimental"
+      "network": "Network"
     },
     "application": {
       "autoUpdate": "Automatic updates",

--- a/apps/electron/src/renderer/src/locales/template.json
+++ b/apps/electron/src/renderer/src/locales/template.json
@@ -108,8 +108,7 @@
       "display": "Display",
       "permissions": "Permissions",
       "data": "Data",
-      "network": "Network",
-      "experimental": "Experimental"
+      "network": "Network"
     },
     "application": {
       "autoUpdate": "Automatic updates",

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -38,7 +38,6 @@ type BarMode = "connecting" | "listening" | "speaking";
 let _soundEnabled = true;
 let _outputMode = "paste";
 let _audioPlaybackMode: AudioPlaybackMode = "off";
-let _streamingAudioEnabled = false;
 let _toneCtx: AudioContext | null = null;
 
 /**
@@ -820,12 +819,10 @@ export default function AppPage(): React.JSX.Element {
         .catch(() => {});
 
       appContextRef.current = null;
-      // Only create the streamer when streaming is enabled.
-      if (_streamingAudioEnabled) {
-        try {
-          getStreamer().setContext(null);
-        } catch {}
-      }
+      // Streaming is always active — prime the streamer's context.
+      try {
+        getStreamer().setContext(null);
+      } catch {}
 
       void refreshNeedsAppContextForCleanup().then((needsAppContext) => {
         if (!needsAppContext || !wantsMicRef.current) return;
@@ -834,20 +831,16 @@ export default function AppPage(): React.JSX.Element {
           .then((app) => {
             if (!wantsMicRef.current) return;
             appContextRef.current = app;
-            if (_streamingAudioEnabled) {
-              try {
-                getStreamer().setContext(app);
-              } catch {}
-            }
+            try {
+              getStreamer().setContext(app);
+            } catch {}
           })
           .catch(() => {
             if (!wantsMicRef.current) return;
             appContextRef.current = null;
-            if (_streamingAudioEnabled) {
-              try {
-                getStreamer().setContext(null);
-              } catch {}
-            }
+            try {
+              getStreamer().setContext(null);
+            } catch {}
           });
       });
 
@@ -871,7 +864,7 @@ export default function AppPage(): React.JSX.Element {
 
       try {
         recordingSessionUsesTransportRef.current =
-          _streamingAudioEnabled && supportsSessionTransportRef.current;
+          supportsSessionTransportRef.current;
 
         // When session transport is active the streamer handles audio capture
         // directly — we only need the raw mic stream for the analyser. When
@@ -914,11 +907,9 @@ export default function AppPage(): React.JSX.Element {
         }, 100);
 
         startListening(stream);
-        if (_streamingAudioEnabled) {
-          try {
-            await getStreamer().startCapture(stream);
-          } catch {}
-        }
+        try {
+          await getStreamer().startCapture(stream);
+        } catch {}
       } catch (err) {
         pendingCommitRef.current = false;
         recorderRef.current.releaseStream();
@@ -1198,20 +1189,11 @@ export default function AppPage(): React.JSX.Element {
       })
       .catch(() => {});
 
-    // Streaming audio flag (experimental — stored in config.freestyle.json).
-    // When enabled, eagerly create the Streamer so the WebSocket connects and
-    // the onConfig callback (which sets supportsSessionTransportRef) fires
-    // before the first recording.
-    getClient()
-      .api.config.$get()
-      .then((r) => (r.ok ? r.json() : null))
-      .then((config) => {
-        if (config?.flags?.streaming_audio === true) {
-          _streamingAudioEnabled = true;
-          getStreamer();
-        }
-      })
-      .catch(() => {});
+    // Streaming is always active. Eagerly create the Streamer so the WebSocket
+    // connects and the onConfig callback (which sets supportsSessionTransportRef)
+    // fires before the first recording. Session-transport support is negotiated
+    // per provider — non-streaming providers fall back to the batch path.
+    getStreamer();
     window.api
       ?.getPillPosition()
       .then(applyPillPosition)
@@ -1233,32 +1215,16 @@ export default function AppPage(): React.JSX.Element {
         _audioPlaybackMode = normalizeAudioPlaybackMode(mode);
       },
     );
-    // Apply the toggle live — the flag is a module-level var read once above,
-    // so without this it wouldn't take effect until the pill window reloaded.
-    // Disabling tears the streamer down so its reconnect loop and AudioContext
-    // don't linger.
-    const removeStreamingAudio = window.api?.onStreamingAudioChanged(
-      (enabled) => {
-        _streamingAudioEnabled = enabled;
-        if (enabled) {
-          getStreamer();
-        } else {
-          streamerRef.current?.destroy();
-          streamerRef.current = null;
-          supportsSessionTransportRef.current = false;
-        }
-      },
-    );
     // The server target (URL/token) changed in Settings. Re-point this window's
     // API client and tear down the streamer so its next connection uses the new
-    // server — no app restart needed. A fresh streamer is created lazily on the
-    // next recording (or immediately if streaming is enabled).
+    // server — no app restart needed. A fresh streamer is created immediately so
+    // session-transport support is renegotiated before the next recording.
     const removeServerChanged = window.api?.onServerChanged(() => {
       void refreshApiBase().finally(() => {
         streamerRef.current?.destroy();
         streamerRef.current = null;
         supportsSessionTransportRef.current = false;
-        if (_streamingAudioEnabled) getStreamer();
+        getStreamer();
       });
     });
     return () => {
@@ -1266,7 +1232,6 @@ export default function AppPage(): React.JSX.Element {
       removeOutputMode?.();
       removeAudioDucking?.();
       removeAudioPlaybackMode?.();
-      removeStreamingAudio?.();
       removeServerChanged?.();
     };
   }, [applyPillPosition, getStreamer]);

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -45,13 +45,7 @@ import { useCloudAuth } from "@renderer/lib/auth-context";
 import { LANGUAGES } from "@renderer/lib/languages";
 import { requestMicAccess, resolveMicStatus } from "@renderer/lib/permissions";
 import { IS_LINUX, IS_MAC, IS_WINDOWS } from "@renderer/lib/platform";
-import {
-  CONFIG_QUERY_KEY,
-  configQueryOptions,
-  type FreestyleConfig,
-  SETTINGS_QUERY_KEY,
-  settingsQueryOptions,
-} from "@renderer/lib/query";
+import { SETTINGS_QUERY_KEY, settingsQueryOptions } from "@renderer/lib/query";
 import {
   type CloudUsageBalance,
   usagePercent,
@@ -64,7 +58,6 @@ import {
   Cloud,
   Download,
   ExternalLink,
-  FlaskConical,
   FolderOpen,
   Info,
   Keyboard,
@@ -119,7 +112,6 @@ const settingsSectionIds = [
   "data",
   "billing",
   "network",
-  "experimental",
 ] as const;
 
 type SettingsSectionId = (typeof settingsSectionIds)[number];
@@ -171,7 +163,6 @@ export default function SettingsPage(): React.JSX.Element {
   const [autoUpdate, setAutoUpdate] = useState(true);
   const [launchAtStartup, setLaunchAtStartup] = useState(false);
   const [showOnLaunch, setShowOnLaunch] = useState(true);
-  const [streamingAudio, setStreamingAudio] = useState(false);
   const [activeSection, setActiveSection] = useState<SettingsSectionId>(() =>
     parseSettingsSection(window.location.hash),
   );
@@ -384,15 +375,6 @@ export default function SettingsPage(): React.JSX.Element {
       setAudioPlaybackMode("duck");
     }
   }, [settingsQuery.data]);
-
-  // Experimental flags from config.freestyle.json, cached alongside the rest of
-  // the settings page rather than re-fetched on every visit.
-  const configQuery = useQuery(configQueryOptions());
-  useEffect(() => {
-    if (configQuery.data) {
-      setStreamingAudio(configQuery.data.flags.streaming_audio === true);
-    }
-  }, [configQuery.data]);
 
   // Load available audio input devices
   useEffect(() => {
@@ -622,27 +604,6 @@ export default function SettingsPage(): React.JSX.Element {
       }
     },
     [saveHistoryRetention],
-  );
-
-  const handleStreamingAudioToggle = useCallback(
-    (enabled: boolean) => {
-      setStreamingAudio(enabled);
-      window.api?.sendStreamingAudioChanged(enabled);
-      getClient()
-        .api.config.flags[":key"].$put({
-          param: { key: "streaming_audio" },
-          json: { value: enabled },
-        })
-        .then(() => {
-          queryClient.setQueryData<FreestyleConfig>(CONFIG_QUERY_KEY, (prev) =>
-            prev
-              ? { ...prev, flags: { ...prev.flags, streaming_audio: enabled } }
-              : prev,
-          );
-        })
-        .catch(() => {});
-    },
-    [queryClient],
   );
 
   const handleAudioPlaybackModeChange = useCallback((value: string) => {
@@ -1166,28 +1127,6 @@ export default function SettingsPage(): React.JSX.Element {
           {activeSection === "billing" && <BillingPanel />}
 
           {activeSection === "network" && <NetworkPanel />}
-
-          {activeSection === "experimental" && (
-            <SettingsPanel>
-              <div className="border-border bg-secondary/40 text-muted-foreground mb-4 flex items-start gap-2.5 rounded-[10px] border px-3.5 py-3 text-[12px] leading-[1.55]">
-                <FlaskConical className="mt-px h-3.5 w-3.5 shrink-0 opacity-70" />
-                <span>
-                  These features are experimental and may change or be removed
-                  in future releases. Enable them to try new capabilities early.
-                </span>
-              </div>
-              <Row
-                label="Streaming audio"
-                desc="Stream audio in real-time for lower-latency dictation. Supported by Freestyle Transcribe, OpenAI, Deepgram, ElevenLabs, and Soniox."
-                last
-              >
-                <Switch
-                  checked={streamingAudio}
-                  onCheckedChange={handleStreamingAudioToggle}
-                />
-              </Row>
-            </SettingsPanel>
-          )}
         </div>
       </div>
     </div>

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -2,7 +2,6 @@ import { sanitizeTranscriptText } from "@freestyle-voice/stt";
 import { createAppLogger } from "@freestyle-voice/utils";
 import { upgradeWebSocket } from "@hono/node-server";
 import { Hono } from "hono";
-import { getFlag } from "../lib/config.js";
 import { getRewritePromptContext } from "../lib/editor/rewrite-context.js";
 import {
   FREESTYLE_CLOUD_PROVIDER_ID,
@@ -47,13 +46,6 @@ const LOG_PIPELINE_LATENCY = process.env.FREESTYLE_LOG_PIPELINE_LATENCY !== "0";
 
 const stream = new Hono().get(
   "/",
-  (c, next) => {
-    // Streaming is gated behind the experimental flag.
-    if (!getFlag("streaming_audio")) {
-      return c.json({ error: "Streaming audio is not enabled" }, 400);
-    }
-    return next();
-  },
   upgradeWebSocket(() => {
     let upstream: StreamSession | null = null;
     let closed = false;


### PR DESCRIPTION
## What

Removes the `streaming_audio` experimental flag gate so real-time streaming dictation runs by default for everyone — no more Experimental toggle required.

Session-transport support is still negotiated per-provider at connect time, so providers that don't support streaming continue to fall back to the batch path automatically. This is purely a "remove the gate" change, not a behavior change to the streaming pipeline itself.

## Changes

- **`stream.ts`** — drop the `getFlag("streaming_audio")` 400-gate middleware (and its unused import).
- **`app.tsx`** — remove the `_streamingAudioEnabled` module var and all 8 guards; always create/use the `Streamer`. Replace the `GET /api/config` mount fetch with an unconditional `getStreamer()`, and remove the `onStreamingAudioChanged` IPC listener.
- **`settings.tsx`** — remove the **Experimental** tab (section id, state, config query, toggle handler, panel) and the now-unused `FlaskConical` + config imports.
- **IPC plumbing** — remove the `settings:streaming-audio-changed` channel from `main/index.ts`, `preload/index.ts`, and `preload/index.d.ts`.
- **locales** — remove the `"experimental"` sections key from `en.json` and `template.json`.

## Kept intentionally

The `config.freestyle.json` infrastructure (`config.ts`, `/api/config` route, `config-route.test.ts`, and `configQueryOptions`/`CONFIG_QUERY_KEY`/`FreestyleConfig` in `query.ts`) is left in place for future feature flags — only the `streaming_audio` flag *usage* is removed.

## Verification

- `pnpm --filter @freestyle-voice/electron run typecheck` — passes (node + web)
- `tsc --noEmit` on server — passes
- `pnpm --filter @freestyle-voice/server run test` — 294/294 pass (incl. retained `config-route.test.ts`)
- `biome check` — clean on all touched files
- Grepped the repo for any dangling `_streamingAudioEnabled` / `streaming_audio` / `onStreamingAudioChanged` references — none remain