### PR TITLE
perf(electron): bound the plugin WebContentsView cache with an LRU cap

### DIFF
--- a/apps/electron/src/main/plugins/view-manager.ts
+++ b/apps/electron/src/main/plugins/view-manager.ts
@@ -11,6 +11,15 @@ export interface ViewBounds {
 }
 
 /**
+ * Maximum number of plugin views kept alive in the cache at once. Each cached
+ * view is a live `WebContentsView` (its own renderer process + GPU surface), so
+ * an unbounded cache leaks a process per distinct plugin page ever visited.
+ * Beyond this many, the least-recently-shown view is evicted (destroyed); it
+ * simply reloads on the next visit.
+ */
+const MAX_CACHED_VIEWS = 6;
+
+/**
  * Hosts plugin UI pages in sandboxed {@link WebContentsView}s overlaid on the
  * dashboard window. The renderer reports the bounds of its placeholder; we size
  * the active view to match. Only one plugin page is visible at a time, but
@@ -76,6 +85,9 @@ export class PluginViewManager {
     // Re-attach from cache if available.
     const cached = this.views.get(key);
     if (cached) {
+      // Mark as most-recently-used by re-inserting at the end of the Map.
+      this.views.delete(key);
+      this.views.set(key, cached);
       if (this.activeKey !== key) {
         this.window.contentView.addChildView(cached);
         this.activeKey = key;
@@ -105,6 +117,7 @@ export class PluginViewManager {
     this.window.contentView.addChildView(view);
     this.activeKey = key;
     this.setBounds(bounds);
+    this.evictLeastRecentlyUsed();
     const url = `${this.getServerBaseUrl()}/api/plugins/${encodeURIComponent(
       slug,
     )}/ui/${entry.replace(/^\/+/, "")}`;
@@ -199,6 +212,25 @@ export class PluginViewManager {
     if (!view) return;
     if (this.window && !this.window.isDestroyed()) {
       this.window.contentView.removeChildView(view);
+    }
+  }
+
+  /**
+   * Evict least-recently-shown views (destroying their renderer processes)
+   * until the cache is within {@link MAX_CACHED_VIEWS}. The Map is ordered
+   * most-recently-used last (see {@link show}), so the oldest entries come
+   * first. The active view is never evicted, even if it's the oldest.
+   */
+  private evictLeastRecentlyUsed(): void {
+    if (this.views.size <= MAX_CACHED_VIEWS) return;
+    for (const [key, view] of this.views) {
+      if (this.views.size <= MAX_CACHED_VIEWS) break;
+      if (key === this.activeKey) continue;
+      if (this.window && !this.window.isDestroyed()) {
+        this.window.contentView.removeChildView(view);
+      }
+      view.webContents.close();
+      this.views.delete(key);
     }
   }
 


### PR DESCRIPTION
## Summary

The plugin view cache (`PluginViewManager`) kept **every** visited plugin page alive indefinitely. Each cached entry is a live `WebContentsView` — its own renderer process + GPU surface — so the cache leaked a process per distinct plugin page ever opened.

This caps the cache at `MAX_CACHED_VIEWS` (6) using the existing `Map` as an LRU:
- `show()` re-inserts the accessed key so it becomes most-recently-used.
- Creating a new view triggers `evictLeastRecentlyUsed()`, which destroys the oldest cached view (`webContents.close()`) until within the cap.
- The **active** view is never evicted, even if it's the oldest.
- Evicted pages simply reload on the next visit (same as a first visit).

Part of a performance audit of `apps/electron` + `apps/server`. Kept as its own PR because it changes view lifecycle and warrants a manual check.

## Testing checklist (please verify before merge)
- [ ] Open 7+ distinct plugin pages, then return to the first — it reloads cleanly (no crash, correct content).
- [ ] Rapidly switch between 2–3 plugin pages — no white flash, no eviction of the visible page.
- [ ] Install/update/uninstall a plugin — `invalidate()` still clears everything (existing behavior).
- [ ] Confirm renderer process count (Electron task manager) stops growing past the cap.

## Notes
- `MAX_CACHED_VIEWS = 6` is a starting value; easy to tune.
- Typecheck (`tsconfig.node`) and `biome` clean. No existing tests cover this class.