### PR TITLE
feat: add MiniMax cleanup LLM support

### DIFF
--- a/apps/electron/src/renderer/src/lib/models.ts
+++ b/apps/electron/src/renderer/src/lib/models.ts
@@ -5,6 +5,13 @@ export interface AvailableModel {
   model_name: string;
   family?: string;
   type: "voice" | "llm";
+  cost_input?: number;
+  cost_output?: number;
+  cost_cache_read?: number;
+  cost_cache_write?: number | null;
+  context_window?: number;
+  input_modalities?: string[];
+  thinking?: string[];
   /** Surfaced in the default picker; non-curated models live behind "All models". */
   curated?: boolean;
   /**
@@ -103,6 +110,8 @@ export const LLM_PROVIDERS = [
   "google",
   "groq",
   "mistral",
+  "minimax",
+  "minimax-cn",
   "openrouter",
   "vercel",
   "local-llm",
@@ -117,6 +126,8 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   elevenlabs: "ElevenLabs",
   soniox: "Soniox",
   mistral: "Mistral",
+  minimax: "MiniMax",
+  "minimax-cn": "MiniMax (China)",
   openrouter: "OpenRouter",
   vercel: "Vercel AI Gateway",
   "freestyle-cloud": "Freestyle Transcribe",
@@ -135,6 +146,10 @@ export const PROVIDER_KEY_URLS: Record<string, string> = {
   anthropic: "https://console.anthropic.com/settings/keys",
   google: "https://aistudio.google.com/apikey",
   mistral: "https://console.mistral.ai/api-keys",
+  minimax:
+    "https://platform.minimax.io/user-center/basic-information/interface-key",
+  "minimax-cn":
+    "https://platform.minimaxi.com/user-center/basic-information/interface-key",
   openrouter: "https://openrouter.ai/keys",
   vercel: "https://vercel.com/d?to=%2F%5Bteam%5D%2F~%2Fai-gateway%2Fapi-keys",
 };

--- a/apps/server/src/lib/llm/minimax.ts
+++ b/apps/server/src/lib/llm/minimax.ts
@@ -1,0 +1,80 @@
+import type { AnthropicLanguageModelOptions } from "@ai-sdk/anthropic";
+import type { PostProcessParams } from "@freestyle-voice/stt";
+
+type CleanupProviderOptions = NonNullable<PostProcessParams["providerOptions"]>;
+
+export const MINIMAX_PROVIDERS = [
+  {
+    providerId: "minimax",
+    providerName: "MiniMax",
+    baseURL: "https://api.minimax.io/anthropic",
+  },
+  {
+    providerId: "minimax-cn",
+    providerName: "MiniMax (China)",
+    baseURL: "https://api.minimaxi.com/anthropic",
+  },
+] as const;
+
+export type MiniMaxProviderId =
+  (typeof MINIMAX_PROVIDERS)[number]["providerId"];
+
+export const MINIMAX_MODELS = [
+  {
+    modelId: "MiniMax-M3",
+    contextWindow: 1_000_000,
+    pricing: {
+      input: 0.6,
+      output: 2.4,
+      cacheRead: 0.12,
+      cacheWrite: null,
+    },
+    inputModalities: ["text", "image", "video"],
+    thinking: ["adaptive", "disabled"],
+  },
+  {
+    modelId: "MiniMax-M2.7",
+    contextWindow: 204_800,
+    pricing: {
+      input: 0.3,
+      output: 1.2,
+      cacheRead: 0.06,
+      cacheWrite: 0.375,
+    },
+    inputModalities: ["text"],
+    thinking: ["always_on"],
+  },
+] as const;
+
+function stripMiniMaxPrefix(modelId: string): string {
+  return modelId.replace(/^minimax(?:-cn)?\//, "");
+}
+
+export function isMiniMaxProviderId(
+  providerId: string,
+): providerId is MiniMaxProviderId {
+  return MINIMAX_PROVIDERS.some(
+    (provider) => provider.providerId === providerId,
+  );
+}
+
+export function getMiniMaxModelMetadata(
+  providerId: string,
+  modelId: string,
+): (typeof MINIMAX_MODELS)[number] | undefined {
+  if (!isMiniMaxProviderId(providerId)) return undefined;
+  const shortId = stripMiniMaxPrefix(modelId);
+  return MINIMAX_MODELS.find((model) => model.modelId === shortId);
+}
+
+export function minimaxCleanupProviderOptions(
+  modelId: string,
+): CleanupProviderOptions | undefined {
+  const model = getMiniMaxModelMetadata("minimax", modelId);
+  if (!model?.thinking.some((mode) => mode === "disabled")) return undefined;
+
+  const anthropic: AnthropicLanguageModelOptions = {
+    thinking: { type: "disabled" },
+  };
+  return { anthropic };
+}

--- a/apps/server/src/lib/llm/registry.ts
+++ b/apps/server/src/lib/llm/registry.ts
@@ -6,6 +6,7 @@ import {
   FREESTYLE_CLOUD_PROVIDER_ID,
   freestyleCloudUrl,
 } from "../freestyle-cloud.js";
+import { MINIMAX_PROVIDERS, minimaxCleanupProviderOptions } from "./minimax.js";
 
 /** The provider-options shape accepted by the cleanup `generateText` call. */
 type CleanupProviderOptions = NonNullable<PostProcessParams["providerOptions"]>;
@@ -99,6 +100,16 @@ const PROVIDERS: LlmProvider[] = [
       return createAnthropic({ apiKey }).chat(modelId);
     },
   },
