### PR TITLE
feat(desktop): show INR pricing for India via cloud geo endpoint

### DIFF
--- a/apps/electron/src/renderer/src/components/upgrade-modal.tsx
+++ b/apps/electron/src/renderer/src/components/upgrade-modal.tsx
@@ -13,6 +13,7 @@ import {
   type CheckoutStatus,
   useCloudUsage,
 } from "@renderer/lib/use-cloud-usage";
+import { usePricing } from "@renderer/lib/use-pricing";
 import { cn } from "@renderer/lib/utils";
 import { Check, CircleCheck, Loader2, Mail } from "lucide-react";
 import {
@@ -80,7 +81,7 @@ export function UpgradeModalProvider({
 }
 
 // ---------------------------------------------------------------------------
-// Pricing content (mirrors freestylevoice.com/pricing)
+// Pricing content (mirrors freestylevoice.com/pricing; currency from cloud)
 // ---------------------------------------------------------------------------
 
 const FREE_FEATURES = [
@@ -208,6 +209,8 @@ export function PricingPlans({
 }: PricingPlansProps): React.JSX.Element {
   const { user, signingIn, signIn } = useCloudAuth();
   const [period, setPeriod] = useState<BillingPeriod>("annual");
+  const pricing = usePricing();
+  const isInr = pricing.currency === "inr";
   const checkoutBusy =
     checkoutStatus === "launching" || checkoutStatus === "pending";
 
@@ -248,7 +251,11 @@ export function PricingPlans({
 
       <div className="grid gap-3 sm:grid-cols-3">
         <PlanCard>
-          <PlanHeader name="Free" price="$0" priceNote="forever" />
+          <PlanHeader
+            name="Free"
+            price={isInr ? "₹0" : "$0"}
+            priceNote="forever"
+          />
           <FeatureList features={FREE_FEATURES} />
           {!isPro ? (
             <Button
@@ -265,7 +272,11 @@ export function PricingPlans({
         <PlanCard featured>
           <PlanHeader
             name="Pro"
-            price={period === "annual" ? "$9" : "$12"}
+            price={
+              period === "annual"
+                ? pricing.annual.display
+                : pricing.monthly.display
+            }
             priceNote={
               period === "annual" ? "/ month, billed annually" : "/ month"
             }
@@ -345,7 +356,7 @@ export function PricingPlans({
         <PlanCard>
           <PlanHeader
             name="Enterprise"
-            price="from $20"
+            price={isInr ? `from ${pricing.monthly.display}` : "from $20"}
             priceNote="/ user / month"
           />
           <FeatureList

--- a/apps/electron/src/renderer/src/lib/use-pricing.ts
+++ b/apps/electron/src/renderer/src/lib/use-pricing.ts
@@ -1,0 +1,56 @@
+import { useQuery } from "@tanstack/react-query";
+import { getClient } from "./api";
+import { ONE_HOUR } from "./query";
+
+/**
+ * Currency-aware Pro pricing from Freestyle Cloud's public `GET /v2/pricing`
+ * (proxied through the local `GET /api/pricing`). Mirrors the cloud response
+ * shape used by the marketing site.
+ */
+export interface CloudPricing {
+  currency: "usd" | "inr";
+  monthly: {
+    /** Amount in the currency's smallest unit (e.g. cents / paise). */
+    amount: number;
+    /** Pre-formatted display string, e.g. "$12" or "₹999". */
+    display: string;
+  };
+  /** Pro annual plan, expressed as the effective per-month price. */
+  annual: {
+    amount: number;
+    display: string;
+  };
+}
+
+/**
+ * USD fallback used as `placeholderData` so the pricing UI never flashes
+ * empty prices while the geo-aware cloud response loads (or if it fails —
+ * the local `/api/pricing` route also returns this same shape on upstream
+ * errors).
+ */
+export const FALLBACK_PRICING: CloudPricing = {
+  currency: "usd",
+  monthly: { amount: 1200, display: "$12" },
+  annual: { amount: 900, display: "$9" },
+};
+
+/**
+ * Geo-aware Pro pricing from Freestyle Cloud (via the local server
+ * passthrough at `GET /api/pricing`). Currency is INR for India, USD
+ * otherwise. Cached for an hour; always returns a usable payload thanks to
+ * the USD placeholder / server-side fallback.
+ */
+export function usePricing(): CloudPricing {
+  const { data } = useQuery({
+    queryKey: ["cloud-pricing"] as const,
+    staleTime: ONE_HOUR,
+    retry: 1,
+    placeholderData: FALLBACK_PRICING,
+    queryFn: async (): Promise<CloudPricing> => {
+      const res = await getClient().api.pricing.$get();
+      if (!res.ok) throw new Error(`Failed to fetch pricing (${res.status})`);
+      return (await res.json()) as CloudPricing;
+    },
+  });
+  return data ?? FALLBACK_PRICING;
+}

--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -209,6 +209,46 @@ export async function fetchCloudConfig(): Promise<CloudConfigResponse> {
   return (await res.json()) as CloudConfigResponse;
 }
 
+/**
+ * Currency-aware Pro pricing from the public `GET /v2/pricing` endpoint.
+ * The cloud picks INR for India (via Cloudflare `cf.country`) and USD
+ * otherwise; amounts come from Stripe multi-currency Price objects.
+ * Unauthenticated and CDN-cacheable — display-only.
+ */
+export interface CloudPricing {
+  currency: "usd" | "inr";
+  /** Pro monthly plan billed monthly. */
+  monthly: {
+    /** Amount in the currency's smallest unit (e.g. cents / paise). */
+    amount: number;
+    /** Pre-formatted display string, e.g. "$12" or "₹999". */
+    display: string;
+  };
+  /** Pro annual plan, expressed as the effective per-month price. */
+  annual: {
+    /** Per-month amount in the currency's smallest unit (annual total / 12). */
+    amount: number;
+    display: string;
+  };
+}
+
+/**
+ * Fetch the public geo-aware pricing payload. Unauthenticated. Currency is
+ * derived from the caller's IP geo by the cloud (India → INR, else USD), so
+ * the desktop's real egress IP is what matters — no `?country=` forwarding
+ * is needed (unlike the Vercel-hosted marketing site).
+ */
+export async function fetchCloudPricing(): Promise<CloudPricing> {
+  const url = `${freestyleCloudUrl()}/v2/pricing`;
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(CLOUD_TRANSCRIBE_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new FreestyleCloudRequestError(res.status, `pricing fetch failed`);
+  }
+  return (await res.json()) as CloudPricing;
+}
+
 function createCloudAuthClient() {
   return createAuthClient({
     baseURL: `${freestyleCloudUrl()}/auth`,

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -19,6 +19,7 @@ import org from "./org.js";
 import outputRoute from "./output.js";
 import pluginsRoute from "./plugins.js";
 import postProcessRoute from "./post-process-route.js";
+import pricing from "./pricing.js";
 import settings from "./settings.js";
 import streamRoute from "./stream.js";
 import transcribe, { transcribePreWarmRoute } from "./transcribe.js";
@@ -74,6 +75,7 @@ const apiRouter = new Hono()
   .route("/events", eventsRoute)
   .route("/usage", usage)
   .route("/billing", billing)
+  .route("/pricing", pricing)
   .route("/org", org)
   .route("/plugins", pluginsRoute)
   .route("/whisper", whisper)

--- a/apps/server/src/routes/pricing.ts
+++ b/apps/server/src/routes/pricing.ts
@@ -1,0 +1,39 @@
+import { createAppLogger } from "@freestyle-voice/utils";
+import { Hono } from "hono";
+import { formatError } from "../lib/format-error.js";
+import {
+  type CloudPricing,
+  fetchCloudPricing,
+} from "../lib/freestyle-cloud.js";
+
+const log = createAppLogger("pricing");
+
+/**
+ * USD fallback when the cloud pricing endpoint is unreachable. Mirrors the
+ * marketing site's hardcoded defaults so the UI never renders blank prices.
+ */
+const FALLBACK_PRICING: CloudPricing = {
+  currency: "usd",
+  monthly: { amount: 1200, display: "$12" },
+  annual: { amount: 900, display: "$9" },
+};
+
+/**
+ * Public passthrough for Freestyle Cloud geo-aware pricing
+ * (`GET /v2/pricing`). Unauthenticated — currency comes from the caller's IP
+ * geo on the cloud side. Always returns a pricing payload: on upstream
+ * failure we fall back to USD so the upgrade UI stays usable offline.
+ */
+const pricing = new Hono().get("/", async (c) => {
+  try {
+    const data = await fetchCloudPricing();
+    return c.json(data);
+  } catch (err) {
+    log.warn(
+      `failed to fetch cloud pricing, using USD fallback: ${formatError(err)}`,
+    );
+    return c.json(FALLBACK_PRICING);
+  }
+});
+
+export default pricing;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the desktop upgrade modal / Settings → Billing pricing UI currency-aware, mirroring the marketing site.

- Adds `fetchCloudPricing()` against Freestyle Cloud's public geo-aware `GET /v2/pricing` (INR for India via Cloudflare `cf.country`, USD otherwise; amounts from Stripe).
- Exposes it locally as unauthenticated `GET /api/pricing` with a USD fallback so the UI never breaks offline.
- `usePricing()` feeds Free / Pro / Enterprise display strings in `PricingPlans` (`₹0` / dynamic Pro / `from {Pro monthly}` for INR; `$0` / `$9`–`$12` / `from $20` for USD).

No checkout changes — Stripe still resolves currency from the multi-currency Price objects already used by the website.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
- [x] Ran `pnpm biome check` on touched files (lint + formatting)
- [x] Ran `pnpm --filter @freestyle-voice/electron typecheck:web` (if touching the app)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f99b830-ecfe-4d8c-92a7-88f6b584ef0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f99b830-ecfe-4d8c-92a7-88f6b584ef0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

