### PR TITLE
fix(electron): default Windows hotkey to Right Alt

### DIFF
--- a/apps/electron/src/shared/hotkey-defaults.ts
+++ b/apps/electron/src/shared/hotkey-defaults.ts
@@ -2,7 +2,8 @@
  * Single source of truth for the default push-to-talk hotkey.
  *
  * - macOS: Fn (Globe) — dedicated dictation key, no modifier conflicts
- * - Windows/Linux: Control+Alt+Space — no Super key, so the OS launcher /
+ * - Windows: Right Alt — a convenient single-key shortcut
+ * - Linux: Control+Alt+Space — no Super key, so the OS launcher /
  *   Start menu never fires alongside dictation, and the real key lets the
  *   native listeners suppress the chord from reaching the focused app
  *
@@ -13,6 +14,8 @@ export function getDefaultHotkey(platform: string = process.platform): string {
   switch (platform) {
     case "darwin":
       return "Fn";
+    case "win32":
+      return "RightAlt";
     default:
       return "Control+Alt+Space";
   }


### PR DESCRIPTION
## Summary

- use `RightAlt` as the default Windows push-to-talk hotkey
- keep the existing macOS and Linux defaults unchanged
- update the shared hotkey documentation

Closes #510

## Testing

- `git diff --check`
- Confirmed onboarding, settings, preload, and main-process registration consume the shared default
- Not run locally: Electron typecheck/app launch (dependencies are not installed, and Corepack's pnpm registry request returned HTTP 403)