+  ...MINIMAX_PROVIDERS.map(
+    ({ providerId, baseURL }): LlmProvider => ({
+      providerId,
+      createModel: async (modelId, apiKey) => {
+        const { createAnthropic } = await import("@ai-sdk/anthropic");
+        return createAnthropic({ authToken: apiKey, baseURL }).chat(modelId);
+      },
+      providerOptions: (modelId) => minimaxCleanupProviderOptions(modelId),
+    }),
+  ),
   {
     providerId: "google",
     createModel: async (modelId, apiKey) => {

--- a/apps/server/src/lib/providers.ts
+++ b/apps/server/src/lib/providers.ts
@@ -8,6 +8,8 @@ const LOCAL_PROVIDERS = new Set(["local-llm"]);
 const PROVIDER_PREFIXED_CHAT_MODELS = new Set([
   "openai",
   "anthropic",
+  "minimax",
+  "minimax-cn",
   "google",
   "mistral",
   "openrouter",

--- a/apps/server/src/lib/validate-key.ts
+++ b/apps/server/src/lib/validate-key.ts
@@ -1,3 +1,5 @@
+import { MINIMAX_PROVIDERS } from "./llm/minimax.js";
+
 /**
  * Per-provider API key validation using free, read-only endpoints.
  *
@@ -153,6 +155,26 @@ async function validateMistral(apiKey: string): Promise<ValidationResult> {
   return { valid: false, error: `Mistral returned HTTP ${res.status}.` };
 }
 
+async function validateMiniMax(
+  apiKey: string,
+  baseURL: string,
+): Promise<ValidationResult> {
+  const res = await fetch(`${baseURL}/v1/models`, {
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.ok) return { valid: true };
+  if (res.status === 401 || res.status === 403)
+    return {
+      valid: false,
+      error: "Invalid API key. Please check and try again.",
+    };
+  return { valid: false, error: `MiniMax returned HTTP ${res.status}.` };
+}
+
 async function validateOpenRouter(apiKey: string): Promise<ValidationResult> {
   const res = await fetch("https://openrouter.ai/api/v1/key", {
     headers: { Authorization: `Bearer ${apiKey}` },
@@ -196,6 +218,12 @@ const LIVE_VALIDATORS: Record<
   anthropic: validateAnthropic,
   google: validateGoogle,
   mistral: validateMistral,
+  ...Object.fromEntries(
+    MINIMAX_PROVIDERS.map(({ providerId, baseURL }) => [
+      providerId,
+      (apiKey: string) => validateMiniMax(apiKey, baseURL),
+    ]),
+  ),
   openrouter: validateOpenRouter,
   vercel: validateVercel,
 };

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -8,6 +8,12 @@ import {
   FREESTYLE_CLOUD_TRANSCRIBE_MODEL_ID,
 } from "../lib/freestyle-cloud.js";
 import {
+  getMiniMaxModelMetadata,
+  isMiniMaxProviderId,
+  MINIMAX_MODELS,
+  MINIMAX_PROVIDERS,
+} from "../lib/llm/minimax.js";
+import {
   LEGACY_MLX_ASR_MODELS,
   MLX_ASR_MODELS,
   MLX_ASR_PROVIDER_ID,
@@ -33,6 +39,11 @@ interface AvailableModel {
   type: "voice" | "llm";
   cost_input?: number;
   cost_output?: number;
+  cost_cache_read?: number;
+  cost_cache_write?: number | null;
+  context_window?: number;
+  input_modalities?: string[];
+  thinking?: string[];
   /** Surfaced in the default picker; non-curated models live behind "All models". */
   curated?: boolean;
   /**
@@ -201,6 +212,7 @@ const SUPPORTED_LLM_PROVIDERS = new Set([
   "google",
   "groq",
   "mistral",
+  ...MINIMAX_PROVIDERS.map((provider) => provider.providerId),
   ...Object.keys(LLM_GATEWAYS),
 ]);
 
@@ -216,6 +228,9 @@ const CURATED_LLM_IDS = new Set([
   "anthropic/claude-haiku-4-5",
   "google/gemini-2.5-flash",
   "mistral/mistral-small-latest",
+  ...MINIMAX_PROVIDERS.flatMap((provider) =>
+    MINIMAX_MODELS.map((model) => `${provider.providerId}/${model.modelId}`),
+  ),
 ]);
 
 const BUILTIN_LLM_MODELS: AvailableModel[] = [
@@ -237,6 +252,24 @@ const BUILTIN_LLM_MODELS: AvailableModel[] = [
     type: "llm",
     curated: true,
   },
+  ...MINIMAX_PROVIDERS.flatMap((provider) =>
+    MINIMAX_MODELS.map((model) => ({
+      provider_id: provider.providerId,
+      provider_name: provider.providerName,
+      model_id: model.modelId,
+      model_name: model.modelId,
+      family: "minimax",
+      type: "llm" as const,
+      cost_input: model.pricing.input,
+      cost_output: model.pricing.output,
+      cost_cache_read: model.pricing.cacheRead,
+      cost_cache_write: model.pricing.cacheWrite,
+      context_window: model.contextWindow,
+      input_modalities: [...model.inputModalities],
+      thinking: [...model.thinking],
+      curated: true,
+    })),
+  ),
 ];
 
 // In-memory cache for models.dev data
@@ -269,6 +302,14 @@ export async function getModelCost(
   providerId: string,
   modelId: string,
 ): Promise<{ input: number; output: number } | null> {
+  const minimaxModel = getMiniMaxModelMetadata(providerId, modelId);
+  if (minimaxModel) {
+    return {
+      input: minimaxModel.pricing.input / 1_000_000,
+      output: minimaxModel.pricing.output / 1_000_000,
+    };
+  }
+
   try {
     const registry = await fetchModelsFromRegistry();
 
@@ -294,6 +335,7 @@ export async function isCleanupModelSupported(
   providerId: string,
   modelId: string,
 ): Promise<boolean> {
+  if (getMiniMaxModelMetadata(providerId, modelId)) return true;
   if (providerId === "local-llm") return true;
   if (providerId in LLM_GATEWAYS) return true;
   if (providerId === FREESTYLE_CLOUD_PROVIDER_ID) return true;
@@ -364,6 +406,8 @@ const models = new Hono()
         if (!provider.models) continue;
 
         for (const [, model] of Object.entries(provider.models)) {
+          const minimaxModel = getMiniMaxModelMetadata(providerId, model.id);
+          if (isMiniMaxProviderId(providerId) && !minimaxModel) continue;
           if (model.status === DEPRECATED_STATUS) continue;
 
           const inputMods = model.modalities?.input ?? [];
@@ -379,8 +423,15 @@ const models = new Hono()
               model_name: model.name,
               family: model.family ?? "",
               type: "llm",
-              cost_input: model.cost?.input,
-              cost_output: model.cost?.output,
+              cost_input: minimaxModel?.pricing.input ?? model.cost?.input,
+              cost_output: minimaxModel?.pricing.output ?? model.cost?.output,
+              cost_cache_read: minimaxModel?.pricing.cacheRead,
+              cost_cache_write: minimaxModel?.pricing.cacheWrite,
+              context_window: minimaxModel?.contextWindow,
+              input_modalities: minimaxModel
+                ? [...minimaxModel.inputModalities]
+                : inputMods,
+              thinking: minimaxModel ? [...minimaxModel.thinking] : undefined,
               curated: CURATED_LLM_IDS.has(`${providerId}/${model.id}`),
               gateway: LLM_GATEWAYS[providerId],
             });

--- a/apps/server/tests/minimax-provider.test.ts
+++ b/apps/server/tests/minimax-provider.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { chat, createAnthropic } = vi.hoisted(() => {
+  const chat = vi.fn(() => ({}));
+  const createAnthropic = vi.fn(() => ({ chat }));
+  return { chat, createAnthropic };
+});
+
+vi.mock("@ai-sdk/anthropic", () => ({ createAnthropic }));
+
+import { getLlmProvider } from "../src/lib/llm/registry.js";
+import { validateApiKey } from "../src/lib/validate-key.js";
+
+describe("MiniMax LLM providers", () => {
+  beforeEach(() => {
+    chat.mockClear();
+    createAnthropic.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    ["minimax", "https://api.minimax.io/anthropic"],
+    ["minimax-cn", "https://api.minimaxi.com/anthropic"],
+  ])("uses the %s regional endpoint", async (providerId, baseURL) => {
+    const provider = getLlmProvider(providerId);
+    expect(provider).not.toBeNull();
+
+    await provider!.createModel("MiniMax-M3", "test-key");
+
+    expect(createAnthropic).toHaveBeenCalledWith({
+      authToken: "test-key",
+      baseURL,
+    });
+    expect(chat).toHaveBeenCalledWith("MiniMax-M3");
+  });
+
+  it.each([
+    ["minimax", "https://api.minimax.io/anthropic/v1/models"],
+    ["minimax-cn", "https://api.minimaxi.com/anthropic/v1/models"],
+  ])("validates %s keys against its regional endpoint", async (providerId, url) => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(validateApiKey(providerId, "test-key")).resolves.toEqual({
+      valid: true,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(url, {
+      headers: {
+        "x-api-key": "test-key",
+        "anthropic-version": "2023-06-01",
+      },
+      signal: expect.any(AbortSignal),
+    });
+  });
+});

--- a/apps/server/tests/post-process-options.test.ts
+++ b/apps/server/tests/post-process-options.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import {
+  getMiniMaxModelMetadata,
+  minimaxCleanupProviderOptions,
+} from "../src/lib/llm/minimax.js";
 import { groqCleanupProviderOptions } from "../src/lib/llm/registry.js";
 
 describe("groqCleanupProviderOptions", () => {
@@ -28,5 +32,46 @@ describe("groqCleanupProviderOptions", () => {
 
   it("leaves non-reasoning groq models alone", () => {
     expect(groqCleanupProviderOptions("llama-3.1-8b-instant")).toBeUndefined();
+  });
+});
+
+describe("minimaxCleanupProviderOptions", () => {
+  it("disables optional thinking for M3 cleanup", () => {
+    expect(minimaxCleanupProviderOptions("MiniMax-M3")).toEqual({
+      anthropic: {
+        thinking: { type: "disabled" },
+      },
+    });
+    expect(minimaxCleanupProviderOptions("minimax-cn/MiniMax-M3")).toEqual({
+      anthropic: {
+        thinking: { type: "disabled" },
+      },
+    });
+  });
+
+  it("keeps always-on thinking unchanged for M2.7 cleanup", () => {
+    expect(minimaxCleanupProviderOptions("MiniMax-M2.7")).toBeUndefined();
+  });
+
+  it("exposes the current model metadata for both regions", () => {
+    expect(getMiniMaxModelMetadata("minimax", "MiniMax-M3")).toMatchObject({
+      contextWindow: 1_000_000,
+      pricing: { input: 0.6, output: 2.4, cacheRead: 0.12 },
+      inputModalities: ["text", "image", "video"],
+      thinking: ["adaptive", "disabled"],
+    });
+    expect(getMiniMaxModelMetadata("minimax-cn", "MiniMax-M2.7")).toMatchObject(
+      {
+        contextWindow: 204_800,
+        pricing: {
+          input: 0.3,
+          output: 1.2,
+          cacheRead: 0.06,
+          cacheWrite: 0.375,
+        },
+        inputModalities: ["text"],
+        thinking: ["always_on"],
+      },
+    );
   });
 });


### PR DESCRIPTION
Reason: Add MiniMax cleanup LLM support with regional endpoints and current model metadata.

## Summary

- Register global and China MiniMax cleanup providers with regional key validation.
- Add MiniMax-M3 and MiniMax-M2.7 pricing, context, input modality, and thinking metadata.
- Disable optional MiniMax-M3 thinking during cleanup while preserving MiniMax-M2.7 behavior.

## Checks

- `pnpm --filter @freestyle-voice/server exec vitest run tests/post-process-options.test.ts tests/minimax-provider.test.ts`
- `pnpm --filter @freestyle-voice/server test`
- `pnpm --filter @freestyle-voice/server build`
- `pnpm --filter @freestyle-voice/electron typecheck`
- `pnpm exec biome check apps/server/src/lib/llm/minimax.ts apps/server/src/lib/llm/registry.ts apps/server/src/lib/providers.ts apps/server/src/lib/validate-key.ts apps/server/src/routes/models.ts apps/server/tests/post-process-options.test.ts apps/server/tests/minimax-provider.test.ts apps/electron/src/renderer/src/lib/models.ts`
