### PR TITLE
docs(remix): restore beUI vendoring notes and flag provider deps

### DIFF
--- a/apps/electron/src/renderer/src/components/agents/README.md
+++ b/apps/electron/src/renderer/src/components/agents/README.md
@@ -1,0 +1,33 @@
+# Vendored agent components (beUI)
+
+These components come from [beUI](https://beui.dev) (MIT), pulled via the shadcn
+registry declared in `apps/electron/components.json`:
+
+```
+npx shadcn@latest add @beui/<name>
+```
+
+They are checked in the same way `components/ui/*` is — the registry is meant to
+be consumed by vendoring, not installed as a package. If you re-run the CLI to
+update or add one, four traps are waiting:
+
+1. **The CLI clobbers `lib/utils.ts`.** The beUI registry ships its own `cn`
+   helper and overwrites ours on add. Discard that change — keep our `lib/utils.ts`.
+
+2. **It writes a self-referential import.** Generated files may import from their
+   own path (e.g. a component importing itself). Rewrite those to the real source.
+
+3. **`m.*`, never `motion.*`.** Everything here renders under
+   `<LazyMotion features={domMax} strict>` in `remix-chat.tsx`. `strict` forbids
+   the eager `motion.*` API and throws at runtime if it slips in — rewrite every
+   `motion.foo` the CLI emits to the tree-shakeable `m.foo`.
+
+4. **Keep the code split.** The chat (and its Motion deps) is lazy-loaded at the
+   `app.tsx` boundary so the dictation entry chunk stays small. Don't import these
+   components into anything that loads on the pill's hot path; keep them behind the
+   `remix-chat` lazy import.
+
+`tool-result` and `agent-code` are deliberately **not** vendored: they pull in
+shiki for syntax highlighting, and Remix's disclosure shows JSON, not source.
+</content>
+</invoke>

--- a/apps/electron/src/renderer/src/components/agents/message-scroller.tsx
+++ b/apps/electron/src/renderer/src/components/agents/message-scroller.tsx
@@ -330,6 +330,9 @@ export function MessageScroller({
     if (!content || !viewport) return;
 
     scheduleRailSync();
+    // characterData + subtree fires on every streamed token; scheduleRailSync
+    // re-reads all messages' textContent. rAF-coalesced and fine at chat
+    // message counts — revisit if threads grow long while streaming.
     const mutationObserver =
       typeof MutationObserver === "undefined"
         ? null

--- a/apps/electron/src/renderer/src/components/motion/preview-rail.tsx
+++ b/apps/electron/src/renderer/src/components/motion/preview-rail.tsx
@@ -60,6 +60,12 @@ function DefaultPreview({ item }: { item: PreviewRailItem }) {
   );
 }
 
+/**
+ * Uses `m.*` (not `motion.*`) and so must render inside a `LazyMotion` provider.
+ * Today its only consumer is `MessageScroller`, rendered under remix-chat's
+ * `<LazyMotion features={domMax} strict>`. Any direct use elsewhere must supply
+ * that provider or `strict` mode will throw at runtime.
+ */
 export function PreviewRail({
   items,
   label = "Section navigation",


### PR DESCRIPTION
Follow-up to #544, addressing the review nitpicks. **Comments and docs only — no behavior change.**

### Changes
1. **Restore `components/agents/README.md`** — #544's commit narrative referenced this file ("where the next person to run the CLI will be standing") but the final commit stripped it. Restored as a concise checklist of the four beUI CLI traps: `lib/utils.ts` clobber, self-referential import, the `m.*`-not-`motion.*` rule under `LazyMotion strict`, and keeping the chat code-split off the dictation hot path.
2. **`PreviewRail` provider note** — documents that it uses `m.*` and must render inside a `LazyMotion` provider. Today its only consumer (`MessageScroller` → `remix-chat`) satisfies this; a future direct use elsewhere would throw under `strict`. Saves the next person a confusing runtime crash.
3. **`MessageScroller` MutationObserver note** — flags that `characterData`+`subtree` fires on every streamed token and `scheduleRailSync` re-reads all messages' `textContent`. rAF-coalesced and fine at current message counts; noted to revisit if threads grow long while streaming.

### Verification
- `typecheck:web` clean
- `biome check` clean
- `knip` clean