### PR TITLE
feat(pill): give the voice pill an arrival and some better endings

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1285,10 +1285,20 @@ async function deliverOutput(
 
   try {
     if (mode === OutputMode.Paste) {
-      await pasteIntoFocusedApp(text, async () => {
-        hidePill();
-        await wait(0);
-      });
+      // The pill deliberately stays up through the paste. It used to be hidden
+      // here, immediately before the synthetic keystroke, which made the
+      // renderer's delivered animation unobservable: by the time `pasteText`
+      // resolved and the capsule began closing into its confirmation mark,
+      // the window it was drawing into had been gone for hundreds of ms.
+      //
+      // Nothing about the paste needs the window down. The pill is created
+      // `focusable: false` (plus a non-activating `panel` on macOS), so it is
+      // never the focused window and the keystroke goes to the same app either
+      // way. Hiding is the renderer's job now — it owns the end of the
+      // session, and calls `pill:hide` when its exit finishes. Both callers of
+      // this function are renderer-driven, so there is always something on the
+      // other side to do it.
+      await pasteIntoFocusedApp(text);
     } else {
       clipboard.writeText(text);
     }

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1285,19 +1285,6 @@ async function deliverOutput(
 
   try {
     if (mode === OutputMode.Paste) {
-      // The pill deliberately stays up through the paste. It used to be hidden
-      // here, immediately before the synthetic keystroke, which made the
-      // renderer's delivered animation unobservable: by the time `pasteText`
-      // resolved and the capsule began closing into its confirmation mark,
-      // the window it was drawing into had been gone for hundreds of ms.
-      //
-      // Nothing about the paste needs the window down. The pill is created
-      // `focusable: false` (plus a non-activating `panel` on macOS), so it is
-      // never the focused window and the keystroke goes to the same app either
-      // way. Hiding is the renderer's job now — it owns the end of the
-      // session, and calls `pill:hide` when its exit finishes. Both callers of
-      // this function are renderer-driven, so there is always something on the
-      // other side to do it.
       await pasteIntoFocusedApp(text);
     } else {
       clipboard.writeText(text);

--- a/apps/electron/src/renderer/src/lib/streamer.test.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.test.ts
@@ -112,7 +112,6 @@ describe("Streamer reconnects an active capture", () => {
     streamer = new Streamer("http://localhost:3000", "", {
       onConfig: vi.fn(),
       onReady: vi.fn(),
-      onPartial: vi.fn(),
       onFinal: vi.fn(),
       onError: vi.fn(),
       onConnectionState: (state) => connectionStates.push(state),

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -26,7 +26,6 @@ export type StreamerConnectionState =
 
 export interface StreamerCallbacks {
   onFinal: (text: string) => void;
-  onCleaned?: (text: string) => void;
   onError: (message: string, code?: string) => void;
   onReady: () => void;
   onConnectionState?: (state: StreamerConnectionState) => void;
@@ -361,16 +360,10 @@ export class Streamer {
           this.flushPendingChunks();
           this.callbacks.onReady();
           break;
-        // Live partials are deliberately not surfaced anywhere in the UI —
-        // the waveform is the feedback while you speak. The message is
-        // acknowledged and dropped rather than dispatched.
         case "partial":
           break;
         case "final":
           this.callbacks.onFinal(msg.text ?? "");
-          break;
-        case "cleaned":
-          this.callbacks.onCleaned?.(msg.text ?? "");
           break;
         case "error":
           this.callbacks.onError(msg.message ?? "Unknown error", msg.code);

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -4,8 +4,9 @@
  * A single Streamer instance stays alive across recording sessions.
  * The renderer↔server WebSocket remains open, while the server may keep
  * the upstream STT provider warm or reopen it per recording depending on
- * provider behavior. Some providers stream live partials; others use the
- * same session transport for a single final transcript on commit.
+ * provider behavior. Live partials are received and dropped — the pill
+ * never shows in-progress text — so what a session yields is a single final
+ * transcript on commit.
  * Recording sessions are delimited by startCapture / commit / cancel
  * rather than rebuilding the whole client pipeline.
  */
@@ -24,7 +25,6 @@ export type StreamerConnectionState =
   | "disconnected";
 
 export interface StreamerCallbacks {
-  onPartial: (text: string) => void;
   onFinal: (text: string) => void;
   onCleaned?: (text: string) => void;
   onError: (message: string, code?: string) => void;
@@ -361,8 +361,10 @@ export class Streamer {
           this.flushPendingChunks();
           this.callbacks.onReady();
           break;
+        // Live partials are deliberately not surfaced anywhere in the UI —
+        // the waveform is the feedback while you speak. The message is
+        // acknowledged and dropped rather than dispatched.
         case "partial":
-          this.callbacks.onPartial(msg.text ?? "");
           break;
         case "final":
           this.callbacks.onFinal(msg.text ?? "");

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -45,6 +45,7 @@ const BAR_X_POSITIONS = Array.from(
   { length: BARS },
   (_, index) => BAR_PITCH * (index + 0.5),
 );
+const BAR_CENTER = (BARS - 1) / 2;
 /**
  * How long each bar represents while recording. Every interval the sampled
  * levels hand off one slot to the left; the bars themselves never move.
@@ -152,33 +153,11 @@ type PillNotice =
   | "unavailable"
   | null;
 
-/**
- * What the row is drawing.
- *
- * There is deliberately no "connecting" mode. The bars only ever show real
- * audio: while the mic is opening they sit at rest, and the first thing that
- * moves them is a sample. A generated ripple in that window reads as "I can
- * hear you, quietly" at the one moment nothing is being heard at all.
- *
- * "settling" is the beat between the two: your last syllable easing down to
- * rest before the machine's sweep starts, so commit is a hand-off rather than
- * a jump cut.
- */
+/** The waveform is either live, settling, or showing transcription progress. */
 type BarMode = "listening" | "settling" | "speaking";
 
-/**
- * How a session ended, and therefore which way the pill leaves. Three endings
- * that were previously one instant `window.hide()`:
- *
- * - "delivered": the text landed. The row closes, a check draws out of it, and
- *   the capsule contracts to a disc around the mark. The only exit allowed to
- *   take its time — all of it runs after the paste, so it costs nothing.
- * - "cancelled": nothing was earned, so nothing is confirmed. Half the
- *   entrance, and deliberately dismissive.
- * - "quiet": nothing was said (a sub-threshold press, an empty result). Same
- *   gesture as cancelled, faster, without the drop.
- */
-type PillExit = "delivered" | "delivered-out" | "cancelled" | "quiet";
+/** Visual treatment for a completed, cancelled, or empty session. */
+type PillExit = "delivered" | "cancelled" | "quiet";
 
 /** Easing of the settle phase — slower than the meter, symmetric. */
 const SETTLE_EASE = 0.24;
@@ -187,36 +166,13 @@ const SETTLE_MS = 180;
 /** Stillness between your voice ending and the machine starting. */
 const HANDOVER_BEAT_MS = 120;
 
-/**
- * The delivered mark, and the length of its path — the dash offset it is drawn
- * from. Hard-coded rather than measured with `getTotalLength()` so the first
- * paint is already in the undrawn state; the path is fixed, so the two can't
- * drift. (Its two segments are ~3.8 and ~7.9 units long.)
- */
 const CHECK_SIZE = 16;
 const CHECK_PATH_LENGTH = 11.7;
 
-/**
- * The delivered sequence. Two rules shaped these numbers:
- *
- * The *closing* is not the point — the mark is. Getting the row out of the way
- * is business, so it moves briskly; the check is the thing the user is meant to
- * read, so it is drawn and then simply **held**. An earlier cut had the mark
- * complete at 300ms and start leaving at 320, which is a confirmation you can
- * miss by blinking.
- *
- * And nothing here animates a layout property. The capsule used to contract to
- * a 30px disc around the check, which meant transitioning `width` — a full
- * layout pass every frame, on a renderer that may still be cold on the first
- * dictation of the session. It read as sluggish and janked exactly where the
- * design wanted to feel most precise. The capsule now holds its shape and
- * leaves on transform and opacity alone.
- */
 const CLOSE_STEP_MS = 18;
 const CLOSE_DUR_MS = 110;
 const CHECK_AT_MS = 90;
 const CHECK_DRAW_MS = 150;
-/** Fully drawn at ~240ms, then this long at rest before it goes. */
 const CHECK_HOLD_MS = 320;
 const CHECK_LEAVE_AT_MS = CHECK_AT_MS + CHECK_DRAW_MS + CHECK_HOLD_MS;
 const CHECK_LEAVE_MS = 110;
@@ -224,20 +180,12 @@ const DELIVERED_TOTAL_MS = CHECK_LEAVE_AT_MS + CHECK_LEAVE_MS;
 const CANCELLED_MS = 140;
 const QUIET_MS = 120;
 
-/** Entrance: one frame at rest, then the capsule rises into place. */
 const ENTER_MS = 260;
-/** Bars arrive right-to-left — the direction samples travel through the row. */
 const ENTER_BAR_STEP_MS = 12;
 const ENTER_BAR_DUR_MS = 180;
 
-/**
- * How long the level may sit under the noise floor before the row admits it
- * isn't hearing anything. Long enough to sit through a pause for breath.
- */
 const SILENCE_MS = 1600;
-/** Per-frame easing of the flatline's draw/retract. */
 const FLAT_EASE = 0.14;
-/** Past this, the status slot opens with an elapsed readout. */
 const ELAPSED_AFTER_MS = 60_000;
 
 // ---------------------------------------------------------------------------
@@ -383,11 +331,6 @@ const ALERT = "#E0805F";
  */
 const BAR_COLOR = "#FFFFFF";
 
-/**
- * The capsule floats over arbitrary content with only a hairline to separate
- * it, which is not enough over a busy background — it dissolves into whatever
- * is behind it. Soft and low: this is separation, not a raised card.
- */
 const PILL_SHADOW = "0 2px 10px rgba(0, 0, 0, 0.22)";
 
 const pillInnerStyle: React.CSSProperties = {
@@ -397,14 +340,8 @@ const pillInnerStyle: React.CSSProperties = {
   border: SURFACE_BORDER,
   backdropFilter: BLUR,
   WebkitBackdropFilter: BLUR,
-  boxShadow: PILL_SHADOW,
   cursor: "grab",
   WebkitAppRegion: "drag",
-  // The delivered mark is an overlay on the capsule, so the capsule has to be
-  // its containing block. `backdrop-filter` already makes one, but relying on
-  // that would mean the mark silently flies to the window corner the day
-  // somebody drops the blur.
-  position: "relative",
 } as React.CSSProperties;
 
 interface TranscribeResult {
@@ -501,31 +438,17 @@ export default function AppPage(): React.JSX.Element {
   const lastCancelWriteRef = useRef(-1);
   const cancelSlotRef = useRef<HTMLSpanElement>(null);
   const waveClipRef = useRef<HTMLSpanElement>(null);
-  const capsuleRef = useRef<HTMLDivElement>(null);
-  const checkRef = useRef<HTMLSpanElement>(null);
-  const checkPathRef = useRef<SVGPathElement>(null);
   const flatlineRef = useRef<SVGLineElement>(null);
-  /**
-   * Silence tracking. `silentSinceRef` is the timestamp the level last went
-   * *above* the noise floor; `flat` is the 0..1 amount of the flatline, eased
-   * in the draw loop so it draws and retracts rather than snapping.
-   */
+  /** Silence state is rendered through the live region and flatline. */
   const silentSinceRef = useRef(0);
   const flatAmountRef = useRef(0);
   const flatTargetRef = useRef(0);
-  /** Mirrors `flatTargetRef` into React only when it crosses, for the live region. */
   const [micSilent, setMicSilent] = useState(false);
   const micSilentRef = useRef(false);
   const [elapsedLabel, setElapsedLabel] = useState<string | null>(null);
   const [exiting, setExiting] = useState<PillExit | null>(null);
-  const exitTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
-  /**
-   * Mirrors `exiting` for the same-tick guard in `dismissPill`. The state
-   * hasn't re-rendered yet when the second caller arrives, and there are
-   * genuinely two: the success path asks for "delivered", then `drainQueue`'s
-   * own `finally` — which cannot know a delivery just happened — asks for
-   * "quiet" a moment later. First ending wins; it is the specific one.
-   */
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Ref guard prevents generic queue cleanup from replacing a specific exit.
   const exitingRef = useRef<PillExit | null>(null);
   const hoveredRef = useRef(false);
   const cancelModeRef = useRef<PillCancelMode>("hover");
@@ -715,8 +638,6 @@ export default function AppPage(): React.JSX.Element {
         return;
       }
 
-      // Whether anything actually reached the user. A plugin that suppressed
-      // the output did not deliver it, and must not be answered with a check.
       let delivered = false;
 
       try {
@@ -773,13 +694,7 @@ export default function AppPage(): React.JSX.Element {
               ? window.api.copyText(deliverText, appContextRef.current)
               : window.api.pasteText(deliverText, appContextRef.current);
 
-          // Start the confirmation on dispatch, not on completion. The text is
-          // in the document within a frame or two of the keystroke, but
-          // `pasteText` doesn't resolve until the main process has waited out
-          // its paste-settle delay — 300ms, and up to 600ms on the legacy
-          // backends. Awaiting that first left the transcribing sweep running
-          // over a document that already had the dictation in it, and the
-          // close only began once the pill had visibly nothing left to do.
+          // Start the exit when delivery is dispatched; pasteText resolves later.
           delivered = true;
           dismissPill("delivered");
 
@@ -805,9 +720,6 @@ export default function AppPage(): React.JSX.Element {
         provider_category: providerCategory,
       });
 
-      // Already started above on the delivering path; this covers the rest —
-      // a suppressed or empty output still has to put the pill away, just
-      // without claiming anything was delivered.
       if (
         !recordingActiveRef.current &&
         queueRef.current.length === 0 &&
@@ -972,7 +884,6 @@ export default function AppPage(): React.JSX.Element {
           }
           resolver({ raw: text, cleaned: text });
         },
-        onCleaned: () => {},
         onError: (msg, code) => {
           const resolver = streamResolverRef.current;
           // Cloud auth expiry and usage limits are terminal — don't fall back
@@ -1030,8 +941,7 @@ export default function AppPage(): React.JSX.Element {
   // The bar elements are created once per mount and only ever have their
   // geometry rewritten, so grab them as the SVG mounts and let the draw loop
   // iterate a plain array instead of querying the DOM 60 times a second.
-  // Scoped to the bar group: the flatline shares this SVG and must never be
-  // mistaken for a level bar.
+  // The flatline is not part of the bar buffer.
   const captureBarLines = useCallback((svg: SVGSVGElement | null) => {
     barLinesRef.current = svg
       ? Array.from(svg.querySelectorAll<SVGLineElement>("[data-bars] line"))
@@ -1054,10 +964,7 @@ export default function AppPage(): React.JSX.Element {
     let fall = FALL;
 
     if (mode === "settling") {
-      // The hand-off. Every bar eases from wherever your voice left it down to
-      // rest — symmetrically, and slower than the live meter — so the last
-      // syllable is set down instead of deleted. Targets are already zero; the
-      // only thing this branch does is own the easing rate.
+      // Let the last live sample settle before switching to the sweep.
       rise = SETTLE_EASE;
       fall = SETTLE_EASE;
     } else if (mode === "speaking") {
@@ -1133,12 +1040,7 @@ export default function AppPage(): React.JSX.Element {
       // becomes a peak once it hands off and joins the history.
       targets[BARS - 1] = barHeightFor(voiceLevel, sample.jitter);
 
-      // ---- Is the mic actually delivering anything? ----
-      // A wrong input device or a hardware mute button renders identically to
-      // a quiet room — a row of resting dots — and today you only find out
-      // from a "No audio captured" dialog after speaking a paragraph. Gated on
-      // the analyser existing, so the getUserMedia window (no audio yet, by
-      // definition) can't trip it.
+      // A sustained floor means the mic may be muted or disconnected.
       if (voiceLevel > BAR_NOISE_FLOOR) {
         silentSinceRef.current = now;
         flatTargetRef.current = 0;
@@ -1172,8 +1074,7 @@ export default function AppPage(): React.JSX.Element {
       (cancelTargetRef.current - cancelOpenRef.current) * CANCEL_EASE;
     cancelOpenRef.current = open;
 
-    // The flatline eases on the same clock as everything else, so it draws
-    // outward from the centre and retracts the moment a real sample lands.
+    // Ease the flatline on the same clock as the bars.
     const flat =
       flatAmountRef.current +
       (flatTargetRef.current - flatAmountRef.current) * FLAT_EASE;
@@ -1199,14 +1100,7 @@ export default function AppPage(): React.JSX.Element {
       const line = lines[i];
       line.setAttribute("y1", String((SVG_HEIGHT + h) / 2));
       line.setAttribute("y2", String((SVG_HEIGHT - h) / 2));
-      // The bars are drawn at full strength — height alone carries the level,
-      // with no dimming on top of it. The one exception is structural: the
-      // oldest bars fade as the cancel button takes their space, so they
-      // dissolve rather than being sliced by the viewport edge closing over
-      // them.
-      // The one structural exception is the oldest bars fading as the cancel
-      // button takes their space; the second is the row dimming while it has
-      // nothing to report, so the flatline is what reads instead of the dots.
+      // Fade the oldest bars for the cancel slot and the whole row for silence.
       const structural = i < CANCEL_HIDDEN_BARS && open > 0 ? 1 - open : 1;
       line.style.opacity = String(structural * (1 - 0.55 * flat));
     }
@@ -1234,8 +1128,9 @@ export default function AppPage(): React.JSX.Element {
   const startBarAnimation = useCallback(
     (mode: BarMode) => {
       cancelAnimationFrame(rafRef.current);
+      const now = performance.now();
       barModeRef.current = mode;
-      modeStartRef.current = performance.now();
+      modeStartRef.current = now;
       // Every mode now writes the shared target buffer, so clear it on the
       // way in. This also means a re-record starts from a flat row instead of
       // inheriting the previous dictation's waveform.
@@ -1245,10 +1140,8 @@ export default function AppPage(): React.JSX.Element {
       // style write against the fresh elements.
       cancelOpenRef.current = cancelTargetRef.current;
       lastCancelWriteRef.current = -1;
-      // Silence is only ever asserted about a live analyser, so every mode
-      // change clears it — including the switch to "speaking", where a
-      // lingering flatline would be about audio that is no longer being read.
-      silentSinceRef.current = mode === "listening" ? performance.now() : 0;
+      // Silence only applies while the analyser is live.
+      silentSinceRef.current = mode === "listening" ? now : 0;
       flatTargetRef.current = 0;
       if (mode !== "listening") flatAmountRef.current = 0;
       if (micSilentRef.current) {
@@ -1256,7 +1149,7 @@ export default function AppPage(): React.JSX.Element {
         setMicSilent(false);
       }
       sampleRef.current = {
-        lastSampleAt: performance.now(),
+        lastSampleAt: now,
         peak: 0,
         jitter: nextJitter(),
       };
@@ -1339,20 +1232,13 @@ export default function AppPage(): React.JSX.Element {
     startBarAnimation,
   ]);
 
-  /**
-   * Commit's hand-off: the row comes to rest, holds still for a beat, and only
-   * then does the machine's sweep start. Without the pause the two waveforms
-   * cross-fade into each other and the moment your voice becomes text — the
-   * pivot the whole product is about — reads as a glitch.
-   */
+  /** Give the live waveform a short settle beat before the progress sweep. */
   const handoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const startHandover = useCallback(() => {
     startBarAnimation("settling");
     if (handoverTimerRef.current) clearTimeout(handoverTimerRef.current);
     handoverTimerRef.current = setTimeout(() => {
       handoverTimerRef.current = null;
-      // Only take the row if nothing else has claimed it in the meantime (a
-      // re-record, a failure, a dismissal).
       if (barModeRef.current === "settling") startBarAnimation("speaking");
     }, SETTLE_MS + HANDOVER_BEAT_MS);
   }, [startBarAnimation]);
@@ -1409,93 +1295,38 @@ export default function AppPage(): React.JSX.Element {
     cancelTargetRef.current = cancelModeRef.current === "always" ? 1 : 0;
     cancelOpenRef.current = cancelTargetRef.current;
     lastCancelWriteRef.current = -1;
-    setElapsedLabel(null);
-    setMicSilent(false);
     setExiting(null);
     exitingRef.current = null;
     // So the next session's `initializing` frames can't read a stale clock.
     startTimeRef.current = 0;
-    for (const timer of exitTimersRef.current) clearTimeout(timer);
-    exitTimersRef.current = [];
+    if (exitTimerRef.current) clearTimeout(exitTimerRef.current);
+    exitTimerRef.current = null;
     stopVisualization();
     window.api.hidePill();
   }, [setPillNotice, stopVisualization, setPillState]);
 
-  /**
-   * The pill leaving, with the ending it earned. `hidePill` stays the
-   * immediate teardown for the cases where something else is taking over the
-   * screen (a sign-in prompt, an upgrade dialog, an error modal) — animating
-   * out from under a modal that is already opening is just latency.
-   *
-   * Every timer is tracked so a new session starting mid-exit cancels it
-   * cleanly rather than hiding the window out from under the new pill.
-   */
+  /** Hide after the selected exit; modal/error paths still call hidePill(). */
   const dismissPill = useCallback(
     (kind: PillExit) => {
       if (!pillActiveRef.current || exitingRef.current) return;
       exitingRef.current = kind;
-      // Recording is over the moment the exit starts, whatever else is still
-      // unwinding — otherwise a hotkey press during the exit sees a live
-      // session and tries to commit into it.
       recordingActiveRef.current = false;
       wantsMicRef.current = false;
       setExiting(kind);
 
-      const after = (delay: number, fn: () => void): void => {
-        exitTimersRef.current.push(setTimeout(fn, delay));
-      };
-
       if (kind !== "delivered") {
-        after(kind === "cancelled" ? CANCELLED_MS : QUIET_MS, hidePill);
+        exitTimerRef.current = setTimeout(
+          hidePill,
+          kind === "cancelled" ? CANCELLED_MS : QUIET_MS,
+        );
         return;
       }
 
-      // ---- Delivered ----
-      // The row closes from the outside in. Every bar collapses *in place*:
-      // scaling the group instead would slide ten round-capped strokes into
-      // each other and the caps clump together well before they merge.
-      //
-      // The draw loop is parked first — it rewrites bar geometry every frame,
-      // and would fight the CSS transitions all the way down.
       cancelAnimationFrame(rafRef.current);
       rafRef.current = 0;
       barModeRef.current = null;
-
-      const lines = barLinesRef.current;
-      for (let i = 0; i < lines.length; i++) {
-        const rank = (BARS - 1) / 2 - Math.abs(i - (BARS - 1) / 2);
-        const delay = Math.round(rank * CLOSE_STEP_MS);
-        lines[i].style.transformOrigin = "50% 50%";
-        lines[i].style.transition =
-          `transform ${CLOSE_DUR_MS}ms cubic-bezier(0.4, 0, 1, 1) ${delay}ms,` +
-          ` opacity ${Math.round(CLOSE_DUR_MS * 0.8)}ms ease ${delay}ms`;
-        lines[i].style.transform = "scaleY(0)";
-        lines[i].style.opacity = "0";
-      }
       if (flatlineRef.current) flatlineRef.current.setAttribute("opacity", "0");
-
-      after(CHECK_AT_MS, () => {
-        // The check draws out of the centre the row just closed on, in the
-        // same white as the bars — the meter resolving, not an icon fading in
-        // over it. It starts while the innermost pair is still collapsing,
-        // which is what binds the two gestures into one.
-        const check = checkRef.current;
-        const path = checkPathRef.current;
-        if (check) {
-          check.style.transition = "opacity 80ms ease";
-          check.style.opacity = "1";
-        }
-        if (path) {
-          path.style.transition = `stroke-dashoffset ${CHECK_DRAW_MS}ms cubic-bezier(0.22, 1, 0.36, 1)`;
-          path.style.strokeDashoffset = "0";
-        }
-      });
-
-      after(CHECK_LEAVE_AT_MS, () => {
-        exitingRef.current = "delivered-out";
-        setExiting("delivered-out");
-      });
-      after(DELIVERED_TOTAL_MS, hidePill);
+      exitTimerRef.current = setTimeout(hidePill, DELIVERED_TOTAL_MS);
     },
     [hidePill],
   );
@@ -1531,6 +1362,12 @@ export default function AppPage(): React.JSX.Element {
       if (wantsMicRef.current) {
         return;
       }
+      if (exitingRef.current) {
+        if (exitTimerRef.current) clearTimeout(exitTimerRef.current);
+        exitTimerRef.current = null;
+        exitingRef.current = null;
+        setExiting(null);
+      }
       wantsMicRef.current = true;
       pillActiveRef.current = true;
       pendingCommitRef.current = false;
@@ -1538,6 +1375,8 @@ export default function AppPage(): React.JSX.Element {
       lastRecordingDurationRef.current = 0;
       setPillNotice(null);
       setCanRetry(false);
+      setElapsedLabel(null);
+      setMicSilent(false);
 
       // Warm the pipeline while the user is speaking so submission doesn't pay
       // startup latency: the local ASR server (whisper/mlx) model load and the
@@ -1574,10 +1413,7 @@ export default function AppPage(): React.JSX.Element {
           });
       });
 
-      // "initializing" is internal bookkeeping for the hotkey-release path; it
-      // has no look of its own. The pill arrives already recording, and the row
-      // waits at rest until the analyser hands it a real sample — which
-      // `startListening` does, without restarting the mode.
+      // Keep initializing as bookkeeping; the waveform starts at rest.
       setPillState("initializing");
       startBarAnimation("listening");
 
@@ -2137,60 +1973,15 @@ export default function AppPage(): React.JSX.Element {
   const showCard = state === "error";
   const active = state !== "idle";
 
-  // ---- Arrival ----
-  // The capsule's enter transition was authored but never ran: the subtree
-  // mounts with its final state already applied, and a CSS transition doesn't
-  // fire on first paint. Hold the resting state for one committed frame, then
-  // release — the same two-frame handshake the card uses for `roomReady`.
-  //
-  // No window-level fade is needed: the pill window is `transparent: true`, so
-  // it shows nothing at all until this paints.
+  // Hold the initial hidden state for one frame so the enter transition runs.
   const [entered, setEntered] = useState(false);
   useEffect(() => {
     if (!active) {
       setEntered(false);
       return;
     }
-    let inner = 0;
-    const outer = requestAnimationFrame(() => {
-      inner = requestAnimationFrame(() => setEntered(true));
-    });
-    return () => {
-      cancelAnimationFrame(outer);
-      cancelAnimationFrame(inner);
-    };
-  }, [active]);
-
-  // The bars arrive right-to-left — the direction samples travel through the
-  // row — from a flat row of nothing to the resting dots. Written straight to
-  // the elements, because the draw loop owns their geometry and React must not
-  // start re-rendering ten <line>s a frame to express this.
-  useEffect(() => {
-    const lines = barLinesRef.current;
-    if (!active || lines.length === 0) return;
-    for (let i = 0; i < lines.length; i++) {
-      lines[i].style.transformOrigin = "50% 50%";
-      lines[i].style.transition = "none";
-      lines[i].style.transform = "scaleY(0)";
-      lines[i].style.opacity = "0";
-    }
-    let inner = 0;
-    const outer = requestAnimationFrame(() => {
-      inner = requestAnimationFrame(() => {
-        for (let i = 0; i < lines.length; i++) {
-          const delay = (lines.length - 1 - i) * ENTER_BAR_STEP_MS;
-          lines[i].style.transition =
-            `transform ${ENTER_BAR_DUR_MS}ms cubic-bezier(0.22, 1, 0.36, 1) ${delay}ms,` +
-            ` opacity ${ENTER_BAR_DUR_MS - 40}ms ease ${delay}ms`;
-          lines[i].style.transform = "scaleY(1)";
-          lines[i].style.opacity = "1";
-        }
-      });
-    });
-    return () => {
-      cancelAnimationFrame(outer);
-      cancelAnimationFrame(inner);
-    };
+    const frame = requestAnimationFrame(() => setEntered(true));
+    return () => cancelAnimationFrame(frame);
   }, [active]);
 
   // ---- Elapsed ----
@@ -2268,39 +2059,16 @@ export default function AppPage(): React.JSX.Element {
           : "Transcription failed";
   const cardBody = failedTranscriptionErrorRef.current;
 
-  // What each surface is *currently drawing*, which is not the same as what
-  // the state says once it starts leaving: the notice that put it there is
-  // usually cleared in the same tick it's dismissed, and re-rendering an empty
-  // label (or a re-derived title) would blank the surface a beat before it has
-  // finished animating out. Latching holds the last real content until the
-  // surface is gone. Writing a ref during render is safe here — it's derived
-  // purely from this render's own values, so a repeat render is a no-op.
-  const statusContentRef = useRef({
-    label: null as string | null,
-    count: null as string | null,
-    isAlert: false,
-  });
-  if (wantsStatus) {
-    statusContentRef.current = {
-      label: statusLabel,
-      count: statusCount,
-      isAlert: statusIsAlert,
-    };
-  }
-  const status = statusContentRef.current;
+  const status = {
+    label: statusLabel,
+    count: statusCount,
+    isAlert: statusIsAlert,
+  };
+  const card = { title: cardTitle, body: cardBody, canRetry };
 
-  const cardContentRef = useRef({ title: "", body: "", canRetry: false });
-  if (showCard) {
-    cardContentRef.current = { title: cardTitle, body: cardBody, canRetry };
-  }
-  const card = cardContentRef.current;
-
-  // The silence notice is the one thing the capsule can't say in a glyph, so
-  // it outranks the generic "Listening" here — this live region is the only
-  // place a screen reader learns the mic has gone quiet.
   const accessibleStatus = showCard
     ? `${cardTitle}. ${cardBody}`
-    : exiting === "delivered" || exiting === "delivered-out"
+    : exiting === "delivered"
       ? "Dictation delivered"
       : (statusLabel ??
         (micSilent
@@ -2346,9 +2114,6 @@ export default function AppPage(): React.JSX.Element {
 
   const cardOpen = showCard && roomReady;
 
-  // The card can sit there for as long as the user takes to answer it, and
-  // the waveform underneath is neither visible nor meaningful by then — park
-  // the draw loop once the capsule has finished fading out.
   useEffect(() => {
     if (!showCard) return;
     const timer = setTimeout(stopVisualization, 260);
@@ -2391,9 +2156,7 @@ export default function AppPage(): React.JSX.Element {
         }
         aria-hidden="true"
       >
-        {/* Drawn under the bars: while the mic is delivering nothing, this
-            draws outward from the centre as the dots dim, so the row reads as
-            a flatline rather than as a quiet room. */}
+        {/* Flatline is drawn under the bars when the mic is silent. */}
         <line
           ref={flatlineRef}
           x1={SVG_WIDTH / 2}
@@ -2406,7 +2169,10 @@ export default function AppPage(): React.JSX.Element {
           opacity={0}
         />
         <g data-bars="">
-          {BAR_X_POSITIONS.map((x) => {
+          {BAR_X_POSITIONS.map((x, index) => {
+            const closeDelay = Math.round(
+              (BAR_CENTER - Math.abs(index - BAR_CENTER)) * CLOSE_STEP_MS,
+            );
             return (
               <line
                 key={x}
@@ -2417,6 +2183,12 @@ export default function AppPage(): React.JSX.Element {
                 stroke={BAR_COLOR}
                 strokeWidth={BAR_WIDTH}
                 strokeLinecap="round"
+                style={
+                  {
+                    "--enter-delay": `${(BARS - 1 - index) * ENTER_BAR_STEP_MS}ms`,
+                    "--close-delay": `${closeDelay}ms`,
+                  } as React.CSSProperties
+                }
               />
             );
           })}
@@ -2454,17 +2226,22 @@ export default function AppPage(): React.JSX.Element {
             pointer-events: auto;
           }
 
-          /* The capsule arrives from the edge it is anchored to, so it reads as
-             coming from off-screen rather than from nowhere in particular.
-             --enter-dy is +6px when the pill sits at the bottom, -6px at the
-             top. */
-          .pill-capsule { transform: scale(0.88) translateY(var(--enter-dy, 6px)); }
+          .pill-capsule {
+            position: relative;
+            box-shadow: ${PILL_SHADOW};
+            transform: scale(0.88) translateY(var(--enter-dy, 6px));
+          }
 
-          /* ---- Endings ----
-             Three of them, and they are not the same gesture. Delivered has
-             something to say and is allowed ~430ms to say it (all of it after
-             the text has landed). Cancelled and quiet earned no confirmation,
-             so they get half the entrance and leave downward. */
+          @keyframes pill-bar-enter {
+            from { transform: scaleY(0); }
+            to { transform: scaleY(1); }
+          }
+          .pill-capsule[data-show="true"] [data-bars] line {
+            transform-origin: 50% 50%;
+            animation: pill-bar-enter ${ENTER_BAR_DUR_MS}ms cubic-bezier(0.22, 1, 0.36, 1)
+              var(--enter-delay) both;
+          }
+
           .pill-capsule[data-exit="cancelled"],
           .pill-capsule[data-exit="quiet"] {
             opacity: 0;
@@ -2477,17 +2254,32 @@ export default function AppPage(): React.JSX.Element {
             transform: scale(0.76);
             transition-duration: ${QUIET_MS}ms;
           }
-          /* Delivered holds its ground while the row closes and the mark draws;
-             only the last beat takes it away. */
-          .pill-capsule[data-exit="delivered-out"] {
-            opacity: 0;
-            transform: scale(0.94);
+
+          @keyframes pill-delivered {
+            0%, ${(CHECK_LEAVE_AT_MS / DELIVERED_TOTAL_MS) * 100}% {
+              opacity: 1;
+              transform: scale(1);
+            }
+            100% {
+              opacity: 0;
+              transform: scale(0.94);
+            }
+          }
+          .pill-capsule[data-exit="delivered"] {
+            animation: pill-delivered ${DELIVERED_TOTAL_MS}ms linear forwards;
             pointer-events: none;
-            transition: opacity ${CHECK_LEAVE_MS}ms ease,
-                        transform ${CHECK_LEAVE_MS}ms cubic-bezier(0.4, 0, 1, 1);
           }
 
-          /* The capsule is draggable and, until now, gave no sign of it. */
+          @keyframes pill-bar-collapse {
+            from { transform: scaleY(1); }
+            to { transform: scaleY(0); }
+          }
+          .pill-capsule[data-exit="delivered"] [data-bars] line {
+            transform-origin: 50% 50%;
+            animation: pill-bar-collapse ${CLOSE_DUR_MS}ms cubic-bezier(0.4, 0, 1, 1)
+              var(--close-delay) both;
+          }
+
           @media (hover: hover) and (pointer: fine) {
             .pill-capsule[data-show="true"]:not([data-exit]):hover {
               transform: translateY(-1px);
@@ -2499,9 +2291,11 @@ export default function AppPage(): React.JSX.Element {
             }
           }
 
-          /* The delivered mark. Drawn, not faded in — and in the same white as
-             the bars, because it is the meter resolving rather than an icon
-             arriving on top of it. */
+          @keyframes pill-check-fade { from { opacity: 0; } to { opacity: 1; } }
+          @keyframes pill-check-draw {
+            from { stroke-dashoffset: ${CHECK_PATH_LENGTH}; }
+            to { stroke-dashoffset: 0; }
+          }
           .pill-check {
             position: absolute;
             inset: 0;
@@ -2511,12 +2305,14 @@ export default function AppPage(): React.JSX.Element {
             opacity: 0;
             pointer-events: none;
           }
+          .pill-capsule[data-exit="delivered"] .pill-check {
+            animation: pill-check-fade 80ms ease ${CHECK_AT_MS}ms both;
+          }
+          .pill-capsule[data-exit="delivered"] .pill-check path {
+            animation: pill-check-draw ${CHECK_DRAW_MS}ms cubic-bezier(0.22, 1, 0.36, 1)
+              ${CHECK_AT_MS}ms both;
+          }
 
-          /* The card grows out of the capsule's own footprint: it starts at the
-             capsule's true ratio (96/300 wide, 30/92 tall) with a
-             proportionally larger corner, so the radius looks constant while
-             the object inflates. Transform and radius only — no width/height
-             animation. */
           .pill-card {
             border-radius: 20px;
             transition: opacity 140ms ease,
@@ -2614,11 +2410,16 @@ export default function AppPage(): React.JSX.Element {
             .pill-status-mark,
             .pill-cancel,
             .pill-action { transition-duration: 1ms !important; }
+            .pill-capsule[data-exit],
+            .pill-capsule[data-show="true"] [data-bars] line,
+            .pill-capsule[data-exit] [data-bars] line,
+            .pill-capsule[data-exit] .pill-check,
+            .pill-capsule[data-exit] .pill-check path {
+              animation-duration: 1ms !important;
+              animation-delay: 0ms !important;
+            }
             .pill-card[data-show="false"] { transform: none; border-radius: 20px; }
             .pill-capsule { transform: none; }
-            /* The check still draws — it is the confirmation, not decoration —
-               but instantly, and it is held rather than animated away. */
-            .pill-check { transition: none !important; }
             /* A spinner that doesn't turn says nothing, so slow it rather
                than stopping it. */
             .pill-spinner { animation-duration: 2.4s; }
@@ -2641,7 +2442,6 @@ export default function AppPage(): React.JSX.Element {
                 pointer-only. */}
             {/* biome-ignore lint/a11y/noStaticElementInteractions: see above */}
             <div
-              ref={capsuleRef}
               className="pill-surface pill-capsule inline-flex items-center"
               data-show={!showCard && entered}
               data-exit={exiting ?? undefined}
@@ -2730,7 +2530,7 @@ export default function AppPage(): React.JSX.Element {
                   the waveform's clip: it takes the place the row occupied, at
                   the row's own centre, and is not subject to the clip that
                   hides retiring samples. */}
-              <span ref={checkRef} className="pill-check" aria-hidden="true">
+              <span className="pill-check" aria-hidden="true">
                 <svg
                   width={CHECK_SIZE}
                   height={CHECK_SIZE}
@@ -2738,7 +2538,6 @@ export default function AppPage(): React.JSX.Element {
                   aria-hidden="true"
                 >
                   <path
-                    ref={checkPathRef}
                     d="M4.1 8.5 6.8 11.2 11.9 5.2"
                     fill="none"
                     stroke={BAR_COLOR}

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -152,7 +152,93 @@ type PillNotice =
   | "unavailable"
   | null;
 
-type BarMode = "connecting" | "listening" | "speaking";
+/**
+ * What the row is drawing.
+ *
+ * There is deliberately no "connecting" mode. The bars only ever show real
+ * audio: while the mic is opening they sit at rest, and the first thing that
+ * moves them is a sample. A generated ripple in that window reads as "I can
+ * hear you, quietly" at the one moment nothing is being heard at all.
+ *
+ * "settling" is the beat between the two: your last syllable easing down to
+ * rest before the machine's sweep starts, so commit is a hand-off rather than
+ * a jump cut.
+ */
+type BarMode = "listening" | "settling" | "speaking";
+
+/**
+ * How a session ended, and therefore which way the pill leaves. Three endings
+ * that were previously one instant `window.hide()`:
+ *
+ * - "delivered": the text landed. The row closes, a check draws out of it, and
+ *   the capsule contracts to a disc around the mark. The only exit allowed to
+ *   take its time — all of it runs after the paste, so it costs nothing.
+ * - "cancelled": nothing was earned, so nothing is confirmed. Half the
+ *   entrance, and deliberately dismissive.
+ * - "quiet": nothing was said (a sub-threshold press, an empty result). Same
+ *   gesture as cancelled, faster, without the drop.
+ */
+type PillExit = "delivered" | "delivered-out" | "cancelled" | "quiet";
+
+/** Easing of the settle phase — slower than the meter, symmetric. */
+const SETTLE_EASE = 0.24;
+/** How long the row takes to come to rest before the sweep starts. */
+const SETTLE_MS = 180;
+/** Stillness between your voice ending and the machine starting. */
+const HANDOVER_BEAT_MS = 120;
+
+/**
+ * The delivered mark, and the length of its path — the dash offset it is drawn
+ * from. Hard-coded rather than measured with `getTotalLength()` so the first
+ * paint is already in the undrawn state; the path is fixed, so the two can't
+ * drift. (Its two segments are ~3.8 and ~7.9 units long.)
+ */
+const CHECK_SIZE = 16;
+const CHECK_PATH_LENGTH = 11.7;
+
+/**
+ * The delivered sequence. Two rules shaped these numbers:
+ *
+ * The *closing* is not the point — the mark is. Getting the row out of the way
+ * is business, so it moves briskly; the check is the thing the user is meant to
+ * read, so it is drawn and then simply **held**. An earlier cut had the mark
+ * complete at 300ms and start leaving at 320, which is a confirmation you can
+ * miss by blinking.
+ *
+ * And nothing here animates a layout property. The capsule used to contract to
+ * a 30px disc around the check, which meant transitioning `width` — a full
+ * layout pass every frame, on a renderer that may still be cold on the first
+ * dictation of the session. It read as sluggish and janked exactly where the
+ * design wanted to feel most precise. The capsule now holds its shape and
+ * leaves on transform and opacity alone.
+ */
+const CLOSE_STEP_MS = 18;
+const CLOSE_DUR_MS = 110;
+const CHECK_AT_MS = 90;
+const CHECK_DRAW_MS = 150;
+/** Fully drawn at ~240ms, then this long at rest before it goes. */
+const CHECK_HOLD_MS = 320;
+const CHECK_LEAVE_AT_MS = CHECK_AT_MS + CHECK_DRAW_MS + CHECK_HOLD_MS;
+const CHECK_LEAVE_MS = 110;
+const DELIVERED_TOTAL_MS = CHECK_LEAVE_AT_MS + CHECK_LEAVE_MS;
+const CANCELLED_MS = 140;
+const QUIET_MS = 120;
+
+/** Entrance: one frame at rest, then the capsule rises into place. */
+const ENTER_MS = 260;
+/** Bars arrive right-to-left — the direction samples travel through the row. */
+const ENTER_BAR_STEP_MS = 12;
+const ENTER_BAR_DUR_MS = 180;
+
+/**
+ * How long the level may sit under the noise floor before the row admits it
+ * isn't hearing anything. Long enough to sit through a pause for breath.
+ */
+const SILENCE_MS = 1600;
+/** Per-frame easing of the flatline's draw/retract. */
+const FLAT_EASE = 0.14;
+/** Past this, the status slot opens with an elapsed readout. */
+const ELAPSED_AFTER_MS = 60_000;
 
 // ---------------------------------------------------------------------------
 // Sound
@@ -297,6 +383,13 @@ const ALERT = "#E0805F";
  */
 const BAR_COLOR = "#FFFFFF";
 
+/**
+ * The capsule floats over arbitrary content with only a hairline to separate
+ * it, which is not enough over a busy background — it dissolves into whatever
+ * is behind it. Soft and low: this is separation, not a raised card.
+ */
+const PILL_SHADOW = "0 2px 10px rgba(0, 0, 0, 0.22)";
+
 const pillInnerStyle: React.CSSProperties = {
   height: PILL_HEIGHT,
   borderRadius: PILL_HEIGHT / 2,
@@ -304,8 +397,14 @@ const pillInnerStyle: React.CSSProperties = {
   border: SURFACE_BORDER,
   backdropFilter: BLUR,
   WebkitBackdropFilter: BLUR,
+  boxShadow: PILL_SHADOW,
   cursor: "grab",
   WebkitAppRegion: "drag",
+  // The delivered mark is an overlay on the capsule, so the capsule has to be
+  // its containing block. `backdrop-filter` already makes one, but relying on
+  // that would mean the mark silently flies to the window corner the day
+  // somebody drops the blur.
+  position: "relative",
 } as React.CSSProperties;
 
 interface TranscribeResult {
@@ -402,6 +501,32 @@ export default function AppPage(): React.JSX.Element {
   const lastCancelWriteRef = useRef(-1);
   const cancelSlotRef = useRef<HTMLSpanElement>(null);
   const waveClipRef = useRef<HTMLSpanElement>(null);
+  const capsuleRef = useRef<HTMLDivElement>(null);
+  const checkRef = useRef<HTMLSpanElement>(null);
+  const checkPathRef = useRef<SVGPathElement>(null);
+  const flatlineRef = useRef<SVGLineElement>(null);
+  /**
+   * Silence tracking. `silentSinceRef` is the timestamp the level last went
+   * *above* the noise floor; `flat` is the 0..1 amount of the flatline, eased
+   * in the draw loop so it draws and retracts rather than snapping.
+   */
+  const silentSinceRef = useRef(0);
+  const flatAmountRef = useRef(0);
+  const flatTargetRef = useRef(0);
+  /** Mirrors `flatTargetRef` into React only when it crosses, for the live region. */
+  const [micSilent, setMicSilent] = useState(false);
+  const micSilentRef = useRef(false);
+  const [elapsedLabel, setElapsedLabel] = useState<string | null>(null);
+  const [exiting, setExiting] = useState<PillExit | null>(null);
+  const exitTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  /**
+   * Mirrors `exiting` for the same-tick guard in `dismissPill`. The state
+   * hasn't re-rendered yet when the second caller arrives, and there are
+   * genuinely two: the success path asks for "delivered", then `drainQueue`'s
+   * own `finally` — which cannot know a delivery just happened — asks for
+   * "quiet" a moment later. First ending wins; it is the specific one.
+   */
+  const exitingRef = useRef<PillExit | null>(null);
   const hoveredRef = useRef(false);
   const cancelModeRef = useRef<PillCancelMode>("hover");
   /**
@@ -530,7 +655,7 @@ export default function AppPage(): React.JSX.Element {
           // result; a new recording is starting — keep the pill visible.
           return;
         } else {
-          hidePill();
+          dismissPill("quiet");
         }
         return;
       }
@@ -590,6 +715,10 @@ export default function AppPage(): React.JSX.Element {
         return;
       }
 
+      // Whether anything actually reached the user. A plugin that suppressed
+      // the output did not deliver it, and must not be answered with a check.
+      let delivered = false;
+
       try {
         const requestedMode =
           _outputMode === "clipboard" ? "clipboard" : "paste";
@@ -639,11 +768,22 @@ export default function AppPage(): React.JSX.Element {
         }
 
         if (shouldDeliver && deliverText.trim()) {
-          if (deliverMode === "clipboard") {
-            await window.api.copyText(deliverText, appContextRef.current);
-          } else {
-            await window.api.pasteText(deliverText, appContextRef.current);
-          }
+          const delivery =
+            deliverMode === "clipboard"
+              ? window.api.copyText(deliverText, appContextRef.current)
+              : window.api.pasteText(deliverText, appContextRef.current);
+
+          // Start the confirmation on dispatch, not on completion. The text is
+          // in the document within a frame or two of the keystroke, but
+          // `pasteText` doesn't resolve until the main process has waited out
+          // its paste-settle delay — 300ms, and up to 600ms on the legacy
+          // backends. Awaiting that first left the transcribing sweep running
+          // over a document that already had the dictation in it, and the
+          // close only began once the pill had visibly nothing left to do.
+          delivered = true;
+          dismissPill("delivered");
+
+          await delivery;
         }
       } catch (err) {
         console.error("[pill] paste/copy failed:", err);
@@ -665,12 +805,15 @@ export default function AppPage(): React.JSX.Element {
         provider_category: providerCategory,
       });
 
+      // Already started above on the delivering path; this covers the rest —
+      // a suppressed or empty output still has to put the pill away, just
+      // without claiming anything was delivered.
       if (
         !recordingActiveRef.current &&
         queueRef.current.length === 0 &&
         pillActiveRef.current
       ) {
-        hidePill();
+        dismissPill(delivered ? "delivered" : "quiet");
       }
     } finally {
       drainingRef.current = false;
@@ -684,7 +827,7 @@ export default function AppPage(): React.JSX.Element {
         !recordingActiveRef.current &&
         isTranscriptionIdle()
       ) {
-        hidePill();
+        dismissPill("quiet");
       }
     }
   }, []);
@@ -809,7 +952,6 @@ export default function AppPage(): React.JSX.Element {
           // stays up until `onReady` says the session is live again, so the
           // mark doesn't blink off and on in the middle of one recovery.
         },
-        onPartial: () => {},
         onFinal: (text) => {
           setPillNotice(null);
           const resolver = streamResolverRef.current;
@@ -888,8 +1030,12 @@ export default function AppPage(): React.JSX.Element {
   // The bar elements are created once per mount and only ever have their
   // geometry rewritten, so grab them as the SVG mounts and let the draw loop
   // iterate a plain array instead of querying the DOM 60 times a second.
+  // Scoped to the bar group: the flatline shares this SVG and must never be
+  // mistaken for a level bar.
   const captureBarLines = useCallback((svg: SVGSVGElement | null) => {
-    barLinesRef.current = svg ? Array.from(svg.querySelectorAll("line")) : [];
+    barLinesRef.current = svg
+      ? Array.from(svg.querySelectorAll<SVGLineElement>("[data-bars] line"))
+      : [];
   }, []);
 
   // One frame: work out what the bars should be aiming at, ease them toward
@@ -907,14 +1053,13 @@ export default function AppPage(): React.JSX.Element {
     let rise = RISE;
     let fall = FALL;
 
-    if (mode === "connecting") {
-      // A slow, low-amplitude breath travelling along the row: the pill is
-      // awake but has nothing to show yet. Deliberately understated so the
-      // jump to real audio levels reads as the pill "catching" your voice.
-      const t = (now - modeStartRef.current) / 1000;
-      for (let i = 0; i < BARS; i++) {
-        targets[i] = 0.06 + 0.07 * (1 + Math.sin(t * 3.2 - i * 0.42));
-      }
+    if (mode === "settling") {
+      // The hand-off. Every bar eases from wherever your voice left it down to
+      // rest — symmetrically, and slower than the live meter — so the last
+      // syllable is set down instead of deleted. Targets are already zero; the
+      // only thing this branch does is own the easing rate.
+      rise = SETTLE_EASE;
+      fall = SETTLE_EASE;
     } else if (mode === "speaking") {
       // Transcribing: a single soft bump sweeping left to right on a loop,
       // with a pause between passes. Reads as progress rather than as audio.
@@ -988,6 +1133,27 @@ export default function AppPage(): React.JSX.Element {
       // becomes a peak once it hands off and joins the history.
       targets[BARS - 1] = barHeightFor(voiceLevel, sample.jitter);
 
+      // ---- Is the mic actually delivering anything? ----
+      // A wrong input device or a hardware mute button renders identically to
+      // a quiet room — a row of resting dots — and today you only find out
+      // from a "No audio captured" dialog after speaking a paragraph. Gated on
+      // the analyser existing, so the getUserMedia window (no audio yet, by
+      // definition) can't trip it.
+      if (voiceLevel > BAR_NOISE_FLOOR) {
+        silentSinceRef.current = now;
+        flatTargetRef.current = 0;
+      } else if (
+        silentSinceRef.current > 0 &&
+        now - silentSinceRef.current > SILENCE_MS
+      ) {
+        flatTargetRef.current = 1;
+      }
+      const wantsSilent = flatTargetRef.current === 1;
+      if (wantsSilent !== micSilentRef.current) {
+        micSilentRef.current = wantsSilent;
+        setMicSilent(wantsSilent);
+      }
+
       // The dashboard's own visualisation is calibrated against the original
       // linear scale, so the level broadcast over IPC stays on it.
       if (now - lastIpcTimeRef.current >= 100) {
@@ -1006,6 +1172,24 @@ export default function AppPage(): React.JSX.Element {
       (cancelTargetRef.current - cancelOpenRef.current) * CANCEL_EASE;
     cancelOpenRef.current = open;
 
+    // The flatline eases on the same clock as everything else, so it draws
+    // outward from the centre and retracts the moment a real sample lands.
+    const flat =
+      flatAmountRef.current +
+      (flatTargetRef.current - flatAmountRef.current) * FLAT_EASE;
+    flatAmountRef.current = flat;
+    const flatline = flatlineRef.current;
+    if (flatline) {
+      if (flat > 0.002) {
+        const half = (SVG_WIDTH / 2 - 2) * flat;
+        flatline.setAttribute("opacity", String(flat * 0.5));
+        flatline.setAttribute("x1", String(SVG_WIDTH / 2 - half));
+        flatline.setAttribute("x2", String(SVG_WIDTH / 2 + half));
+      } else {
+        flatline.setAttribute("opacity", "0");
+      }
+    }
+
     const lines = barLinesRef.current;
     for (let i = 0; i < lines.length; i++) {
       const val = bars[i] ?? 0;
@@ -1020,8 +1204,11 @@ export default function AppPage(): React.JSX.Element {
       // oldest bars fade as the cancel button takes their space, so they
       // dissolve rather than being sliced by the viewport edge closing over
       // them.
-      line.style.opacity =
-        i < CANCEL_HIDDEN_BARS && open > 0 ? String(1 - open) : "1";
+      // The one structural exception is the oldest bars fading as the cancel
+      // button takes their space; the second is the row dimming while it has
+      // nothing to report, so the flatline is what reads instead of the dots.
+      const structural = i < CANCEL_HIDDEN_BARS && open > 0 ? 1 - open : 1;
+      line.style.opacity = String(structural * (1 - 0.55 * flat));
     }
 
     // Writing these lays out the capsule, so only do it while the value is
@@ -1058,6 +1245,16 @@ export default function AppPage(): React.JSX.Element {
       // style write against the fresh elements.
       cancelOpenRef.current = cancelTargetRef.current;
       lastCancelWriteRef.current = -1;
+      // Silence is only ever asserted about a live analyser, so every mode
+      // change clears it — including the switch to "speaking", where a
+      // lingering flatline would be about audio that is no longer being read.
+      silentSinceRef.current = mode === "listening" ? performance.now() : 0;
+      flatTargetRef.current = 0;
+      if (mode !== "listening") flatAmountRef.current = 0;
+      if (micSilentRef.current) {
+        micSilentRef.current = false;
+        setMicSilent(false);
+      }
       sampleRef.current = {
         lastSampleAt: performance.now(),
         peak: 0,
@@ -1142,7 +1339,29 @@ export default function AppPage(): React.JSX.Element {
     startBarAnimation,
   ]);
 
+  /**
+   * Commit's hand-off: the row comes to rest, holds still for a beat, and only
+   * then does the machine's sweep start. Without the pause the two waveforms
+   * cross-fade into each other and the moment your voice becomes text — the
+   * pivot the whole product is about — reads as a glitch.
+   */
+  const handoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startHandover = useCallback(() => {
+    startBarAnimation("settling");
+    if (handoverTimerRef.current) clearTimeout(handoverTimerRef.current);
+    handoverTimerRef.current = setTimeout(() => {
+      handoverTimerRef.current = null;
+      // Only take the row if nothing else has claimed it in the meantime (a
+      // re-record, a failure, a dismissal).
+      if (barModeRef.current === "settling") startBarAnimation("speaking");
+    }, SETTLE_MS + HANDOVER_BEAT_MS);
+  }, [startBarAnimation]);
+
   const stopVisualization = useCallback(() => {
+    if (handoverTimerRef.current) {
+      clearTimeout(handoverTimerRef.current);
+      handoverTimerRef.current = null;
+    }
     cancelAnimationFrame(rafRef.current);
     rafRef.current = 0;
     barModeRef.current = null;
@@ -1162,6 +1381,10 @@ export default function AppPage(): React.JSX.Element {
       peak: 0,
       jitter: { scale: 1, trim: 0 },
     };
+    silentSinceRef.current = 0;
+    flatAmountRef.current = 0;
+    flatTargetRef.current = 0;
+    micSilentRef.current = false;
   }, []);
 
   // ---- Hide pill ----
@@ -1186,20 +1409,107 @@ export default function AppPage(): React.JSX.Element {
     cancelTargetRef.current = cancelModeRef.current === "always" ? 1 : 0;
     cancelOpenRef.current = cancelTargetRef.current;
     lastCancelWriteRef.current = -1;
+    setElapsedLabel(null);
+    setMicSilent(false);
+    setExiting(null);
+    exitingRef.current = null;
+    // So the next session's `initializing` frames can't read a stale clock.
+    startTimeRef.current = 0;
+    for (const timer of exitTimersRef.current) clearTimeout(timer);
+    exitTimersRef.current = [];
     stopVisualization();
     window.api.hidePill();
   }, [setPillNotice, stopVisualization, setPillState]);
 
+  /**
+   * The pill leaving, with the ending it earned. `hidePill` stays the
+   * immediate teardown for the cases where something else is taking over the
+   * screen (a sign-in prompt, an upgrade dialog, an error modal) — animating
+   * out from under a modal that is already opening is just latency.
+   *
+   * Every timer is tracked so a new session starting mid-exit cancels it
+   * cleanly rather than hiding the window out from under the new pill.
+   */
+  const dismissPill = useCallback(
+    (kind: PillExit) => {
+      if (!pillActiveRef.current || exitingRef.current) return;
+      exitingRef.current = kind;
+      // Recording is over the moment the exit starts, whatever else is still
+      // unwinding — otherwise a hotkey press during the exit sees a live
+      // session and tries to commit into it.
+      recordingActiveRef.current = false;
+      wantsMicRef.current = false;
+      setExiting(kind);
+
+      const after = (delay: number, fn: () => void): void => {
+        exitTimersRef.current.push(setTimeout(fn, delay));
+      };
+
+      if (kind !== "delivered") {
+        after(kind === "cancelled" ? CANCELLED_MS : QUIET_MS, hidePill);
+        return;
+      }
+
+      // ---- Delivered ----
+      // The row closes from the outside in. Every bar collapses *in place*:
+      // scaling the group instead would slide ten round-capped strokes into
+      // each other and the caps clump together well before they merge.
+      //
+      // The draw loop is parked first — it rewrites bar geometry every frame,
+      // and would fight the CSS transitions all the way down.
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = 0;
+      barModeRef.current = null;
+
+      const lines = barLinesRef.current;
+      for (let i = 0; i < lines.length; i++) {
+        const rank = (BARS - 1) / 2 - Math.abs(i - (BARS - 1) / 2);
+        const delay = Math.round(rank * CLOSE_STEP_MS);
+        lines[i].style.transformOrigin = "50% 50%";
+        lines[i].style.transition =
+          `transform ${CLOSE_DUR_MS}ms cubic-bezier(0.4, 0, 1, 1) ${delay}ms,` +
+          ` opacity ${Math.round(CLOSE_DUR_MS * 0.8)}ms ease ${delay}ms`;
+        lines[i].style.transform = "scaleY(0)";
+        lines[i].style.opacity = "0";
+      }
+      if (flatlineRef.current) flatlineRef.current.setAttribute("opacity", "0");
+
+      after(CHECK_AT_MS, () => {
+        // The check draws out of the centre the row just closed on, in the
+        // same white as the bars — the meter resolving, not an icon fading in
+        // over it. It starts while the innermost pair is still collapsing,
+        // which is what binds the two gestures into one.
+        const check = checkRef.current;
+        const path = checkPathRef.current;
+        if (check) {
+          check.style.transition = "opacity 80ms ease";
+          check.style.opacity = "1";
+        }
+        if (path) {
+          path.style.transition = `stroke-dashoffset ${CHECK_DRAW_MS}ms cubic-bezier(0.22, 1, 0.36, 1)`;
+          path.style.strokeDashoffset = "0";
+        }
+      });
+
+      after(CHECK_LEAVE_AT_MS, () => {
+        exitingRef.current = "delivered-out";
+        setExiting("delivered-out");
+      });
+      after(DELIVERED_TOTAL_MS, hidePill);
+    },
+    [hidePill],
+  );
+
   const resumeTranscribingOrHide = useCallback(() => {
     if (isTranscriptionIdle()) {
-      hidePill();
+      dismissPill("quiet");
     } else {
       setPillState("transcribing");
       startBarAnimation("speaking");
       void drainQueue();
     }
   }, [
-    hidePill,
+    dismissPill,
     setPillState,
     startBarAnimation,
     drainQueue,
@@ -1264,8 +1574,12 @@ export default function AppPage(): React.JSX.Element {
           });
       });
 
+      // "initializing" is internal bookkeeping for the hotkey-release path; it
+      // has no look of its own. The pill arrives already recording, and the row
+      // waits at rest until the analyser hands it a real sample — which
+      // `startListening` does, without restarting the mode.
       setPillState("initializing");
-      startBarAnimation("connecting");
+      startBarAnimation("listening");
 
       // Play the start cue immediately, before ducking lowers the system
       // volume — otherwise the tone is attenuated to DUCKED_VOLUME and is
@@ -1313,7 +1627,7 @@ export default function AppPage(): React.JSX.Element {
           if (forReRecord) {
             resumeTranscribingOrHide();
           } else {
-            hidePill();
+            dismissPill("quiet");
           }
           return;
         }
@@ -1341,6 +1655,7 @@ export default function AppPage(): React.JSX.Element {
       startBarAnimation,
       startListening,
       hidePill,
+      dismissPill,
       getStreamer,
       setPillNotice,
       setPillState,
@@ -1390,7 +1705,7 @@ export default function AppPage(): React.JSX.Element {
 
     window.api?.sendRecordingCommitted();
     setPillState("transcribing");
-    startBarAnimation("speaking");
+    startHandover();
 
     // Streaming session transport path: the streamer already has the audio —
     // commit it over the WebSocket and wait for the server's final message.
@@ -1595,7 +1910,7 @@ export default function AppPage(): React.JSX.Element {
   }, [
     hidePill,
     drainQueue,
-    startBarAnimation,
+    startHandover,
     setPillState,
     resumeTranscribingOrHide,
     isTranscriptionIdle,
@@ -1612,8 +1927,8 @@ export default function AppPage(): React.JSX.Element {
     void restoreSystemAudioSafely();
     streamerRef.current?.cancel();
     window.api?.sendRecordingCancelled();
-    hidePill();
-  }, [hidePill, restoreSystemAudioSafely]);
+    dismissPill("cancelled");
+  }, [dismissPill, restoreSystemAudioSafely]);
 
   // ---- Preferences ----
   const applyPillPosition = useCallback((pos: string | null | undefined) => {
@@ -1746,7 +2061,7 @@ export default function AppPage(): React.JSX.Element {
         void startRecording(false);
       } else if (s === "transcribing" && !wantsMicRef.current) {
         if (isTranscriptionIdle()) {
-          hidePill();
+          dismissPill("quiet");
           return;
         }
         // A pending streaming commit owns the single WebSocket + PCM buffer,
@@ -1772,7 +2087,7 @@ export default function AppPage(): React.JSX.Element {
         !wantsMicRef.current &&
         isTranscriptionIdle()
       ) {
-        hidePill();
+        dismissPill("quiet");
       }
     });
     const removeCancel = window.api.onPillCancel(() => {
@@ -1787,7 +2102,7 @@ export default function AppPage(): React.JSX.Element {
     startRecording,
     commitRecording,
     cancelRecording,
-    hidePill,
+    dismissPill,
     isTranscriptionIdle,
     setPillNotice,
   ]);
@@ -1820,6 +2135,95 @@ export default function AppPage(): React.JSX.Element {
   // glyph, and the words behind it are in the tooltip and to screen readers.
   const isFreestyleCloud = providerCategoryRef.current === "freestyle_cloud";
   const showCard = state === "error";
+  const active = state !== "idle";
+
+  // ---- Arrival ----
+  // The capsule's enter transition was authored but never ran: the subtree
+  // mounts with its final state already applied, and a CSS transition doesn't
+  // fire on first paint. Hold the resting state for one committed frame, then
+  // release — the same two-frame handshake the card uses for `roomReady`.
+  //
+  // No window-level fade is needed: the pill window is `transparent: true`, so
+  // it shows nothing at all until this paints.
+  const [entered, setEntered] = useState(false);
+  useEffect(() => {
+    if (!active) {
+      setEntered(false);
+      return;
+    }
+    let inner = 0;
+    const outer = requestAnimationFrame(() => {
+      inner = requestAnimationFrame(() => setEntered(true));
+    });
+    return () => {
+      cancelAnimationFrame(outer);
+      cancelAnimationFrame(inner);
+    };
+  }, [active]);
+
+  // The bars arrive right-to-left — the direction samples travel through the
+  // row — from a flat row of nothing to the resting dots. Written straight to
+  // the elements, because the draw loop owns their geometry and React must not
+  // start re-rendering ten <line>s a frame to express this.
+  useEffect(() => {
+    const lines = barLinesRef.current;
+    if (!active || lines.length === 0) return;
+    for (let i = 0; i < lines.length; i++) {
+      lines[i].style.transformOrigin = "50% 50%";
+      lines[i].style.transition = "none";
+      lines[i].style.transform = "scaleY(0)";
+      lines[i].style.opacity = "0";
+    }
+    let inner = 0;
+    const outer = requestAnimationFrame(() => {
+      inner = requestAnimationFrame(() => {
+        for (let i = 0; i < lines.length; i++) {
+          const delay = (lines.length - 1 - i) * ENTER_BAR_STEP_MS;
+          lines[i].style.transition =
+            `transform ${ENTER_BAR_DUR_MS}ms cubic-bezier(0.22, 1, 0.36, 1) ${delay}ms,` +
+            ` opacity ${ENTER_BAR_DUR_MS - 40}ms ease ${delay}ms`;
+          lines[i].style.transform = "scaleY(1)";
+          lines[i].style.opacity = "1";
+        }
+      });
+    });
+    return () => {
+      cancelAnimationFrame(outer);
+      cancelAnimationFrame(inner);
+    };
+  }, [active]);
+
+  // ---- Elapsed ----
+  // Nothing is said about duration until a dictation is genuinely long, and
+  // then it uses the status slot that already exists for growing the capsule
+  // by exactly one mark — the waveform doesn't move.
+  //
+  // Gated on "recording" alone, and never on `initializing`: the clock only
+  // starts when the mic is actually open, so during initialization
+  // `startTimeRef` still holds 0 (first session) or the previous session's
+  // start. Reading it then measures the age of the epoch — which is how the
+  // very first press of a fresh process ended up opening the slot on a
+  // 29-million-minute readout.
+  useEffect(() => {
+    if (state !== "recording" || startTimeRef.current === 0) {
+      setElapsedLabel(null);
+      return;
+    }
+    const tick = (): void => {
+      const ms = Date.now() - startTimeRef.current;
+      if (ms < ELAPSED_AFTER_MS) {
+        setElapsedLabel(null);
+        return;
+      }
+      const secs = Math.floor(ms / 1000);
+      setElapsedLabel(
+        `${Math.floor(secs / 60)}:${String(secs % 60).padStart(2, "0")}`,
+      );
+    };
+    tick();
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  }, [state]);
 
   // What that mark means. Errors are the card's job, so a "working" notice
   // here is a spinner and a stalled one is the alert mark.
@@ -1844,10 +2248,15 @@ export default function AppPage(): React.JSX.Element {
     pillNotice === "limit";
 
   // Only worth showing when more than one dictation is stacked up; a single
-  // in-flight transcription is already implied by the sweeping waveform.
-  const statusCount =
-    pendingCount > 1 && !statusLabel ? String(pendingCount) : null;
-  const wantsStatus = !showCard && !!(statusLabel || statusCount);
+  // in-flight transcription is already implied by the sweeping waveform. A
+  // queue outranks the clock — a backlog is the more actionable fact, and the
+  // slot holds one mark.
+  const statusCount = statusLabel
+    ? null
+    : pendingCount > 1
+      ? String(pendingCount)
+      : elapsedLabel;
+  const wantsStatus = !showCard && !exiting && !!(statusLabel || statusCount);
 
   const cardTitle =
     pillNotice === "sign-in"
@@ -1886,16 +2295,23 @@ export default function AppPage(): React.JSX.Element {
   }
   const card = cardContentRef.current;
 
+  // The silence notice is the one thing the capsule can't say in a glyph, so
+  // it outranks the generic "Listening" here — this live region is the only
+  // place a screen reader learns the mic has gone quiet.
   const accessibleStatus = showCard
     ? `${cardTitle}. ${cardBody}`
-    : (statusLabel ??
-      (state === "initializing"
-        ? "Preparing microphone"
-        : state === "recording"
-          ? "Listening"
-          : state === "transcribing"
-            ? "Transcribing"
-            : ""));
+    : exiting === "delivered" || exiting === "delivered-out"
+      ? "Dictation delivered"
+      : (statusLabel ??
+        (micSilent
+          ? "No audio from your microphone"
+          : state === "initializing"
+            ? "Preparing microphone"
+            : state === "recording"
+              ? "Listening"
+              : state === "transcribing"
+                ? "Transcribing"
+                : ""));
 
   // ---- Room for the card ----
   // The capsule, status mark and all, fits the pill window as it is; only the
@@ -1975,20 +2391,36 @@ export default function AppPage(): React.JSX.Element {
         }
         aria-hidden="true"
       >
-        {BAR_X_POSITIONS.map((x) => {
-          return (
-            <line
-              key={x}
-              x1={x}
-              y1={SVG_HEIGHT / 2 + BAR_WIDTH / 2}
-              x2={x}
-              y2={SVG_HEIGHT / 2 - BAR_WIDTH / 2}
-              stroke={BAR_COLOR}
-              strokeWidth={BAR_WIDTH}
-              strokeLinecap="round"
-            />
-          );
-        })}
+        {/* Drawn under the bars: while the mic is delivering nothing, this
+            draws outward from the centre as the dots dim, so the row reads as
+            a flatline rather than as a quiet room. */}
+        <line
+          ref={flatlineRef}
+          x1={SVG_WIDTH / 2}
+          y1={SVG_HEIGHT / 2}
+          x2={SVG_WIDTH / 2}
+          y2={SVG_HEIGHT / 2}
+          stroke={BAR_COLOR}
+          strokeWidth={1}
+          strokeLinecap="round"
+          opacity={0}
+        />
+        <g data-bars="">
+          {BAR_X_POSITIONS.map((x) => {
+            return (
+              <line
+                key={x}
+                x1={x}
+                y1={SVG_HEIGHT / 2 + BAR_WIDTH / 2}
+                x2={x}
+                y2={SVG_HEIGHT / 2 - BAR_WIDTH / 2}
+                stroke={BAR_COLOR}
+                strokeWidth={BAR_WIDTH}
+                strokeLinecap="round"
+              />
+            );
+          })}
+        </g>
       </svg>
     </span>
   );
@@ -2017,10 +2449,89 @@ export default function AppPage(): React.JSX.Element {
           .pill-surface[data-show="true"] {
             opacity: 1;
             transform: none;
-            transition: opacity 200ms ease, transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+            transition: opacity ${ENTER_MS - 100}ms ease,
+                        transform ${ENTER_MS}ms cubic-bezier(0.22, 1, 0.36, 1);
             pointer-events: auto;
           }
-          .pill-card[data-show="false"] { transform: scale(0.94) translateY(4px); }
+
+          /* The capsule arrives from the edge it is anchored to, so it reads as
+             coming from off-screen rather than from nowhere in particular.
+             --enter-dy is +6px when the pill sits at the bottom, -6px at the
+             top. */
+          .pill-capsule { transform: scale(0.88) translateY(var(--enter-dy, 6px)); }
+
+          /* ---- Endings ----
+             Three of them, and they are not the same gesture. Delivered has
+             something to say and is allowed ~430ms to say it (all of it after
+             the text has landed). Cancelled and quiet earned no confirmation,
+             so they get half the entrance and leave downward. */
+          .pill-capsule[data-exit="cancelled"],
+          .pill-capsule[data-exit="quiet"] {
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity ${CANCELLED_MS}ms ease,
+                        transform ${CANCELLED_MS}ms cubic-bezier(0.4, 0, 1, 1);
+          }
+          .pill-capsule[data-exit="cancelled"] { transform: scale(0.7) translateY(4px); }
+          .pill-capsule[data-exit="quiet"] {
+            transform: scale(0.76);
+            transition-duration: ${QUIET_MS}ms;
+          }
+          /* Delivered holds its ground while the row closes and the mark draws;
+             only the last beat takes it away. */
+          .pill-capsule[data-exit="delivered-out"] {
+            opacity: 0;
+            transform: scale(0.94);
+            pointer-events: none;
+            transition: opacity ${CHECK_LEAVE_MS}ms ease,
+                        transform ${CHECK_LEAVE_MS}ms cubic-bezier(0.4, 0, 1, 1);
+          }
+
+          /* The capsule is draggable and, until now, gave no sign of it. */
+          @media (hover: hover) and (pointer: fine) {
+            .pill-capsule[data-show="true"]:not([data-exit]):hover {
+              transform: translateY(-1px);
+              border-color: rgba(255, 255, 255, 0.16);
+              box-shadow: 0 5px 16px rgba(0, 0, 0, 0.26);
+              transition: transform 140ms cubic-bezier(0.22, 1, 0.36, 1),
+                          border-color 140ms ease,
+                          box-shadow 140ms ease;
+            }
+          }
+
+          /* The delivered mark. Drawn, not faded in — and in the same white as
+             the bars, because it is the meter resolving rather than an icon
+             arriving on top of it. */
+          .pill-check {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            opacity: 0;
+            pointer-events: none;
+          }
+
+          /* The card grows out of the capsule's own footprint: it starts at the
+             capsule's true ratio (96/300 wide, 30/92 tall) with a
+             proportionally larger corner, so the radius looks constant while
+             the object inflates. Transform and radius only — no width/height
+             animation. */
+          .pill-card {
+            border-radius: 20px;
+            transition: opacity 140ms ease,
+                        transform 140ms cubic-bezier(0.4, 0, 1, 1),
+                        border-radius 140ms ease;
+          }
+          .pill-card[data-show="false"] {
+            transform: scale(0.32, 0.34);
+            border-radius: 60px;
+          }
+          .pill-card[data-show="true"] {
+            transition: opacity 180ms ease,
+                        transform 300ms cubic-bezier(0.22, 1, 0.36, 1),
+                        border-radius 300ms cubic-bezier(0.22, 1, 0.36, 1);
+          }
 
           /* The status mark's slot, opening from the capsule's right end the
              same way the cancel slot opens from its left. */
@@ -2096,11 +2607,18 @@ export default function AppPage(): React.JSX.Element {
           @media (prefers-reduced-motion: reduce) {
             .pill-surface,
             .pill-surface[data-show="true"],
+            .pill-capsule[data-exit],
+            .pill-card,
+            .pill-card[data-show="true"],
             .pill-status,
             .pill-status-mark,
             .pill-cancel,
             .pill-action { transition-duration: 1ms !important; }
-            .pill-card[data-show="false"] { transform: none; }
+            .pill-card[data-show="false"] { transform: none; border-radius: 20px; }
+            .pill-capsule { transform: none; }
+            /* The check still draws — it is the confirmation, not decoration —
+               but instantly, and it is held rather than animated away. */
+            .pill-check { transition: none !important; }
             /* A spinner that doesn't turn says nothing, so slow it rather
                than stopping it. */
             .pill-spinner { animation-duration: 2.4s; }
@@ -2123,16 +2641,22 @@ export default function AppPage(): React.JSX.Element {
                 pointer-only. */}
             {/* biome-ignore lint/a11y/noStaticElementInteractions: see above */}
             <div
-              className="pill-surface inline-flex items-center"
-              data-show={!showCard}
+              ref={capsuleRef}
+              className="pill-surface pill-capsule inline-flex items-center"
+              data-show={!showCard && entered}
+              data-exit={exiting ?? undefined}
               onMouseEnter={handlePillEnter}
               onMouseLeave={handlePillLeave}
-              style={{
-                ...pillInnerStyle,
-                transformOrigin,
-                marginBottom: pillAlign === "end" ? 8 : 0,
-                marginTop: pillAlign === "start" ? 8 : 0,
-              }}
+              style={
+                {
+                  ...pillInnerStyle,
+                  transformOrigin,
+                  marginBottom: pillAlign === "end" ? 8 : 0,
+                  marginTop: pillAlign === "start" ? 8 : 0,
+                  // Arrive from the edge the pill is anchored to.
+                  "--enter-dy": pillAlign === "start" ? "-6px" : "6px",
+                } as React.CSSProperties
+              }
             >
               {/* The fixed core: the cancel slot's width is driven by the draw
                   loop, from zero (closed) to CANCEL_SLOT — the disc plus the
@@ -2200,6 +2724,33 @@ export default function AppPage(): React.JSX.Element {
                 </span>
 
                 {waveform}
+              </span>
+
+              {/* The delivered mark, centred on the capsule rather than inside
+                  the waveform's clip: it takes the place the row occupied, at
+                  the row's own centre, and is not subject to the clip that
+                  hides retiring samples. */}
+              <span ref={checkRef} className="pill-check" aria-hidden="true">
+                <svg
+                  width={CHECK_SIZE}
+                  height={CHECK_SIZE}
+                  viewBox="0 0 16 16"
+                  aria-hidden="true"
+                >
+                  <path
+                    ref={checkPathRef}
+                    d="M4.1 8.5 6.8 11.2 11.9 5.2"
+                    fill="none"
+                    stroke={BAR_COLOR}
+                    strokeWidth={1.9}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    style={{
+                      strokeDasharray: CHECK_PATH_LENGTH,
+                      strokeDashoffset: CHECK_PATH_LENGTH,
+                    }}
+                  />
+                </svg>
               </span>
 
               {/* Status, outside the core: the capsule grows to the right by
@@ -2302,12 +2853,14 @@ export default function AppPage(): React.JSX.Element {
           <div className={layerClass} aria-hidden={!cardOpen}>
             <div
               className="pill-surface pill-card"
-              data-show={cardOpen}
+              data-show={cardOpen && !exiting}
               style={
                 {
                   width: PILL_CARD_WIDTH,
                   padding: "13px 15px 12px",
-                  borderRadius: 20,
+                  // The corner radius is animated (see `.pill-card`), so it
+                  // has to live in the stylesheet — an inline value would
+                  // outrank the rule and freeze it at the open size.
                   background: SURFACE,
                   border: SURFACE_BORDER,
                   backdropFilter: BLUR,
@@ -2391,7 +2944,7 @@ export default function AppPage(): React.JSX.Element {
                 <button
                   type="button"
                   className="pill-action pill-action-ghost"
-                  onClick={hidePill}
+                  onClick={() => dismissPill("cancelled")}
                 >
                   Dismiss
                 </button>

--- a/specs/voice-pill-motion.md
+++ b/specs/voice-pill-motion.md
@@ -1,0 +1,250 @@
+# Voice pill — motion design
+
+Status: **implemented** on `design/voice-pill-motion`. Verified by driving the
+real renderer headlessly (see §9) — arrival ramp, bar stagger, settle beat,
+outside-in close, check draw, capsule contraction, cancel exit, silence
+flatline, and the capsule→card morph are all measured, not eyeballed.
+
+Target: `apps/electron/src/renderer/src/pages/app.tsx`, with one change to the
+paste path in `apps/electron/src/main/index.ts` (§7) and one deletion in
+`apps/electron/src/renderer/src/lib/streamer.ts`.
+
+---
+
+## 1. Why
+
+The pill's waveform is the strongest thing in the product — the response curve,
+the peak-hold shift register and the cancel-slot width budget are all carefully
+built. What the pill doesn't have is a **body**: it blinks into existence on the
+hotkey and vanishes the instant the paste resolves. The two moments a user
+actually notices are the two with no design in them.
+
+Everything below serves one thesis: **the pill is an object that arrives,
+listens, works and leaves** — not a texture that flickers on and off over
+someone's sentence.
+
+## 2. Principles
+
+1. **The bars never lie.** The waveform draws real audio and nothing else. The
+   `connecting` breath — a generated ripple during `getUserMedia` — is cut.
+2. **Every exit is a sentence ending.** Delivered, cancelled and failed are
+   three different endings; today they are one instant disappearance.
+   Confirmation is earned motion. Cancellation earns none.
+3. **Prose stays in the card.** The capsule may grow by one 16px mark, never by
+   a label. Words go to the tooltip, the `aria-live` region, and the card.
+4. **Exit faster than you entered.** 260ms in, 140ms out. The one ending
+   allowed to take its time is the one with something to say — and it spends
+   that time holding the mark, not performing the departure.
+
+Curves, both already in the file: `cubic-bezier(0.22, 1, 0.36, 1)` for
+arrivals, `cubic-bezier(0.4, 0, 1, 1)` for departures. No new easing vocabulary.
+
+## 3. Pain points this answers
+
+| # | Defect | Evidence |
+|---|---|---|
+| 01 | The entrance animation never runs. `.pill-surface` is authored to start at `opacity: 0; scale(0.96)`, but React mounts the subtree with `data-show="true"` already set and CSS transitions don't fire on first paint. `showInactive()` reveals an opaque window. | `app.tsx` `.pill-surface`; `index.ts:863` |
+| 02 | Nothing acknowledges success. The renderer hides the window in the same tick the paste resolves — and the main process had already hidden it before the keystroke (§7) — so a working dictation and a silently-swallowed paste look identical. | `app.tsx` `hidePill`; `index.ts` `deliverOutput` |
+| 03 | The waveform fakes it while the mic opens — the `connecting` ripple reads as "I hear you, quietly" at the one moment nothing is heard. | `runBars`, `mode === "connecting"` |
+| 04 | Commit deletes the last syllable: `targetsRef.fill(0)` plus both easing constants swapped in one frame. | `startBarAnimation` |
+| 05 | A dead microphone is indistinguishable from a quiet room until the `"No audio captured"` dialog. | `commitRecording` |
+| 06 | The capsule has no shadow on any background — a 1px 10%-white border is its only separation, and `cursor: grab` has no visual partner. | `pillInnerStyle` |
+| 07 | The failure card crossfades with the capsule instead of growing out of it, so it reads as a second window. | the two `layerClass` layers |
+
+## 4. The score
+
+Nine moments. Timings are the full sequence length; overlapping segments are
+noted.
+
+### 1 · Arrival — 260ms
+Capsule enters at `opacity 0`, `scale(0.88)`, offset 6px from the anchored edge
+(`+6` bottom-anchored, `-6` top). Opacity over 160ms, transform over 260ms.
+The ten bars enter as resting dots, staggered **right-to-left** at 12ms — the
+direction samples actually travel through the row — capped at 108ms.
+
+No OS-level window fade is needed or wanted: the pill window is already
+`transparent: true`, so it is invisible until the capsule paints. The fix is
+purely the mount handshake — render one frame at `data-show="false"`, then flip,
+using the same double-`requestAnimationFrame` the card already uses for
+`roomReady`.
+
+### 2 · Listening — continuous, unchanged
+The live meter and the hover-driven cancel slot ship as-is. Two additions:
+- **Permanent soft shadow** `0 2px 10px rgba(0,0,0,0.22)` so the capsule
+  survives a busy backdrop.
+- **Hover lift** `translateY(-1px)`, border 10% → 16% white, shadow to
+  `0 5px 16px rgba(0,0,0,0.26)`, 140ms. Hover already reaches the drag region
+  (the shipped cancel reveal proves it).
+
+### 3 · Silence — 260ms, new
+1600ms continuously under `BAR_NOISE_FLOOR` while the analyser exists, and the
+row admits it: dots dim to 45% and a hairline draws outward from the centre over
+220ms. Retracts on the first real sample. Gated on
+`analyserNodeRef.current !== null` so the `getUserMedia` window can't trip it.
+No capsule text — tooltip and live region carry "No audio from your microphone".
+
+### 4 · Long dictation — 260ms, new
+Past 60s the existing status slot opens with a mono elapsed readout (`1:00`,
+ticking). This reuses the mechanism already built for exactly this — the capsule
+grows right by one mark's width and the waveform does not move.
+
+### 5 · Handover — 480ms, new
+Bars ease from wherever they are to rest over 180ms (rise = fall = 0.24, no
+`fill(0)`), then **120ms of stillness**, then the sweep begins. The pivot from your voice to the machine gets a beat instead of a jump
+cut.
+
+Implementation: a `settle` phase inside the draw loop, not a React state.
+
+### 6 · Delivered — 670ms, new · **the focal moment**
+| Window | What |
+|---|---|
+| 0–182ms | the row **closes from the outside in**: each bar collapses `scaleY` → 0 *in place*, five pairs, outermost first, 18ms apart, 110ms each |
+| 90–240ms | the check draws out of the centre the row closed on — `stroke-dasharray`, in the **same white as the bars**, because it is the meter resolving, not an icon fading in on top. It starts while the innermost pair is still collapsing, which is what binds the two gestures into one. |
+| 240–560ms | **held.** The mark is the point; the closing was only clearing a path to it. |
+| 560–670ms | capsule leaves on `opacity` + `scale(0.94)`, then `window.api.hidePill()` |
+
+**Start it on dispatch, not on completion.** `window.api.pasteText` does not
+resolve until the main process has waited out `pasteSettleMs` — 300ms, up to
+600ms on the legacy backends — long after the text is actually in the document.
+Awaiting it before beginning the close left the transcribing sweep running over
+a document that already had the dictation in it, then closed the pill from a
+standing start. The renderer now fires `dismissPill("delivered")` the moment
+delivery is dispatched and awaits the promise afterwards. Measured
+paste→close-start: **5–17ms**.
+
+**Do not converge the bars by scaling the group.** A `scaleX` on the row
+translates ten round-capped strokes toward each other, and the caps collide into
+a clump with jarring slivers between them before they merge. Extinguishing each
+bar where it stands keeps the row's pitch intact for the whole gesture, and no
+two marks ever touch. The draw loop must be stopped (`mode = "off"`) before the
+close so it stops rewriting bar geometry underneath the CSS transitions.
+
+**Do not animate the capsule's width.** An earlier cut contracted it to a 30px
+disc around the check, which meant transitioning `width` — a full layout pass
+every frame, on a renderer that may still be cold on the first dictation of a
+session. It read as sluggish and janked precisely where the design wanted to
+feel most exact. The capsule now holds its shape and leaves on transform and
+opacity alone; the mark simply takes the place the row occupied. The check is an
+overlay, so `pillInnerStyle` carries `position: relative` to be its containing
+block rather than depending on `backdrop-filter` incidentally making one.
+
+Budget the time where the meaning is: the close is business and moves briskly;
+the mark is what the user reads and gets a 320ms hold. The reverse — a leisurely
+close and a mark that starts leaving 20ms after it finishes drawing — is a
+confirmation you can miss by blinking.
+
+Reduced motion: skip the choreography, hold the check, hide.
+
+### 7 · Cancelled — 140ms, new
+`scale(0.7)`, `translateY(+4px)`, `opacity 0`. Half the entrance, no mark,
+deliberately dismissive. The sub-250ms "nothing said" path uses the same exit at
+120ms without the drop.
+
+### 8 · Failed — 360ms, new
+The card grows out of the capsule's footprint. Card starts at
+`scale(0.32, 0.34)` — its true ratio to the capsule — with `border-radius: 60px`
+so the corner *looks* constant through the inflation, `transform-origin` at the
+capsule's centre. Capsule leaves over 120ms from t=0; card arrives 60–360ms.
+Transform and radius only; no width/height animation. The existing
+`setPillExpanded` + double-rAF room handshake already provides the window space.
+
+### 9 · Recovered — 240ms, new
+Retry runs the morph backwards: card deflates over 110ms, capsule inflates over
+240ms already showing the sweep, with the "Retrying" mark in the status slot.
+
+## 5. Removals
+
+- **The `connecting` BarMode**, with its `runBars` branch and its
+  `startBarAnimation("connecting")` call. `initializing` stays as internal state
+  (the hotkey-release path needs it) but renders identically to `recording`:
+  the pill arrives and the bars sit at rest until real audio moves them.
+  Recording begins the moment the pill is summoned.
+- **Live partial plumbing.** `onPartial` is a live wire into a no-op. Product
+  position is that partials belong nowhere in the UI, so the callback and its
+  `case "partial"` dispatch come out rather than tempting a future reader.
+
+## 6. Accepted as-is
+
+- `.pill-status` animates `width`. It is a 22px slot and the capsule genuinely
+  must grow; FLIP here would be more machinery than the problem deserves.
+- The capsule is not keyboard-reachable (`focusable: false` on the window).
+  Escape is a global shortcut and remains the keyboard path.
+- **Drag** gets hover feedback only. A deeper shadow *while dragging* would need
+  a `pill:dragging` IPC message off the main process's existing `will-move` /
+  `moved` listeners — worth doing, but it is the one item here that adds IPC, so
+  it is called out rather than assumed.
+
+## 7. The pill must stay up through the paste
+
+`deliverOutput` used to hide the pill window from inside `pasteIntoFocusedApp`'s
+`beforePaste` callback, immediately before the synthetic keystroke. That made
+the delivered animation **unobservable in principle**: the renderer only starts
+it once `pasteText` resolves, by which point the window it draws into had been
+gone for hundreds of milliseconds. The check had never once been seen.
+
+Nothing about pasting needed the window down. The pill is created
+`focusable: false`, plus a non-activating `panel` on macOS, so it is never the
+focused window and the keystroke reaches the same application either way.
+Hiding now belongs entirely to the renderer, which owns the end of the session
+and sends `pill:hide` when its exit finishes. Both callers of `deliverOutput`
+are renderer-driven, so there is always something on the other side to do it.
+
+**Regression test to keep:** measure the gap between the `pasteText` IPC and the
+`pill:hide` IPC. It must be ≥ the delivered exit's length (~430ms). Anything
+that re-introduces an earlier hide silently deletes the confirmation while
+every renderer-side assertion still passes.
+
+## 8. Three traps
+
+All three looked correct in review and were only visible under measurement or on a real first run.
+
+**Endings race, and the vague one wins by default.** The success path asks for
+`"delivered"`, and then `drainQueue`'s own `finally` — which has no way to know
+a delivery just happened — asks for `"quiet"` a moment later. State hasn't
+re-rendered in between, so the second call overwrote the first and every
+successful dictation left via the *cancelled* gesture. `dismissPill` now guards
+on a ref (`exitingRef`), first ending wins. Anything that adds a new call site
+must keep that ordering property: the specific ending is always requested
+before the generic cleanup one.
+
+**A clock that hasn't started reads as the age of the epoch.** The elapsed
+readout was gated on `recording || initializing`, but `startTimeRef` is only set
+once the mic is actually open. On the first press of a fresh process it is still
+`0`, so `Date.now() - 0` cleared the 60s threshold instantly and the status slot
+opened on a `29763131:43` readout — a stray number at the pill's right edge,
+every first startup. It is now gated on `recording` alone plus a non-zero start,
+and the ref is reset between sessions so a stale one can't leak either.
+
+**An inline style silently outranks an animated property.** The card carried
+`borderRadius: 20` in its inline style object, so the
+`.pill-card[data-show="false"] { border-radius: 60px }` start value never
+applied and the corner stayed pinned at 20px through the whole morph — which
+still *looks* plausible in a screenshot, because the scale animation is doing
+the visible work. Anything the stylesheet animates must not also be set inline.
+
+## 9. Verifying it
+
+`getBoundingClientRect()` sampling across a transition is what proves motion
+actually runs — the outside-in close, for instance, is confirmed by the
+bar-to-bar gap holding at exactly 6.0px for every frame of the collapse, which
+is the property that distinguishes it from the group-scale version that
+clumped.
+
+See `[[freestyle-pill-preview-harness]]` for the recipe. Two corrections to it:
+resolve `ws` from `.pnpm` as well (and take `ws@8` — `ws@7` has no
+`WebSocketServer` export), and pass an explicit `executablePath` for Chromium,
+which currently only exists as `chromium_headless_shell-*`.
+
+Silence needs a genuinely silent input — the fake device emits a tone, so the
+flatline correctly never fires against it. Generate one with
+`ffmpeg -f lavfi -i anullsrc=r=48000:cl=mono -t 12 silence.wav` and pass
+`--use-file-for-fake-audio-capture=<path>%noloop`.
+
+## 10. Rebuilding the prototype
+
+The prototype reimplements the pill in vanilla JS at true geometry (30px
+capsule, 96px core, 10 bars at 6px pitch) with the shipped response curve, so
+what you see is dimensionally the component. Levels are synthesised — there is
+no mic in a static page — while the real waveform runs the same math on real
+audio. See `[[freestyle-pill-preview-harness]]` for driving the *actual*
+renderer headlessly, which is how the implementation should be verified.


### PR DESCRIPTION
Four beats now: arrival, listening, handover, departure.
This branch and its commits are to make the pill more animated and give it some small details that make it better to use. 
- Arrival: the enter transition existed but never ran — React mounted the subtree with `data-show="true"` already set, and CSS transitions don't fire on first paint. Held for one committed frame, then released; the bars stagger in right-to-left, the direction samples travel through the row.
- Handover: commit used to zero the targets and swap both easing constants in one frame, deleting your last syllable. It now settles to rest over 180ms, holds still for a beat, and only then starts the machine's sweep.
- Departure: delivered, cancelled and quiet were one instant `window.hide()`. Delivered closes the row from the outside in — every bar collapsing in place, so no two round caps ever slide into each other — draws a check out of the centre in the same white, and holds it. Cancelled gets half the entrance and no mark.
- Silence: 1.6s under the noise floor and the row admits it, rather than letting a muted mic look exactly like a quiet room until the "No audio captured" dialog.
- The capsule gains a soft shadow (it had none, and dissolved into busy backdrops) and lifts under the pointer, so `cursor: grab` has a partner.
