### PR TITLE
fix(electron): default Windows push-to-talk hotkey to Right Alt

### DIFF
--- a/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
+++ b/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
@@ -248,14 +248,13 @@ export interface RightModifierUpdateEvent {
   explicitLeft?: boolean;
 }
 
-/** Maps DOM `KeyboardEvent.code` to the side-specific token it represents (macOS only). */
+/** Maps DOM `KeyboardEvent.code` to the side-specific token it represents. */
 function domRightModifierToken(e: KeyboardEvent): string | null {
-  if (!IS_MAC) return null;
   switch (e.code) {
     case "MetaRight":
-      return "RightCommand";
+      return IS_MAC ? "RightCommand" : "RightSuper";
     case "AltRight":
-      return "RightOption";
+      return IS_MAC ? "RightOption" : "RightAlt";
     case "ControlRight":
       return "RightControl";
     case "ShiftRight":

--- a/apps/electron/src/shared/hotkey-defaults.ts
+++ b/apps/electron/src/shared/hotkey-defaults.ts
@@ -2,7 +2,8 @@
  * Single source of truth for the default push-to-talk hotkey.
  *
  * - macOS: Fn (Globe) — dedicated dictation key, no modifier conflicts
- * - Windows/Linux: Control+Alt+Space — no Super key, so the OS launcher /
+ * - Windows: Right Alt — a single dedicated key, no modifier chord needed
+ * - Linux: Control+Alt+Space — no Super key, so the OS launcher /
  *   Start menu never fires alongside dictation, and the real key lets the
  *   native listeners suppress the chord from reaching the focused app
  *
@@ -13,6 +14,8 @@ export function getDefaultHotkey(platform: string = process.platform): string {
   switch (platform) {
     case "darwin":
       return "Fn";
+    case "win32":
+      return "RightAlt";
     default:
       return "Control+Alt+Space";
   }


### PR DESCRIPTION
Windows previously defaulted to the 3-key Control+Alt+Space chord. Match macOS's single dedicated-key pattern (Fn) by defaulting to Right Alt instead. Also extends the settings hotkey recorder's DOM fallback capture to distinguish left/right modifiers on Windows and Linux (it only ever handled macOS), which is now required since a lone right-side modifier can be a valid recorded hotkey.

<!--
  Thanks for contributing! A few quick reminders before you submit.

  PR title must follow Conventional Commits, e.g.:
    fix: prevent duplicate settings requests
    feat(plugins): add update checks
  Allowed types: feat, fix, docs, chore, refactor, test, ci, build, perf, style, revert
  It's used for the squash commit and the release changelog. A CI check enforces this.
-->

## Summary

- Windows now defaults to the single Right Alt key for push-to-talk, matching macOS's single dedicated-key pattern (Fn), instead of the 3-key Control+Alt+Space chord
- Extends the Settings hotkey recorder's DOM-capture fallback to distinguish left/right modifiers on Windows and Linux — previously only macOS could tell AltRight from AltLeft, which silently collapsed a recorded Right Alt into generic Alt


## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
- [x] Ran `pnpm biome check .` (lint + formatting)
- [x] Ran `pnpm --filter @freestyle-voice/electron typecheck:web` (if touching the app)
