### PR TITLE
feat: Handle Soniox max pending chunks

### DIFF
--- a/apps/server/src/lib/streaming/providers/soniox.ts
+++ b/apps/server/src/lib/streaming/providers/soniox.ts
@@ -16,6 +16,7 @@ const SONIOX_WS_URL = "wss://stt-rt.soniox.com/transcribe-websocket";
 const COMMIT_TIMEOUT_MS = 8_000;
 const KEEPALIVE_INTERVAL_MS = 10_000;
 const FIN_TOKEN = "<fin>";
+const MAX_PENDING_CHUNKS = 1024;
 
 interface SonioxToken {
   text?: string;
@@ -157,6 +158,7 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
     let commitTimeout: ReturnType<typeof setTimeout> | null = null;
     let keepAlive: ReturnType<typeof setInterval> | null = null;
     let configured = false;
+    let pendingChunks: ArrayBuffer[] = [];
 
     const ws = new WebSocket(SONIOX_WS_URL);
 
@@ -185,6 +187,20 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
       });
       ws.send(JSON.stringify(config));
       configured = true;
+    }
+
+    function flushPendingChunks(): void {
+      for (const chunk of pendingChunks) {
+        ws.send(Buffer.from(chunk));
+      }
+      pendingChunks = [];
+    }
+
+    function sendFinalize(): void {
+      if (finalizeSent) return;
+      finalizeSent = true;
+      ws.send(JSON.stringify({ type: "finalize" }));
+      ws.send("");
     }
 
     function deliverFinal(): void {
@@ -240,6 +256,10 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
 
     ws.on("open", () => {
       sendConfig();
+      flushPendingChunks();
+      if (commitRequested) {
+        sendFinalize();
+      }
       keepAlive = setInterval(() => {
         if (ws.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: "keepalive" }));
@@ -282,16 +302,27 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
 
     ws.on("close", () => {
       stopKeepAlive();
+      if (commitRequested && !finalDelivered) {
+        deliverFinal();
+      }
       callbacks.onClose();
     });
 
     return {
       sendAudio(chunk: ArrayBuffer): void {
+        if (finalizeSent || finalDelivered) return;
+        if (ws.readyState === WebSocket.CONNECTING) {
+          if (pendingChunks.length < MAX_PENDING_CHUNKS) {
+            pendingChunks.push(chunk);
+          }
+          return;
+        }
         if (ws.readyState !== WebSocket.OPEN || !configured) return;
         ws.send(Buffer.from(chunk));
       },
       reset(): void {
         clearCommitTimeout();
+        pendingChunks = [];
         finalTokens.length = 0;
         nonFinalTokens = [];
         sourceFinalTokens.length = 0;
@@ -304,23 +335,20 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
       commit(): void {
         commitRequested = true;
         clearCommitTimeout();
+        commitTimeout = setTimeout(() => {
+          deliverFinal();
+        }, COMMIT_TIMEOUT_MS);
 
+        if (ws.readyState === WebSocket.CONNECTING) return;
         if (ws.readyState !== WebSocket.OPEN) {
           deliverFinal();
           return;
         }
-
-        // Force Soniox to finalize all pending tokens immediately (minimizes tail latency).
-        ws.send(JSON.stringify({ type: "finalize" }));
-        finalizeSent = true;
-        maybeDeliverAfterFinalize();
-
-        commitTimeout = setTimeout(() => {
-          deliverFinal();
-        }, COMMIT_TIMEOUT_MS);
+        sendFinalize();
       },
       cancel(): void {
         clearCommitTimeout();
+        pendingChunks = [];
         finalTokens.length = 0;
         nonFinalTokens = [];
         sourceFinalTokens.length = 0;


### PR DESCRIPTION
## Summary
We set max pending chunks in Soniox. Helps better handle short audio snippets streaming to Soniox via WS 

<!-- What does this PR do and why? -->

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
- [ ] Ran `pnpm biome check .` (lint + formatting)
- [ ] Ran `pnpm --filter @freestyle-voice/electron typecheck:web` (if touching the app)
