### PR TITLE
fix(electron): improve permission handling for dictation startup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,6 +398,11 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+      - name: Run macOS permission flow E2E tests
+        working-directory: apps/electron
+        timeout-minutes: 5
+        run: pnpm run test:e2e tests/permission-flow.test.ts
+
       - name: Verify native binaries in package
         working-directory: apps/electron
         run: node scripts/verify-native-binaries.mjs

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -74,6 +74,7 @@ import {
   protocol,
   screen,
   shell,
+  systemPreferences,
   Tray,
 } from "electron";
 import { autoUpdater } from "electron-updater";
@@ -100,6 +101,12 @@ import {
   startLinuxPasteHelper,
   stopLinuxPasteHelper,
 } from "./paste";
+import {
+  type DictationPermission,
+  missingDictationPermission,
+  resolveAccessibilityPermission,
+  shouldWarnAboutAccessibilityAtStartup,
+} from "./permission-checks";
 import {
   FreestyleEventType,
   OutputMode,
@@ -302,12 +309,9 @@ let settingsWindow: BrowserWindow | null = null;
 let settingsWindowCreating: Promise<void> | null = null;
 let tray: Tray | null = null;
 let keyListener: NativeKeyListener | null = null;
-// Latching flag: set only once the native key listener has started
-// successfully, which requires Accessibility permission and therefore
-// proves it is granted. NOT set on the globalShortcut fallback, which
-// needs no permission and would otherwise produce a false positive. The
-// flag persists even when keyListener is temporarily torn down for hotkey
-// recording.
+// Latching flag: records that the native key listener started successfully.
+// It persists while the listener is temporarily torn down for hotkey recording,
+// but is never used to override the current macOS Accessibility trust result.
 let accessibilityConfirmed = false;
 let hotkeyPressed = false;
 let currentHotkeyAccel: string | null = null;
@@ -715,14 +719,9 @@ async function buildSettingsWindow(initialPath?: string): Promise<void> {
   // is an async server call; doing it first means there's no await gap between
   // assigning `settingsWindow` and using it, so a close (or a concurrent open)
   // during the probe can't null-deref or show a half-loaded window.
-  let onboardingDone = readSettings().onboardingComplete === true;
-  // Also consider onboarding done if the server reports any configured models
-  // (existing users who never went through onboarding). Read through the API
-  // rather than opening the SQLite file, so a configured remote server counts.
-  if (!onboardingDone && (await getConfiguredModelCount()) > 0) {
-    onboardingDone = true;
-  }
-  const startPath = !onboardingDone ? "/onboarding" : (initialPath ?? "/today");
+  const startPath = (await isOnboardingActive())
+    ? "/onboarding"
+    : (initialPath ?? "/today");
 
   settingsWindow = new BrowserWindow({
     width: 1152,
@@ -1383,6 +1382,16 @@ async function getConfiguredModelCount(): Promise<number> {
 }
 
 /**
+ * Matches the route decision in buildSettingsWindow. Existing users who have
+ * configured models are treated as onboarded even if the lightweight setting
+ * predates onboardingComplete.
+ */
+async function isOnboardingActive(): Promise<boolean> {
+  if (readSettings().onboardingComplete === true) return false;
+  return (await getConfiguredModelCount()) === 0;
+}
+
+/**
  * Probe `/api/health` at `baseUrl` and confirm it's actually a Freestyle server
  * (not some other service that happens to hold the port). Returns false on any
  * network error or non-matching identity.
@@ -1543,6 +1552,93 @@ function showSettingsWindow(path?: string): void {
   }
   settingsWindow.show();
   settingsWindow.focus();
+}
+
+const ACCESSIBILITY_SETTINGS_URL =
+  "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility";
+const MICROPHONE_SETTINGS_URL =
+  "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Microphone";
+
+function hasCurrentAccessibilityPermission(): boolean {
+  if (process.platform !== "darwin") return true;
+  const state = resolveAccessibilityPermission(
+    process.platform,
+    systemPreferences.isTrustedAccessibilityClient(false),
+    accessibilityConfirmed,
+  );
+  if (accessibilityConfirmed && !state.accessibilityConfirmed) {
+    hotkeyLog.warn("macOS Accessibility permission is no longer available.");
+  }
+  accessibilityConfirmed = state.accessibilityConfirmed;
+  return state.granted;
+}
+
+function getMissingDictationPermission(): DictationPermission | null {
+  const microphoneStatus =
+    process.platform === "linux"
+      ? "unknown"
+      : systemPreferences.getMediaAccessStatus("microphone");
+  return missingDictationPermission(
+    process.platform,
+    hasCurrentAccessibilityPermission(),
+    microphoneStatus,
+  );
+}
+
+function openAccessibilitySettings(): void {
+  if (process.platform !== "darwin") return;
+  // Passing true adds Freestyle to the Accessibility list and shows the native
+  // prompt; macOS still requires the user to enable the toggle themselves.
+  systemPreferences.isTrustedAccessibilityClient(true);
+  void shell.openExternal(ACCESSIBILITY_SETTINGS_URL);
+}
+
+function openMicrophoneSettings(): void {
+  if (process.platform === "darwin") {
+    void shell.openExternal(MICROPHONE_SETTINGS_URL);
+  } else if (process.platform === "win32") {
+    void shell.openExternal("ms-settings:privacy-microphone");
+  }
+}
+
+let permissionDialogPromise: Promise<void> | null = null;
+
+function showRequiredPermissionDialog(
+  permission: DictationPermission,
+): Promise<void> {
+  if (permissionDialogPromise) return permissionDialogPromise;
+
+  const accessibility = permission === "accessibility";
+  permissionDialogPromise = dialog
+    .showMessageBox({
+      type: "error",
+      title: accessibility
+        ? "Accessibility Permission Required"
+        : "Microphone Permission Required",
+      message: accessibility
+        ? "Accessibility permission is required for dictation and text insertion."
+        : "Microphone permission is required for dictation.",
+      detail: accessibility
+        ? "Enable Freestyle in System Settings > Privacy & Security > Accessibility."
+        : process.platform === "darwin"
+          ? "Enable Freestyle in System Settings > Privacy & Security > Microphone."
+          : "Enable microphone access for Freestyle in Windows Settings.",
+      buttons: ["Open System Settings", "Cancel"],
+      defaultId: 0,
+      cancelId: 1,
+    })
+    .then(({ response }) => {
+      if (response !== 0) return;
+      if (accessibility) {
+        openAccessibilitySettings();
+      } else {
+        openMicrophoneSettings();
+      }
+    })
+    .finally(() => {
+      permissionDialogPromise = null;
+    });
+  return permissionDialogPromise;
 }
 
 function isRunningFromReadOnlyLocation(): boolean {
@@ -2055,56 +2151,38 @@ app.whenReady().then(async () => {
       return "unknown";
     }
     // macOS and Windows both report the real privacy-settings state here.
-    const { systemPreferences } = await import("electron");
     return systemPreferences.getMediaAccessStatus("microphone");
   });
 
   ipcMain.handle("permissions:request-mic", async () => {
     if (process.platform === "darwin") {
-      const { systemPreferences } = await import("electron");
       const granted = await systemPreferences.askForMediaAccess("microphone");
       return granted ? "granted" : "denied";
     }
     if (process.platform === "win32") {
       // Windows has no programmatic prompt; report the privacy-settings
       // state so the UI can send the user to Settings when it's denied.
-      const { systemPreferences } = await import("electron");
       return systemPreferences.getMediaAccessStatus("microphone");
     }
     return "unknown"; // Linux: renderer probes getUserMedia instead
   });
 
   ipcMain.handle("permissions:check-accessibility", async () => {
-    if (process.platform === "darwin") {
-      const { systemPreferences } = await import("electron");
-      const trusted = systemPreferences.isTrustedAccessibilityClient(false);
-      return trusted || accessibilityConfirmed;
-    }
-    return true;
+    return hasCurrentAccessibilityPermission();
   });
 
-  ipcMain.on("permissions:open-accessibility", async () => {
-    if (process.platform === "darwin") {
-      // Passing `true` pops the native "would like to control this computer"
-      // prompt and adds Freestyle to the Accessibility list automatically, so
-      // the user only has to flip the toggle (macOS never lets us flip it).
-      const { systemPreferences } = await import("electron");
-      systemPreferences.isTrustedAccessibilityClient(true);
-      shell.openExternal(
-        "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility",
-      );
-    }
+  ipcMain.on("permissions:open-accessibility", () => {
+    openAccessibilitySettings();
   });
 
   ipcMain.on("permissions:open-mic-settings", () => {
-    if (process.platform === "darwin") {
-      shell.openExternal(
-        "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Microphone",
-      );
-    } else if (process.platform === "win32") {
-      shell.openExternal("ms-settings:privacy-microphone");
-    }
+    openMicrophoneSettings();
   });
+
+  if (process.env.FREESTYLE_E2E === "1") {
+    ipcMain.on("e2e:trigger-hotkey-down", handleNativeHotkeyDown);
+    ipcMain.on("e2e:trigger-hotkey-up", handleNativeHotkeyUp);
+  }
 
   // IPC: Linux system setup (input-group access for the hotkey listener and
   // the xdotool/wtype paste fallback). Returns null on other platforms.
@@ -2237,6 +2315,20 @@ app.whenReady().then(async () => {
   createTray();
 
   createAppWindow();
+
+  // Onboarding already has dedicated permission cards. Existing users instead
+  // get one actionable warning once a user-facing window can be shown.
+  void isOnboardingActive().then((onboardingActive) => {
+    if (
+      shouldWarnAboutAccessibilityAtStartup(
+        process.platform,
+        onboardingActive,
+        hasCurrentAccessibilityPermission(),
+      )
+    ) {
+      void showRequiredPermissionDialog("accessibility");
+    }
+  });
 
   // Clamp the pill to valid display bounds when monitors change.
   const repositionPillForDisplayChange = (): void => {
@@ -2629,6 +2721,13 @@ function hotkeyModeFromSettings(
 }
 
 function sendHotkeyDown(): void {
+  const missingPermission = getMissingDictationPermission();
+  if (missingPermission) {
+    hotkeyPressed = false;
+    clearHotkeyStuckWatchdog();
+    void showRequiredPermissionDialog(missingPermission);
+    return;
+  }
   showPill();
   relayServerEvent({ type: FreestyleEventType.RecordingStarted });
   if (pillReadyPromise) {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -105,7 +105,8 @@ import {
   type DictationPermission,
   missingDictationPermission,
   resolveAccessibilityPermission,
-  shouldWarnAboutAccessibilityAtStartup,
+  type StartupPermissionWarning,
+  startupPermissionWarning,
 } from "./permission-checks";
 import {
   FreestyleEventType,
@@ -1574,15 +1575,18 @@ function hasCurrentAccessibilityPermission(): boolean {
 }
 
 function getMissingDictationPermission(): DictationPermission | null {
-  const microphoneStatus =
-    process.platform === "linux"
-      ? "unknown"
-      : systemPreferences.getMediaAccessStatus("microphone");
+  const microphoneStatus = getCurrentMicrophonePermission();
   return missingDictationPermission(
     process.platform,
     hasCurrentAccessibilityPermission(),
     microphoneStatus,
   );
+}
+
+function getCurrentMicrophonePermission(): string {
+  return process.platform === "darwin" || process.platform === "win32"
+    ? systemPreferences.getMediaAccessStatus("microphone")
+    : "unknown";
 }
 
 function openAccessibilitySettings(): void {
@@ -1604,34 +1608,45 @@ function openMicrophoneSettings(): void {
 let permissionDialogPromise: Promise<void> | null = null;
 
 function showRequiredPermissionDialog(
-  permission: DictationPermission,
+  permission: StartupPermissionWarning,
 ): Promise<void> {
   if (permissionDialogPromise) return permissionDialogPromise;
 
   const accessibility = permission === "accessibility";
+  const both = permission === "accessibility-and-microphone";
   permissionDialogPromise = dialog
     .showMessageBox({
       type: "error",
-      title: accessibility
-        ? "Accessibility Permission Required"
-        : "Microphone Permission Required",
-      message: accessibility
-        ? "Accessibility permission is required for dictation and text insertion."
-        : "Microphone permission is required for dictation.",
-      detail: accessibility
-        ? "Enable Freestyle in System Settings > Privacy & Security > Accessibility."
-        : process.platform === "darwin"
-          ? "Enable Freestyle in System Settings > Privacy & Security > Microphone."
-          : "Enable microphone access for Freestyle in Windows Settings.",
-      buttons: ["Open System Settings", "Cancel"],
+      title: both
+        ? "Permissions Required"
+        : accessibility
+          ? "Accessibility Permission Required"
+          : "Microphone Permission Required",
+      message: both
+        ? "Accessibility and Microphone permissions are required before dictation can work."
+        : accessibility
+          ? "Accessibility permission is required for dictation and text insertion."
+          : "Microphone access is required to record dictation.",
+      detail: both
+        ? "Enable Freestyle in System Settings > Privacy & Security under Accessibility and Microphone."
+        : accessibility
+          ? "Enable Freestyle in System Settings > Privacy & Security > Accessibility."
+          : process.platform === "darwin"
+            ? "Enable Freestyle in System Settings > Privacy & Security > Microphone."
+            : "Enable microphone access for Freestyle in Windows Settings.",
+      buttons: both
+        ? ["Open Accessibility Settings", "Open Microphone Settings", "Not Now"]
+        : ["Open System Settings", "Cancel"],
       defaultId: 0,
-      cancelId: 1,
+      cancelId: both ? 2 : 1,
     })
     .then(({ response }) => {
-      if (response !== 0) return;
-      if (accessibility) {
+      if (both) {
+        if (response === 0) openAccessibilitySettings();
+        if (response === 1) openMicrophoneSettings();
+      } else if (response === 0 && accessibility) {
         openAccessibilitySettings();
-      } else {
+      } else if (response === 0) {
         openMicrophoneSettings();
       }
     })
@@ -2319,14 +2334,14 @@ app.whenReady().then(async () => {
   // Onboarding already has dedicated permission cards. Existing users instead
   // get one actionable warning once a user-facing window can be shown.
   void isOnboardingActive().then((onboardingActive) => {
-    if (
-      shouldWarnAboutAccessibilityAtStartup(
-        process.platform,
-        onboardingActive,
-        hasCurrentAccessibilityPermission(),
-      )
-    ) {
-      void showRequiredPermissionDialog("accessibility");
+    const warning = startupPermissionWarning(
+      process.platform,
+      onboardingActive,
+      hasCurrentAccessibilityPermission(),
+      getCurrentMicrophonePermission(),
+    );
+    if (warning) {
+      void showRequiredPermissionDialog(warning);
     }
   });
 

--- a/apps/electron/src/main/permission-checks.ts
+++ b/apps/electron/src/main/permission-checks.ts
@@ -1,0 +1,50 @@
+export type DictationPermission = "accessibility" | "microphone";
+
+export interface AccessibilityPermissionState {
+  granted: boolean;
+  accessibilityConfirmed: boolean;
+}
+
+/**
+ * The live macOS trust result is authoritative. The listener confirmation
+ * latch may record a prior successful start, but it must never override a
+ * currently untrusted system state.
+ */
+export function resolveAccessibilityPermission(
+  platform: NodeJS.Platform,
+  trusted: boolean,
+  accessibilityConfirmed: boolean,
+): AccessibilityPermissionState {
+  if (platform !== "darwin") {
+    return { granted: true, accessibilityConfirmed };
+  }
+  return {
+    granted: trusted,
+    accessibilityConfirmed: trusted ? accessibilityConfirmed : false,
+  };
+}
+
+export function missingDictationPermission(
+  platform: NodeJS.Platform,
+  accessibilityGranted: boolean,
+  microphoneStatus: string,
+): DictationPermission | null {
+  if (platform === "darwin" && !accessibilityGranted) {
+    return "accessibility";
+  }
+  if (
+    platform !== "linux" &&
+    (microphoneStatus === "denied" || microphoneStatus === "restricted")
+  ) {
+    return "microphone";
+  }
+  return null;
+}
+
+export function shouldWarnAboutAccessibilityAtStartup(
+  platform: NodeJS.Platform,
+  onboardingActive: boolean,
+  accessibilityGranted: boolean,
+): boolean {
+  return platform === "darwin" && !onboardingActive && !accessibilityGranted;
+}

--- a/apps/electron/src/main/permission-checks.ts
+++ b/apps/electron/src/main/permission-checks.ts
@@ -1,4 +1,7 @@
 export type DictationPermission = "accessibility" | "microphone";
+export type StartupPermissionWarning =
+  | DictationPermission
+  | "accessibility-and-microphone";
 
 export interface AccessibilityPermissionState {
   granted: boolean;
@@ -41,10 +44,24 @@ export function missingDictationPermission(
   return null;
 }
 
-export function shouldWarnAboutAccessibilityAtStartup(
+export function startupPermissionWarning(
   platform: NodeJS.Platform,
   onboardingActive: boolean,
   accessibilityGranted: boolean,
-): boolean {
-  return platform === "darwin" && !onboardingActive && !accessibilityGranted;
+  microphoneStatus: string,
+): StartupPermissionWarning | null {
+  if (onboardingActive || (platform !== "darwin" && platform !== "win32")) {
+    return null;
+  }
+
+  const accessibilityMissing = platform === "darwin" && !accessibilityGranted;
+  const microphoneMissing =
+    microphoneStatus === "denied" || microphoneStatus === "restricted";
+
+  if (accessibilityMissing && microphoneMissing) {
+    return "accessibility-and-microphone";
+  }
+  if (accessibilityMissing) return "accessibility";
+  if (microphoneMissing) return "microphone";
+  return null;
 }

--- a/apps/electron/tests/fixtures/permission-main.cjs
+++ b/apps/electron/tests/fixtures/permission-main.cjs
@@ -75,6 +75,15 @@ global.fetch = async (input, init) => {
       record({ type: "pipeline-event", body: JSON.parse(body) });
     }
   }
+  if (
+    process.env.FREESTYLE_E2E_ONBOARDING_COMPLETE === "false" &&
+    url.endsWith("/api/models/configured")
+  ) {
+    return new Response("[]", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
   return originalFetch(input, init);
 };
 

--- a/apps/electron/tests/fixtures/permission-main.cjs
+++ b/apps/electron/tests/fixtures/permission-main.cjs
@@ -1,0 +1,81 @@
+const { appendFileSync, mkdirSync } = require("node:fs");
+const electron = require("electron");
+
+const eventsPath = process.env.FREESTYLE_E2E_PERMISSION_EVENTS;
+const userDataDir = process.env.FREESTYLE_E2E_USER_DATA_DIR;
+
+if (userDataDir) {
+  mkdirSync(userDataDir, { recursive: true });
+  electron.app.setPath("userData", userDataDir);
+}
+
+function record(event) {
+  if (!eventsPath) return;
+  appendFileSync(eventsPath, `${JSON.stringify(event)}\n`);
+}
+
+Object.defineProperty(
+  electron.systemPreferences,
+  "isTrustedAccessibilityClient",
+  {
+    configurable: true,
+    value: (prompt) => {
+      record({ type: "accessibility-check", prompt });
+      return process.env.FREESTYLE_E2E_ACCESSIBILITY === "granted";
+    },
+  },
+);
+
+Object.defineProperty(electron.systemPreferences, "getMediaAccessStatus", {
+  configurable: true,
+  value: (mediaType) => {
+    record({ type: "media-check", mediaType });
+    return process.env.FREESTYLE_E2E_MICROPHONE ?? "granted";
+  },
+});
+
+Object.defineProperty(electron.dialog, "showMessageBox", {
+  configurable: true,
+  value: async (options) => {
+    record({ type: "dialog", options });
+    return {
+      response: Number(process.env.FREESTYLE_E2E_DIALOG_RESPONSE ?? 1),
+      checkboxChecked: false,
+    };
+  },
+});
+
+Object.defineProperty(electron.shell, "openExternal", {
+  configurable: true,
+  value: async (url) => {
+    record({ type: "open-external", url });
+  },
+});
+
+electron.ipcMain.on("e2e:mic-requested", () => {
+  record({ type: "mic-requested" });
+});
+
+const originalFetch = global.fetch;
+global.fetch = async (input, init) => {
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+  if (url.endsWith("/api/events")) {
+    const body =
+      typeof init?.body === "string"
+        ? init.body
+        : input instanceof Request
+          ? await input.clone().text()
+          : "";
+    if (body) {
+      record({ type: "pipeline-event", body: JSON.parse(body) });
+    }
+  }
+  return originalFetch(input, init);
+};
+
+require("../../out/main/index.js");

--- a/apps/electron/tests/permission-checks.test.ts
+++ b/apps/electron/tests/permission-checks.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import {
+  missingDictationPermission,
+  resolveAccessibilityPermission,
+  shouldWarnAboutAccessibilityAtStartup,
+} from "../src/main/permission-checks";
+
+test("missing accessibility permission triggers a startup warning", () => {
+  expect(shouldWarnAboutAccessibilityAtStartup("darwin", false, false)).toBe(
+    true,
+  );
+});
+
+test("granted accessibility permission does not trigger a startup warning", () => {
+  expect(shouldWarnAboutAccessibilityAtStartup("darwin", false, true)).toBe(
+    false,
+  );
+});
+
+test("onboarding suppresses the duplicate startup warning", () => {
+  expect(shouldWarnAboutAccessibilityAtStartup("darwin", true, false)).toBe(
+    false,
+  );
+});
+
+test("missing accessibility permission blocks dictation", () => {
+  expect(missingDictationPermission("darwin", false, "granted")).toBe(
+    "accessibility",
+  );
+});
+
+test("denied microphone permission blocks dictation", () => {
+  expect(missingDictationPermission("darwin", true, "denied")).toBe(
+    "microphone",
+  );
+});
+
+test("granted permissions allow dictation", () => {
+  expect(missingDictationPermission("darwin", true, "granted")).toBeNull();
+});
+
+test("a stale accessibility latch cannot override current macOS trust", () => {
+  expect(resolveAccessibilityPermission("darwin", false, true)).toEqual({
+    granted: false,
+    accessibilityConfirmed: false,
+  });
+});

--- a/apps/electron/tests/permission-checks.test.ts
+++ b/apps/electron/tests/permission-checks.test.ts
@@ -2,25 +2,59 @@ import { expect, test } from "@playwright/test";
 import {
   missingDictationPermission,
   resolveAccessibilityPermission,
-  shouldWarnAboutAccessibilityAtStartup,
+  startupPermissionWarning,
 } from "../src/main/permission-checks";
 
 test("missing accessibility permission triggers a startup warning", () => {
-  expect(shouldWarnAboutAccessibilityAtStartup("darwin", false, false)).toBe(
-    true,
+  expect(startupPermissionWarning("darwin", false, false, "granted")).toBe(
+    "accessibility",
   );
 });
 
 test("granted accessibility permission does not trigger a startup warning", () => {
-  expect(shouldWarnAboutAccessibilityAtStartup("darwin", false, true)).toBe(
-    false,
-  );
+  expect(startupPermissionWarning("darwin", false, true, "granted")).toBeNull();
 });
 
 test("onboarding suppresses the duplicate startup warning", () => {
-  expect(shouldWarnAboutAccessibilityAtStartup("darwin", true, false)).toBe(
-    false,
+  expect(startupPermissionWarning("darwin", true, false, "denied")).toBeNull();
+});
+
+test("denied and restricted microphone states trigger a startup warning", () => {
+  expect(startupPermissionWarning("darwin", false, true, "denied")).toBe(
+    "microphone",
   );
+  expect(startupPermissionWarning("darwin", false, true, "restricted")).toBe(
+    "microphone",
+  );
+});
+
+test("granted and not-determined microphone states do not trigger a startup warning", () => {
+  expect(startupPermissionWarning("darwin", false, true, "granted")).toBeNull();
+  expect(
+    startupPermissionWarning("darwin", false, true, "not-determined"),
+  ).toBeNull();
+});
+
+test("missing accessibility and microphone permissions use one combined warning", () => {
+  expect(startupPermissionWarning("darwin", false, false, "denied")).toBe(
+    "accessibility-and-microphone",
+  );
+});
+
+test("Windows explicit microphone denial triggers its supported warning path", () => {
+  expect(startupPermissionWarning("win32", false, true, "denied")).toBe(
+    "microphone",
+  );
+});
+
+test("Linux does not receive an OS-specific startup permission warning", () => {
+  expect(startupPermissionWarning("linux", false, true, "denied")).toBeNull();
+});
+
+test("unsupported platforms do not receive an OS-specific startup permission warning", () => {
+  expect(
+    startupPermissionWarning("freebsd", false, false, "denied"),
+  ).toBeNull();
 });
 
 test("missing accessibility permission blocks dictation", () => {

--- a/apps/electron/tests/permission-flow.test.ts
+++ b/apps/electron/tests/permission-flow.test.ts
@@ -15,6 +15,11 @@ import {
 } from "@playwright/test";
 import { _electron as electron } from "playwright";
 
+test.skip(
+  process.platform !== "darwin",
+  "Permission flow integration tests require macOS permission APIs.",
+);
+
 interface RecordedEvent {
   type: string;
   options?: {

--- a/apps/electron/tests/permission-flow.test.ts
+++ b/apps/electron/tests/permission-flow.test.ts
@@ -1,0 +1,326 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  type ElectronApplication,
+  expect,
+  type Page,
+  test,
+} from "@playwright/test";
+import { _electron as electron } from "playwright";
+
+interface RecordedEvent {
+  type: string;
+  options?: {
+    title?: string;
+    message?: string;
+    detail?: string;
+    buttons?: string[];
+  };
+  body?: { type?: string };
+  url?: string;
+}
+
+interface LaunchOptions {
+  accessibility: "granted" | "denied";
+  microphone?: "granted" | "denied" | "restricted" | "not-determined";
+  onboardingComplete?: boolean;
+  dialogResponse?: number;
+}
+
+interface LaunchedApp {
+  app: ElectronApplication;
+  dashboard: Page;
+  eventsPath: string;
+}
+
+async function waitForDashboard(app: ElectronApplication): Promise<Page> {
+  await app.firstWindow();
+  await expect
+    .poll(() => app.windows().find((page) => !page.url().includes("pill")))
+    .toBeTruthy();
+  const dashboard = app.windows().find((page) => !page.url().includes("pill"));
+  if (!dashboard) throw new Error("Dashboard window did not open");
+  await dashboard.waitForLoadState("domcontentloaded");
+  return dashboard;
+}
+
+function readEvents(eventsPath: string): RecordedEvent[] {
+  if (!existsSync(eventsPath)) return [];
+  return readFileSync(eventsPath, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as RecordedEvent);
+}
+
+async function launchPermissionApp(
+  options: LaunchOptions,
+): Promise<LaunchedApp> {
+  const testDir = mkdtempSync(join(tmpdir(), "freestyle-permissions-e2e-"));
+  const userDataDir = join(testDir, "user-data");
+  const eventsPath = join(testDir, "events.jsonl");
+  mkdirSync(userDataDir, { recursive: true });
+  if (options.onboardingComplete) {
+    writeFileSync(
+      join(userDataDir, "settings.json"),
+      JSON.stringify({ onboardingComplete: true }),
+    );
+  }
+
+  const app = await electron.launch({
+    args: [
+      resolve(__dirname, "fixtures/permission-main.cjs"),
+      "--use-fake-device-for-media-stream",
+      "--use-fake-ui-for-media-stream",
+    ],
+    env: {
+      ...process.env,
+      NODE_ENV: "development",
+      FREESTYLE_E2E: "1",
+      FREESTYLE_E2E_ACCESSIBILITY: options.accessibility,
+      FREESTYLE_E2E_MICROPHONE: options.microphone ?? "granted",
+      FREESTYLE_E2E_DIALOG_RESPONSE: String(options.dialogResponse ?? 1),
+      FREESTYLE_E2E_PERMISSION_EVENTS: eventsPath,
+      FREESTYLE_E2E_USER_DATA_DIR: userDataDir,
+      ELECTRON_DISABLE_SECURITY_WARNINGS: "true",
+    },
+    timeout: 30_000,
+  });
+
+  return { app, dashboard: await waitForDashboard(app), eventsPath };
+}
+
+async function waitForPermissionCheck(eventsPath: string): Promise<void> {
+  await expect
+    .poll(() =>
+      readEvents(eventsPath).some(
+        (event) => event.type === "accessibility-check",
+      ),
+    )
+    .toBe(true);
+}
+
+async function triggerHotkeyDown(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.electron.ipcRenderer.send("e2e:trigger-hotkey-down");
+  });
+}
+
+async function instrumentMicrophoneRequest(
+  app: ElectronApplication,
+): Promise<void> {
+  const pill = app.windows().find((page) => page.url().includes("pill"));
+  if (!pill) throw new Error("Pill window did not open");
+  await pill.evaluate(() => {
+    const original = navigator.mediaDevices.getUserMedia.bind(
+      navigator.mediaDevices,
+    );
+    Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
+      configurable: true,
+      value: async (constraints: MediaStreamConstraints) => {
+        window.electron.ipcRenderer.send("e2e:mic-requested");
+        return original(constraints);
+      },
+    });
+  });
+}
+
+test("startup warns once and opens Accessibility settings when requested", async () => {
+  const launched = await launchPermissionApp({
+    accessibility: "denied",
+    onboardingComplete: true,
+    dialogResponse: 0,
+  });
+  try {
+    await waitForPermissionCheck(launched.eventsPath);
+    await expect
+      .poll(
+        () =>
+          readEvents(launched.eventsPath).filter(
+            (event) =>
+              event.type === "dialog" &&
+              event.options?.title === "Accessibility Permission Required",
+          ).length,
+      )
+      .toBe(1);
+
+    const events = readEvents(launched.eventsPath);
+    const warning = events.find((event) => event.type === "dialog")?.options;
+    expect(warning?.message).toContain(
+      "required for dictation and text insertion",
+    );
+    expect(warning?.buttons).toContain("Open System Settings");
+    expect(
+      events.some(
+        (event) =>
+          event.type === "open-external" &&
+          event.url?.includes("Privacy_Accessibility"),
+      ),
+    ).toBe(true);
+  } finally {
+    await launched.app.close();
+  }
+});
+
+test("startup does not warn when Accessibility permission is granted", async () => {
+  const launched = await launchPermissionApp({
+    accessibility: "granted",
+    onboardingComplete: true,
+  });
+  try {
+    await waitForPermissionCheck(launched.eventsPath);
+    expect(
+      readEvents(launched.eventsPath).some(
+        (event) =>
+          event.type === "dialog" &&
+          event.options?.title === "Accessibility Permission Required",
+      ),
+    ).toBe(false);
+  } finally {
+    await launched.app.close();
+  }
+});
+
+test("onboarding does not receive a duplicate startup warning", async () => {
+  const launched = await launchPermissionApp({
+    accessibility: "denied",
+  });
+  try {
+    await expect.poll(() => launched.dashboard.url()).toContain("/onboarding");
+    await waitForPermissionCheck(launched.eventsPath);
+    expect(
+      readEvents(launched.eventsPath).some(
+        (event) =>
+          event.type === "dialog" &&
+          event.options?.title === "Accessibility Permission Required",
+      ),
+    ).toBe(false);
+  } finally {
+    await launched.app.close();
+  }
+});
+
+test("denied Accessibility blocks dictation before RecordingStarted", async () => {
+  const launched = await launchPermissionApp({
+    accessibility: "denied",
+    onboardingComplete: true,
+  });
+  try {
+    await waitForPermissionCheck(launched.eventsPath);
+    await instrumentMicrophoneRequest(launched.app);
+    const dialogsBefore = readEvents(launched.eventsPath).filter(
+      (event) => event.type === "dialog",
+    ).length;
+    await triggerHotkeyDown(launched.dashboard);
+    await expect
+      .poll(
+        () =>
+          readEvents(launched.eventsPath).filter(
+            (event) => event.type === "dialog",
+          ).length,
+      )
+      .toBe(dialogsBefore + 1);
+
+    const events = readEvents(launched.eventsPath);
+    expect(
+      events.some(
+        (event) =>
+          event.type === "pipeline-event" &&
+          event.body?.type === "recordingStarted",
+      ),
+    ).toBe(false);
+    expect(events.some((event) => event.type === "mic-requested")).toBe(false);
+    expect(
+      await launched.app.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows()
+          .filter((window) => window.webContents.getURL().includes("pill"))
+          .some((window) => window.isVisible()),
+      ),
+    ).toBe(false);
+  } finally {
+    await launched.app.close();
+  }
+});
+
+test("denied Microphone blocks dictation before RecordingStarted", async () => {
+  const launched = await launchPermissionApp({
+    accessibility: "granted",
+    microphone: "denied",
+    onboardingComplete: true,
+  });
+  try {
+    await waitForPermissionCheck(launched.eventsPath);
+    await instrumentMicrophoneRequest(launched.app);
+    await triggerHotkeyDown(launched.dashboard);
+    await expect
+      .poll(() =>
+        readEvents(launched.eventsPath).some(
+          (event) =>
+            event.type === "dialog" &&
+            event.options?.title === "Microphone Permission Required",
+        ),
+      )
+      .toBe(true);
+
+    expect(
+      readEvents(launched.eventsPath).some(
+        (event) =>
+          event.type === "pipeline-event" &&
+          event.body?.type === "recordingStarted",
+      ),
+    ).toBe(false);
+    expect(
+      readEvents(launched.eventsPath).some(
+        (event) => event.type === "mic-requested",
+      ),
+    ).toBe(false);
+  } finally {
+    await launched.app.close();
+  }
+});
+
+test("granted permissions allow the existing dictation flow", async () => {
+  const launched = await launchPermissionApp({
+    accessibility: "granted",
+    microphone: "granted",
+    onboardingComplete: true,
+  });
+  try {
+    await waitForPermissionCheck(launched.eventsPath);
+    await instrumentMicrophoneRequest(launched.app);
+    await triggerHotkeyDown(launched.dashboard);
+    await expect
+      .poll(() =>
+        readEvents(launched.eventsPath).some(
+          (event) =>
+            event.type === "pipeline-event" &&
+            event.body?.type === "recordingStarted",
+        ),
+      )
+      .toBe(true);
+    await expect
+      .poll(() =>
+        readEvents(launched.eventsPath).some(
+          (event) => event.type === "mic-requested",
+        ),
+      )
+      .toBe(true);
+    await expect
+      .poll(() =>
+        launched.app.evaluate(({ BrowserWindow }) =>
+          BrowserWindow.getAllWindows()
+            .filter((window) => window.webContents.getURL().includes("pill"))
+            .some((window) => window.isVisible()),
+        ),
+      )
+      .toBe(true);
+  } finally {
+    await launched.app.close();
+  }
+});

--- a/apps/electron/tests/permission-flow.test.ts
+++ b/apps/electron/tests/permission-flow.test.ts
@@ -96,14 +96,22 @@ async function launchPermissionApp(
   return { app, dashboard: await waitForDashboard(app), eventsPath };
 }
 
-async function waitForPermissionCheck(eventsPath: string): Promise<void> {
+async function waitForStartupPermissionChecks(
+  eventsPath: string,
+): Promise<void> {
   await expect
-    .poll(() =>
-      readEvents(eventsPath).some(
-        (event) => event.type === "accessibility-check",
-      ),
-    )
+    .poll(() => {
+      const events = readEvents(eventsPath);
+      return (
+        events.some((event) => event.type === "accessibility-check") &&
+        events.some((event) => event.type === "media-check")
+      );
+    })
     .toBe(true);
+}
+
+function permissionDialogs(eventsPath: string): RecordedEvent[] {
+  return readEvents(eventsPath).filter((event) => event.type === "dialog");
 }
 
 async function triggerHotkeyDown(page: Page): Promise<void> {
@@ -138,7 +146,7 @@ test("startup warns once and opens Accessibility settings when requested", async
     dialogResponse: 0,
   });
   try {
-    await waitForPermissionCheck(launched.eventsPath);
+    await waitForStartupPermissionChecks(launched.eventsPath);
     await expect
       .poll(
         () =>
@@ -174,14 +182,8 @@ test("startup does not warn when Accessibility permission is granted", async () 
     onboardingComplete: true,
   });
   try {
-    await waitForPermissionCheck(launched.eventsPath);
-    expect(
-      readEvents(launched.eventsPath).some(
-        (event) =>
-          event.type === "dialog" &&
-          event.options?.title === "Accessibility Permission Required",
-      ),
-    ).toBe(false);
+    await waitForStartupPermissionChecks(launched.eventsPath);
+    expect(permissionDialogs(launched.eventsPath)).toHaveLength(0);
   } finally {
     await launched.app.close();
   }
@@ -190,17 +192,117 @@ test("startup does not warn when Accessibility permission is granted", async () 
 test("onboarding does not receive a duplicate startup warning", async () => {
   const launched = await launchPermissionApp({
     accessibility: "denied",
+    microphone: "denied",
   });
   try {
     await expect.poll(() => launched.dashboard.url()).toContain("/onboarding");
-    await waitForPermissionCheck(launched.eventsPath);
+    await waitForStartupPermissionChecks(launched.eventsPath);
+    expect(permissionDialogs(launched.eventsPath)).toHaveLength(0);
+  } finally {
+    await launched.app.close();
+  }
+});
+
+test("startup warns for denied Microphone and opens its privacy settings", async () => {
+  const launched = await launchPermissionApp({
+    accessibility: "granted",
+    microphone: "denied",
+    onboardingComplete: true,
+    dialogResponse: 0,
+  });
+  try {
+    await waitForStartupPermissionChecks(launched.eventsPath);
+    await expect
+      .poll(() => permissionDialogs(launched.eventsPath).length)
+      .toBe(1);
+
+    const events = readEvents(launched.eventsPath);
+    const warning = permissionDialogs(launched.eventsPath)[0]?.options;
+    expect(warning?.title).toBe("Microphone Permission Required");
+    expect(warning?.message).toContain(
+      "Microphone access is required to record dictation",
+    );
+    expect(warning?.buttons).toContain("Open System Settings");
     expect(
-      readEvents(launched.eventsPath).some(
+      events.some(
         (event) =>
-          event.type === "dialog" &&
-          event.options?.title === "Accessibility Permission Required",
+          event.type === "open-external" &&
+          event.url?.includes("Privacy_Microphone"),
       ),
-    ).toBe(false);
+    ).toBe(true);
+    expect(events.some((event) => event.type === "pipeline-event")).toBe(false);
+    expect(events.some((event) => event.type === "mic-requested")).toBe(false);
+  } finally {
+    await launched.app.close();
+  }
+});
+
+test("startup warns when Microphone permission is restricted", async () => {
+  const launched = await launchPermissionApp({
+    accessibility: "granted",
+    microphone: "restricted",
+    onboardingComplete: true,
+  });
+  try {
+    await waitForStartupPermissionChecks(launched.eventsPath);
+    await expect
+      .poll(() => permissionDialogs(launched.eventsPath).length)
+      .toBe(1);
+    expect(permissionDialogs(launched.eventsPath)[0]?.options?.title).toBe(
+      "Microphone Permission Required",
+    );
+  } finally {
+    await launched.app.close();
+  }
+});
+
+for (const microphone of ["granted", "not-determined"] as const) {
+  test(`startup does not warn when Microphone permission is ${microphone}`, async () => {
+    const launched = await launchPermissionApp({
+      accessibility: "granted",
+      microphone,
+      onboardingComplete: true,
+    });
+    try {
+      await waitForStartupPermissionChecks(launched.eventsPath);
+      expect(permissionDialogs(launched.eventsPath)).toHaveLength(0);
+    } finally {
+      await launched.app.close();
+    }
+  });
+}
+
+test("startup combines missing Accessibility and Microphone into one warning", async () => {
+  const launched = await launchPermissionApp({
+    accessibility: "denied",
+    microphone: "denied",
+    onboardingComplete: true,
+    dialogResponse: 1,
+  });
+  try {
+    await waitForStartupPermissionChecks(launched.eventsPath);
+    await expect
+      .poll(() => permissionDialogs(launched.eventsPath).length)
+      .toBe(1);
+
+    const events = readEvents(launched.eventsPath);
+    const warning = permissionDialogs(launched.eventsPath)[0]?.options;
+    expect(warning?.title).toBe("Permissions Required");
+    expect(warning?.message).toContain(
+      "Accessibility and Microphone permissions are required",
+    );
+    expect(warning?.buttons).toEqual([
+      "Open Accessibility Settings",
+      "Open Microphone Settings",
+      "Not Now",
+    ]);
+    expect(events.filter((event) => event.type === "open-external")).toEqual([
+      expect.objectContaining({
+        url: expect.stringContaining("Privacy_Microphone"),
+      }),
+    ]);
+    expect(events.some((event) => event.type === "pipeline-event")).toBe(false);
+    expect(events.some((event) => event.type === "mic-requested")).toBe(false);
   } finally {
     await launched.app.close();
   }
@@ -212,7 +314,7 @@ test("denied Accessibility blocks dictation before RecordingStarted", async () =
     onboardingComplete: true,
   });
   try {
-    await waitForPermissionCheck(launched.eventsPath);
+    await waitForStartupPermissionChecks(launched.eventsPath);
     await instrumentMicrophoneRequest(launched.app);
     const dialogsBefore = readEvents(launched.eventsPath).filter(
       (event) => event.type === "dialog",
@@ -255,18 +357,13 @@ test("denied Microphone blocks dictation before RecordingStarted", async () => {
     onboardingComplete: true,
   });
   try {
-    await waitForPermissionCheck(launched.eventsPath);
+    await waitForStartupPermissionChecks(launched.eventsPath);
     await instrumentMicrophoneRequest(launched.app);
+    const dialogsBefore = permissionDialogs(launched.eventsPath).length;
     await triggerHotkeyDown(launched.dashboard);
     await expect
-      .poll(() =>
-        readEvents(launched.eventsPath).some(
-          (event) =>
-            event.type === "dialog" &&
-            event.options?.title === "Microphone Permission Required",
-        ),
-      )
-      .toBe(true);
+      .poll(() => permissionDialogs(launched.eventsPath).length)
+      .toBe(dialogsBefore + 1);
 
     expect(
       readEvents(launched.eventsPath).some(
@@ -292,7 +389,7 @@ test("granted permissions allow the existing dictation flow", async () => {
     onboardingComplete: true,
   });
   try {
-    await waitForPermissionCheck(launched.eventsPath);
+    await waitForStartupPermissionChecks(launched.eventsPath);
     await instrumentMicrophoneRequest(launched.app);
     await triggerHotkeyDown(launched.dashboard);
     await expect

--- a/apps/electron/tests/permission-flow.test.ts
+++ b/apps/electron/tests/permission-flow.test.ts
@@ -30,7 +30,7 @@ interface RecordedEvent {
 interface LaunchOptions {
   accessibility: "granted" | "denied";
   microphone?: "granted" | "denied" | "restricted" | "not-determined";
-  onboardingComplete?: boolean;
+  onboardingComplete: boolean;
   dialogResponse?: number;
 }
 
@@ -66,12 +66,10 @@ async function launchPermissionApp(
   const userDataDir = join(testDir, "user-data");
   const eventsPath = join(testDir, "events.jsonl");
   mkdirSync(userDataDir, { recursive: true });
-  if (options.onboardingComplete) {
-    writeFileSync(
-      join(userDataDir, "settings.json"),
-      JSON.stringify({ onboardingComplete: true }),
-    );
-  }
+  writeFileSync(
+    join(userDataDir, "settings.json"),
+    JSON.stringify({ onboardingComplete: options.onboardingComplete }),
+  );
 
   const app = await electron.launch({
     args: [
@@ -86,6 +84,7 @@ async function launchPermissionApp(
       FREESTYLE_E2E_ACCESSIBILITY: options.accessibility,
       FREESTYLE_E2E_MICROPHONE: options.microphone ?? "granted",
       FREESTYLE_E2E_DIALOG_RESPONSE: String(options.dialogResponse ?? 1),
+      FREESTYLE_E2E_ONBOARDING_COMPLETE: String(options.onboardingComplete),
       FREESTYLE_E2E_PERMISSION_EVENTS: eventsPath,
       FREESTYLE_E2E_USER_DATA_DIR: userDataDir,
       ELECTRON_DISABLE_SECURITY_WARNINGS: "true",
@@ -193,6 +192,7 @@ test("onboarding does not receive a duplicate startup warning", async () => {
   const launched = await launchPermissionApp({
     accessibility: "denied",
     microphone: "denied",
+    onboardingComplete: false,
   });
   try {
     await expect.poll(() => launched.dashboard.url()).toContain("/onboarding");


### PR DESCRIPTION
## Summary

This PR improves the Electron permission flow by preventing dictation from starting when required permissions are unavailable and by providing clearer startup guidance for existing users.

## What changed

### Fail-fast permission preflight

- Added a permission preflight before dictation starts.
- Prevented `RecordingStarted`, microphone capture, transcription, and paste from running when required permissions are unavailable.
- Preserved the existing recording flow when permissions are granted.

### Accessibility

- Use the live macOS Accessibility trust state instead of relying on stale cached state.
- Clear stale Accessibility permission state when trust has been revoked.
- Show startup warnings for existing users when Accessibility permission is required.
- Continue suppressing startup warnings during onboarding to avoid duplicate permission dialogs.

### Microphone

- Added startup warnings for denied and restricted microphone permissions.
- Continue using the existing `getUserMedia` flow when permission is `not-determined`.
- Show a combined startup warning when both Accessibility and Microphone permissions are unavailable.
- Preserve the existing Linux permission flow.

### Tests

- Added regression coverage for startup permission decisions.
- Added startup warning coverage.
- Added permission preflight tests.
- Added combined permission warning tests.
- Improved Electron E2E fixture isolation so onboarding state is deterministic and independent of existing user data.

## Validation

-  Biome
-  Node typecheck
-  Web typecheck
-  Electron tests
-  Electron production build
-  Full Electron E2E suite (54/54 passing)

Closes #511