### PR TITLE
feat: refine sidebar profile tile and add profile shortcut

### DIFF
--- a/apps/electron/src/renderer/src/components/cloud-profile.tsx
+++ b/apps/electron/src/renderer/src/components/cloud-profile.tsx
@@ -10,6 +10,7 @@ import {
 import { Progress } from "@renderer/components/ui/progress";
 import { useUpgradeModal } from "@renderer/components/upgrade-modal";
 import { useCloudAuth } from "@renderer/lib/auth-context";
+import { LINKS } from "@renderer/lib/links";
 import { usagePercent, useCloudUsage } from "@renderer/lib/use-cloud-usage";
 import { cn } from "@renderer/lib/utils";
 import {
@@ -130,21 +131,20 @@ export function CloudProfileButton(): React.JSX.Element {
             />
           ) : null}
           <span className="min-w-0 flex-1 text-left leading-tight">
-            <span className="flex items-center gap-1.5">
-              <span className="text-foreground min-w-0 truncate font-medium">
-                {user.name || user.email}
-              </span>
+            <span className="text-foreground block min-w-0 truncate font-medium">
+              {user.name || user.email}
+            </span>
+            <span className="mt-0.5 flex items-center gap-1.5">
               {isPro ? (
                 <Badge className="mono h-4 shrink-0 px-1.5 text-[9px] uppercase tracking-[0.12em]">
                   Pro
                 </Badge>
-              ) : null}
+              ) : (
+                <span className="text-muted-foreground min-w-0 truncate text-[11px]">
+                  Free plan
+                </span>
+              )}
             </span>
-            {user.name ? (
-              <span className="text-muted-foreground block truncate text-[11px]">
-                {user.email}
-              </span>
-            ) : null}
           </span>
           <ChevronsUpDown className="text-muted-foreground size-3.5 shrink-0" />
         </button>
@@ -155,13 +155,24 @@ export function CloudProfileButton(): React.JSX.Element {
         sideOffset={6}
         className="w-[200px]"
       >
-        <div className="px-1.5 py-1">
-          <div className="text-foreground truncate text-[13px] font-medium">
-            {user.name || user.email}
+        <div className="flex items-center gap-1.5 px-1.5 py-1">
+          <div className="min-w-0 flex-1">
+            <div className="text-foreground truncate text-[13px] font-medium">
+              {user.name || user.email}
+            </div>
+            <div className="text-muted-foreground truncate text-[11px]">
+              {user.email}
+            </div>
           </div>
-          <div className="text-muted-foreground truncate text-[11px]">
-            {user.email}
-          </div>
+          <button
+            type="button"
+            aria-label="Manage profile"
+            title="Manage profile"
+            onClick={() => void window.api.openExternal(LINKS.cloudProfile)}
+            className="text-muted-foreground hover:text-foreground hover:bg-card focus-visible:ring-ring flex size-6 shrink-0 items-center justify-center rounded-[6px] transition-colors focus-visible:ring-1 focus-visible:outline-none"
+          >
+            <Settings className="size-3.5" />
+          </button>
         </div>
         <DropdownMenuSeparator />
         {isPro ? (

--- a/apps/electron/src/renderer/src/lib/links.ts
+++ b/apps/electron/src/renderer/src/lib/links.ts
@@ -4,4 +4,5 @@ export const LINKS = {
   discord: "https://discord.gg/Fmgt5yZCDu",
   contributing:
     "https://github.com/freestyle-voice/freestyle/blob/main/CONTRIBUTING.md",
+  cloudProfile: "https://freestylevoice.com/profile",
 } as const;


### PR DESCRIPTION
## Summary

Cleans up the sidebar user tile and adds a quick way to manage the cloud profile.

- **Removed the email from the tile button.** It was redundant (the email still shows in the dropdown menu header, which is the one place it makes sense). Removing it frees up horizontal space for the name.
- **Moved plan status to its own line under the name.** The `Pro` badge no longer sits next to the name squeezing it — it now lives on a second line. Free users see a `Free plan` label there instead.
- **Added a gear button** to the dropdown's user-info header that opens the cloud profile page (`https://freestylevoice.com/profile`) in the system browser, so users can manage their account.

## On the org name

The original ask was to show the **organization name** on that second line. That data isn't available in the app today — the signed-in user (`CloudUser`) only carries `id/email/name/image`, and the Freestyle Cloud session (better-auth) is fetched without the organization plugin, so no org/team info reaches the client. Surfacing a real org name would need backend work on Freestyle Cloud plus plumbing through the server. As agreed, this PR shows the **plan** on that line as the available stand-in; the layout leaves a natural spot to swap in an org name later.

## Screateснот-worthy details

- Gear button has `aria-label`/`title` "Manage profile" for accessibility.
- Uses the existing `window.api.openExternal` + `LINKS` pattern (new `LINKS.cloudProfile` constant).

## Testing

- `pnpm --filter electron typecheck:web` — clean
- Biome lint/format — clean

> Note: split out from the number-formatting work (#513) to keep concerns separate.