### PR TITLE
feat(models): add OpenRouter AI gateway for cleanup post-processing

### DIFF
--- a/apps/electron/src/renderer/src/lib/models.ts
+++ b/apps/electron/src/renderer/src/lib/models.ts
@@ -104,6 +104,7 @@ export const LLM_PROVIDERS = [
   "groq",
   "mistral",
   "openrouter",
+  "vercel",
   "local-llm",
 ];
 
@@ -117,6 +118,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   soniox: "Soniox",
   mistral: "Mistral",
   openrouter: "OpenRouter",
+  vercel: "Vercel AI Gateway",
   "freestyle-cloud": "Freestyle Transcribe",
   "local-llm": "Local LLM",
   "local-whisper": "Local Whisper",
@@ -134,6 +136,7 @@ export const PROVIDER_KEY_URLS: Record<string, string> = {
   google: "https://aistudio.google.com/apikey",
   mistral: "https://console.mistral.ai/api-keys",
   openrouter: "https://openrouter.ai/keys",
+  vercel: "https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fai-gateway%2Fapi-keys",
 };
 
 export function displayProviderName(

--- a/apps/electron/src/renderer/src/lib/models.ts
+++ b/apps/electron/src/renderer/src/lib/models.ts
@@ -98,6 +98,7 @@ export const LLM_PROVIDERS = [
   "google",
   "groq",
   "mistral",
+  "openrouter",
   "local-llm",
 ];
 
@@ -127,6 +128,7 @@ export const PROVIDER_KEY_URLS: Record<string, string> = {
   anthropic: "https://console.anthropic.com/settings/keys",
   google: "https://aistudio.google.com/apikey",
   mistral: "https://console.mistral.ai/api-keys",
+  openrouter: "https://openrouter.ai/keys",
 };
 
 export function displayProviderName(

--- a/apps/electron/src/renderer/src/lib/models.ts
+++ b/apps/electron/src/renderer/src/lib/models.ts
@@ -7,6 +7,11 @@ export interface AvailableModel {
   type: "voice" | "llm";
   /** Surfaced in the default picker; non-curated models live behind "All models". */
   curated?: boolean;
+  /**
+   * Display name of the LLM gateway fronting this model (e.g. "OpenRouter"),
+   * shown as a small badge in the picker. Absent for first-party vendors.
+   */
+  gateway?: string;
 }
 
 export interface WhisperModelDef {

--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -68,6 +68,8 @@ interface Row {
   selected: boolean;
   /** Shown by default; non-curated rows live behind "Show all models". */
   curated?: boolean;
+  /** LLM gateway display name (e.g. "OpenRouter"); rendered as a meta badge. */
+  gateway?: string;
   recommended?: boolean;
   hasKey?: boolean;
   status?: WhisperModelDownloadState["status"];
@@ -166,13 +168,21 @@ function buildLlmRows(
   for (const [providerId, { providerName, models }] of m.llmModelsByProvider) {
     if (providerId === FREESTYLE_CLOUD_CLEANUP.provider_id) continue;
     for (const model of models) {
+      // For gateway models the meta line reads "<vendor> via <gateway>"
+      // (e.g. "Microsoft via OpenRouter"). Vendor is the model_id prefix; some
+      // gateway IDs carry a "~" alias prefix ("~openai/...") — strip it.
+      const vendor = model.model_id.replace(/^~/, "").split("/")[0] ?? "";
+      const meta = model.gateway
+        ? vendor.charAt(0).toUpperCase() + vendor.slice(1)
+        : providerName;
       rows.push({
         key: model.model_id,
         name: model.model_name,
         source: "cloud",
         provider: providerId,
-        meta: providerName,
+        meta,
         curated: model.curated === true,
+        gateway: model.gateway,
         selected:
           m.defaultLlm?.model_id === model.model_id &&
           m.defaultLlm?.provider === model.provider_id,
@@ -323,7 +333,11 @@ export function ModelList({
       r.provider !== filter
     )
       return false;
-    if (q && !`${r.name} ${r.meta}`.toLowerCase().includes(q)) return false;
+    if (
+      q &&
+      !`${r.name} ${r.meta} ${r.gateway ?? ""}`.toLowerCase().includes(q)
+    )
+      return false;
     return true;
   });
   const visible = filteredRows.filter((r) => {
@@ -550,7 +564,16 @@ function ModelRow({
           )}
         </div>
         <div className="text-muted-foreground mt-0.5 text-[12px]">
-          {row.meta}
+          {row.gateway ? (
+            <>
+              {row.meta}
+              {row.meta && " "}
+              <span className="text-muted-foreground/70">via</span>{" "}
+              {row.gateway}
+            </>
+          ) : (
+            row.meta
+          )}
         </div>
         {local && status === "error" && row.state?.error && (
           <div className="text-destructive mt-1 text-[11.5px] leading-snug">

--- a/apps/server/src/lib/llm/registry.ts
+++ b/apps/server/src/lib/llm/registry.ts
@@ -145,6 +145,18 @@ const PROVIDERS: LlmProvider[] = [
     },
   },
   {
+    // Vercel AI Gateway — OpenAI-compatible chat-completions API. Model IDs are
+    // `<vendor>/<model>` (e.g. `anthropic/claude-opus-4.8`), used as-is.
+    providerId: "vercel",
+    createModel: async (modelId, apiKey) => {
+      const { createOpenAI } = await import("@ai-sdk/openai");
+      return createOpenAI({
+        apiKey,
+        baseURL: "https://ai-gateway.vercel.sh/v1",
+      }).chat(modelId);
+    },
+  },
+  {
     providerId: "local-llm",
     local: true,
     createModel: async (modelId) => {

--- a/apps/server/src/lib/llm/registry.ts
+++ b/apps/server/src/lib/llm/registry.ts
@@ -131,6 +131,20 @@ const PROVIDERS: LlmProvider[] = [
     },
   },
   {
+    // OpenRouter is an AI gateway exposing an OpenAI-compatible
+    // chat-completions API. Model IDs are stored prefixed as
+    // `openrouter/<vendor>/<model>` and stripped to `<vendor>/<model>` before
+    // being handed to the gateway (see `PROVIDER_PREFIXED_CHAT_MODELS`).
+    providerId: "openrouter",
+    createModel: async (modelId, apiKey) => {
+      const { createOpenAI } = await import("@ai-sdk/openai");
+      return createOpenAI({
+        apiKey,
+        baseURL: "https://openrouter.ai/api/v1",
+      }).chat(modelId);
+    },
+  },
+  {
     providerId: "local-llm",
     local: true,
     createModel: async (modelId) => {

--- a/apps/server/src/lib/providers.ts
+++ b/apps/server/src/lib/providers.ts
@@ -11,6 +11,7 @@ const PROVIDER_PREFIXED_CHAT_MODELS = new Set([
   "google",
   "mistral",
   "openrouter",
+  "vercel",
   "local-llm",
   "freestyle-cloud",
 ]);

--- a/apps/server/src/lib/providers.ts
+++ b/apps/server/src/lib/providers.ts
@@ -10,6 +10,7 @@ const PROVIDER_PREFIXED_CHAT_MODELS = new Set([
   "anthropic",
   "google",
   "mistral",
+  "openrouter",
   "local-llm",
   "freestyle-cloud",
 ]);

--- a/apps/server/src/lib/validate-key.ts
+++ b/apps/server/src/lib/validate-key.ts
@@ -25,6 +25,10 @@ const FORMAT_HINTS: Record<string, { prefix: string; hint: string }> = {
     prefix: "gsk_",
     hint: 'Groq keys start with "gsk_".',
   },
+  openrouter: {
+    prefix: "sk-or-",
+    hint: 'OpenRouter keys start with "sk-or-".',
+  },
 };
 
 function checkFormat(provider: string, key: string): string | null {
@@ -149,6 +153,20 @@ async function validateMistral(apiKey: string): Promise<ValidationResult> {
   return { valid: false, error: `Mistral returned HTTP ${res.status}.` };
 }
 
+async function validateOpenRouter(apiKey: string): Promise<ValidationResult> {
+  const res = await fetch("https://openrouter.ai/api/v1/key", {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.ok) return { valid: true };
+  if (res.status === 401)
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  return { valid: false, error: `OpenRouter returned HTTP ${res.status}.` };
+}
+
 // ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
@@ -164,6 +182,7 @@ const LIVE_VALIDATORS: Record<
   anthropic: validateAnthropic,
   google: validateGoogle,
   mistral: validateMistral,
+  openrouter: validateOpenRouter,
 };
 
 export async function validateApiKey(

--- a/apps/server/src/lib/validate-key.ts
+++ b/apps/server/src/lib/validate-key.ts
@@ -167,6 +167,20 @@ async function validateOpenRouter(apiKey: string): Promise<ValidationResult> {
   return { valid: false, error: `OpenRouter returned HTTP ${res.status}.` };
 }
 
+async function validateVercel(apiKey: string): Promise<ValidationResult> {
+  const res = await fetch("https://ai-gateway.vercel.sh/v1/models", {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.ok) return { valid: true };
+  if (res.status === 401 || res.status === 403)
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  return { valid: false, error: `Vercel returned HTTP ${res.status}.` };
+}
+
 // ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
@@ -183,6 +197,7 @@ const LIVE_VALIDATORS: Record<
   google: validateGoogle,
   mistral: validateMistral,
   openrouter: validateOpenRouter,
+  vercel: validateVercel,
 };
 
 export async function validateApiKey(

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -191,6 +191,7 @@ const BUILTIN_VOICE_MODELS: AvailableModel[] = [
 // gateway here and it works end to end with no further wiring.
 const LLM_GATEWAYS: Record<string, string> = {
   openrouter: "OpenRouter",
+  vercel: "Vercel AI Gateway",
 };
 
 // Cleanup-LLM providers the app can actually run (see lib/providers.ts).

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -35,6 +35,12 @@ interface AvailableModel {
   cost_output?: number;
   /** Surfaced in the default picker; non-curated models live behind "All models". */
   curated?: boolean;
+  /**
+   * Display name of the LLM gateway fronting this model (e.g. "OpenRouter"),
+   * when the provider is an aggregator rather than a first-party vendor. The
+   * picker shows this as a small badge next to the model.
+   */
+  gateway?: string;
 }
 
 const DEPRECATED_STATUS = "deprecated";
@@ -83,64 +89,6 @@ async function fetchLocalLlmModels(): Promise<AvailableModel[]> {
     cost_input: 0,
     cost_output: 0,
   }));
-}
-
-interface OpenRouterModel {
-  id: string;
-  name?: string;
-  architecture?: { input_modalities?: string[]; output_modalities?: string[] };
-  pricing?: { prompt?: string; completion?: string };
-}
-
-// OpenRouter is an AI gateway with an OpenAI-compatible API. Its catalog isn't
-// in models.dev, so we fetch it directly (mirrors `fetchLocalLlmModels`) and
-// only when the user has stored an OpenRouter key. Pricing is per-token USD;
-// we scale to per-million to match the models.dev cost convention.
-async function fetchOpenRouterModels(): Promise<AvailableModel[]> {
-  const db = getDb();
-  const row = db
-    .prepare("SELECT key FROM api_keys WHERE provider = 'openrouter'")
-    .get() as { key: string } | undefined;
-  if (!row?.key) return [];
-
-  const res = await fetch("https://openrouter.ai/api/v1/models", {
-    headers: { Authorization: `Bearer ${row.key}` },
-    signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
-  });
-  if (!res.ok) return [];
-
-  const data = (await res.json()) as { data?: OpenRouterModel[] };
-  if (!data.data || !Array.isArray(data.data)) return [];
-
-  const models: AvailableModel[] = [];
-  for (const m of data.data) {
-    const inputMods = m.architecture?.input_modalities ?? ["text"];
-    const outputMods = m.architecture?.output_modalities ?? ["text"];
-    if (!inputMods.includes("text") || !outputMods.includes("text")) continue;
-    if (
-      UNSUITABLE_CLEANUP_MODEL_PATTERN.test(`${m.id} ${m.name ?? ""}`.trim())
-    ) {
-      continue;
-    }
-
-    const promptPrice = Number(m.pricing?.prompt);
-    const completionPrice = Number(m.pricing?.completion);
-    models.push({
-      provider_id: "openrouter",
-      provider_name: "OpenRouter",
-      model_id: `openrouter/${m.id}`,
-      model_name: m.name ?? m.id,
-      family: m.id.split("/")[0] ?? "openrouter",
-      type: "llm",
-      cost_input: Number.isFinite(promptPrice)
-        ? promptPrice * 1_000_000
-        : undefined,
-      cost_output: Number.isFinite(completionPrice)
-        ? completionPrice * 1_000_000
-        : undefined,
-    });
-  }
-  return models;
 }
 
 // Local voice models (curated + legacy that's still downloaded — the
@@ -235,6 +183,16 @@ const BUILTIN_VOICE_MODELS: AvailableModel[] = [
   },
 ];
 
+// OpenAI-compatible LLM gateways (aggregators fronting many vendors' models).
+// Their catalogs live in models.dev under a single provider key, so they flow
+// through the same registry loop as first-party vendors — no key required to
+// list them. Models are tagged with the gateway's display name (badge in the
+// picker) and stay non-curated (behind "Show all models"). Add any future
+// gateway here and it works end to end with no further wiring.
+const LLM_GATEWAYS: Record<string, string> = {
+  openrouter: "OpenRouter",
+};
+
 // Cleanup-LLM providers the app can actually run (see lib/providers.ts).
 const SUPPORTED_LLM_PROVIDERS = new Set([
   "openai",
@@ -242,6 +200,7 @@ const SUPPORTED_LLM_PROVIDERS = new Set([
   "google",
   "groq",
   "mistral",
+  ...Object.keys(LLM_GATEWAYS),
 ]);
 
 // One fast-tier cleanup model per provider, surfaced by default; everything
@@ -335,7 +294,7 @@ export async function isCleanupModelSupported(
   modelId: string,
 ): Promise<boolean> {
   if (providerId === "local-llm") return true;
-  if (providerId === "openrouter") return true;
+  if (providerId in LLM_GATEWAYS) return true;
   if (providerId === FREESTYLE_CLOUD_PROVIDER_ID) return true;
 
   try {
@@ -422,6 +381,7 @@ const models = new Hono()
               cost_input: model.cost?.input,
               cost_output: model.cost?.output,
               curated: CURATED_LLM_IDS.has(`${providerId}/${model.id}`),
+              gateway: LLM_GATEWAYS[providerId],
             });
           }
         }
@@ -467,13 +427,6 @@ const models = new Hono()
         available.push(...localModels.map((m) => ({ ...m, curated: true })));
       } catch {
         // Local LLM server not reachable
-      }
-
-      try {
-        const openRouterModels = await fetchOpenRouterModels();
-        available.push(...openRouterModels);
-      } catch {
-        // OpenRouter unreachable or no key — gateway models simply omitted
       }
 
       return c.json(available);

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -85,6 +85,64 @@ async function fetchLocalLlmModels(): Promise<AvailableModel[]> {
   }));
 }
 
+interface OpenRouterModel {
+  id: string;
+  name?: string;
+  architecture?: { input_modalities?: string[]; output_modalities?: string[] };
+  pricing?: { prompt?: string; completion?: string };
+}
+
+// OpenRouter is an AI gateway with an OpenAI-compatible API. Its catalog isn't
+// in models.dev, so we fetch it directly (mirrors `fetchLocalLlmModels`) and
+// only when the user has stored an OpenRouter key. Pricing is per-token USD;
+// we scale to per-million to match the models.dev cost convention.
+async function fetchOpenRouterModels(): Promise<AvailableModel[]> {
+  const db = getDb();
+  const row = db
+    .prepare("SELECT key FROM api_keys WHERE provider = 'openrouter'")
+    .get() as { key: string } | undefined;
+  if (!row?.key) return [];
+
+  const res = await fetch("https://openrouter.ai/api/v1/models", {
+    headers: { Authorization: `Bearer ${row.key}` },
+    signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) return [];
+
+  const data = (await res.json()) as { data?: OpenRouterModel[] };
+  if (!data.data || !Array.isArray(data.data)) return [];
+
+  const models: AvailableModel[] = [];
+  for (const m of data.data) {
+    const inputMods = m.architecture?.input_modalities ?? ["text"];
+    const outputMods = m.architecture?.output_modalities ?? ["text"];
+    if (!inputMods.includes("text") || !outputMods.includes("text")) continue;
+    if (
+      UNSUITABLE_CLEANUP_MODEL_PATTERN.test(`${m.id} ${m.name ?? ""}`.trim())
+    ) {
+      continue;
+    }
+
+    const promptPrice = Number(m.pricing?.prompt);
+    const completionPrice = Number(m.pricing?.completion);
+    models.push({
+      provider_id: "openrouter",
+      provider_name: "OpenRouter",
+      model_id: `openrouter/${m.id}`,
+      model_name: m.name ?? m.id,
+      family: m.id.split("/")[0] ?? "openrouter",
+      type: "llm",
+      cost_input: Number.isFinite(promptPrice)
+        ? promptPrice * 1_000_000
+        : undefined,
+      cost_output: Number.isFinite(completionPrice)
+        ? completionPrice * 1_000_000
+        : undefined,
+    });
+  }
+  return models;
+}
+
 // Local voice models (curated + legacy that's still downloaded — the
 // /available handler filters to ready models, so legacy entries only
 // surface for installs that already have them on disk).
@@ -277,6 +335,7 @@ export async function isCleanupModelSupported(
   modelId: string,
 ): Promise<boolean> {
   if (providerId === "local-llm") return true;
+  if (providerId === "openrouter") return true;
   if (providerId === FREESTYLE_CLOUD_PROVIDER_ID) return true;
 
   try {
@@ -408,6 +467,13 @@ const models = new Hono()
         available.push(...localModels.map((m) => ({ ...m, curated: true })));
       } catch {
         // Local LLM server not reachable
+      }
+
+      try {
+        const openRouterModels = await fetchOpenRouterModels();
+        available.push(...openRouterModels);
+      } catch {
+        // OpenRouter unreachable or no key — gateway models simply omitted
       }
 
       return c.json(available);


### PR DESCRIPTION
## Summary

Adds support for an AI Gateway — **OpenRouter** — as a provider in the post-processing (cleanup) models section, so users can bring their own OpenRouter key and reach hundreds of models behind one credential. OpenRouter is OpenAI-compatible, so it reuses the existing `createOpenAI({ apiKey, baseURL })` pattern already used by `freestyle-cloud` and `local-llm`. No new server dependency.

Closes #500

## Changes

**Server**
- `lib/llm/registry.ts` — new `openrouter` `LlmProvider` descriptor (`baseURL: https://openrouter.ai/api/v1`).
- `lib/providers.ts` — `openrouter` added to `PROVIDER_PREFIXED_CHAT_MODELS` (IDs stored as `openrouter/<vendor>/<model>`, stripped before the API call).
- `routes/models.ts` — `fetchOpenRouterModels()` dynamically fetches the OpenRouter catalog (only when a key is stored; mirrors `fetchLocalLlmModels`), filters to text→text and skips guard/embedding/etc. models, and scales per-token pricing to per-million to match the models.dev cost convention. Also short-circuits `isCleanupModelSupported` to `true` for `openrouter` (models.dev doesn't know gateway IDs, so cleanup would otherwise be skipped).
- `lib/validate-key.ts` — `openrouter` live validator (`GET /api/v1/key`) plus an `sk-or-` format hint.

**Renderer**
- `lib/models.ts` — `openrouter` added to `LLM_PROVIDERS` (otherwise `groupByProvider` filters it out) and a `PROVIDER_KEY_URLS` entry (`https://openrouter.ai/keys`). Display name already existed.

The post-process pipeline, `api_keys` storage, validation schemas, and the BYOK model/key-entry UI are provider-agnostic (string-keyed) and unchanged. OpenRouter is automatically classified under the "Your API key" (BYOK) cleanup tier since it isn't in `MANAGED_LLM_PROVIDERS`.

## Testing

- `tsc --noEmit` passes for both `apps/server` and the electron renderer (`typecheck:web`).
- Biome check clean on all changed files.
- `apps/server` post-process test suites pass (`post-process-options`, `post-process-control`).

## Acceptance criteria (from #500)

- [x] Users can add an OpenRouter API key under the BYOK cleanup tier.
- [x] OpenRouter models appear in the cleanup picker and can be set as default.
- [x] Selecting an OpenRouter model isn't skipped by the unsupported-cleanup-model guard.
- [x] Invalid OpenRouter keys are rejected with a clear error at key-entry time.