### PR TITLE
fix(mobile): iPad responsive layout — centered content column + type scale

### DIFF
--- a/apps/mobile/src/app/(app)/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/index.tsx
@@ -11,14 +11,16 @@ import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
 import { TranscriptView } from "@/components/transcript-view";
 import { Waveform } from "@/components/waveform";
-import { Fonts, Radius, Spacing } from "@/constants/theme";
+import { Fonts, Layout, Radius, Spacing } from "@/constants/theme";
 import { useAuth } from "@/hooks/use-auth";
+import { useResponsive } from "@/hooks/use-responsive";
 import { useTheme } from "@/hooks/use-theme";
 import { useDictation } from "@/lib/audio/use-dictation";
 
 export default function VoiceScreen() {
   const theme = useTheme();
   const { signedIn } = useAuth();
+  const { brandSize } = useResponsive();
   // This tab stays mounted while the resident keyboard session runs in the
   // background provider. Gate its mic on focus so the Home recorder can't fight
   // the resident session for the audio session (two active recorders = "Could
@@ -62,57 +64,68 @@ export default function VoiceScreen() {
   return (
     <ThemedView style={styles.container}>
       <SafeAreaView style={styles.safeArea}>
-        <View style={styles.header}>
-          <ThemedText type="title" style={styles.brand}>
-            Freestyle
-          </ThemedText>
-          <HeaderActions />
-        </View>
-
-        <TranscriptView
-          text={text}
-          partial={partial}
-          placeholder="Your words will appear here."
-        />
-
-        {text && micState === "idle" ? (
-          <View style={styles.actions}>
-            <Pressable
-              onPress={copy}
-              style={[styles.action, { backgroundColor: theme.primary }]}
+        <View style={styles.column}>
+          <View style={styles.header}>
+            <ThemedText
+              type="title"
+              style={[
+                styles.brand,
+                { fontSize: brandSize, lineHeight: brandSize + 4 },
+              ]}
             >
-              <ThemedText
-                style={[styles.actionText, { color: theme.primaryForeground }]}
-              >
-                {copied ? "Copied" : "Copy"}
-              </ThemedText>
-            </Pressable>
-            <Pressable
-              onPress={share}
-              style={[styles.actionOutline, { borderColor: theme.border }]}
-            >
-              <ThemedText style={styles.actionText}>Share</ThemedText>
-            </Pressable>
-            <Pressable
-              onPress={clear}
-              style={[styles.actionOutline, { borderColor: theme.border }]}
-            >
-              <ThemedText style={styles.actionText}>Clear</ThemedText>
-            </Pressable>
+              Freestyle
+            </ThemedText>
+            <HeaderActions />
           </View>
-        ) : null}
 
-        <View style={styles.footer}>
-          <Waveform level={level} active={micState === "recording"} />
-          <ThemedText themeColor="mutedForeground" style={styles.status}>
-            {status}
-          </ThemedText>
-          <MicButton
-            state={micState}
-            level={level}
-            onPressIn={onPressIn}
-            onPressOut={onPressOut}
+          <TranscriptView
+            text={text}
+            partial={partial}
+            placeholder="Your words will appear here."
           />
+
+          {text && micState === "idle" ? (
+            <View style={styles.actions}>
+              <Pressable
+                onPress={copy}
+                style={[styles.action, { backgroundColor: theme.primary }]}
+              >
+                <ThemedText
+                  style={[
+                    styles.actionText,
+                    { color: theme.primaryForeground },
+                  ]}
+                >
+                  {copied ? "Copied" : "Copy"}
+                </ThemedText>
+              </Pressable>
+              <Pressable
+                onPress={share}
+                style={[styles.actionOutline, { borderColor: theme.border }]}
+              >
+                <ThemedText style={styles.actionText}>Share</ThemedText>
+              </Pressable>
+              <Pressable
+                onPress={clear}
+                style={[styles.actionOutline, { borderColor: theme.border }]}
+              >
+                <ThemedText style={styles.actionText}>Clear</ThemedText>
+              </Pressable>
+            </View>
+          ) : null}
+
+          <View style={styles.footer}>
+            <Waveform level={level} active={micState === "recording"} />
+            <ThemedText themeColor="mutedForeground" style={styles.status}>
+              {status}
+            </ThemedText>
+            <MicButton
+              state={micState}
+              level={level}
+              onPressIn={onPressIn}
+              onPressOut={onPressOut}
+            />
+          </View>
         </View>
       </SafeAreaView>
     </ThemedView>
@@ -122,6 +135,12 @@ export default function VoiceScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   safeArea: { flex: 1, paddingHorizontal: Spacing.four },
+  column: {
+    flex: 1,
+    width: "100%",
+    maxWidth: Layout.contentMaxWidth,
+    alignSelf: "center" as const,
+  },
   header: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -129,7 +148,7 @@ const styles = StyleSheet.create({
     paddingTop: Spacing.three,
     paddingBottom: Spacing.two,
   },
-  brand: { fontSize: 30, lineHeight: 34 },
+  brand: {},
   actions: {
     flexDirection: "row",
     justifyContent: "center",

--- a/apps/mobile/src/components/floating-tab-bar.tsx
+++ b/apps/mobile/src/components/floating-tab-bar.tsx
@@ -23,7 +23,7 @@ import {
 import { Pressable, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { Radius, Spacing } from "@/constants/theme";
+import { Layout, Radius, Spacing } from "@/constants/theme";
 import { useTheme } from "@/hooks/use-theme";
 
 interface NavSpec {
@@ -156,6 +156,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
     width: "100%",
+    maxWidth: Layout.tabBarMaxWidth,
     height: BAR_HEIGHT,
     paddingHorizontal: Spacing.four,
     borderRadius: Radius.full,

--- a/apps/mobile/src/components/settings-ui.tsx
+++ b/apps/mobile/src/components/settings-ui.tsx
@@ -16,7 +16,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { HeaderActions } from "@/components/header-actions";
 import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
-import { Fonts, Radius, Spacing } from "@/constants/theme";
+import { Fonts, Layout, Radius, Spacing } from "@/constants/theme";
+import { useResponsive } from "@/hooks/use-responsive";
 import { useTheme } from "@/hooks/use-theme";
 
 /**
@@ -35,10 +36,11 @@ export function SettingsScreenScaffold({
 }) {
   const theme = useTheme();
   const router = useRouter();
+  const { navTitleSize } = useResponsive();
   return (
     <ThemedView style={styles.screen}>
       <SafeAreaView style={styles.safeArea} edges={["top", "left", "right"]}>
-        <View style={styles.navBar}>
+        <View style={[styles.navBar, styles.centerColumn]}>
           <Pressable
             onPress={() => router.back()}
             hitSlop={12}
@@ -51,14 +53,21 @@ export function SettingsScreenScaffold({
               Back
             </ThemedText>
           </Pressable>
-          <ThemedText type="title" style={styles.navTitle} numberOfLines={1}>
+          <ThemedText
+            type="title"
+            style={[
+              styles.navTitle,
+              { fontSize: navTitleSize, lineHeight: navTitleSize + 4 },
+            ]}
+            numberOfLines={1}
+          >
             {title}
           </ThemedText>
           {/* Balances the back button so the title stays centered. */}
           <View style={styles.navBack} />
         </View>
         <ScrollView
-          contentContainerStyle={styles.body}
+          contentContainerStyle={[styles.body, styles.centerColumn]}
           showsVerticalScrollIndicator={false}
           keyboardShouldPersistTaps="handled"
         >
@@ -94,13 +103,17 @@ export function TabScreenScaffold({
   action?: ReactNode;
   children: ReactNode;
 }) {
+  const { tabTitleSize } = useResponsive();
   return (
     <ThemedView style={styles.screen}>
       <SafeAreaView style={styles.safeArea} edges={["top", "left", "right"]}>
-        <View style={styles.tabHeader}>
+        <View style={[styles.tabHeader, styles.centerColumn]}>
           <ThemedText
             type="title"
-            style={styles.tabHeaderTitle}
+            style={[
+              styles.tabHeaderTitle,
+              { fontSize: tabTitleSize, lineHeight: tabTitleSize + 4 },
+            ]}
             numberOfLines={1}
           >
             {title}
@@ -111,7 +124,11 @@ export function TabScreenScaffold({
           </View>
         </View>
         <ScrollView
-          contentContainerStyle={[styles.body, styles.tabBody]}
+          contentContainerStyle={[
+            styles.body,
+            styles.tabBody,
+            styles.centerColumn,
+          ]}
           showsVerticalScrollIndicator={false}
           keyboardShouldPersistTaps="handled"
         >
@@ -238,6 +255,11 @@ export function OptionCard({
 const styles = StyleSheet.create({
   screen: { flex: 1 },
   safeArea: { flex: 1, paddingHorizontal: Spacing.four },
+  centerColumn: {
+    width: "100%",
+    maxWidth: Layout.contentMaxWidth,
+    alignSelf: "center" as const,
+  },
   navBar: {
     flexDirection: "row",
     alignItems: "center",
@@ -255,8 +277,6 @@ const styles = StyleSheet.create({
   navTitle: {
     flex: 1,
     textAlign: "center",
-    fontSize: 26,
-    lineHeight: 30,
   },
   backText: { fontFamily: Fonts.sansMedium, fontSize: 15 },
   // Pushed pages have no tab bar, but the dictation strip can slide down into
@@ -274,8 +294,6 @@ const styles = StyleSheet.create({
   },
   tabHeaderTitle: {
     flex: 1,
-    fontSize: 30,
-    lineHeight: 34,
   },
   tabHeaderActions: {
     flexDirection: "row",

--- a/apps/mobile/src/components/transcript-view.tsx
+++ b/apps/mobile/src/components/transcript-view.tsx
@@ -2,6 +2,7 @@ import { ScrollView, StyleSheet } from "react-native";
 
 import { ThemedText } from "@/components/themed-text";
 import { Spacing } from "@/constants/theme";
+import { useResponsive } from "@/hooks/use-responsive";
 import { useTheme } from "@/hooks/use-theme";
 
 interface TranscriptViewProps {
@@ -19,6 +20,7 @@ export function TranscriptView({
   placeholder,
 }: TranscriptViewProps) {
   const theme = useTheme();
+  const { transcriptSize, transcriptPlaceholderSize } = useResponsive();
   const empty = !text && !partial;
 
   return (
@@ -28,14 +30,37 @@ export function TranscriptView({
       showsVerticalScrollIndicator={false}
     >
       {empty ? (
-        <ThemedText themeColor="mutedForeground" style={styles.placeholder}>
+        <ThemedText
+          themeColor="mutedForeground"
+          style={[
+            styles.placeholder,
+            {
+              fontSize: transcriptPlaceholderSize,
+              lineHeight: transcriptPlaceholderSize + 10,
+            },
+          ]}
+        >
           {placeholder}
         </ThemedText>
       ) : (
-        <ThemedText style={styles.text}>
+        <ThemedText
+          style={[
+            styles.text,
+            { fontSize: transcriptSize, lineHeight: transcriptSize + 10 },
+          ]}
+        >
           {text}
           {text && partial ? " " : ""}
-          <ThemedText style={[styles.text, { color: theme.mutedForeground }]}>
+          <ThemedText
+            style={[
+              styles.text,
+              {
+                color: theme.mutedForeground,
+                fontSize: transcriptSize,
+                lineHeight: transcriptSize + 10,
+              },
+            ]}
+          >
             {partial}
           </ThemedText>
         </ThemedText>
@@ -47,6 +72,6 @@ export function TranscriptView({
 const styles = StyleSheet.create({
   scroll: { flex: 1 },
   content: { paddingVertical: Spacing.three },
-  text: { fontSize: 20, lineHeight: 30 },
-  placeholder: { fontSize: 18, lineHeight: 28 },
+  text: {},
+  placeholder: {},
 });

--- a/apps/mobile/src/constants/theme.ts
+++ b/apps/mobile/src/constants/theme.ts
@@ -83,3 +83,26 @@ export const Radius = {
   "2xl": 18,
   full: 999,
 } as const;
+
+/**
+ * Responsive layout tokens for iPad / tablet support.
+ *
+ * `contentMaxWidth` caps the reading/settings column so content doesn't stretch
+ * edge-to-edge on wide screens. On phones the maxWidth is wider than the screen
+ * minus gutters, so it's a no-op. On iPad, content centers automatically via
+ * `alignSelf: "center"`.
+ *
+ * `tabBarMaxWidth` caps the floating tab bar pill so the 5 icons stay compact.
+ *
+ * `tabletBreakpoint` is the window width above which we apply a modest
+ * typographic scale-up (titles, transcript). `useWindowDimensions()` makes this
+ * rotation- and Split-View-safe with no manual listener.
+ */
+export const Layout = {
+  /** Max width for the centered content column (cards, lists, inputs). */
+  contentMaxWidth: 600,
+  /** Max width for the floating tab bar pill. */
+  tabBarMaxWidth: 480,
+  /** Window width threshold above which we treat the device as a tablet. */
+  tabletBreakpoint: 700,
+} as const;

--- a/apps/mobile/src/hooks/use-responsive.ts
+++ b/apps/mobile/src/hooks/use-responsive.ts
@@ -1,0 +1,33 @@
+/**
+ * Responsive layout hook for iPad / tablet support.
+ *
+ * Returns `isTablet` (true when the window is wider than the tablet breakpoint)
+ * and ready-to-use font sizes that scale up modestly on wide screens so titles
+ * and body text read proportionally on the larger canvas.
+ *
+ * Because it wraps `useWindowDimensions()`, it recomputes automatically on
+ * rotation, Split View resize, and Slide Over — no manual listener needed.
+ */
+
+import { useWindowDimensions } from "react-native";
+
+import { Layout } from "@/constants/theme";
+
+export function useResponsive() {
+  const { width } = useWindowDimensions();
+  const isTablet = width >= Layout.tabletBreakpoint;
+
+  return {
+    isTablet,
+    /** Tab screen title: 30 on phone, 36 on tablet. */
+    tabTitleSize: isTablet ? 36 : 30,
+    /** Pushed-page nav title: 26 on phone, 30 on tablet. */
+    navTitleSize: isTablet ? 30 : 26,
+    /** Brand wordmark on Home: 30 on phone, 36 on tablet. */
+    brandSize: isTablet ? 36 : 30,
+    /** Transcript body text: 20 on phone, 24 on tablet. */
+    transcriptSize: isTablet ? 24 : 20,
+    /** Transcript placeholder: 18 on phone, 22 on tablet. */
+    transcriptPlaceholderSize: isTablet ? 22 : 18,
+  } as const;
+}


### PR DESCRIPTION
## Problem

Content stretches edge-to-edge on iPad screens — cards, headers, inputs, list rows, and the tab bar span the full ~1024–1280pt width with no max-width constraint, making everything feel sparse and stretched.

## Solution

Add a centered content column with `maxWidth: 600` and modest tablet typographic scale-up. Uses pure flex `maxWidth` + `alignSelf: 'center'` — no-op on phones (column wider than screen minus gutters), centers on iPad, and adapts live to rotation / Slide Over / Split View.

### Changes

1. **Layout tokens** (`theme.ts`): `contentMaxWidth: 600`, `tabBarMaxWidth: 480`, `tabletBreakpoint: 700`
2. **`useResponsive` hook** (new): wraps `useWindowDimensions()` → returns `isTablet` + responsive font sizes
3. **`TabScreenScaffold` + `SettingsScreenScaffold`** (`settings-ui.tsx`): header row + ScrollView content wrapped in centered column — drives History, Vocabulary, Tone, Dictionary, Settings, Profile, Keyboard pages
4. **Home tab** (`index.tsx`): header + transcript + mic footer wrapped in centered column
5. **`TranscriptView`**: responsive font sizes (20→24 on tablet)
6. **Floating tab bar**: pill capped at 480pt max width

### Screens fixed
- Home (voice screen)
- History
- Cleanup & Tone
- Vocabulary
- Dictionary
- Settings
- Profile
- Keyboard setup
- Tab bar

### Verification
- `pnpm --filter @freestyle-voice/mobile run typecheck` ✅
- `pnpm --filter @freestyle-voice/mobile run lint` ✅