### PR TITLE
fix: Change the default Windows hotkey to Right Alt

### DIFF
--- a/apps/electron/src/shared/hotkey-defaults.ts
+++ b/apps/electron/src/shared/hotkey-defaults.ts
@@ -2,7 +2,8 @@
  * Single source of truth for the default push-to-talk hotkey.
  *
  * - macOS: Fn (Globe) — dedicated dictation key, no modifier conflicts
- * - Windows/Linux: Control+Alt+Space — no Super key, so the OS launcher /
+ * - Windows: Right Alt — a convenient single-key shortcut
+ * - Linux: Control+Alt+Space — no Super key, so the OS launcher /
  *   Start menu never fires alongside dictation, and the real key lets the
  *   native listeners suppress the chord from reaching the focused app
  *
@@ -13,6 +14,8 @@ export function getDefaultHotkey(platform: string = process.platform): string {
   switch (platform) {
     case "darwin":
       return "Fn";
+    case "win32":
+      return "RightAlt";
     default:
       return "Control+Alt+Space";
   }


### PR DESCRIPTION
Fixes #510.

## Summary

[Good First Issue] Change the default Windows hotkey to Right Alt

## Validation

- Mechanical gate: +4/-1, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->