### PR TITLE
feat: add local dismissible notifications store and useDismissible hook

### DIFF
--- a/apps/electron/src/renderer/src/hooks/use-dismissible.ts
+++ b/apps/electron/src/renderer/src/hooks/use-dismissible.ts
@@ -1,4 +1,7 @@
-import { notificationKeySchema } from "@freestyle-voice/validations";
+import {
+  type DismissibleNotificationState,
+  notificationKeySchema,
+} from "@freestyle-voice/validations";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { getClient } from "../lib/api";
@@ -7,15 +10,45 @@ import {
   dismissedNotificationsQueryOptions,
 } from "../lib/query";
 
-export interface UseDismissibleResult {
-  /** True once the dismissed-keys list has loaded (or a prior cache exists). */
-  ready: boolean;
-  /** Whether this key has been dismissed on this device. */
-  dismissed: boolean;
-  /** Permanently dismiss — records the key so the UI won't show again. */
-  dismiss: () => void;
-  /** Undo a dismissal — removes the key so the UI can show again. */
-  reset: () => void;
+type WriteResponse = { ok: boolean; status: number };
+
+// Serialize writes per notification key across every hook instance. Without a
+// queue, a rapid dismiss → reset can reach the server as DELETE → PUT and leave
+// SQLite disagreeing with the latest optimistic UI state.
+const writeQueues = new Map<string, Promise<void>>();
+const writeGenerations = new Map<string, number>();
+
+function beginWrite(key: string): number {
+  const generation = (writeGenerations.get(key) ?? 0) + 1;
+  writeGenerations.set(key, generation);
+  return generation;
+}
+
+function enqueueWrite(
+  key: string,
+  generation: number,
+  request: () => Promise<WriteResponse>,
+  rollback: () => void,
+): void {
+  const previous = writeQueues.get(key) ?? Promise.resolve();
+  const current = previous.then(async () => {
+    try {
+      const response = await request();
+      if (!response.ok) throw new Error(`Write failed (${response.status})`);
+    } catch {
+      // A newer action owns the UI now and will run next in this same queue.
+      // Only the latest operation may revert its optimistic change.
+      if (writeGenerations.get(key) === generation) rollback();
+    }
+  });
+  writeQueues.set(key, current);
+  void current.finally(() => {
+    if (writeQueues.get(key) !== current) return;
+    writeQueues.delete(key);
+    if (writeGenerations.get(key) === generation) {
+      writeGenerations.delete(key);
+    }
+  });
 }
 
 /**
@@ -24,9 +57,10 @@ export interface UseDismissibleResult {
  * /api/dismissed-notifications` via a shared React Query cache so every
  * consumer of the same (or different) key shares one fetch.
  *
- * Presence of `key` in the list means dismissed. Writes are optimistic; a
- * non-OK response rolls the cache back (or invalidates if we have no
- * snapshot). Invalid / empty keys are no-ops.
+ * Presence of `key` in the list means dismissed. Writes are optimistic and
+ * mutation-safe: an in-flight list fetch is cancelled first, and a failed
+ * write reverts only its own key (never an unrelated concurrent mutation).
+ * Invalid / empty keys are no-ops.
  *
  * Storage follows the configured Freestyle server — the same SQLite DB as
  * settings/vocabulary. On a remote server that means dismissals are shared
@@ -39,93 +73,94 @@ export interface UseDismissibleResult {
  * return <Banner onClose={dismiss} />;
  * ```
  */
-export function useDismissible(key: string): UseDismissibleResult {
+export function useDismissible(key: string): DismissibleNotificationState {
   const queryClient = useQueryClient();
-  const { data, isPending, isError } = useQuery(
-    dismissedNotificationsQueryOptions(),
-  );
+  const { data } = useQuery(dismissedNotificationsQueryOptions());
 
-  // Fail closed on a first-fetch error (no cached data): don't flash a
-  // previously-dismissed banner while the loopback is unreachable.
-  const dismissed =
-    (data ?? []).includes(key) || (isError && data === undefined);
-  // Ready once we have a definitive answer — success, cached data under
-  // error, or a hard error we fail-closed on above.
-  const ready = !isPending;
+  const dismissed = (data ?? []).includes(key);
+  // An error without cached data is not a definitive answer. Consumers keep
+  // their UI hidden until a successful fetch (or a prior cache) exists.
+  const ready = data !== undefined;
 
   const dismiss = useCallback(() => {
     const parsed = notificationKeySchema.safeParse(key);
     if (!parsed.success) return;
 
+    const generation = beginWrite(parsed.data);
+    // Cancellation is initiated before the synchronous optimistic patch, so
+    // the initial GET cannot overwrite it. `revert: false` keeps our patch
+    // when cancellation settles.
+    void queryClient.cancelQueries(
+      { queryKey: DISMISSED_NOTIFICATIONS_QUERY_KEY },
+      { revert: false },
+    );
     const previous = queryClient.getQueryData<string[]>(
       DISMISSED_NOTIFICATIONS_QUERY_KEY,
     );
+    const wasDismissed = previous?.includes(parsed.data) ?? false;
     queryClient.setQueryData<string[]>(
       DISMISSED_NOTIFICATIONS_QUERY_KEY,
-      (prev) =>
-        prev?.includes(parsed.data) ? prev : [...(prev ?? []), parsed.data],
+      (current) =>
+        current?.includes(parsed.data)
+          ? current
+          : [...(current ?? []), parsed.data],
     );
 
-    void getClient()
-      .api["dismissed-notifications"][":key"].$put({
-        param: { key: parsed.data },
-      })
-      .then((res) => {
-        if (res.ok) return;
-        if (previous !== undefined) {
-          queryClient.setQueryData(DISMISSED_NOTIFICATIONS_QUERY_KEY, previous);
-        } else {
-          void queryClient.invalidateQueries({
-            queryKey: DISMISSED_NOTIFICATIONS_QUERY_KEY,
-          });
+    enqueueWrite(
+      parsed.data,
+      generation,
+      () =>
+        getClient().api["dismissed-notifications"][":key"].$put({
+          param: { key: parsed.data },
+        }),
+      () => {
+        if (!wasDismissed) {
+          queryClient.setQueryData<string[]>(
+            DISMISSED_NOTIFICATIONS_QUERY_KEY,
+            (current) => (current ?? []).filter((item) => item !== parsed.data),
+          );
         }
-      })
-      .catch(() => {
-        if (previous !== undefined) {
-          queryClient.setQueryData(DISMISSED_NOTIFICATIONS_QUERY_KEY, previous);
-        } else {
-          void queryClient.invalidateQueries({
-            queryKey: DISMISSED_NOTIFICATIONS_QUERY_KEY,
-          });
-        }
-      });
+      },
+    );
   }, [key, queryClient]);
 
   const reset = useCallback(() => {
     const parsed = notificationKeySchema.safeParse(key);
     if (!parsed.success) return;
 
+    const generation = beginWrite(parsed.data);
+    void queryClient.cancelQueries(
+      { queryKey: DISMISSED_NOTIFICATIONS_QUERY_KEY },
+      { revert: false },
+    );
     const previous = queryClient.getQueryData<string[]>(
       DISMISSED_NOTIFICATIONS_QUERY_KEY,
     );
+    const wasDismissed = previous?.includes(parsed.data) ?? false;
     queryClient.setQueryData<string[]>(
       DISMISSED_NOTIFICATIONS_QUERY_KEY,
-      (prev) => (prev ?? []).filter((k) => k !== parsed.data),
+      (current) => (current ?? []).filter((item) => item !== parsed.data),
     );
 
-    void getClient()
-      .api["dismissed-notifications"][":key"].$delete({
-        param: { key: parsed.data },
-      })
-      .then((res) => {
-        if (res.ok) return;
-        if (previous !== undefined) {
-          queryClient.setQueryData(DISMISSED_NOTIFICATIONS_QUERY_KEY, previous);
-        } else {
-          void queryClient.invalidateQueries({
-            queryKey: DISMISSED_NOTIFICATIONS_QUERY_KEY,
-          });
+    enqueueWrite(
+      parsed.data,
+      generation,
+      () =>
+        getClient().api["dismissed-notifications"][":key"].$delete({
+          param: { key: parsed.data },
+        }),
+      () => {
+        if (wasDismissed) {
+          queryClient.setQueryData<string[]>(
+            DISMISSED_NOTIFICATIONS_QUERY_KEY,
+            (current) =>
+              current?.includes(parsed.data)
+                ? current
+                : [...(current ?? []), parsed.data],
+          );
         }
-      })
-      .catch(() => {
-        if (previous !== undefined) {
-          queryClient.setQueryData(DISMISSED_NOTIFICATIONS_QUERY_KEY, previous);
-        } else {
-          void queryClient.invalidateQueries({
-            queryKey: DISMISSED_NOTIFICATIONS_QUERY_KEY,
-          });
-        }
-      });
+      },
+    );
   }, [key, queryClient]);
 
   return { ready, dismissed, dismiss, reset };

--- a/apps/electron/src/renderer/src/hooks/use-dismissible.ts
+++ b/apps/electron/src/renderer/src/hooks/use-dismissible.ts
@@ -1,3 +1,4 @@
+import { notificationKeySchema } from "@freestyle-voice/validations";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { getClient } from "../lib/api";
@@ -7,7 +8,7 @@ import {
 } from "../lib/query";
 
 export interface UseDismissibleResult {
-  /** True once the dismissed-keys list has loaded (or failed). */
+  /** True once the dismissed-keys list has loaded (or a prior cache exists). */
   ready: boolean;
   /** Whether this key has been dismissed on this device. */
   dismissed: boolean;
@@ -23,9 +24,13 @@ export interface UseDismissibleResult {
  * /api/dismissed-notifications` via a shared React Query cache so every
  * consumer of the same (or different) key shares one fetch.
  *
- * Presence of `key` in the list means dismissed. Writes are optimistic and
- * fire-and-forget — a failed PUT/DELETE leaves the optimistic UI state in
- * place until the next refetch.
+ * Presence of `key` in the list means dismissed. Writes are optimistic; a
+ * non-OK response rolls the cache back (or invalidates if we have no
+ * snapshot). Invalid / empty keys are no-ops.
+ *
+ * Storage follows the configured Freestyle server — the same SQLite DB as
+ * settings/vocabulary. On a remote server that means dismissals are shared
+ * across every renderer pointed at it (consistent with how settings work).
  *
  * @example
  * ```tsx
@@ -36,33 +41,91 @@ export interface UseDismissibleResult {
  */
 export function useDismissible(key: string): UseDismissibleResult {
   const queryClient = useQueryClient();
-  const { data, isLoading } = useQuery(dismissedNotificationsQueryOptions());
+  const { data, isPending, isError } = useQuery(
+    dismissedNotificationsQueryOptions(),
+  );
 
-  const dismissed = (data ?? []).includes(key);
-  const ready = !isLoading;
+  // Fail closed on a first-fetch error (no cached data): don't flash a
+  // previously-dismissed banner while the loopback is unreachable.
+  const dismissed =
+    (data ?? []).includes(key) || (isError && data === undefined);
+  // Ready once we have a definitive answer — success, cached data under
+  // error, or a hard error we fail-closed on above.
+  const ready = !isPending;
 
   const dismiss = useCallback(() => {
+    const parsed = notificationKeySchema.safeParse(key);
+    if (!parsed.success) return;
+
+    const previous = queryClient.getQueryData<string[]>(
+      DISMISSED_NOTIFICATIONS_QUERY_KEY,
+    );
     queryClient.setQueryData<string[]>(
       DISMISSED_NOTIFICATIONS_QUERY_KEY,
-      (prev) => (prev?.includes(key) ? prev : [...(prev ?? []), key]),
+      (prev) =>
+        prev?.includes(parsed.data) ? prev : [...(prev ?? []), parsed.data],
     );
-    getClient()
+
+    void getClient()
       .api["dismissed-notifications"][":key"].$put({
-        param: { key },
+        param: { key: parsed.data },
       })
-      .catch(() => {});
+      .then((res) => {
+        if (res.ok) return;
+        if (previous !== undefined) {
+          queryClient.setQueryData(DISMISSED_NOTIFICATIONS_QUERY_KEY, previous);
+        } else {
+          void queryClient.invalidateQueries({
+            queryKey: DISMISSED_NOTIFICATIONS_QUERY_KEY,
+          });
+        }
+      })
+      .catch(() => {
+        if (previous !== undefined) {
+          queryClient.setQueryData(DISMISSED_NOTIFICATIONS_QUERY_KEY, previous);
+        } else {
+          void queryClient.invalidateQueries({
+            queryKey: DISMISSED_NOTIFICATIONS_QUERY_KEY,
+          });
+        }
+      });
   }, [key, queryClient]);
 
   const reset = useCallback(() => {
+    const parsed = notificationKeySchema.safeParse(key);
+    if (!parsed.success) return;
+
+    const previous = queryClient.getQueryData<string[]>(
+      DISMISSED_NOTIFICATIONS_QUERY_KEY,
+    );
     queryClient.setQueryData<string[]>(
       DISMISSED_NOTIFICATIONS_QUERY_KEY,
-      (prev) => (prev ?? []).filter((k) => k !== key),
+      (prev) => (prev ?? []).filter((k) => k !== parsed.data),
     );
-    getClient()
+
+    void getClient()
       .api["dismissed-notifications"][":key"].$delete({
-        param: { key },
+        param: { key: parsed.data },
       })
-      .catch(() => {});
+      .then((res) => {
+        if (res.ok) return;
+        if (previous !== undefined) {
+          queryClient.setQueryData(DISMISSED_NOTIFICATIONS_QUERY_KEY, previous);
+        } else {
+          void queryClient.invalidateQueries({
+            queryKey: DISMISSED_NOTIFICATIONS_QUERY_KEY,
+          });
+        }
+      })
+      .catch(() => {
+        if (previous !== undefined) {
+          queryClient.setQueryData(DISMISSED_NOTIFICATIONS_QUERY_KEY, previous);
+        } else {
+          void queryClient.invalidateQueries({
+            queryKey: DISMISSED_NOTIFICATIONS_QUERY_KEY,
+          });
+        }
+      });
   }, [key, queryClient]);
 
   return { ready, dismissed, dismiss, reset };

--- a/apps/electron/src/renderer/src/hooks/use-dismissible.ts
+++ b/apps/electron/src/renderer/src/hooks/use-dismissible.ts
@@ -1,0 +1,69 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { getClient } from "../lib/api";
+import {
+  DISMISSED_NOTIFICATIONS_QUERY_KEY,
+  dismissedNotificationsQueryOptions,
+} from "../lib/query";
+
+export interface UseDismissibleResult {
+  /** True once the dismissed-keys list has loaded (or failed). */
+  ready: boolean;
+  /** Whether this key has been dismissed on this device. */
+  dismissed: boolean;
+  /** Permanently dismiss — records the key so the UI won't show again. */
+  dismiss: () => void;
+  /** Undo a dismissal — removes the key so the UI can show again. */
+  reset: () => void;
+}
+
+/**
+ * Device-local dismissible state for in-app dialogs/banners (changelogs,
+ * feature prompts, profile nudges). Backed by `GET/PUT/DELETE
+ * /api/dismissed-notifications` via a shared React Query cache so every
+ * consumer of the same (or different) key shares one fetch.
+ *
+ * Presence of `key` in the list means dismissed. Writes are optimistic and
+ * fire-and-forget — a failed PUT/DELETE leaves the optimistic UI state in
+ * place until the next refetch.
+ *
+ * @example
+ * ```tsx
+ * const { dismissed, dismiss, ready } = useDismissible("profile_info_prompt");
+ * if (!ready || dismissed) return null;
+ * return <Banner onClose={dismiss} />;
+ * ```
+ */
+export function useDismissible(key: string): UseDismissibleResult {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery(dismissedNotificationsQueryOptions());
+
+  const dismissed = (data ?? []).includes(key);
+  const ready = !isLoading;
+
+  const dismiss = useCallback(() => {
+    queryClient.setQueryData<string[]>(
+      DISMISSED_NOTIFICATIONS_QUERY_KEY,
+      (prev) => (prev?.includes(key) ? prev : [...(prev ?? []), key]),
+    );
+    getClient()
+      .api["dismissed-notifications"][":key"].$put({
+        param: { key },
+      })
+      .catch(() => {});
+  }, [key, queryClient]);
+
+  const reset = useCallback(() => {
+    queryClient.setQueryData<string[]>(
+      DISMISSED_NOTIFICATIONS_QUERY_KEY,
+      (prev) => (prev ?? []).filter((k) => k !== key),
+    );
+    getClient()
+      .api["dismissed-notifications"][":key"].$delete({
+        param: { key },
+      })
+      .catch(() => {});
+  }, [key, queryClient]);
+
+  return { ready, dismissed, dismiss, reset };
+}

--- a/apps/electron/src/renderer/src/lib/query.ts
+++ b/apps/electron/src/renderer/src/lib/query.ts
@@ -60,6 +60,32 @@ export function configQueryOptions() {
 }
 
 /**
+ * Shared query key for dismissed notification keys
+ * (`GET /api/dismissed-notifications`). One key so every `useDismissible`
+ * consumer shares a single cached list.
+ */
+export const DISMISSED_NOTIFICATIONS_QUERY_KEY = [
+  "dismissed-notifications",
+] as const;
+
+/**
+ * Query options for the device-local dismissed-notification key list. Use with
+ * `useQuery`:
+ *
+ *   const { data } = useQuery(dismissedNotificationsQueryOptions());
+ */
+export function dismissedNotificationsQueryOptions() {
+  return {
+    queryKey: DISMISSED_NOTIFICATIONS_QUERY_KEY,
+    queryFn: async (): Promise<string[]> => {
+      const res = await getClient().api["dismissed-notifications"].$get();
+      if (!res.ok) throw new Error("Failed to load dismissed notifications");
+      return (await res.json()) as string[];
+    },
+  };
+}
+
+/**
  * Shared QueryClient factory for the renderer. Defaults suit a desktop SPA:
  * - `refetchOnWindowFocus: false` — the user switches apps constantly; focus
  *   refetches would be noisy. Freshness is driven by explicit invalidation

--- a/apps/electron/src/renderer/src/pages/history.tsx
+++ b/apps/electron/src/renderer/src/pages/history.tsx
@@ -185,30 +185,55 @@ export default function HistoryPage(): React.JSX.Element {
   // The filter dialog is transient UI, not persisted state.
   const [filtersOpen, setFiltersOpen] = useState(false);
 
-  // The intro hero (dictation tutorial) can be dismissed with its X and
-  // brought back from the filter dialog's Tutorial toggle. Persisted via the
-  // shared dismissed-notifications store (SQLite) so the choice survives
-  // navigation and app restarts.
+  // Keep the legacy localStorage flag as a synchronous compatibility mirror:
+  // it prevents a flash for users who dismissed the hero before the SQLite
+  // store existed and preserves their choice if the migration PUT fails.
+  const [legacyHeroDismissed, setLegacyHeroDismissed] = usePersistentState<
+    "0" | "1"
+  >(
+    "today.heroDismissed",
+    "0",
+    (value): value is "0" | "1" => value === "0" || value === "1",
+  );
   const {
-    dismissed: heroDismissed,
-    dismiss: dismissHero,
-    reset: resetHero,
+    dismissed: storedHeroDismissed,
+    dismiss: persistHeroDismissal,
+    reset: resetStoredHeroDismissal,
     ready: heroReady,
   } = useDismissible(KNOWN_NOTIFICATION_KEYS.TODAY_TUTORIAL_HERO);
+  const heroDismissed = storedHeroDismissed || legacyHeroDismissed === "1";
+  const migrationAttemptedRef = useRef(false);
 
-  // One-time migration from the previous localStorage flag so users who
-  // already dismissed the hero don't see it flash back after this change.
+  // Best-effort one-time migration per mount. The legacy mirror is deliberately
+  // retained until the user explicitly resets the tutorial; if this PUT fails,
+  // the old dismissal still survives and migration retries next app launch.
   useEffect(() => {
-    if (!heroReady || heroDismissed) return;
-    try {
-      const legacy = localStorage.getItem("today.heroDismissed");
-      if (legacy !== "1") return;
-      localStorage.removeItem("today.heroDismissed");
-      dismissHero();
-    } catch {
-      // localStorage unavailable — nothing to migrate.
+    if (
+      !heroReady ||
+      storedHeroDismissed ||
+      legacyHeroDismissed !== "1" ||
+      migrationAttemptedRef.current
+    ) {
+      return;
     }
-  }, [heroReady, heroDismissed, dismissHero]);
+    migrationAttemptedRef.current = true;
+    persistHeroDismissal();
+  }, [
+    heroReady,
+    storedHeroDismissed,
+    legacyHeroDismissed,
+    persistHeroDismissal,
+  ]);
+
+  const dismissHero = useCallback(() => {
+    setLegacyHeroDismissed("1");
+    persistHeroDismissal();
+  }, [persistHeroDismissal, setLegacyHeroDismissed]);
+
+  const resetHero = useCallback(() => {
+    setLegacyHeroDismissed("0");
+    resetStoredHeroDismissal();
+  }, [resetStoredHeroDismissal, setLegacyHeroDismissed]);
 
   const setShowTutorial = useCallback(
     (value: boolean) => {

--- a/apps/electron/src/renderer/src/pages/history.tsx
+++ b/apps/electron/src/renderer/src/pages/history.tsx
@@ -1,6 +1,7 @@
 import {
   DEFAULT_HISTORY_FILTERS,
   type HistoryFiltersSetting,
+  KNOWN_NOTIFICATION_KEYS,
   parseHistoryFilters,
 } from "@freestyle-voice/validations";
 import { DragSpacer } from "@renderer/components/drag-spacer";
@@ -25,6 +26,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@renderer/components/ui/tooltip";
+import { useDismissible } from "@renderer/hooks/use-dismissible";
 import {
   usePersistentJsonState,
   usePersistentState,
@@ -184,20 +186,36 @@ export default function HistoryPage(): React.JSX.Element {
   const [filtersOpen, setFiltersOpen] = useState(false);
 
   // The intro hero (dictation tutorial) can be dismissed with its X and
-  // brought back from the filter dialog's Tutorial toggle. Persisted in
-  // localStorage so the choice survives navigation and app restarts.
-  const [heroDismissed, setHeroDismissed] = usePersistentState<"0" | "1">(
-    "today.heroDismissed",
-    "0",
-    (v): v is "0" | "1" => v === "0" || v === "1",
-  );
-  const dismissHero = useCallback(
-    () => setHeroDismissed("1"),
-    [setHeroDismissed],
-  );
+  // brought back from the filter dialog's Tutorial toggle. Persisted via the
+  // shared dismissed-notifications store (SQLite) so the choice survives
+  // navigation and app restarts.
+  const {
+    dismissed: heroDismissed,
+    dismiss: dismissHero,
+    reset: resetHero,
+    ready: heroReady,
+  } = useDismissible(KNOWN_NOTIFICATION_KEYS.TODAY_TUTORIAL_HERO);
+
+  // One-time migration from the previous localStorage flag so users who
+  // already dismissed the hero don't see it flash back after this change.
+  useEffect(() => {
+    if (!heroReady || heroDismissed) return;
+    try {
+      const legacy = localStorage.getItem("today.heroDismissed");
+      if (legacy !== "1") return;
+      localStorage.removeItem("today.heroDismissed");
+      dismissHero();
+    } catch {
+      // localStorage unavailable — nothing to migrate.
+    }
+  }, [heroReady, heroDismissed, dismissHero]);
+
   const setShowTutorial = useCallback(
-    (value: boolean) => setHeroDismissed(value ? "0" : "1"),
-    [setHeroDismissed],
+    (value: boolean) => {
+      if (value) resetHero();
+      else dismissHero();
+    },
+    [dismissHero, resetHero],
   );
 
   // Stats sidebar visibility and width. Open by default, collapsible, and
@@ -518,7 +536,7 @@ export default function HistoryPage(): React.JSX.Element {
 
   const isGenuineEmpty = stats?.unfiltered_total_sessions === 0;
 
-  const hero = heroDismissed === "0" && !isGenuineEmpty && (
+  const hero = heroReady && !heroDismissed && !isGenuineEmpty && (
     <div className="relative mb-7">
       <button
         type="button"
@@ -669,7 +687,7 @@ export default function HistoryPage(): React.JSX.Element {
       diffMode={diffMode}
       showAiEdits={showAiEdits}
       nerdMode={nerdMode}
-      showTutorial={heroDismissed === "0"}
+      showTutorial={heroReady && !heroDismissed}
       onSelectRange={selectDateRange}
       onDiffModeChange={setDiffMode}
       onShowAiEditsChange={setShowAiEdits}

--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import { KeyboardDictationStrip } from "@/components/keyboard-dictation-strip";
 import { useAuth } from "@/hooks/use-auth";
+import { DismissiblesProvider } from "@/lib/dismissibles";
 import { EntriesProvider } from "@/lib/entries";
 import { HistoryProvider } from "@/lib/history";
 import { KeyboardDictationProvider } from "@/lib/keyboard/keyboard-dictation-provider";
@@ -29,18 +30,20 @@ export default function AppLayout() {
       <EntriesProvider>
         <HistoryProvider>
           <OnboardingProvider>
-            <KeyboardDictationProvider>
-              <OnboardingGate />
-              <Stack screenOptions={{ headerShown: false }}>
-                <Stack.Screen name="(tabs)" />
-                <Stack.Screen name="onboarding" />
-                <Stack.Screen name="settings" />
-                <Stack.Screen name="profile" />
-                <Stack.Screen name="keyboard-setup" />
-                <Stack.Screen name="billing" />
-              </Stack>
-              <KeyboardDictationStrip />
-            </KeyboardDictationProvider>
+            <DismissiblesProvider>
+              <KeyboardDictationProvider>
+                <OnboardingGate />
+                <Stack screenOptions={{ headerShown: false }}>
+                  <Stack.Screen name="(tabs)" />
+                  <Stack.Screen name="onboarding" />
+                  <Stack.Screen name="settings" />
+                  <Stack.Screen name="profile" />
+                  <Stack.Screen name="keyboard-setup" />
+                  <Stack.Screen name="billing" />
+                </Stack>
+                <KeyboardDictationStrip />
+              </KeyboardDictationProvider>
+            </DismissiblesProvider>
           </OnboardingProvider>
         </HistoryProvider>
       </EntriesProvider>

--- a/apps/mobile/src/lib/dismissibles.tsx
+++ b/apps/mobile/src/lib/dismissibles.tsx
@@ -11,7 +11,10 @@
  * no-ops so a typo can't poison the store.
  */
 
-import { notificationKeySchema } from "@freestyle-voice/validations";
+import {
+  type DismissibleNotificationState,
+  notificationKeySchema,
+} from "@freestyle-voice/validations";
 import {
   createContext,
   type ReactNode,
@@ -48,16 +51,21 @@ export function DismissiblesProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const stored = await getJsonPref<string[]>(STORAGE_KEY, []);
-      if (cancelled) return;
-      setKeys(
-        new Set(
-          stored.filter(
-            (k): k is string => typeof k === "string" && isValidKey(k),
+      try {
+        const stored = await getJsonPref<string[]>(STORAGE_KEY, []);
+        if (cancelled) return;
+        setKeys(
+          new Set(
+            stored.filter(
+              (k): k is string => typeof k === "string" && isValidKey(k),
+            ),
           ),
-        ),
-      );
-      setReady(true);
+        );
+      } catch {
+        // Storage can be unavailable; degrade to an empty in-memory store.
+      } finally {
+        if (!cancelled) setReady(true);
+      }
     })();
     return () => {
       cancelled = true;
@@ -68,32 +76,42 @@ export function DismissiblesProvider({ children }: { children: ReactNode }) {
   // concurrent double-invokes can't write AsyncStorage for a discarded state.
   useEffect(() => {
     if (!ready) return;
-    void setJsonPref(STORAGE_KEY, [...keys]);
+    void setJsonPref(STORAGE_KEY, [...keys]).catch(() => {});
   }, [keys, ready]);
 
-  const dismiss = useCallback((key: string) => {
-    const parsed = notificationKeySchema.safeParse(key);
-    if (!parsed.success) return;
+  const dismiss = useCallback(
+    (key: string) => {
+      // Consumers should already gate on `ready`; enforcing it here prevents
+      // an early action from being overwritten by the hydration result.
+      if (!ready) return;
+      const parsed = notificationKeySchema.safeParse(key);
+      if (!parsed.success) return;
 
-    setKeys((prev) => {
-      if (prev.has(parsed.data)) return prev;
-      const next = new Set(prev);
-      next.add(parsed.data);
-      return next;
-    });
-  }, []);
+      setKeys((prev) => {
+        if (prev.has(parsed.data)) return prev;
+        const next = new Set(prev);
+        next.add(parsed.data);
+        return next;
+      });
+    },
+    [ready],
+  );
 
-  const reset = useCallback((key: string) => {
-    const parsed = notificationKeySchema.safeParse(key);
-    if (!parsed.success) return;
+  const reset = useCallback(
+    (key: string) => {
+      if (!ready) return;
+      const parsed = notificationKeySchema.safeParse(key);
+      if (!parsed.success) return;
 
-    setKeys((prev) => {
-      if (!prev.has(parsed.data)) return prev;
-      const next = new Set(prev);
-      next.delete(parsed.data);
-      return next;
-    });
-  }, []);
+      setKeys((prev) => {
+        if (!prev.has(parsed.data)) return prev;
+        const next = new Set(prev);
+        next.delete(parsed.data);
+        return next;
+      });
+    },
+    [ready],
+  );
 
   const value = useMemo(
     () => ({ ready, dismissedKeys: keys, dismiss, reset }),
@@ -107,17 +125,6 @@ export function DismissiblesProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export interface UseDismissibleResult {
-  /** True once AsyncStorage has hydrated. */
-  ready: boolean;
-  /** Whether this key has been dismissed on this device. */
-  dismissed: boolean;
-  /** Permanently dismiss — records the key so the UI won't show again. */
-  dismiss: () => void;
-  /** Undo a dismissal — removes the key so the UI can show again. */
-  reset: () => void;
-}
-
 /**
  * Per-key view over the shared dismissibles store.
  *
@@ -128,7 +135,7 @@ export interface UseDismissibleResult {
  * return <Banner onClose={dismiss} />;
  * ```
  */
-export function useDismissible(key: string): UseDismissibleResult {
+export function useDismissible(key: string): DismissibleNotificationState {
   const ctx = useContext(DismissiblesContext);
   if (!ctx) {
     throw new Error(

--- a/apps/mobile/src/lib/dismissibles.tsx
+++ b/apps/mobile/src/lib/dismissibles.tsx
@@ -1,0 +1,132 @@
+/**
+ * Device-local dismissible state for in-app dialogs/banners (changelogs,
+ * feature prompts, profile nudges). Persisted via the shared AsyncStorage pref
+ * store as a JSON string array. Presence of a key means dismissed.
+ *
+ * Not cloud-synced — dismissals are per-device (same treatment as
+ * `onboarding_complete`). Exposes a `ready` gate so consumers don't flash a
+ * dialog before the stored list has hydrated.
+ */
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { getJsonPref, setJsonPref } from "./storage";
+
+const STORAGE_KEY = "dismissed_notifications";
+
+interface DismissiblesContextValue {
+  ready: boolean;
+  dismissedKeys: ReadonlySet<string>;
+  dismiss: (key: string) => void;
+  reset: (key: string) => void;
+}
+
+const DismissiblesContext = createContext<DismissiblesContextValue | null>(
+  null,
+);
+
+export function DismissiblesProvider({ children }: { children: ReactNode }) {
+  const [keys, setKeys] = useState<Set<string>>(() => new Set());
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const stored = await getJsonPref<string[]>(STORAGE_KEY, []);
+      setKeys(
+        new Set(stored.filter((k) => typeof k === "string" && k.length > 0)),
+      );
+      setReady(true);
+    })();
+  }, []);
+
+  const persist = useCallback((next: Set<string>) => {
+    void setJsonPref(STORAGE_KEY, [...next]);
+  }, []);
+
+  const dismiss = useCallback(
+    (key: string) => {
+      setKeys((prev) => {
+        if (prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.add(key);
+        persist(next);
+        return next;
+      });
+    },
+    [persist],
+  );
+
+  const reset = useCallback(
+    (key: string) => {
+      setKeys((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        persist(next);
+        return next;
+      });
+    },
+    [persist],
+  );
+
+  const value = useMemo(
+    () => ({ ready, dismissedKeys: keys, dismiss, reset }),
+    [ready, keys, dismiss, reset],
+  );
+
+  return (
+    <DismissiblesContext.Provider value={value}>
+      {children}
+    </DismissiblesContext.Provider>
+  );
+}
+
+export interface UseDismissibleResult {
+  /** True once AsyncStorage has hydrated. */
+  ready: boolean;
+  /** Whether this key has been dismissed on this device. */
+  dismissed: boolean;
+  /** Permanently dismiss — records the key so the UI won't show again. */
+  dismiss: () => void;
+  /** Undo a dismissal — removes the key so the UI can show again. */
+  reset: () => void;
+}
+
+/**
+ * Per-key view over the shared dismissibles store.
+ *
+ * @example
+ * ```tsx
+ * const { dismissed, dismiss, ready } = useDismissible("profile_info_prompt");
+ * if (!ready || dismissed) return null;
+ * return <Banner onClose={dismiss} />;
+ * ```
+ */
+export function useDismissible(key: string): UseDismissibleResult {
+  const ctx = useContext(DismissiblesContext);
+  if (!ctx) {
+    throw new Error(
+      "useDismissible must be used within a DismissiblesProvider",
+    );
+  }
+
+  const { ready, dismissedKeys, dismiss: dismissKey, reset: resetKey } = ctx;
+
+  const dismiss = useCallback(() => dismissKey(key), [dismissKey, key]);
+  const reset = useCallback(() => resetKey(key), [resetKey, key]);
+
+  return {
+    ready,
+    dismissed: dismissedKeys.has(key),
+    dismiss,
+    reset,
+  };
+}

--- a/apps/mobile/src/lib/dismissibles.tsx
+++ b/apps/mobile/src/lib/dismissibles.tsx
@@ -6,8 +6,12 @@
  * Not cloud-synced — dismissals are per-device (same treatment as
  * `onboarding_complete`). Exposes a `ready` gate so consumers don't flash a
  * dialog before the stored list has hydrated.
+ *
+ * Keys must match {@link notificationKeySchema}; invalid / empty keys are
+ * no-ops so a typo can't poison the store.
  */
 
+import { notificationKeySchema } from "@freestyle-voice/validations";
 import {
   createContext,
   type ReactNode,
@@ -33,49 +37,63 @@ const DismissiblesContext = createContext<DismissiblesContextValue | null>(
   null,
 );
 
+function isValidKey(key: string): boolean {
+  return notificationKeySchema.safeParse(key).success;
+}
+
 export function DismissiblesProvider({ children }: { children: ReactNode }) {
   const [keys, setKeys] = useState<Set<string>>(() => new Set());
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     (async () => {
       const stored = await getJsonPref<string[]>(STORAGE_KEY, []);
+      if (cancelled) return;
       setKeys(
-        new Set(stored.filter((k) => typeof k === "string" && k.length > 0)),
+        new Set(
+          stored.filter(
+            (k): k is string => typeof k === "string" && isValidKey(k),
+          ),
+        ),
       );
       setReady(true);
     })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  const persist = useCallback((next: Set<string>) => {
-    void setJsonPref(STORAGE_KEY, [...next]);
+  // Persist after hydrate. Kept outside setState updaters so Strict Mode /
+  // concurrent double-invokes can't write AsyncStorage for a discarded state.
+  useEffect(() => {
+    if (!ready) return;
+    void setJsonPref(STORAGE_KEY, [...keys]);
+  }, [keys, ready]);
+
+  const dismiss = useCallback((key: string) => {
+    const parsed = notificationKeySchema.safeParse(key);
+    if (!parsed.success) return;
+
+    setKeys((prev) => {
+      if (prev.has(parsed.data)) return prev;
+      const next = new Set(prev);
+      next.add(parsed.data);
+      return next;
+    });
   }, []);
 
-  const dismiss = useCallback(
-    (key: string) => {
-      setKeys((prev) => {
-        if (prev.has(key)) return prev;
-        const next = new Set(prev);
-        next.add(key);
-        persist(next);
-        return next;
-      });
-    },
-    [persist],
-  );
+  const reset = useCallback((key: string) => {
+    const parsed = notificationKeySchema.safeParse(key);
+    if (!parsed.success) return;
 
-  const reset = useCallback(
-    (key: string) => {
-      setKeys((prev) => {
-        if (!prev.has(key)) return prev;
-        const next = new Set(prev);
-        next.delete(key);
-        persist(next);
-        return next;
-      });
-    },
-    [persist],
-  );
+    setKeys((prev) => {
+      if (!prev.has(parsed.data)) return prev;
+      const next = new Set(prev);
+      next.delete(parsed.data);
+      return next;
+    });
+  }, []);
 
   const value = useMemo(
     () => ({ ready, dismissedKeys: keys, dismiss, reset }),

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -52,6 +52,7 @@ const TIMEOUT_PREFIXES = [
   "/api/settings",
   "/api/keys",
   "/api/dictionary",
+  "/api/dismissed-notifications",
   "/api/vocabulary",
   "/api/history",
   "/api/models",

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -7,7 +7,7 @@ import { countFixes } from "./fixes.js";
 // and would otherwise perturb test module-mock ordering.
 const DEFAULT_CLOUD_URL = "https://service.freestylevoice.com";
 
-const SCHEMA_VERSION = 18;
+const SCHEMA_VERSION = 19;
 
 // Legacy default format-rule patterns (used only by pre-v12 migrations below):
 // domain/phrase entries match as substrings of url+title+app; bare words match
@@ -547,6 +547,19 @@ function applyMigrations(db: DatabaseSync, currentVersion: number): void {
         next_attempt_at TEXT NOT NULL DEFAULT (datetime('now')),
         attempts        INTEGER NOT NULL DEFAULT 0,
         last_error      TEXT
+      )
+    `);
+  }
+
+  if (currentVersion < 19) {
+    // Device-local dismissals for in-app dialogs/banners (changelogs, feature
+    // prompts, profile nudges). Presence of a key means the corresponding UI
+    // has been dismissed and should not be shown again. Not synced to cloud —
+    // dismissals are per-device.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS dismissed_notifications (
+        key          TEXT PRIMARY KEY,
+        dismissed_at TEXT NOT NULL DEFAULT (datetime('now'))
       )
     `);
   }

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -552,10 +552,10 @@ function applyMigrations(db: DatabaseSync, currentVersion: number): void {
   }
 
   if (currentVersion < 19) {
-    // Device-local dismissals for in-app dialogs/banners (changelogs, feature
-    // prompts, profile nudges). Presence of a key means the corresponding UI
-    // has been dismissed and should not be shown again. Not synced to cloud —
-    // dismissals are per-device.
+    // Dismissals for in-app dialogs/banners (changelogs, feature prompts,
+    // profile nudges). Presence of a key means the corresponding UI has been
+    // dismissed and should not be shown again. Not synced to Freestyle Cloud —
+    // stored alongside settings in this server's SQLite DB.
     db.exec(`
       CREATE TABLE IF NOT EXISTS dismissed_notifications (
         key          TEXT PRIMARY KEY,

--- a/apps/server/src/routes/dismissed-notifications.ts
+++ b/apps/server/src/routes/dismissed-notifications.ts
@@ -14,7 +14,15 @@ const dismissedNotifications = new Hono()
     const rows = db
       .prepare("SELECT key FROM dismissed_notifications ORDER BY key ASC")
       .all() as { key: string }[];
-    return c.json(rows.map((row) => row.key));
+    return c.json(
+      rows.flatMap((row) => {
+        const parsed = notificationKeySchema.safeParse(row.key);
+        // Rows written by this route are already canonical. Do not normalize a
+        // corrupt/manual row here: returning a key different from the stored
+        // primary key would make it impossible for DELETE to remove that row.
+        return parsed.success && parsed.data === row.key ? [row.key] : [];
+      }),
+    );
   })
   .put("/:key", (c) => {
     const key = c.req.param("key");

--- a/apps/server/src/routes/dismissed-notifications.ts
+++ b/apps/server/src/routes/dismissed-notifications.ts
@@ -3,9 +3,10 @@ import { Hono } from "hono";
 import { getDb } from "../lib/db.js";
 
 /**
- * Device-local dismissals for in-app dialogs/banners (changelogs, feature
- * prompts, profile nudges). Presence of a key means the corresponding UI has
- * been dismissed. Not synced to cloud — dismissals are per-device.
+ * Dismissals for in-app dialogs/banners (changelogs, feature prompts, profile
+ * nudges). Presence of a key means the corresponding UI has been dismissed.
+ * Not synced to Freestyle Cloud — stored in the local (or configured remote)
+ * server's SQLite DB, the same place settings/vocabulary live.
  */
 const dismissedNotifications = new Hono()
   .get("/", (c) => {

--- a/apps/server/src/routes/dismissed-notifications.ts
+++ b/apps/server/src/routes/dismissed-notifications.ts
@@ -1,0 +1,48 @@
+import { notificationKeySchema } from "@freestyle-voice/validations";
+import { Hono } from "hono";
+import { getDb } from "../lib/db.js";
+
+/**
+ * Device-local dismissals for in-app dialogs/banners (changelogs, feature
+ * prompts, profile nudges). Presence of a key means the corresponding UI has
+ * been dismissed. Not synced to cloud — dismissals are per-device.
+ */
+const dismissedNotifications = new Hono()
+  .get("/", (c) => {
+    const db = getDb();
+    const rows = db
+      .prepare("SELECT key FROM dismissed_notifications ORDER BY key ASC")
+      .all() as { key: string }[];
+    return c.json(rows.map((row) => row.key));
+  })
+  .put("/:key", (c) => {
+    const key = c.req.param("key");
+    const parsed = notificationKeySchema.safeParse(key);
+    if (!parsed.success) {
+      return c.json({ error: "Invalid notification key" }, 400);
+    }
+
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO dismissed_notifications (key) VALUES (?)
+       ON CONFLICT(key) DO NOTHING`,
+    ).run(parsed.data);
+
+    return c.json({ key: parsed.data, dismissed: true });
+  })
+  .delete("/:key", (c) => {
+    const key = c.req.param("key");
+    const parsed = notificationKeySchema.safeParse(key);
+    if (!parsed.success) {
+      return c.json({ error: "Invalid notification key" }, 400);
+    }
+
+    const db = getDb();
+    db.prepare("DELETE FROM dismissed_notifications WHERE key = ?").run(
+      parsed.data,
+    );
+
+    return c.json({ key: parsed.data, dismissed: false });
+  });
+
+export default dismissedNotifications;

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -11,6 +11,7 @@ import auth from "./auth.js";
 import billing from "./billing.js";
 import configRoute from "./config.js";
 import dictionary from "./dictionary.js";
+import dismissedNotifications from "./dismissed-notifications.js";
 import eventsRoute from "./events.js";
 import history from "./history.js";
 import mlxAsr from "./mlx-asr.js";
@@ -69,6 +70,7 @@ const apiRouter = new Hono()
   .route("/transcribe", transcribePreWarmRoute)
   .route("/history", history)
   .route("/dictionary", dictionary)
+  .route("/dismissed-notifications", dismissedNotifications)
   .route("/vocabulary", vocabulary)
   .route("/post-process", postProcessRoute)
   .route("/output", outputRoute)

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -256,6 +256,23 @@ describe("Dismissed notifications", () => {
     expect(await get.json()).toEqual(["changelog.1.0.0"]);
   });
 
+  it("GET sorts valid keys and ignores corrupt rows", async () => {
+    const db = getDb();
+    const insert = db.prepare(
+      "INSERT INTO dismissed_notifications (key) VALUES (?)",
+    );
+    insert.run("today.tutorial_hero");
+    insert.run("profile_info_prompt");
+    insert.run("INVALID KEY");
+    insert.run(" padded_key ");
+
+    const get = await req("/api/dismissed-notifications");
+    expect(await get.json()).toEqual([
+      "profile_info_prompt",
+      "today.tutorial_hero",
+    ]);
+  });
+
   it("PUT rejects an invalid key", async () => {
     const put = await req("/api/dismissed-notifications/BAD KEY!", {
       method: "PUT",

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -215,6 +215,73 @@ describe("Settings", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Dismissed notifications CRUD
+// ---------------------------------------------------------------------------
+
+describe("Dismissed notifications", () => {
+  beforeEach(() => {
+    getDb().exec("DELETE FROM dismissed_notifications");
+  });
+
+  it("GET /api/dismissed-notifications returns empty list initially", async () => {
+    const res = await req("/api/dismissed-notifications");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("PUT dismisses a key and GET lists it", async () => {
+    const put = await req("/api/dismissed-notifications/profile_info_prompt", {
+      method: "PUT",
+    });
+    expect(put.status).toBe(200);
+    expect(await put.json()).toEqual({
+      key: "profile_info_prompt",
+      dismissed: true,
+    });
+
+    const get = await req("/api/dismissed-notifications");
+    expect(await get.json()).toEqual(["profile_info_prompt"]);
+  });
+
+  it("PUT is idempotent for an already-dismissed key", async () => {
+    await req("/api/dismissed-notifications/changelog.1.0.0", {
+      method: "PUT",
+    });
+    const put = await req("/api/dismissed-notifications/changelog.1.0.0", {
+      method: "PUT",
+    });
+    expect(put.status).toBe(200);
+
+    const get = await req("/api/dismissed-notifications");
+    expect(await get.json()).toEqual(["changelog.1.0.0"]);
+  });
+
+  it("PUT rejects an invalid key", async () => {
+    const put = await req("/api/dismissed-notifications/BAD KEY!", {
+      method: "PUT",
+    });
+    expect(put.status).toBe(400);
+  });
+
+  it("DELETE resets a dismissal", async () => {
+    await req("/api/dismissed-notifications/profile_info_prompt", {
+      method: "PUT",
+    });
+    const del = await req("/api/dismissed-notifications/profile_info_prompt", {
+      method: "DELETE",
+    });
+    expect(del.status).toBe(200);
+    expect(await del.json()).toEqual({
+      key: "profile_info_prompt",
+      dismissed: false,
+    });
+
+    const get = await req("/api/dismissed-notifications");
+    expect(await get.json()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Dictionary CRUD
 // ---------------------------------------------------------------------------
 

--- a/apps/server/tests/api.test.ts
+++ b/apps/server/tests/api.test.ts
@@ -263,6 +263,20 @@ describe("Dismissed notifications", () => {
     expect(put.status).toBe(400);
   });
 
+  it("PUT rejects an empty key", async () => {
+    const put = await req("/api/dismissed-notifications/%20", {
+      method: "PUT",
+    });
+    expect(put.status).toBe(400);
+  });
+
+  it("DELETE rejects an invalid key", async () => {
+    const del = await req("/api/dismissed-notifications/NOT%20VALID", {
+      method: "DELETE",
+    });
+    expect(del.status).toBe(400);
+  });
+
   it("DELETE resets a dismissal", async () => {
     await req("/api/dismissed-notifications/profile_info_prompt", {
       method: "PUT",

--- a/apps/server/tests/dismissed-notifications-migration.test.ts
+++ b/apps/server/tests/dismissed-notifications-migration.test.ts
@@ -42,7 +42,7 @@ describe("dismissed_notifications migration (v19)", () => {
     const version = db
       .prepare("SELECT version FROM schema_version WHERE id = 1")
       .get() as { version: number };
-    expect(version.version).toBe(19);
+    expect(version.version).toBeGreaterThanOrEqual(19);
 
     // The expected columns are present and usable. Idempotent insert.
     db.prepare(`INSERT INTO dismissed_notifications (key) VALUES (?)`).run(

--- a/apps/server/tests/dismissed-notifications-migration.test.ts
+++ b/apps/server/tests/dismissed-notifications-migration.test.ts
@@ -9,17 +9,17 @@ afterEach(() => {
   db = null;
 });
 
-describe("sync_outbox migration (v18)", () => {
-  it("creates the sync_outbox table when upgrading an existing DB", () => {
+describe("dismissed_notifications migration (v19)", () => {
+  it("creates the dismissed_notifications table when upgrading an existing DB", () => {
     db = new DatabaseSync(":memory:");
-    // Minimal pre-v18 DB: just the version marker + settings table. The v18
+    // Minimal pre-v19 DB: just the version marker + settings table. The v19
     // migration only adds a new table, so no prior tables are required.
     db.exec(`
       CREATE TABLE schema_version (
         id INTEGER PRIMARY KEY CHECK(id = 1),
         version INTEGER NOT NULL
       );
-      INSERT INTO schema_version (id, version) VALUES (1, 17);
+      INSERT INTO schema_version (id, version) VALUES (1, 18);
 
       CREATE TABLE settings (
         key TEXT PRIMARY KEY,
@@ -33,7 +33,7 @@ describe("sync_outbox migration (v18)", () => {
     // Table exists.
     const table = db
       .prepare(
-        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'sync_outbox'",
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'dismissed_notifications'",
       )
       .get();
     expect(table).toBeDefined();
@@ -44,22 +44,21 @@ describe("sync_outbox migration (v18)", () => {
       .get() as { version: number };
     expect(version.version).toBe(19);
 
-    // The expected columns are present and usable.
+    // The expected columns are present and usable. Idempotent insert.
+    db.prepare(`INSERT INTO dismissed_notifications (key) VALUES (?)`).run(
+      "profile_info_prompt",
+    );
     db.prepare(
-      `INSERT INTO sync_outbox (cloud_field, payload) VALUES (?, ?)`,
-    ).run("languages", '{"languages":["en"]}');
+      `INSERT INTO dismissed_notifications (key) VALUES (?)
+       ON CONFLICT(key) DO NOTHING`,
+    ).run("profile_info_prompt");
+
     const stored = db
       .prepare(
-        "SELECT cloud_field, payload, attempts, next_attempt_at FROM sync_outbox",
+        "SELECT key, dismissed_at FROM dismissed_notifications WHERE key = ?",
       )
-      .get() as {
-      cloud_field: string;
-      payload: string;
-      attempts: number;
-      next_attempt_at: string;
-    };
-    expect(stored.cloud_field).toBe("languages");
-    expect(stored.attempts).toBe(0);
-    expect(stored.next_attempt_at).toBeTruthy();
+      .get("profile_info_prompt") as { key: string; dismissed_at: string };
+    expect(stored.key).toBe("profile_info_prompt");
+    expect(stored.dismissed_at).toBeTruthy();
   });
 });

--- a/apps/server/tests/sync-outbox-migration.test.ts
+++ b/apps/server/tests/sync-outbox-migration.test.ts
@@ -44,7 +44,7 @@ describe("sync_outbox migration (v18)", () => {
     const version = db
       .prepare("SELECT version FROM schema_version WHERE id = 1")
       .get() as { version: number };
-    expect(version.version).toBe(19);
+    expect(version.version).toBeGreaterThanOrEqual(18);
 
     // The expected columns are present and usable.
     db.prepare(

--- a/apps/server/tests/sync-outbox-migration.test.ts
+++ b/apps/server/tests/sync-outbox-migration.test.ts
@@ -14,6 +14,8 @@ describe("sync_outbox migration (v18)", () => {
     db = new DatabaseSync(":memory:");
     // Minimal pre-v18 DB: just the version marker + settings table. The v18
     // migration only adds a new table, so no prior tables are required.
+    // initSchema then runs every subsequent migration through SCHEMA_VERSION,
+    // so the final version asserted below is the current schema head.
     db.exec(`
       CREATE TABLE schema_version (
         id INTEGER PRIMARY KEY CHECK(id = 1),

--- a/packages/validations/src/index.ts
+++ b/packages/validations/src/index.ts
@@ -9,6 +9,7 @@ export * from "./export.js";
 export * from "./local-llm.js";
 export * from "./member-preferences.js";
 export * from "./models.js";
+export * from "./notifications.js";
 export * from "./openai-stt.js";
 export * from "./plugins.js";
 export * from "./post-process.js";

--- a/packages/validations/src/notifications.ts
+++ b/packages/validations/src/notifications.ts
@@ -24,6 +24,8 @@ export type NotificationKey = z.infer<typeof notificationKeySchema>;
 export const KNOWN_NOTIFICATION_KEYS = {
   /** Nudge to fill out job title / industry on the profile. */
   PROFILE_INFO_PROMPT: "profile_info_prompt",
+  /** Today-page dictation tutorial hero (dismissible banner). */
+  TODAY_TUTORIAL_HERO: "today.tutorial_hero",
 } as const;
 
 export type KnownNotificationKey =

--- a/packages/validations/src/notifications.ts
+++ b/packages/validations/src/notifications.ts
@@ -15,6 +15,18 @@ export const notificationKeySchema = z
 
 export type NotificationKey = z.infer<typeof notificationKeySchema>;
 
+/** Cross-platform return contract for `useDismissible(key)`. */
+export interface DismissibleNotificationState {
+  /** True once the persisted dismissal state has hydrated. */
+  ready: boolean;
+  /** Whether this key has been dismissed in the current store. */
+  dismissed: boolean;
+  /** Record the key so its notification is not shown again. */
+  dismiss: () => void;
+  /** Remove the key so its notification may be shown again. */
+  reset: () => void;
+}
+
 /**
  * Registry of concrete dialog/banner keys shared by desktop and mobile.
  * Object keys are UPPER_SNAKE constants; values are the persisted lowercase

--- a/packages/validations/src/notifications.ts
+++ b/packages/validations/src/notifications.ts
@@ -1,0 +1,30 @@
+import { z } from "zod/v3";
+
+/**
+ * Format guard for dismissible-notification keys. Keys are short opaque
+ * identifiers (e.g. `profile_info_prompt`, `changelog.1.2.0`) used as the
+ * primary key of the local `dismissed_notifications` table / AsyncStorage list.
+ * Presence of a key means the corresponding dialog/banner has been dismissed.
+ */
+export const notificationKeySchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .regex(/^[a-z0-9_.:-]+$/);
+
+export type NotificationKey = z.infer<typeof notificationKeySchema>;
+
+/**
+ * Registry of concrete dialog/banner keys shared by desktop and mobile.
+ * Object keys are UPPER_SNAKE constants; values are the persisted lowercase
+ * identifiers. Hooks still accept any string — this is just the source of
+ * truth for real use-sites so callers don't typo free-form literals.
+ */
+export const KNOWN_NOTIFICATION_KEYS = {
+  /** Nudge to fill out job title / industry on the profile. */
+  PROFILE_INFO_PROMPT: "profile_info_prompt",
+} as const;
+
+export type KnownNotificationKey =
+  (typeof KNOWN_NOTIFICATION_KEYS)[keyof typeof KNOWN_NOTIFICATION_KEYS];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a local dismissible-notifications store so in-app dialogs/banners (changelogs, feature prompts, profile nudges) can be permanently dismissed. Desktop and mobile expose a uniform `useDismissible(key)` hook returning `{ dismissed, dismiss, reset, ready }`.

This is **not cloud-synced**. Desktop persists in the configured Freestyle server's SQLite (same place as settings); mobile uses device AsyncStorage.

## Changes

### Shared
- `notificationKeySchema` and `KNOWN_NOTIFICATION_KEYS`
- Shared `DismissibleNotificationState` hook-return contract

### Desktop server
- Schema v19: `dismissed_notifications` table
- `GET/PUT/DELETE /api/dismissed-notifications[/:key]`
- Canonical-key filtering protects clients from corrupt/manual DB rows
- Migration and API tests, including invalid/empty/corrupt key cases

### Desktop renderer
- Shared React Query options and `useDismissible`
- Synchronous optimistic UI with initial-fetch cancellation
- Per-key write queues serialize rapid dismiss/reset operations across hook instances
- Mutation-safe rollback reverts only the failed key
- Today tutorial hero migrated to `useDismissible`
- Legacy localStorage compatibility mirror prevents flashes/data loss and retries migration on a later launch after failure

### Mobile
- `DismissiblesProvider` and `useDismissible` over AsyncStorage
- Storage failures degrade to in-memory state without unhandled rejections
- Actions are gated until hydration to prevent hydrate/write races
- Effect-based persistence avoids side effects inside state updaters
- Wired into the authenticated app provider tree

## Usage

```tsx
const { dismissed, dismiss, ready } = useDismissible(
  KNOWN_NOTIFICATION_KEYS.PROFILE_INFO_PROMPT,
);
if (!ready || dismissed) return null;
// close button calls dismiss()
```

## Verification
- [x] Full server suite: 53 files / 402 tests
- [x] Electron typecheck
- [x] Mobile typecheck
- [x] Biome
- [x] Knip
- [x] Migration, CRUD, invalid key, sorting, and corrupt-row tests
- [ ] Manual: dismiss Today tutorial, restart — remains dismissed; Filters → Tutorial restores it
- [ ] Manual: mobile dismiss/reset persists across restart
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df60b30a-2c40-4ed4-96e3-b8d9b4119b77?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df60b30a-2c40-4ed4-96e3-b8d9b4119b77&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

