### PR TITLE
ci(electron): stop flaky macOS permission E2E from red-lining CI

### DIFF
--- a/apps/electron/playwright.config.ts
+++ b/apps/electron/playwright.config.ts
@@ -3,7 +3,11 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests",
   timeout: 60_000,
-  retries: 0,
+  // Launching and quitting a real Electron app is occasionally flaky on CI
+  // runners (a hung quit shows up as a test timeout plus a worker teardown
+  // timeout). Retry there so one bad launch doesn't red-line the whole run;
+  // locally we keep 0 so flakes stay visible.
+  retries: process.env.CI ? 2 : 0,
   workers: 1, // Electron tests must run serially
   reporter: "list",
   use: {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -3085,12 +3085,33 @@ function cleanupBeforeQuit(): void {
 
 app.on("before-quit", (event) => {
   if (isUpdaterQuitting) {
-    cleanupBeforeQuit();
+    try {
+      cleanupBeforeQuit();
+    } catch (err) {
+      log.warn(
+        `cleanup before updater quit failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
     return;
   }
   if (isQuitting) return;
   isQuitting = true;
   event.preventDefault();
-  cleanupBeforeQuit();
-  app.exit(0);
+  // We preventDefault above, so `app.exit(0)` is the only thing that ends the
+  // process. Keep it in a `finally` — if any cleanup step throws (a native
+  // listener already torn down, a dead child process), the app would otherwise
+  // stay alive forever with no windows, which is what a hung quit looks like.
+  try {
+    cleanupBeforeQuit();
+  } catch (err) {
+    log.warn(
+      `cleanup before quit failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  } finally {
+    app.exit(0);
+  }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `Build (macOS)` job (and therefore the required `CI Status` check) fails intermittently on unrelated PRs — e.g. [#531](https://github.com/freestyle-voice/freestyle/pull/531). It is **not** caused by those PRs: the same failure reproduces on `main`, hitting a *different* test each run.

| Run | Failing test |
| --- | --- |
| [main @ 400944b](https://github.com/freestyle-voice/freestyle/actions/runs/30742956785/job/91495180513) | `startup does not warn when Accessibility permission is granted` |
| [main @ f529a40](https://github.com/freestyle-voice/freestyle/actions/runs/30721038564/job/91424924238) | `startup combines missing Accessibility and Microphone into one warning` |
| [main @ 3f936a2](https://github.com/freestyle-voice/freestyle/actions/runs/30716070860/job/91411874545) | `startup warns for denied Microphone and opens its privacy settings` |

Every occurrence has the same signature: exactly one test hits the 60s timeout, immediately followed by `Worker teardown timeout of 60000ms exceeded`. That is what it looks like when `electronApp.close()` calls `app.quit()` and the process never exits.

## Changes

- **Retry Electron E2E on CI** (`retries: process.env.CI ? 2 : 0`). Kept at `0` locally so flakes stay visible during development.
- **Always run `app.exit(0)` in the `before-quit` handler.** The handler calls `event.preventDefault()`, so `app.exit(0)` is the only thing that ends the process — if any cleanup step throws (a native listener already torn down, a dead child process), the app stays alive with no windows, which matches the hung-quit signature above. Cleanup is now wrapped so the exit runs in a `finally`, with the failure logged.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
- [x] Ran `pnpm biome check` on touched files (lint + formatting)
- [x] Ran `pnpm --filter @freestyle-voice/electron typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f99b830-ecfe-4d8c-92a7-88f6b584ef0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f99b830-ecfe-4d8c-92a7-88f6b584ef0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

