### PR TITLE
feat(Biasing): Get Soniox ASR biasing to work properly. 

### DIFF
--- a/apps/electron/src/renderer/src/lib/models.ts
+++ b/apps/electron/src/renderer/src/lib/models.ts
@@ -211,7 +211,7 @@ export const VOICE_META: Record<
     cost: 0.4,
     note: "Excellent across 99 languages",
   },
-  "soniox/stt-rt-v4": {
+  "soniox/stt-rt-v5": {
     speed: 5,
     quality: 5,
     cost: 0.12,

--- a/apps/server/src/lib/streaming-stt.ts
+++ b/apps/server/src/lib/streaming-stt.ts
@@ -35,11 +35,20 @@ export function openStreamingSession(opts: {
   model: string;
   language?: string;
   bias?: AsrVocabularyBias | null;
+  appContext?: string | null;
   cleanup?: StreamCleanupPreferences;
   callbacks: StreamCallbacks;
 }): StreamSession {
-  const { providerId, apiKey, model, language, bias, cleanup, callbacks } =
-    opts;
+  const {
+    providerId,
+    apiKey,
+    model,
+    language,
+    bias,
+    appContext,
+    cleanup,
+    callbacks,
+  } = opts;
 
   const provider = getProvider(providerId);
   if (!provider) {
@@ -59,6 +68,7 @@ export function openStreamingSession(opts: {
     model,
     language,
     bias,
+    appContext,
     cleanup,
     callbacks,
   });

--- a/apps/server/src/lib/streaming/providers/freestyle-cloud.ts
+++ b/apps/server/src/lib/streaming/providers/freestyle-cloud.ts
@@ -75,7 +75,8 @@ export class FreestyleCloudTranscriptionProvider
   }
 
   openStreamingSession(opts: StreamingSessionOptions): StreamSession {
-    const { apiKey, model, language, cleanup, callbacks, bias } = opts;
+    const { apiKey, model, language, cleanup, callbacks, bias, appContext } =
+      opts;
 
     if (!apiKey) {
       throw new FreestyleCloudAuthError();
@@ -103,6 +104,7 @@ export class FreestyleCloudTranscriptionProvider
       language: language || undefined,
       skipPostProcess: cleanup?.skipPostProcess ?? false,
       ...(vocabulary ? { vocabulary } : {}),
+      ...(currentContext ? { context: currentContext } : {}),
       ...(cleanup && !cleanup.skipPostProcess
         ? {
             intensity: cleanup.intensity,
@@ -122,8 +124,8 @@ export class FreestyleCloudTranscriptionProvider
     let configured = false;
     let closed = false;
     // Track context and audio duration so we can forward them with commit.
-    // The stream route sets these via context messages and the commit payload.
-    let currentContext: string | null = null;
+    // The stream route updates these via context messages and the commit payload.
+    let currentContext: string | null = appContext ?? null;
     let currentAudioDurationMs = 0;
 
     ws.on("open", () => {

--- a/apps/server/src/lib/streaming/providers/soniox.ts
+++ b/apps/server/src/lib/streaming/providers/soniox.ts
@@ -1,5 +1,8 @@
 import WebSocket from "ws";
-import { sonioxContextFromBias } from "../transcribe-bias.js";
+import {
+  sonioxContextFromBias,
+  sonioxGeneralFromAppContext,
+} from "../transcribe-bias.js";
 import type {
   StreamingSessionOptions,
   StreamSession,
@@ -35,6 +38,7 @@ function buildSonioxSessionConfig(opts: {
   model: string;
   language?: string;
   bias?: TranscribeOptions["bias"];
+  appContext?: string | null;
 }): Record<string, unknown> {
   const config: Record<string, unknown> = {
     api_key: opts.apiKey,
@@ -46,8 +50,12 @@ function buildSonioxSessionConfig(opts: {
   };
   const hints = languageHints(opts.language);
   if (hints) config.language_hints = hints;
-  const context = sonioxContextFromBias(opts.bias);
-  if (context) config.context = context;
+  const context: Record<string, unknown> = {
+    ...sonioxContextFromBias(opts.bias),
+  };
+  const general = sonioxGeneralFromAppContext(opts.appContext);
+  if (general) context.general = general;
+  if (Object.keys(context).length > 0) config.context = context;
   return config;
 }
 
@@ -75,6 +83,7 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
         ws.send(JSON.stringify(config));
         ws.send(Buffer.from(opts.audio));
         ws.send(JSON.stringify({ type: "finalize" }));
+        ws.send("");
       });
 
       ws.on("message", (raw) => {
@@ -104,10 +113,6 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
           else nonFinal.push(token);
         }
 
-        if (nonFinal.length === 0 && finalTokens.length > 0) {
-          finish(renderTokens(finalTokens, []).trim());
-        }
-
         if (msg.finished) {
           finish(renderTokens(finalTokens, nonFinal).trim());
         }
@@ -128,7 +133,7 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
   }
 
   openStreamingSession(opts: StreamingSessionOptions): StreamSession {
-    const { apiKey, model, language, bias, callbacks } = opts;
+    const { apiKey, model, language, bias, appContext, callbacks } = opts;
     const short = stripProviderPrefix(model);
 
     const finalTokens: SonioxToken[] = [];
@@ -162,6 +167,7 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
         model,
         language,
         bias,
+        appContext,
       });
       ws.send(JSON.stringify(config));
       configured = true;

--- a/apps/server/src/lib/streaming/transcribe-bias.ts
+++ b/apps/server/src/lib/streaming/transcribe-bias.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { parseAppContext } from "freestyle-voice";
 import type { AsrVocabularyBias } from "../vocabulary-bias.js";
 import type { TranscribeResult } from "./types.js";
 import { CLOUD_TRANSCRIBE_TIMEOUT_MS, stripProviderPrefix } from "./types.js";
@@ -151,4 +152,31 @@ export function sonioxContextFromBias(
   if (bias.terms.length > 0) context.terms = bias.terms;
   if (bias.text?.trim()) context.text = bias.text.trim();
   return Object.keys(context).length > 0 ? context : undefined;
+}
+
+export interface SonioxGeneralEntry {
+  key: string;
+  value: string;
+}
+
+const SONIOX_GENERAL_VALUE_MAX_CHARS = 256;
+
+export function sonioxGeneralFromAppContext(
+  appContext: string | null | undefined,
+): SonioxGeneralEntry[] | undefined {
+  const parsed = parseAppContext(appContext);
+  if (!parsed) return undefined;
+  const entries: SonioxGeneralEntry[] = [];
+  const push = (key: string, value: string | undefined) => {
+    const trimmed = value?.trim();
+    if (!trimmed) return;
+    entries.push({
+      key,
+      value: trimmed.slice(0, SONIOX_GENERAL_VALUE_MAX_CHARS),
+    });
+  };
+  push("application", parsed.appName);
+  push("window title", parsed.windowTitle);
+  push("url", parsed.url);
+  return entries.length > 0 ? entries : undefined;
 }

--- a/apps/server/src/lib/streaming/types.ts
+++ b/apps/server/src/lib/streaming/types.ts
@@ -41,6 +41,7 @@ export interface TranscribeOptions {
   language?: string;
   /** ASR-only vocabulary bias for the first recognition pass. */
   bias?: AsrVocabularyBias | null;
+  appContext?: string | null;
 }
 
 export interface TranscribeResult {
@@ -93,6 +94,7 @@ export interface StreamingSessionOptions {
   language?: string;
   /** ASR-only vocabulary bias for the first recognition pass. */
   bias?: AsrVocabularyBias | null;
+  appContext?: string | null;
   /**
    * Cleanup preferences for server-side post-processing providers. Mirrors the
    * batch `/v2/transcribe` payload so streaming and batch behave identically.

--- a/apps/server/src/lib/vocabulary-bias.ts
+++ b/apps/server/src/lib/vocabulary-bias.ts
@@ -1,5 +1,8 @@
 import { stripProviderPrefix } from "./streaming/types.js";
-import { loadVocabularyTerms } from "./vocabulary.js";
+import {
+  buildVocabularyNoteText,
+  loadVocabularyEntries,
+} from "./vocabulary.js";
 
 /** ASR-only vocabulary bias (first recognition step). Not used in post-process. */
 export type AsrVocabularyBias =
@@ -13,6 +16,8 @@ const PROMPT_CHAR_BUDGET = 900;
 const DEEPGRAM_KEYTERM_MAX = 100;
 /** Keep streaming URLs short — long keyterm lists break the WS handshake. */
 const DEEPGRAM_STREAMING_KEYTERM_MAX = 25;
+const SONIOX_TERM_MAX = 500;
+const SONIOX_TERMS_CHAR_BUDGET = 6000;
 const ELEVENLABS_BATCH_KEYTERM_MAX = 100;
 const ELEVENLABS_REALTIME_KEYTERM_MAX = 50;
 const ELEVENLABS_TERM_MAX_CHARS = 20;
@@ -67,6 +72,18 @@ function expandNova2Keywords(terms: string[]): string[] {
   return out;
 }
 
+function capSonioxTerms(terms: string[]): string[] {
+  const capped = capTerms(terms, SONIOX_TERM_MAX);
+  const out: string[] = [];
+  let used = 0;
+  for (const term of capped) {
+    if (used + term.length > SONIOX_TERMS_CHAR_BUDGET) break;
+    out.push(term);
+    used += term.length;
+  }
+  return out;
+}
+
 function capElevenLabsTerms(
   terms: string[],
   maxCount: number,
@@ -99,8 +116,9 @@ export function buildAsrVocabularyBias(
   modelId: string,
   terms: string[],
   streaming = false,
+  noteText?: string,
 ): AsrVocabularyBias | null {
-  const capped = capTerms(terms, DEEPGRAM_KEYTERM_MAX);
+  const capped = capTerms(terms, SONIOX_TERM_MAX);
   if (capped.length === 0) return null;
 
   const short = stripProviderPrefix(modelId);
@@ -147,8 +165,15 @@ export function buildAsrVocabularyBias(
         ? { kind: "elevenlabs-keyterms", terms: keyterms }
         : null;
     }
-    case "soniox": {
-      return { kind: "soniox-context", terms: capped };
+    case "soniox":
+    case "freestyle-cloud": {
+      const sonioxTerms = capSonioxTerms(capped);
+      if (sonioxTerms.length === 0) return null;
+      return {
+        kind: "soniox-context",
+        terms: sonioxTerms,
+        ...(noteText ? { text: noteText } : {}),
+      };
     }
     case "local-mlx": {
       const text = `Technical terms: ${capped.join(", ")}`.slice(
@@ -167,6 +192,12 @@ export function resolveAsrVocabularyBias(
   modelId: string,
   streaming = false,
 ): AsrVocabularyBias | null {
-  const terms = loadVocabularyTerms();
-  return buildAsrVocabularyBias(providerId, modelId, terms, streaming);
+  const entries = loadVocabularyEntries();
+  return buildAsrVocabularyBias(
+    providerId,
+    modelId,
+    entries.map((e) => e.term),
+    streaming,
+    buildVocabularyNoteText(entries),
+  );
 }

--- a/apps/server/src/lib/vocabulary.ts
+++ b/apps/server/src/lib/vocabulary.ts
@@ -11,30 +11,59 @@ export interface VocabularyRow {
   updated_at: string;
 }
 
-/** All vocabulary terms for ASR biasing, longest first for provider limits. */
-export function loadVocabularyTerms(): string[] {
+export interface VocabularyEntry {
+  term: string;
+  notes: string | null;
+}
+
+export function loadVocabularyEntries(): VocabularyEntry[] {
   const db = getDb();
   try {
     const rows = db
       .prepare(
-        "SELECT term FROM vocabulary ORDER BY length(term) DESC, created_at DESC",
+        "SELECT term, notes FROM vocabulary ORDER BY length(term) DESC, created_at DESC",
       )
-      .all() as { term: string }[];
-    return rows.map((r) => r.term.trim()).filter(Boolean);
+      .all() as { term: string; notes: string | null }[];
+    return rows
+      .map((r) => ({ term: r.term.trim(), notes: r.notes?.trim() || null }))
+      .filter((r) => r.term.length > 0);
   } catch (err) {
     log.error(`Failed to load vocabulary terms: ${err}`);
     return [];
   }
 }
 
+/** All vocabulary terms for ASR biasing, longest first for provider limits. */
+export function loadVocabularyTerms(): string[] {
+  return loadVocabularyEntries().map((e) => e.term);
+}
+
+const NOTE_TEXT_MAX_CHARS = 2000;
+
+export function buildVocabularyNoteText(
+  entries: VocabularyEntry[],
+): string | undefined {
+  const lines: string[] = [];
+  let used = 0;
+  for (const entry of entries) {
+    if (!entry.notes) continue;
+    const line = `${entry.term}: ${entry.notes}`;
+    if (used + line.length + 1 > NOTE_TEXT_MAX_CHARS) continue;
+    lines.push(line);
+    used += line.length + 1;
+  }
+  return lines.length > 0 ? lines.join("\n") : undefined;
+}
+
 /**
  * Raw custom-vocabulary bias forwarded to Freestyle Cloud's `/v2/transcribe`.
  * The cloud assembles the recognizer prompt from these terms, so the desktop
  * sends the raw values rather than a formatted prompt. Shape mirrors the
- * cloud's `{ terms }` contract.
+ * cloud's `{ terms, text }` contract.
  */
 export interface CloudVocabularyBias {
   terms: string[];
+  text?: string;
 }
 
 /**
@@ -43,7 +72,8 @@ export interface CloudVocabularyBias {
  * field entirely.
  */
 export function getCloudVocabularyBias(): CloudVocabularyBias | undefined {
-  const terms = loadVocabularyTerms();
-  if (terms.length === 0) return undefined;
-  return { terms };
+  const entries = loadVocabularyEntries();
+  if (entries.length === 0) return undefined;
+  const text = buildVocabularyNoteText(entries);
+  return { terms: entries.map((e) => e.term), ...(text ? { text } : {}) };
 }

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -170,8 +170,8 @@ const BUILTIN_VOICE_MODELS: AvailableModel[] = [
   {
     provider_id: "soniox",
     provider_name: "Soniox",
-    model_id: "soniox/stt-rt-v4",
-    model_name: "Soniox Realtime v4",
+    model_id: "soniox/stt-rt-v5",
+    model_name: "Soniox Realtime v5",
     family: "soniox",
     type: "voice",
   },

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -321,6 +321,7 @@ const stream = new Hono().get(
         model: voice.model_id,
         language: config.language,
         bias: config.bias,
+        appContext: effectiveAppContext(),
         cleanup,
         callbacks: {
           onReady: (readyModel) => {

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -418,6 +418,7 @@ const transcribeRoute = new Hono().post("/", async (c) => {
           ? { language: languageOverride ?? language }
           : {}),
         bias,
+        appContext,
       });
       rawText = sanitizeTranscriptText(result.text);
 

--- a/apps/server/tests/transcribe-bias.test.ts
+++ b/apps/server/tests/transcribe-bias.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  sonioxContextFromBias,
+  sonioxGeneralFromAppContext,
+} from "../src/lib/streaming/transcribe-bias.js";
+
+describe("sonioxContextFromBias", () => {
+  it("forwards terms and text", () => {
+    expect(
+      sonioxContextFromBias({
+        kind: "soniox-context",
+        terms: ["Freestyle"],
+        text: "Freestyle: our dictation app",
+      }),
+    ).toEqual({
+      terms: ["Freestyle"],
+      text: "Freestyle: our dictation app",
+    });
+  });
+
+  it("returns undefined for non-soniox bias kinds", () => {
+    expect(
+      sonioxContextFromBias({ kind: "prompt", text: "Terms: Freestyle." }),
+    ).toBeUndefined();
+    expect(sonioxContextFromBias(null)).toBeUndefined();
+  });
+});
+
+describe("sonioxGeneralFromAppContext", () => {
+  it("builds entries from a JSON app-context payload", () => {
+    const general = sonioxGeneralFromAppContext(
+      JSON.stringify({
+        app: "Slack",
+        windowTitle: "#engineering — Freestyle",
+        url: "https://app.slack.com/client",
+      }),
+    );
+    expect(general).toEqual([
+      { key: "application", value: "Slack" },
+      { key: "window title", value: "#engineering — Freestyle" },
+      { key: "url", value: "https://app.slack.com/client" },
+    ]);
+  });
+
+  it("treats a bare string as the application name", () => {
+    expect(sonioxGeneralFromAppContext("Notes")).toEqual([
+      { key: "application", value: "Notes" },
+    ]);
+  });
+
+  it("returns undefined for missing or empty context", () => {
+    expect(sonioxGeneralFromAppContext(null)).toBeUndefined();
+    expect(sonioxGeneralFromAppContext(undefined)).toBeUndefined();
+    expect(sonioxGeneralFromAppContext(JSON.stringify({}))).toBeUndefined();
+  });
+
+  it("caps entry values at 256 characters", () => {
+    const general = sonioxGeneralFromAppContext(
+      JSON.stringify({ windowTitle: "x".repeat(400) }),
+    );
+    expect(general).toHaveLength(1);
+    expect(general?.[0].value).toHaveLength(256);
+  });
+});

--- a/apps/server/tests/vocabulary-bias.test.ts
+++ b/apps/server/tests/vocabulary-bias.test.ts
@@ -228,11 +228,31 @@ describe("resolveAsrVocabularyBias", () => {
       expect(bias.text).toContain("Freestyle");
     }
   });
+
+  it("feeds term notes into soniox background text", async () => {
+    const { getDb } = await import("../src/lib/db.js");
+    const { resolveAsrVocabularyBias } = await import(
+      "../src/lib/vocabulary-bias.js"
+    );
+
+    const db = getDb();
+    db.prepare("INSERT INTO vocabulary (term, notes) VALUES (?, ?)").run(
+      "Soniox",
+      "speech-to-text provider",
+    );
+
+    const bias = resolveAsrVocabularyBias("soniox", "stt-rt-v5", true);
+    expect(bias?.kind).toBe("soniox-context");
+    if (bias?.kind === "soniox-context") {
+      expect(bias.terms).toContain("Soniox");
+      expect(bias.text).toContain("Soniox: speech-to-text provider");
+    }
+  });
 });
 
 describe("soniox", () => {
   it("builds soniox-context bias with terms", () => {
-    const bias = buildAsrVocabularyBias("soniox", "stt-rt-v4", [
+    const bias = buildAsrVocabularyBias("soniox", "stt-rt-v5", [
       "Freestyle",
       "Kubernetes",
     ]);
@@ -243,7 +263,71 @@ describe("soniox", () => {
   });
 
   it("returns null for empty terms", () => {
-    const bias = buildAsrVocabularyBias("soniox", "stt-rt-v4", []);
+    const bias = buildAsrVocabularyBias("soniox", "stt-rt-v5", []);
+    expect(bias).toBeNull();
+  });
+
+  it("caps terms at 500", () => {
+    const bias = buildAsrVocabularyBias("soniox", "stt-rt-v5", terms(600));
+    expect(bias?.kind).toBe("soniox-context");
+    if (bias?.kind === "soniox-context") {
+      expect(bias.terms).toHaveLength(500);
+    }
+  });
+
+  it("caps cumulative term characters at 6000", () => {
+    const longTerms = terms(100, "x".repeat(100));
+    const bias = buildAsrVocabularyBias("soniox", "stt-rt-v5", longTerms);
+    expect(bias?.kind).toBe("soniox-context");
+    if (bias?.kind === "soniox-context") {
+      const totalChars = bias.terms.reduce((sum, t) => sum + t.length, 0);
+      expect(totalChars).toBeLessThanOrEqual(6000);
+      expect(bias.terms.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("includes note text as background context", () => {
+    const bias = buildAsrVocabularyBias(
+      "soniox",
+      "stt-rt-v5",
+      ["Freestyle"],
+      true,
+      "Freestyle: our voice dictation app",
+    );
+    expect(bias).toEqual({
+      kind: "soniox-context",
+      terms: ["Freestyle"],
+      text: "Freestyle: our voice dictation app",
+    });
+  });
+
+  it("omits text when no note text is supplied", () => {
+    const bias = buildAsrVocabularyBias("soniox", "stt-rt-v5", ["Freestyle"]);
+    expect(bias).toEqual({ kind: "soniox-context", terms: ["Freestyle"] });
+  });
+});
+
+describe("freestyle-cloud", () => {
+  it("builds soniox-context bias for the cloud streaming path", () => {
+    const bias = buildAsrVocabularyBias(
+      "freestyle-cloud",
+      "freestyle-cloud/streaming",
+      ["Freestyle", "Kubernetes"],
+      true,
+    );
+    expect(bias).toEqual({
+      kind: "soniox-context",
+      terms: ["Freestyle", "Kubernetes"],
+    });
+  });
+
+  it("returns null for empty terms", () => {
+    const bias = buildAsrVocabularyBias(
+      "freestyle-cloud",
+      "freestyle-cloud/streaming",
+      [],
+      true,
+    );
     expect(bias).toBeNull();
   });
 });


### PR DESCRIPTION
<!--
  Thanks for contributing! A few quick reminders before you submit.

  PR title must follow Conventional Commits, e.g.:
    fix: prevent duplicate settings requests
    feat(plugins): add update checks
  Allowed types: feat, fix, docs, chore, refactor, test, ci, build, perf, style, revert
  It's used for the squash commit and the release changelog. A CI check enforces this.
-->

## Summary

Right now we didn't have ASR biasing the vocabulary feature, hooked up correctly to the Soniox model. In this PR we make sure that we pass in all of that additional context over to our streaming endpoint that runs Soniox. 

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
- [ ] Ran `pnpm biome check .` (lint + formatting)
- [ ] Ran `pnpm --filter @freestyle-voice/electron typecheck:web` (if touching the app)
