### PR TITLE
feat(electron): widen update banner to max-w-5xl

### DIFF
--- a/apps/electron/src/renderer/src/shell.tsx
+++ b/apps/electron/src/renderer/src/shell.tsx
@@ -347,7 +347,7 @@ export default function AppShell(): React.JSX.Element {
           </a>
         </div>
 
-        <UpdateBanner className="relative z-50 mt-14 w-[calc(100%-3rem)] max-w-2xl self-center" />
+        <UpdateBanner className="relative z-50 mt-14 w-[calc(100%-3rem)] max-w-5xl self-center" />
 
         <main
           className="flex min-h-0 flex-1 flex-col overflow-hidden"


### PR DESCRIPTION
## What

Widens the in-app update banner from `max-w-2xl` (~672px) to `max-w-5xl` (~1024px) so it stretches further across the content area.

## Change

Single line in `apps/electron/src/renderer/src/shell.tsx`:

```diff
-<UpdateBanner className="relative z-50 mt-14 w-[calc(100%-3rem)] max-w-2xl self-center" />
+<UpdateBanner className="relative z-50 mt-14 w-[calc(100%-3rem)] max-w-5xl self-center" />
```

- Bumps the max-width cap so the banner is wider and better balanced with the surrounding layout.
- Keeps `w-[calc(100%-3rem)]` to preserve the 1.5rem side gutters (banner doesn't touch the window edges).
- Banner internals (`update-banner.tsx`) are unchanged — its `justify-between` flex layout spreads the version text (left) and action button (right) to the container edges.
- Remains a thin, non-dismissible strip; no behavior change.

## Verification

- `pnpm --filter electron typecheck:web` passes.
- Pure Tailwind class change; no logic touched.