### PR TITLE
feat(remix): more polish on the UX & UI, adds orbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ test-results/
 .env.local
 .env.*.local
 !.env.example
+
+# Throwaway Remix card preview harness (see AGENTS.md)
+apps/electron/vite.remix-preview.config.ts
+apps/electron/src/renderer/remix-preview.html
+apps/electron/src/renderer/src/remix-preview.tsx

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -61,6 +61,7 @@
     "remark-gfm": "^4.0.0",
     "shadcn": "^4.8.0",
     "tailwind-merge": "^3.6.0",
+    "thinking-orbs": "^0.2.0",
     "tw-animate-css": "^1.4.0",
     "winston": "^3.17.0",
     "ws": "^8.21.0",

--- a/apps/electron/src/renderer/src/components/remix-bar.tsx
+++ b/apps/electron/src/renderer/src/components/remix-bar.tsx
@@ -1,3 +1,4 @@
+import { EASE_OUT_CSS } from "@renderer/lib/ease";
 import type React from "react";
 import { useCallback, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -65,8 +66,8 @@ function RemixBar(): React.JSX.Element {
           border-radius: 999px;
           background: rgba(22, 20, 15, 0.98);
           border: 1px solid rgba(245, 241, 228, 0.35);
-          transition: width 220ms cubic-bezier(0.22, 1, 0.36, 1),
-            height 220ms cubic-bezier(0.22, 1, 0.36, 1),
+          transition: width 220ms ${EASE_OUT_CSS},
+            height 220ms ${EASE_OUT_CSS},
             border-color 220ms ease;
         }
         .bar-hit[data-hot="true"] .bar-strip {

--- a/apps/electron/src/renderer/src/components/remix-chat-surface.ts
+++ b/apps/electron/src/renderer/src/components/remix-chat-surface.ts
@@ -2,6 +2,12 @@
  * window without importing the chat (and its animation deps). */
 export const REMIX_CHAT_SURFACE = { width: 408, height: 560 } as const;
 
+/** The card grows with its content between these two. 560 stays the room the
+ * window reserves, so growing never has to resize the window — the card just
+ * occupies more of a space that is already there. */
+export const REMIX_CHAT_MIN_HEIGHT = 132;
+export const REMIX_CHAT_MAX_HEIGHT = REMIX_CHAT_SURFACE.height;
+
 /** Resting strip size; grows when a settled run shows the final message. */
 export const REMIX_CHAT_STRIP = { width: 320, height: 44 } as const;
 

--- a/apps/electron/src/renderer/src/components/remix-chat-surface.ts
+++ b/apps/electron/src/renderer/src/components/remix-chat-surface.ts
@@ -2,9 +2,8 @@
  * window without importing the chat (and its animation deps). */
 export const REMIX_CHAT_SURFACE = { width: 408, height: 560 } as const;
 
-/** The card grows with its content between these two. 560 stays the room the
- * window reserves, so growing never has to resize the window — the card just
- * occupies more of a space that is already there. */
+/** The card grows between these two inside room the window already holds, so
+ * growing never resizes the window. */
 export const REMIX_CHAT_MIN_HEIGHT = 132;
 export const REMIX_CHAT_MAX_HEIGHT = REMIX_CHAT_SURFACE.height;
 

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -7,6 +7,7 @@ import { ThinkingShimmer } from "@renderer/components/agents/loading-states/thin
 import { MessageScroller } from "@renderer/components/agents/message-scroller";
 import { capture } from "@renderer/lib/analytics";
 import { apiFetch } from "@renderer/lib/api";
+import { EASE_MORPH_CSS, EASE_OUT_CSS, MORPH_MS } from "@renderer/lib/ease";
 import {
   DefaultChatTransport,
   type DynamicToolUIPart,
@@ -17,6 +18,7 @@ import {
   type ToolUIPart,
   type UIMessage,
 } from "ai";
+import { ArrowUp, ChevronRight, Plus, Square, X } from "lucide-react";
 import { domMax, LazyMotion } from "motion/react";
 import type React from "react";
 import {
@@ -421,20 +423,23 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
 
   const busy = status === "submitted" || status === "streaming";
 
-  const narrating = useMemo(
-    () =>
-      messages.some(
-        (message) =>
-          message.role === "assistant" &&
-          message.parts.some(
-            (part) =>
-              isToolOrDynamicToolUIPart(part) &&
-              part.state !== "output-available" &&
-              part.state !== "output-error",
-          ),
-      ),
-    [messages],
-  );
+  /**
+   * Only the turn in progress can hold a live tool call. Scanning the whole
+   * thread let one non-terminal part pin the pill to "narrating" for good.
+   */
+  const narrating = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (message.role !== "assistant") continue;
+      return message.parts.some(
+        (part) =>
+          isToolOrDynamicToolUIPart(part) &&
+          part.state !== "output-available" &&
+          part.state !== "output-error",
+      );
+    }
+    return false;
+  }, [messages]);
 
   const [settled, setSettled] = useState(false);
   useEffect(() => {
@@ -545,12 +550,25 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
   const [miniContentHeight, setMiniContentHeight] = useState<number | null>(
     null,
   );
+  /**
+   * The last unbroken run of text — the answer, without the narration that
+   * preceded the work, which the activity rows already cover. Anchored on the
+   * last run rather than "after the final tool" so a turn signing off with a
+   * delivery tool keeps its answer.
+   */
   const finalText = useMemo(() => {
     if (busy) return null;
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
       if (message.role !== "assistant") continue;
+      const end = message.parts.findLastIndex(
+        (part) => isTextUIPart(part) && part.text.trim() !== "",
+      );
+      if (end === -1) return null;
+      let start = end;
+      while (start > 0 && isTextUIPart(message.parts[start - 1])) start--;
       const text = message.parts
+        .slice(start, end + 1)
         .filter(isTextUIPart)
         .map((part) => part.text)
         .join("")
@@ -559,8 +577,12 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
     }
     return null;
   }, [messages, busy]);
-  const showFullFinal =
-    minimized && settled && notice === null && finalText !== null;
+  /**
+   * Not gated on `minimized`: the strip is only visible while minimized, and
+   * gating made the outgoing face restructure mid-exit — hovering to expand
+   * flashed the one-line form at strip height against the bottom edge.
+   */
+  const showFullFinal = settled && notice === null && finalText !== null;
   const miniStripHeight = showFullFinal
     ? Math.min(
         Math.max(
@@ -774,19 +796,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
                 aria-label="Start a new thread"
                 title="Start a new thread"
               >
-                <svg
-                  width="13"
-                  height="13"
-                  viewBox="0 0 14 14"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M7 2.5v9M2.5 7h9"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
-                </svg>
+                <Plus size={13} strokeWidth={1.7} aria-hidden="true" />
               </button>
               <button
                 type="button"
@@ -798,19 +808,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
                 aria-label="Close"
                 title="Close (Esc)"
               >
-                <svg
-                  width="11"
-                  height="11"
-                  viewBox="0 0 10 10"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M2 2l6 6M8 2l-6 6"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
-                </svg>
+                <X size={12} strokeWidth={1.7} aria-hidden="true" />
               </button>
             </span>
           </div>
@@ -894,49 +892,30 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
                 }
               }}
             />
-            {busy ? (
-              <button
-                type="button"
-                className="remix-chat-send"
-                onClick={() => stop()}
-                aria-label="Stop"
-                title="Stop"
-              >
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 12 12"
+            {/* One button, two glyphs: the state that changes is the run's,
+                not the control's. The outgoing glyph blurs so the swap reads
+                as one object. */}
+            <button
+              type="button"
+              className="remix-chat-send"
+              data-busy={busy}
+              disabled={!busy && !input.trim()}
+              onClick={busy ? () => stop() : submit}
+              aria-label={busy ? "Stop" : "Send"}
+              title={busy ? "Stop" : "Send"}
+            >
+              <span className="remix-chat-send-glyph" data-on={!busy}>
+                <ArrowUp size={14} strokeWidth={2} aria-hidden="true" />
+              </span>
+              <span className="remix-chat-send-glyph" data-on={busy}>
+                <Square
+                  size={11}
+                  strokeWidth={0}
+                  fill="currentColor"
                   aria-hidden="true"
-                >
-                  <rect x="1.5" y="1.5" width="9" height="9" rx="2" />
-                </svg>
-              </button>
-            ) : (
-              <button
-                type="button"
-                className="remix-chat-send"
-                disabled={!input.trim()}
-                onClick={submit}
-                aria-label="Send"
-                title="Send"
-              >
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 16 16"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M8 12.8V3.6M4.1 7.4 8 3.5l3.9 3.9"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </button>
-            )}
+                />
+              </span>
+            </button>
           </div>
         </div>
       </LazyMotion>
@@ -996,7 +975,9 @@ function latestActivity(messages: UIMessage[], busy: boolean): string {
         };
         const finished =
           part.state === "output-available" || part.state === "output-error";
-        return finished && !busy ? labels.done : labels.doing;
+        // Keyed on the tool's state, not the run's: gating on `!busy` left a
+        // fast search reading "Searching the web…" for the rest of the turn.
+        return finished ? labels.done : labels.doing;
       }
       if (isTextUIPart(part) && part.text.trim()) {
         const line = part.text.trim().split("\n")[0] ?? "";
@@ -1092,23 +1073,13 @@ function ToolStepLabel({
         aria-expanded={open}
       >
         <span className="remix-chat-step-label">{label}</span>
-        <svg
+        <ChevronRight
           className="remix-chat-step-chevron"
           data-open={open}
-          width="8"
-          height="8"
-          viewBox="0 0 8 8"
+          size={9}
+          strokeWidth={1.7}
           aria-hidden="true"
-        >
-          <path
-            d="M2.5 1.5 5.5 4 2.5 6.5"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
+        />
       </button>
       <AgentDisclosure open={open}>
         {/* Spans: AgentActivity puts labels in a <span>; block tags would be invalid. */}
@@ -1224,31 +1195,32 @@ const REMIX_CHAT_CSS = `
     color: ${INK};
   }
 
+  /* One shape changing, not two surfaces swapping: the incoming face lands as
+     .pill-chat-morph finishes resizing the box (${MORPH_MS}ms). No visibility
+     — a stepped one cannot retarget, and expand is onMouseEnter, so a graze
+     could strand a face visible but unhittable. */
   .remix-chat-face-strip {
     opacity: 0;
     pointer-events: none;
-    visibility: hidden;
-    transition: opacity 110ms ease, visibility 0s 110ms;
+    transition: opacity 150ms ease;
   }
   .remix-chat[data-minimized="true"] .remix-chat-face-strip {
     opacity: 1;
     pointer-events: auto;
-    visibility: visible;
-    transition: opacity 200ms ease 60ms, visibility 0s;
+    transition: opacity 210ms ${EASE_MORPH_CSS} ${MORPH_MS - 210}ms;
   }
   .remix-chat-face-full {
     display: flex;
     flex-direction: column;
     min-height: 0;
     opacity: 1;
-    visibility: visible;
-    transition: opacity 220ms ease 60ms, visibility 0s;
+    pointer-events: auto;
+    transition: opacity 210ms ${EASE_MORPH_CSS} ${MORPH_MS - 210}ms;
   }
   .remix-chat[data-minimized="true"] .remix-chat-face-full {
     opacity: 0;
     pointer-events: none;
-    visibility: hidden;
-    transition: opacity 110ms ease, visibility 0s 110ms;
+    transition: opacity 150ms ease;
   }
 
   .remix-mini {
@@ -1288,6 +1260,20 @@ const REMIX_CHAT_CSS = `
     font-size: 12.5px;
     line-height: 1.5;
     color: ${INK_DIM};
+  }
+
+  /* The box morphs over ${MORPH_MS}ms; without this the words inside swapped
+     in one frame, and it read as the card vanishing and a strip appearing.
+     Opens at 0.55, not 0: a throttled window parks an animation on its first
+     frame — no fill mode reaches a timeline stuck at t=0 — so that frame has
+     to stay legible. */
+  .remix-mini-message,
+  .remix-mini-line {
+    animation: remix-mini-content ${MORPH_MS - 60}ms ${EASE_MORPH_CSS};
+  }
+  @keyframes remix-mini-content {
+    from { opacity: 0.55; transform: translateY(-2px); }
+    to { opacity: 1; transform: none; }
   }
   /* No color here — TextShimmer paints via background-clip; color would hide it. */
   .remix-mini-line {
@@ -1334,9 +1320,11 @@ const REMIX_CHAT_CSS = `
     background: none;
     color: ${INK_FAINT};
     cursor: pointer;
-    transition: background 140ms ease, color 140ms ease;
+    transition: background 140ms ease, color 140ms ease,
+      transform 140ms ${EASE_OUT_CSS};
   }
   .remix-chat-icon:hover { background: rgba(245, 241, 228, 0.08); color: ${INK}; }
+  .remix-chat-icon:active { transform: scale(0.94); }
 
   .remix-chat-scroll { flex: 1; min-height: 0; }
   .remix-chat-thread {
@@ -1471,8 +1459,10 @@ const REMIX_CHAT_CSS = `
     text-overflow: ellipsis;
     white-space: nowrap;
     cursor: pointer;
+    transition: background 140ms ease, transform 140ms ${EASE_OUT_CSS};
   }
   .remix-chat-chip:hover { background: rgba(245, 241, 228, 0.15); }
+  .remix-chat-chip:active { transform: scale(0.97); }
   .remix-chat-quick {
     display: flex;
     flex-wrap: wrap;
@@ -1518,12 +1508,44 @@ const REMIX_CHAT_CSS = `
     background: rgba(245, 241, 228, 0.92);
     color: rgba(24, 22, 18, 0.95);
     cursor: pointer;
-    transition: opacity 140ms ease, transform 140ms ease;
+    position: relative;
+    transition: opacity 140ms ease, transform 140ms ${EASE_OUT_CSS},
+      background 160ms ease;
   }
-  .remix-chat-send svg rect { fill: currentColor; }
   .remix-chat-send:disabled { opacity: 0.3; cursor: default; }
-  .remix-chat-send:not(:disabled):hover { transform: scale(1.06); }
-  .remix-chat-send:not(:disabled):active { transform: scale(0.95); }
+  /* Press feedback only — a hover scale on the most-clicked control here is
+     decoration at a frequency tier that has no budget for it. */
+  .remix-chat-send:not(:disabled):active { transform: scale(0.94); }
+  .remix-chat-send[data-busy="true"] { background: rgba(245, 241, 228, 0.55); }
+  .remix-chat-send-glyph {
+    position: absolute;
+    inset: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: opacity 190ms ${EASE_OUT_CSS}, transform 190ms ${EASE_OUT_CSS},
+      filter 190ms ${EASE_OUT_CSS};
+  }
+  .remix-chat-send-glyph[data-on="false"] {
+    opacity: 0;
+    transform: scale(0.72);
+    filter: blur(2px);
+  }
+  .remix-chat-send-glyph[data-on="true"] {
+    opacity: 1;
+    transform: none;
+    filter: blur(0);
+  }
+
+  /* The card carries its own palette; the UA default ring is a blue halo. */
+  .remix-chat-icon:focus-visible,
+  .remix-chat-chip:focus-visible,
+  .remix-chat-send:focus-visible,
+  .remix-chat-step-head:focus-visible {
+    outline: 1px solid rgba(245, 241, 228, 0.5);
+    outline-offset: 2px;
+    border-radius: 7px;
+  }
 
   .remix-md { line-height: 1.6; word-break: break-word; }
   .remix-md > *:first-child { margin-top: 0; }
@@ -1579,4 +1601,30 @@ const REMIX_CHAT_CSS = `
     text-align: left;
   }
   .remix-md th { background: rgba(245, 241, 228, 0.06); font-weight: 600; }
+
+  /* app.tsx's block only names .pill-*, and this card is a separate <style>.
+     Keep the fades, drop the travel, scale and blur. */
+  @media (prefers-reduced-motion: reduce) {
+    .remix-chat-icon:active,
+    .remix-chat-chip:active,
+    .remix-chat-send:not(:disabled):active { transform: none; }
+    .remix-chat-send-glyph[data-on="false"] {
+      transform: none;
+      filter: none;
+    }
+    .remix-chat-send-glyph { transition-duration: 120ms; }
+    /* The rotation stays — it is the only open/closed affordance. */
+    .remix-chat-step-chevron { transition-duration: 1ms; }
+    .remix-chat-face-strip,
+    .remix-chat[data-minimized="true"] .remix-chat-face-strip,
+    .remix-chat-face-full,
+    .remix-chat[data-minimized="true"] .remix-chat-face-full {
+      transition-duration: 120ms;
+      transition-delay: 0ms;
+    }
+    @keyframes remix-mini-content {
+      from { opacity: 0.55; }
+      to { opacity: 1; }
+    }
+  }
 `;

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -97,8 +97,7 @@ export function RemixChat(props: RemixChatProps): React.JSX.Element {
     props.initialInstruction,
   );
 
-  // Surface sizes to this until natural-height measurement lands. The cap
-  // keeps the pill from jumping to an empty 560px.
+  // The cap keeps the pill from jumping to an empty 560px.
   useEffect(() => {
     props.onHeightChange?.(REMIX_CHAT_MAX_HEIGHT);
   }, [props.onHeightChange]);
@@ -199,26 +198,15 @@ export function RemixChat(props: RemixChatProps): React.JSX.Element {
   );
 }
 
-/**
- * The box both marks are centred in, so the line of text beside them never
- * shifts when a run lands.
- */
+/** The box both marks share, so the text beside them never shifts. */
 const MINI_MARK = 22;
 
-/**
- * The settled check's ink, inset from that box: a solid disc reads heavier
- * than the orb's dotted sphere at the same diameter.
- */
+/** Inset in that box: a solid disc reads heavier than a dotted sphere. */
 const REST_MARK = 19;
 
 /**
- * The running orb, at its native scale.
- *
- * Not the 64 preset scaled down. Supersampling looks right in the backing
- * store and wrong on screen: the compositor resolves a CSS-scaled canvas with
- * bilinear filtering, and a field of sub-pixel dots run through that shimmers
- * — grainier than the coarse preset it was meant to fix. Canvas pixels map
- * 1:1 to device pixels here, which is the only arrangement that cannot alias.
+ * Native scale, not the 64 preset scaled down: a CSS-scaled canvas is resolved
+ * with bilinear filtering, and a field of sub-pixel dots through that shimmers.
  */
 function MiniOrb({ state }: { state: "composing" | "searching" }) {
   return (
@@ -235,9 +223,8 @@ const SWEEP_TOTAL_MS = SWEEP_ARC_MS + SWEEP_FLOOD_MS;
 const SWEEP_ARC_END = SWEEP_ARC_MS / SWEEP_TOTAL_MS;
 
 /**
- * @param active Whether the strip is the visible face. Both faces stay
- * mounted, so an ungated sweep burns behind `opacity: 0` and leaves a check
- * already drawn by the time the pill shows it.
+ * @param active Whether the strip is the visible face. Both stay mounted, so
+ * an ungated sweep burns behind `opacity: 0` and is spent before it is seen.
  */
 function RestMark({ failed, active }: { failed: boolean; active: boolean }) {
   const maskId = useId();
@@ -246,15 +233,9 @@ function RestMark({ failed, active }: { failed: boolean; active: boolean }) {
   const circumference = 2 * Math.PI * 6.1;
 
   /**
-   * The markup is the RESTING state — filled disc, spent arc — and the
-   * entrance is one `fill: "none"` timeline played over it.
-   *
-   * That direction is deliberate. Any fill mode that holds a keyframe leaves
-   * the mark showing the *opening* frame wherever the timeline cannot run: an
-   * occluded window freezes WAAPI at t=0, and the pill is occluded often. With
-   * no fill, a frozen or skipped animation degrades to the correct final look
-   * instead of an empty circle. Both legs ride one timeline for the same
-   * reason — a delayed second animation would strand the disc mid-sweep.
+   * The markup is the resting state and the entrance plays over it with
+   * `fill: "none"`, so a timeline that cannot run degrades to settled rather
+   * than to an empty circle. Both legs ride one timeline so neither strands.
    */
   useLayoutEffect(() => {
     const arc = arcRef.current;
@@ -266,9 +247,7 @@ function RestMark({ failed, active }: { failed: boolean; active: boolean }) {
       typeof window === "undefined" ||
       window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ===
         true ||
-      // An occluded window does not advance WAAPI, and an animation parked at
-      // its first frame would leave the mark drawn as an empty circle. Nobody
-      // is watching an entrance they cannot see, so skip straight to settled.
+      // Occluded windows don't advance WAAPI; skip straight to settled.
       document.hidden
     ) {
       return;
@@ -307,10 +286,8 @@ function RestMark({ failed, active }: { failed: boolean; active: boolean }) {
         transform: "scale(0.42)",
         opacity: 0,
         filter: "blur(1.4px)",
-        // Overshoots a few percent and settles back. A straight ease-out
-        // landed the colour like a light switch, with nowhere for the
-        // impact to go; the blur resolving alongside keeps the arc and the
-        // disc reading as one object rather than two swapping places.
+        // Overshoots and settles back; a straight ease-out landed the
+        // colour like a light switch, with nowhere for the impact to go.
         easing: "cubic-bezier(0.34, 1.16, 0.36, 1)",
       },
       {
@@ -637,15 +614,11 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
   const busy = status === "submitted" || status === "streaming";
   const busyRef = useRef(busy);
   busyRef.current = busy;
-  // Anything the user would want to read after walking away. Same ref
-  // treatment as `busy`, and for the same reason.
+  // Same ref treatment as `busy`, and for the same reason.
   const hasContentRef = useRef(false);
   hasContentRef.current = messages.length > 0;
 
-  /**
-   * Only the turn in progress can hold a live tool call. Scanning the whole
-   * thread let one non-terminal part pin the pill to "narrating" for good.
-   */
+  /** Scanning the whole thread let one stuck part pin this true for good. */
   const narrating = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
@@ -742,9 +715,8 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
       minimizeTimerRef.current = setTimeout(() => {
         minimizeTimerRef.current = null;
         document.removeEventListener("mouseover", handleOver);
-        // Read through the ref, not the closure: a run that starts during the
-        // grace window has to count, and putting `busy` in this effect's deps
-        // would tear the listeners down and rebuild them on every token.
+        // Refs, not the closure: a run starting inside the grace window has
+        // to count, and `busy` in the deps would rebuild these every token.
         onMinimize({
           busy: busyRef.current,
           hasContent: hasContentRef.current,
@@ -776,10 +748,8 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
     null,
   );
   /**
-   * The last unbroken run of text — the answer, without the narration that
-   * preceded the work, which the activity rows already cover. Anchored on the
-   * last run rather than "after the final tool" so a turn signing off with a
-   * delivery tool keeps its answer.
+   * The last unbroken run of text: the answer, without the narration before it.
+   * Not "after the final tool" — a turn can sign off with a delivery tool.
    */
   const finalText = useMemo(() => {
     if (busy) return null;
@@ -802,11 +772,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
     }
     return null;
   }, [messages, busy]);
-  /**
-   * Not gated on `minimized`: the strip is only visible while minimized, and
-   * gating made the outgoing face restructure mid-exit — hovering to expand
-   * flashed the one-line form at strip height against the bottom edge.
-   */
+  /** Not gated on `minimized`, or the leaving face restructures mid-exit. */
   const showFullFinal = settled && notice === null && finalText !== null;
   const miniStripHeight = showFullFinal
     ? Math.min(
@@ -1212,8 +1178,8 @@ function latestActivity(messages: UIMessage[], busy: boolean): string {
         };
         const finished =
           part.state === "output-available" || part.state === "output-error";
-        // Keyed on the tool's state, not the run's: gating on `!busy` left a
-        // fast search reading "Searching the web…" for the rest of the turn.
+        // The tool's state, not the run's: `!busy` left a fast search
+        // reading "Searching the web…" for the rest of the turn.
         return finished ? labels.done : labels.doing;
       }
       if (isTextUIPart(part) && part.text.trim()) {
@@ -1449,10 +1415,9 @@ const REMIX_CHAT_CSS = `
     color: ${INK};
   }
 
-  /* One shape changing, not two surfaces swapping: the incoming face lands as
-     .pill-chat-morph finishes resizing the box (${MORPH_MS}ms). No visibility
-     — a stepped one cannot retarget, and expand is onMouseEnter, so a graze
-     could strand a face visible but unhittable. */
+  /* One shape changing, not two swapping: the incoming face lands as
+     .pill-chat-morph finishes resizing the box. No visibility — a stepped one
+     cannot retarget, so a graze could strand a face visible but unhittable. */
   .remix-chat-face-strip {
     opacity: 0;
     pointer-events: none;
@@ -1477,8 +1442,7 @@ const REMIX_CHAT_CSS = `
     transition: opacity 150ms ease;
   }
 
-  /* Padding is measured to the mark's box, not the ink inside it, so 12 left
-     against 16 right reads as even — the mark's own air makes up the rest. */
+  /* Measured to the mark's box, not its ink: 12 left reads even against 16. */
   .remix-mini {
     display: flex;
     align-items: center;
@@ -1486,9 +1450,8 @@ const REMIX_CHAT_CSS = `
     height: 100%;
     padding: 0 16px 0 12px;
   }
-  /* Opened by a landed answer. Top-aligned, because a paragraph beside a
-     centred mark reads as misaligned the moment it wraps. Vertical padding
-     sums to MINI_STRIP_PAD, which is what measures the grown pill. */
+  /* Top-aligned: a paragraph beside a centred mark reads as misaligned once
+     it wraps. Vertical padding sums to MINI_STRIP_PAD. */
   .remix-mini[data-full="true"] {
     align-items: flex-start;
     height: 100%;
@@ -1505,11 +1468,9 @@ const REMIX_CHAT_CSS = `
     color: ${INK_DIM};
   }
 
-  /* The box morphs over ${MORPH_MS}ms; without this the words inside swapped
-     in one frame, and it read as the card vanishing and a strip appearing.
-     Opens at 0.55, not 0: a throttled window parks an animation on its first
-     frame — no fill mode reaches a timeline stuck at t=0 — so that frame has
-     to stay legible. */
+  /* Without this the words swapped in one frame under a morphing box. Opens
+     at 0.55, not 0: a throttled window parks an animation on its first frame,
+     and no fill mode reaches a timeline stuck at t=0. */
   .remix-mini-message,
   .remix-mini-line {
     animation: remix-mini-content ${MORPH_MS - 60}ms ${EASE_MORPH_CSS};
@@ -1768,8 +1729,7 @@ const REMIX_CHAT_CSS = `
       background 160ms ease;
   }
   .remix-chat-send:disabled { opacity: 0.3; cursor: default; }
-  /* Press feedback only — a hover scale on the most-clicked control here is
-     decoration at a frequency tier that has no budget for it. */
+  /* Press feedback only; hover growth on the most-clicked control is noise. */
   .remix-chat-send:not(:disabled):active { transform: scale(0.94); }
   .remix-chat-send[data-busy="true"] { background: rgba(245, 241, 228, 0.55); }
   .remix-chat-send-glyph {
@@ -1858,8 +1818,7 @@ const REMIX_CHAT_CSS = `
   }
   .remix-md th { background: rgba(245, 241, 228, 0.06); font-weight: 600; }
 
-  /* app.tsx's block only names .pill-*, and this card is a separate <style>.
-     Keep the fades, drop the travel, scale and blur. */
+  /* app.tsx's block only names .pill-*; this card is a separate <style>. */
   @media (prefers-reduced-motion: reduce) {
     .remix-chat-icon:active,
     .remix-chat-chip:active,

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -635,6 +635,12 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
     });
 
   const busy = status === "submitted" || status === "streaming";
+  const busyRef = useRef(busy);
+  busyRef.current = busy;
+  // Anything the user would want to read after walking away. Same ref
+  // treatment as `busy`, and for the same reason.
+  const hasContentRef = useRef(false);
+  hasContentRef.current = messages.length > 0;
 
   /**
    * Only the turn in progress can hold a live tool call. Scanning the whole
@@ -736,7 +742,13 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
       minimizeTimerRef.current = setTimeout(() => {
         minimizeTimerRef.current = null;
         document.removeEventListener("mouseover", handleOver);
-        onMinimize();
+        // Read through the ref, not the closure: a run that starts during the
+        // grace window has to count, and putting `busy` in this effect's deps
+        // would tear the listeners down and rebuild them on every token.
+        onMinimize({
+          busy: busyRef.current,
+          hasContent: hasContentRef.current,
+        });
       }, MINIMIZE_GRACE_MS);
       document.addEventListener("mouseover", handleOver);
     };

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -25,6 +25,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -32,9 +33,11 @@ import {
 } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { ThinkingOrb } from "thinking-orbs";
 import type { RemixSelectionPayload } from "../../../shared/remix";
 import { FreestyleMark } from "./freestyle-mark";
 import {
+  REMIX_CHAT_MAX_HEIGHT,
   REMIX_CHAT_STRIP,
   REMIX_CHAT_SURFACE,
   type RemixChatAnchor,
@@ -77,9 +80,12 @@ export interface RemixChatProps {
   initialInstruction: string | null;
   minimized: boolean;
   onMiniHeightChange?: (height: number) => void;
+  /** Natural height of the full card so the surface can size to its thread. */
+  onHeightChange?: (height: number) => void;
   anchor: RemixChatAnchor;
   onExpand: () => void;
-  onMinimize: () => void;
+  /** Lets the owner keep a live or answered run on screen as the pill. */
+  onMinimize: (options?: { busy?: boolean; hasContent?: boolean }) => void;
   onClose: () => void;
 }
 
@@ -90,6 +96,12 @@ export function RemixChat(props: RemixChatProps): React.JSX.Element {
   const [initialInstruction, setInitialInstruction] = useState(
     props.initialInstruction,
   );
+
+  // Surface sizes to this until natural-height measurement lands. The cap
+  // keeps the pill from jumping to an empty 560px.
+  useEffect(() => {
+    props.onHeightChange?.(REMIX_CHAT_MAX_HEIGHT);
+  }, [props.onHeightChange]);
 
   // Pill is focusable:false; follow the card so the composer can take keyboard.
   useEffect(() => {
@@ -187,6 +199,204 @@ export function RemixChat(props: RemixChatProps): React.JSX.Element {
   );
 }
 
+/**
+ * The box both marks are centred in, so the line of text beside them never
+ * shifts when a run lands.
+ */
+const MINI_MARK = 22;
+
+/**
+ * The settled check's ink, inset from that box: a solid disc reads heavier
+ * than the orb's dotted sphere at the same diameter.
+ */
+const REST_MARK = 19;
+
+/**
+ * The running orb, at its native scale.
+ *
+ * Not the 64 preset scaled down. Supersampling looks right in the backing
+ * store and wrong on screen: the compositor resolves a CSS-scaled canvas with
+ * bilinear filtering, and a field of sub-pixel dots run through that shimmers
+ * — grainier than the coarse preset it was meant to fix. Canvas pixels map
+ * 1:1 to device pixels here, which is the only arrangement that cannot alias.
+ */
+function MiniOrb({ state }: { state: "composing" | "searching" }) {
+  return (
+    <span className="remix-mini-mark">
+      <ThinkingOrb state={state} size={20} theme="dark" />
+    </span>
+  );
+}
+
+/** Arc close, then colour flood. One timeline, so neither leg can strand. */
+const SWEEP_ARC_MS = 150;
+const SWEEP_FLOOD_MS = 300;
+const SWEEP_TOTAL_MS = SWEEP_ARC_MS + SWEEP_FLOOD_MS;
+const SWEEP_ARC_END = SWEEP_ARC_MS / SWEEP_TOTAL_MS;
+
+/**
+ * @param active Whether the strip is the visible face. Both faces stay
+ * mounted, so an ungated sweep burns behind `opacity: 0` and leaves a check
+ * already drawn by the time the pill shows it.
+ */
+function RestMark({ failed, active }: { failed: boolean; active: boolean }) {
+  const maskId = useId();
+  const arcRef = useRef<SVGCircleElement | null>(null);
+  const discRef = useRef<SVGRectElement | null>(null);
+  const circumference = 2 * Math.PI * 6.1;
+
+  /**
+   * The markup is the RESTING state — filled disc, spent arc — and the
+   * entrance is one `fill: "none"` timeline played over it.
+   *
+   * That direction is deliberate. Any fill mode that holds a keyframe leaves
+   * the mark showing the *opening* frame wherever the timeline cannot run: an
+   * occluded window freezes WAAPI at t=0, and the pill is occluded often. With
+   * no fill, a frozen or skipped animation degrades to the correct final look
+   * instead of an empty circle. Both legs ride one timeline for the same
+   * reason — a delayed second animation would strand the disc mid-sweep.
+   */
+  useLayoutEffect(() => {
+    const arc = arcRef.current;
+    const disc = discRef.current;
+    if (!arc || !disc) return;
+    // Nothing to play to: the strip is the hidden face right now.
+    if (!active) return;
+    if (
+      typeof window === "undefined" ||
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ===
+        true ||
+      // An occluded window does not advance WAAPI, and an animation parked at
+      // its first frame would leave the mark drawn as an empty circle. Nobody
+      // is watching an entrance they cannot see, so skip straight to settled.
+      document.hidden
+    ) {
+      return;
+    }
+    disc.style.transformOrigin = "8px 8px";
+    const options: KeyframeAnimationOptions = {
+      duration: SWEEP_TOTAL_MS,
+      fill: "none",
+    };
+    const arcFrames: Keyframe[] = [
+      {
+        offset: 0,
+        opacity: 1,
+        strokeDashoffset: `${circumference}`,
+        easing: EASE_OUT_CSS,
+      },
+      {
+        offset: SWEEP_ARC_END,
+        opacity: 1,
+        strokeDashoffset: "0",
+        easing: "ease-out",
+      },
+      { offset: SWEEP_ARC_END + 0.09, opacity: 0, strokeDashoffset: "0" },
+      { offset: 1, opacity: 0, strokeDashoffset: "0" },
+    ];
+    const discFrames: Keyframe[] = [
+      {
+        offset: 0,
+        transform: "scale(0.42)",
+        opacity: 0,
+        filter: "blur(1.4px)",
+        easing: "linear",
+      },
+      {
+        offset: SWEEP_ARC_END,
+        transform: "scale(0.42)",
+        opacity: 0,
+        filter: "blur(1.4px)",
+        // Overshoots a few percent and settles back. A straight ease-out
+        // landed the colour like a light switch, with nowhere for the
+        // impact to go; the blur resolving alongside keeps the arc and the
+        // disc reading as one object rather than two swapping places.
+        easing: "cubic-bezier(0.34, 1.16, 0.36, 1)",
+      },
+      {
+        offset: 0.75,
+        transform: "scale(1.055)",
+        opacity: 1,
+        filter: "blur(0px)",
+      },
+      { offset: 1, transform: "scale(1)", opacity: 1, filter: "blur(0px)" },
+    ];
+
+    // One frame of daylight: the same commit grows the pill, and starting into
+    // that window resize drops the arc leg.
+    let running: Animation[] = [];
+    const frame = requestAnimationFrame(() => {
+      running = [
+        arc.animate(arcFrames, options),
+        disc.animate(discFrames, options),
+      ];
+    });
+    // Without this a re-mount stacks a second copy on the first.
+    return () => {
+      cancelAnimationFrame(frame);
+      for (const animation of running) animation.cancel();
+    };
+  }, [circumference, active]);
+
+  const color = failed ? "rgba(224, 128, 95, 0.92)" : INK;
+  const glyph = failed ? (
+    <path
+      d="M 5.6 5.6 L 10.4 10.4 M 10.4 5.6 L 5.6 10.4"
+      stroke="#000"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      fill="none"
+    />
+  ) : (
+    <path
+      d="M 5.35 8.25 L 7.15 10.05 L 10.75 5.95"
+      stroke="#000"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    />
+  );
+
+  return (
+    <span className="remix-mini-mark">
+      <svg
+        width={REST_MARK}
+        height={REST_MARK}
+        viewBox="0 0 16 16"
+        aria-hidden="true"
+      >
+        <mask id={maskId}>
+          <rect width="16" height="16" fill="#000" />
+          <circle cx="8" cy="8" r="6.9" fill="#fff" />
+          {glyph}
+        </mask>
+        <circle
+          ref={arcRef}
+          cx="8"
+          cy="8"
+          r="6.1"
+          fill="none"
+          stroke={color}
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={0}
+          opacity={0}
+          transform="rotate(-90 8 8)"
+        />
+        <rect
+          ref={discRef}
+          width="16"
+          height="16"
+          fill={color}
+          mask={`url(#${maskId})`}
+        />
+      </svg>
+    </span>
+  );
+}
+
 function MiniStrip(props: {
   text: string;
   busy?: boolean;
@@ -202,12 +412,13 @@ function MiniStrip(props: {
     >
       <style>{REMIX_CHAT_CSS}</style>
       <div className="remix-mini" role="status" aria-live="polite">
-        <span
-          className="remix-mini-dot"
-          data-busy={props.busy === true}
-          data-failed={props.failed === true}
-        />
-        <span className="remix-mini-text">{props.text}</span>
+        {props.busy ? (
+          <MiniOrb state="composing" />
+        ) : (
+          /* MiniStrip only ever renders as the minimized face. */
+          <RestMark failed={props.failed === true} active />
+        )}
+        <span className="remix-mini-line remix-mini-text">{props.text}</span>
       </div>
     </div>
   );
@@ -220,7 +431,7 @@ interface RemixThreadProps {
   minimized: boolean;
   anchor: RemixChatAnchor;
   onExpand: () => void;
-  onMinimize: () => void;
+  onMinimize: (options?: { busy?: boolean; hasContent?: boolean }) => void;
   onClose: () => void;
   onNewThread: () => void;
   onMiniHeightChange?: (height: number) => void;
@@ -236,8 +447,10 @@ interface ActionRow {
 const MINIMIZE_GRACE_MS = 380;
 const MINI_IDLE_DISMISS_MS = 7000;
 const MINI_SETTLED_DISMISS_MS = 3000;
-const MINI_STRIP_PAD = 24; // .remix-mini[data-full] vertical padding
-const MINI_STRIP_MAX = 316; // main's 340 window cap minus the chrome
+/** Vertical padding of the expanded pill. */
+const MINI_STRIP_PAD = 24;
+/** Main's 340 window cap, minus the chrome. */
+const MINI_STRIP_MAX = 316;
 
 function RemixThread(props: RemixThreadProps): React.JSX.Element {
   const { thread, minimized, anchor, onExpand, onMinimize, onClose } = props;
@@ -754,11 +967,14 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
           aria-hidden={!minimized}
         >
           <div className="remix-mini" data-full={showFullFinal}>
-            <span
-              className="remix-mini-dot"
-              data-busy={busy || !settled}
-              data-failed={notice !== null}
-            />
+            {/* The orb only earns its canvas while something is actually
+                running; a settled pill is a line of text with a mark next to
+                it, and a resting orb would animate for no reason. */}
+            {busy || !settled ? (
+              <MiniOrb state={narrating ? "searching" : "composing"} />
+            ) : (
+              <RestMark failed={notice !== null} active={minimized} />
+            )}
             {showFullFinal ? (
               <div className="remix-mini-message" ref={miniMessageRef}>
                 <Markdown text={finalText ?? ""} />
@@ -840,8 +1056,17 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
                     : `${action.label} failed — ${action.detail ?? ""}`}
               </div>
             ))}
-            {messages.map((message) => (
-              <MessageRow key={message.id} message={message} busy={busy} />
+            {messages.map((message, index) => (
+              <MessageRow
+                key={message.id}
+                message={message}
+                busy={busy}
+                streaming={
+                  busy &&
+                  index === messages.length - 1 &&
+                  message.role === "assistant"
+                }
+              />
             ))}
             {busy && !narrating && (
               <ThinkingShimmer className="remix-chat-busy">
@@ -992,9 +1217,12 @@ function latestActivity(messages: UIMessage[], busy: boolean): string {
 const MessageRow = memo(function MessageRow({
   message,
   busy,
+  streaming = false,
 }: {
   message: UIMessage;
   busy: boolean;
+  /** Growing assistant text — render plain until the stream settles. */
+  streaming?: boolean;
 }): React.JSX.Element {
   if (message.role === "user") {
     const text = message.parts
@@ -1028,17 +1256,31 @@ const MessageRow = memo(function MessageRow({
             busy={busy}
           />
         ) : (
-          <AssistantText key={`text-${block.index}`} text={block.text} />
+          <AssistantText
+            key={`text-${block.index}`}
+            text={block.text}
+            streaming={streaming}
+          />
         ),
       )}
     </div>
   );
 });
 
-function AssistantText({ text }: { text: string }): React.JSX.Element {
+function AssistantText({
+  text,
+  streaming = false,
+}: {
+  text: string;
+  streaming?: boolean;
+}): React.JSX.Element {
   return (
     <div className="remix-chat-response">
-      <Markdown text={text} />
+      {streaming ? (
+        <div className="remix-md remix-md-plain">{text}</div>
+      ) : (
+        <Markdown text={text} />
+      )}
     </div>
   );
 }
@@ -1223,35 +1465,24 @@ const REMIX_CHAT_CSS = `
     transition: opacity 150ms ease;
   }
 
+  /* Padding is measured to the mark's box, not the ink inside it, so 12 left
+     against 16 right reads as even — the mark's own air makes up the rest. */
   .remix-mini {
     display: flex;
     align-items: center;
-    gap: 9px;
+    gap: 8px;
     height: 100%;
-    padding: 0 16px 0 13px;
+    padding: 0 16px 0 12px;
   }
-  .remix-mini-dot {
-    flex-shrink: 0;
-    width: 7px;
-    height: 7px;
-    border-radius: 999px;
-    background: ${OLIVE};
-  }
-  .remix-mini-dot[data-busy="true"] {
-    background: #F5F1E4;
-    animation: remix-mini-pulse 1.1s ease-in-out infinite;
-  }
-  .remix-mini-dot[data-failed="true"] { background: rgba(224, 128, 95, 0.9); }
-  @keyframes remix-mini-pulse {
-    0%, 100% { opacity: 0.35; transform: scale(0.8); }
-    50% { opacity: 1; transform: scale(1); }
-  }
+  /* Opened by a landed answer. Top-aligned, because a paragraph beside a
+     centred mark reads as misaligned the moment it wraps. Vertical padding
+     sums to MINI_STRIP_PAD, which is what measures the grown pill. */
   .remix-mini[data-full="true"] {
     align-items: flex-start;
     height: 100%;
-    padding: 12px 16px;
+    padding: 12px 16px 12px 12px;
   }
-  .remix-mini[data-full="true"] .remix-mini-dot { margin-top: 5px; }
+  .remix-mini[data-full="true"] .remix-mini-mark { margin-top: -1px; }
   .remix-mini-message {
     flex: 1;
     min-width: 0;
@@ -1275,6 +1506,18 @@ const REMIX_CHAT_CSS = `
     from { opacity: 0.55; transform: translateY(-2px); }
     to { opacity: 1; transform: none; }
   }
+
+  /* One box for both states, so the text does not shift when a run lands. */
+  .remix-mini-mark {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: ${MINI_MARK}px;
+    height: ${MINI_MARK}px;
+    overflow: hidden;
+  }
+
   /* No color here — TextShimmer paints via background-clip; color would hide it. */
   .remix-mini-line {
     flex: 1;
@@ -1396,7 +1639,7 @@ const REMIX_CHAT_CSS = `
   .remix-chat-step-chevron {
     flex-shrink: 0;
     opacity: 0.5;
-    transition: transform 140ms ease, opacity 140ms ease;
+    transition: transform 140ms ${EASE_OUT_CSS}, opacity 140ms ease;
   }
   .remix-chat-step-head:hover .remix-chat-step-chevron { opacity: 1; }
   .remix-chat-step-chevron[data-open="true"] { transform: rotate(90deg); opacity: 1; }
@@ -1548,6 +1791,7 @@ const REMIX_CHAT_CSS = `
   }
 
   .remix-md { line-height: 1.6; word-break: break-word; }
+  .remix-md-plain { white-space: pre-wrap; }
   .remix-md > *:first-child { margin-top: 0; }
   .remix-md > *:last-child { margin-bottom: 0; }
   .remix-md p { margin: 0 0 8px; }

--- a/apps/electron/src/renderer/src/lib/ease.ts
+++ b/apps/electron/src/renderer/src/lib/ease.ts
@@ -1,9 +1,14 @@
-export const EASE_OUT = [0.16, 1, 0.3, 1] as const;
+export const EASE_OUT = [0.22, 1, 0.36, 1] as const;
 export const EASE_IN_OUT = [0.77, 0, 0.175, 1] as const;
 export const EASE_DRAWER = [0.32, 0.72, 0, 1] as const;
 
 /** CSS string form of EASE_OUT for inline style transitions. */
-export const EASE_OUT_CSS = "cubic-bezier(0.16, 1, 0.3, 1)";
+export const EASE_OUT_CSS = "cubic-bezier(0.22, 1, 0.36, 1)";
+
+/** Shape changes — the pill growing into the card, and anything landing with
+ * it. Softer off the mark than EASE_OUT, so a resizing box doesn't snap. */
+export const EASE_MORPH_CSS = "cubic-bezier(0.3, 0.9, 0.3, 1)";
+export const MORPH_MS = 320;
 
 /** Press feedback on buttons and other tappable surfaces. */
 export const SPRING_PRESS = {

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -18,6 +18,7 @@ import {
   getNeedsAppContextForCleanup,
   refreshNeedsAppContextForCleanup,
 } from "@renderer/lib/cleanup-app-context";
+import { EASE_MORPH_CSS, MORPH_MS } from "@renderer/lib/ease";
 import { Recorder, RecorderSupersededError } from "@renderer/lib/recorder";
 import { Streamer, type StreamerConnectionState } from "@renderer/lib/streamer";
 import {
@@ -3194,9 +3195,9 @@ export default function AppPage(): React.JSX.Element {
             transition: opacity 180ms ease,
               transform 380ms cubic-bezier(0.22, 1.12, 0.36, 1),
               filter 220ms ease,
-              width 320ms cubic-bezier(0.3, 0.9, 0.3, 1),
-              height 320ms cubic-bezier(0.3, 0.9, 0.3, 1),
-              border-radius 320ms cubic-bezier(0.3, 0.9, 0.3, 1);
+              width ${MORPH_MS}ms ${EASE_MORPH_CSS},
+              height ${MORPH_MS}ms ${EASE_MORPH_CSS},
+              border-radius ${MORPH_MS}ms ${EASE_MORPH_CSS};
           }
 
           /* ---- Remix card ---- */

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -315,11 +315,7 @@ const PILL_CARD_WIDTH = 300;
  * dictation failure card can carry a Retry, and a button that vanishes while
  * you are deciding is worse than one that lingers.
  */
-/**
- * How long the pill window stays up after a remix session is cleared, so the
- * card's own exit transition (the longest leg is 170ms) is on screen rather
- * than cut off by the window vanishing in the same frame.
- */
+/** Window lingers this long so the card's exit (170ms) is actually seen. */
 const REMIX_EXIT_MS = 190;
 
 const REMIX_WARNING_MS = 4500;
@@ -357,9 +353,7 @@ const STATUS_SLOT = STATUS_SIZE + STATUS_GAP;
 const SURFACE = "rgba(22, 20, 15, 0.98)";
 const SURFACE_BORDER = "1px solid rgba(255, 255, 255, 0.10)";
 const BLUR = "blur(20px) saturate(120%)";
-/** The card is a big surface standing over someone else's work for as long as
- * they need it, so it casts: a tight contact shadow to seat the edge, and a
- * wide ambient one for the lift. */
+/** The card stands over someone else's work, so it casts: contact + ambient. */
 const CARD_SHADOW = [
   "0 1px 2px rgba(0, 0, 0, 0.32)",
   "0 10px 24px -8px rgba(0, 0, 0, 0.46)",
@@ -464,10 +458,8 @@ interface RemixSession {
    */
   minimized?: boolean;
   /**
-   * The full conversation has been on screen in this session — either opened
-   * straight out of the bar, or hover-expanded from the strip. It decides what
-   * leaving the card means: dropping back to the strip is only useful for a
-   * session the user has not looked at yet.
+   * The conversation has been on screen. Decides what leaving means: falling
+   * back to the strip only helps a session the user hasn't looked at yet.
    */
   openedFull?: boolean;
 }
@@ -529,9 +521,8 @@ export default function AppPage(): React.JSX.Element {
   }, []);
   const setRemix = useCallback(
     (next: RemixSession | null) => {
-      // A session starting inside the exit window takes the pill back; the
-      // hide scheduled for the outgoing one would otherwise pull the window
-      // out from under it a moment later.
+      // A new session inside the exit window takes the pill back, or the
+      // outgoing hide pulls the window out from under it.
       if (next) clearRemixExitTimer();
       remixRef.current = next;
       setRemixState(next);
@@ -2001,9 +1992,8 @@ export default function AppPage(): React.JSX.Element {
       setRemix(null);
       stopVisualization();
       if (options.hide === false) return;
-      // The card animates itself out on `data-show="false"`; hiding the window
-      // in the same frame is what made the session vanish with no motion at
-      // all. Hold the window for the length of the transition instead.
+      // Hiding the window in the same frame as `data-show="false"` made the
+      // session vanish with no motion at all.
       clearRemixExitTimer();
       remixExitTimerRef.current = setTimeout(() => {
         remixExitTimerRef.current = null;
@@ -2022,11 +2012,8 @@ export default function AppPage(): React.JSX.Element {
   const minimizeRemixChat = useCallback(
     (options?: { busy?: boolean; hasContent?: boolean }) => {
       if (!remixRef.current) return;
-      // A run in flight, or a conversation that has already said something,
-      // collapses to the pill — that one line is how the user watches an
-      // answer land after walking away. A card with nothing in it has nothing
-      // to collapse *to*: it was opened out of the bar and never used, and
-      // folding it into an empty pill leaves a second thing to dismiss.
+      // A live or answered run collapses to the pill; an untouched card has
+      // nothing to collapse *to*, so it would just be a second dismissal.
       const worthKeeping = options?.busy || options?.hasContent;
       if (remixRef.current.openedFull && !worthKeeping) {
         endRemix();
@@ -2660,10 +2647,7 @@ export default function AppPage(): React.JSX.Element {
     // is already in flight (main kicked it off before sending this).
     const removeOpenChat = window.api.onRemixOpenChat(() => {
       if (stateRef.current !== "idle" || pillActiveRef.current) return;
-      // `openedFull` from the start: this entrance skips the strip entirely,
-      // so the conversation is already the thing on screen and the pointer
-      // leaving should end the session, not fold it into a strip the user
-      // never asked for.
+      // openedFull from the start: this entrance skips the strip entirely.
       if (remixRef.current) {
         patchRemix({ phase: "chat", minimized: false, openedFull: true });
         return;
@@ -2769,10 +2753,8 @@ export default function AppPage(): React.JSX.Element {
   const [remixMiniHeight, setRemixMiniHeight] = useState<number>(
     REMIX_CHAT_STRIP.height,
   );
-  // The full card's height, reported by RemixChat from its own content. The
-  // window's room is unchanged (still the 560 cap), so a shorter card just
-  // occupies less of a space already reserved — no window resize, and the
-  // morph transition already animates height.
+  // Reported by RemixChat from its own content. The window's room is
+  // unchanged, so a shorter card just uses less of a space already reserved.
   const [remixCardHeight, setRemixCardHeight] = useState<number>(
     REMIX_CHAT_MIN_HEIGHT,
   );
@@ -3066,9 +3048,8 @@ export default function AppPage(): React.JSX.Element {
     borderRadius: 20,
     background: SURFACE,
     border: SURFACE_BORDER,
-    // No backdrop-filter here, unlike the capsule: at SURFACE's 0.98 alpha the
-    // blur renders nothing, so the card paid for a compositing pass that showed
-    // zero pixels. What it lacked was depth.
+    // No backdrop-filter: at SURFACE's 0.98 alpha the blur renders nothing,
+    // so the card paid for a compositing pass showing zero pixels.
     boxShadow: CARD_SHADOW,
     transformOrigin,
     marginBottom: pillAlign === "end" ? 8 : 0,
@@ -3275,12 +3256,8 @@ export default function AppPage(): React.JSX.Element {
               border-radius ${MORPH_MS}ms ${EASE_MORPH_CSS};
           }
 
-          /* The chat card leaves the way it arrived, reversed. Without this it
-             inherited .pill-card[data-show="false"], which collapses toward the
-             capsule — but the chat card never came out of one, so folding into
-             one read as a different animation entirely. Shorter than the
-             entrance and with no overshoot: something on its way out shouldn't
-             ask to be watched. */
+          /* Retraces its own summon. Without this it inherited the dictation
+             card's exit and folded into a capsule it never came out of. */
           .pill-card.pill-chat-morph[data-show="false"] {
             transform: scale(0.93)
               translateY(calc(var(--pill-rise, 10px) * 0.55));
@@ -3555,7 +3532,10 @@ export default function AppPage(): React.JSX.Element {
         `}
       </style>
 
-      {(state !== "idle" || showRemixCard) && (
+      {/* `remixView` too: the session clears the frame a remix ends, and
+          mounting on the live one tore the surfaces out in that same frame, so
+          `data-show="false"` had nothing left to animate. */}
+      {(state !== "idle" || showRemixCard || remixView !== null) && (
         <>
           <span className="sr-only" role="status" aria-live="polite">
             {accessibleStatus}

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -1,6 +1,7 @@
 import { REMIX_PRESETS } from "@freestyle-voice/validations";
 import { FreestyleMark } from "@renderer/components/freestyle-mark";
 import {
+  REMIX_CHAT_MIN_HEIGHT,
   REMIX_CHAT_STRIP,
   REMIX_CHAT_SURFACE,
 } from "@renderer/components/remix-chat-surface";
@@ -314,6 +315,13 @@ const PILL_CARD_WIDTH = 300;
  * dictation failure card can carry a Retry, and a button that vanishes while
  * you are deciding is worse than one that lingers.
  */
+/**
+ * How long the pill window stays up after a remix session is cleared, so the
+ * card's own exit transition (the longest leg is 170ms) is on screen rather
+ * than cut off by the window vanishing in the same frame.
+ */
+const REMIX_EXIT_MS = 190;
+
 const REMIX_WARNING_MS = 4500;
 const FAILURE_CARD_MS = 9000;
 /**
@@ -349,6 +357,14 @@ const STATUS_SLOT = STATUS_SIZE + STATUS_GAP;
 const SURFACE = "rgba(22, 20, 15, 0.98)";
 const SURFACE_BORDER = "1px solid rgba(255, 255, 255, 0.10)";
 const BLUR = "blur(20px) saturate(120%)";
+/** The card is a big surface standing over someone else's work for as long as
+ * they need it, so it casts: a tight contact shadow to seat the edge, and a
+ * wide ambient one for the lift. */
+const CARD_SHADOW = [
+  "0 1px 2px rgba(0, 0, 0, 0.32)",
+  "0 10px 24px -8px rgba(0, 0, 0, 0.46)",
+  "0 30px 60px -24px rgba(0, 0, 0, 0.40)",
+].join(", ");
 /** Cream ink, and the terracotta the palette reserves for failures. */
 const INK = "#F5F1E4";
 const ALERT = "#E0805F";
@@ -447,6 +463,13 @@ interface RemixSession {
    * hovering the strip is what opens the full conversation.
    */
   minimized?: boolean;
+  /**
+   * The full conversation has been on screen in this session — either opened
+   * straight out of the bar, or hover-expanded from the strip. It decides what
+   * leaving the card means: dropping back to the strip is only useful for a
+   * session the user has not looked at yet.
+   */
+  openedFull?: boolean;
 }
 
 /** A promise that something else resolves. Used to await the selection. */
@@ -496,10 +519,25 @@ export default function AppPage(): React.JSX.Element {
   // ---- Remix ----
   const [remix, setRemixState] = useState<RemixSession | null>(null);
   const remixRef = useRef<RemixSession | null>(null);
-  const setRemix = useCallback((next: RemixSession | null) => {
-    remixRef.current = next;
-    setRemixState(next);
+  /** Pending window hide, held open while the card's exit transition runs. */
+  const remixExitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearRemixExitTimer = useCallback(() => {
+    if (remixExitTimerRef.current) {
+      clearTimeout(remixExitTimerRef.current);
+      remixExitTimerRef.current = null;
+    }
   }, []);
+  const setRemix = useCallback(
+    (next: RemixSession | null) => {
+      // A session starting inside the exit window takes the pill back; the
+      // hide scheduled for the outgoing one would otherwise pull the window
+      // out from under it a moment later.
+      if (next) clearRemixExitTimer();
+      remixRef.current = next;
+      setRemixState(next);
+    },
+    [clearRemixExitTimer],
+  );
   /** Patch the live session, ignoring the call if it has since been torn down. */
   const patchRemix = useCallback((patch: Partial<RemixSession>) => {
     const current = remixRef.current;
@@ -1962,22 +2000,42 @@ export default function AppPage(): React.JSX.Element {
       window.api?.setRemixRouteKeys(false);
       setRemix(null);
       stopVisualization();
-      if (options.hide !== false) window.api?.hidePill();
+      if (options.hide === false) return;
+      // The card animates itself out on `data-show="false"`; hiding the window
+      // in the same frame is what made the session vanish with no motion at
+      // all. Hold the window for the length of the transition instead.
+      clearRemixExitTimer();
+      remixExitTimerRef.current = setTimeout(() => {
+        remixExitTimerRef.current = null;
+        window.api?.hidePill();
+      }, REMIX_EXIT_MS);
     },
-    [clearRemixHoldTimer, setRemix, stopVisualization],
+    [clearRemixExitTimer, clearRemixHoldTimer, setRemix, stopVisualization],
   );
 
   const closeRemix = useCallback(() => endRemix(), [endRemix]);
   const expandRemixChat = useCallback(() => {
     if (remixRef.current?.minimized !== false) {
-      patchRemix({ minimized: false });
+      patchRemix({ minimized: false, openedFull: true });
     }
   }, [patchRemix]);
-  const minimizeRemixChat = useCallback(() => {
-    if (remixRef.current && remixRef.current.minimized !== true) {
-      patchRemix({ minimized: true });
-    }
-  }, [patchRemix]);
+  const minimizeRemixChat = useCallback(
+    (options?: { busy?: boolean; hasContent?: boolean }) => {
+      if (!remixRef.current) return;
+      // A run in flight, or a conversation that has already said something,
+      // collapses to the pill — that one line is how the user watches an
+      // answer land after walking away. A card with nothing in it has nothing
+      // to collapse *to*: it was opened out of the bar and never used, and
+      // folding it into an empty pill leaves a second thing to dismiss.
+      const worthKeeping = options?.busy || options?.hasContent;
+      if (remixRef.current.openedFull && !worthKeeping) {
+        endRemix();
+        return;
+      }
+      if (remixRef.current.minimized !== true) patchRemix({ minimized: true });
+    },
+    [endRemix, patchRemix],
+  );
 
   /**
    * Show a failure and leave the card up. Unlike the phases above this one
@@ -2602,8 +2660,12 @@ export default function AppPage(): React.JSX.Element {
     // is already in flight (main kicked it off before sending this).
     const removeOpenChat = window.api.onRemixOpenChat(() => {
       if (stateRef.current !== "idle" || pillActiveRef.current) return;
+      // `openedFull` from the start: this entrance skips the strip entirely,
+      // so the conversation is already the thing on screen and the pointer
+      // leaving should end the session, not fold it into a strip the user
+      // never asked for.
       if (remixRef.current) {
-        patchRemix({ phase: "chat", minimized: false });
+        patchRemix({ phase: "chat", minimized: false, openedFull: true });
         return;
       }
       remixSelectionRef.current = deferred<string | null>();
@@ -2613,6 +2675,7 @@ export default function AppPage(): React.JSX.Element {
         selection: null,
         initialInstruction: null,
         minimized: false,
+        openedFull: true,
       });
     });
 
@@ -2706,8 +2769,18 @@ export default function AppPage(): React.JSX.Element {
   const [remixMiniHeight, setRemixMiniHeight] = useState<number>(
     REMIX_CHAT_STRIP.height,
   );
+  // The full card's height, reported by RemixChat from its own content. The
+  // window's room is unchanged (still the 560 cap), so a shorter card just
+  // occupies less of a space already reserved — no window resize, and the
+  // morph transition already animates height.
+  const [remixCardHeight, setRemixCardHeight] = useState<number>(
+    REMIX_CHAT_MIN_HEIGHT,
+  );
   useEffect(() => {
-    if (!showRemixChat) setRemixMiniHeight(REMIX_CHAT_STRIP.height);
+    if (!showRemixChat) {
+      setRemixMiniHeight(REMIX_CHAT_STRIP.height);
+      setRemixCardHeight(REMIX_CHAT_MIN_HEIGHT);
+    }
   }, [showRemixChat]);
 
   // Hold the initial hidden state for one frame so the enter transition runs.
@@ -2993,8 +3066,10 @@ export default function AppPage(): React.JSX.Element {
     borderRadius: 20,
     background: SURFACE,
     border: SURFACE_BORDER,
-    backdropFilter: BLUR,
-    WebkitBackdropFilter: BLUR,
+    // No backdrop-filter here, unlike the capsule: at SURFACE's 0.98 alpha the
+    // blur renders nothing, so the card paid for a compositing pass that showed
+    // zero pixels. What it lacked was depth.
+    boxShadow: CARD_SHADOW,
     transformOrigin,
     marginBottom: pillAlign === "end" ? 8 : 0,
     marginTop: pillAlign === "start" ? 8 : 0,
@@ -3198,6 +3273,25 @@ export default function AppPage(): React.JSX.Element {
               width ${MORPH_MS}ms ${EASE_MORPH_CSS},
               height ${MORPH_MS}ms ${EASE_MORPH_CSS},
               border-radius ${MORPH_MS}ms ${EASE_MORPH_CSS};
+          }
+
+          /* The chat card leaves the way it arrived, reversed. Without this it
+             inherited .pill-card[data-show="false"], which collapses toward the
+             capsule — but the chat card never came out of one, so folding into
+             one read as a different animation entirely. Shorter than the
+             entrance and with no overshoot: something on its way out shouldn't
+             ask to be watched. */
+          .pill-card.pill-chat-morph[data-show="false"] {
+            transform: scale(0.93)
+              translateY(calc(var(--pill-rise, 10px) * 0.55));
+            border-radius: 18px;
+            filter: blur(3px);
+            transition: opacity 130ms ease,
+              transform 170ms cubic-bezier(0.36, 0, 0.66, -0.2),
+              filter 130ms ease,
+              width 170ms cubic-bezier(0.36, 0, 0.66, -0.2),
+              height 170ms cubic-bezier(0.36, 0, 0.66, -0.2),
+              border-radius 170ms ease;
           }
 
           /* ---- Remix card ---- */
@@ -3944,7 +4038,7 @@ export default function AppPage(): React.JSX.Element {
                     }
                   : {
                       width: REMIX_CHAT_SURFACE.width,
-                      height: REMIX_CHAT_SURFACE.height,
+                      height: remixCardHeight,
                       borderRadius: 18,
                       padding: 0,
                       overflow: "hidden",
@@ -3972,6 +4066,7 @@ export default function AppPage(): React.JSX.Element {
                     onMinimize={minimizeRemixChat}
                     onClose={closeRemix}
                     onMiniHeightChange={setRemixMiniHeight}
+                    onHeightChange={setRemixCardHeight}
                   />
                 </Suspense>
               )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
+      thinking-orbs:
+        specifier: ^0.2.0
+        version: 0.2.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -9849,6 +9852,12 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thinking-orbs@0.2.0:
+    resolution: {integrity: sha512-CQux/YsLlB9nY60BDpZ/uW7knAvXg+U2T/gzrzuLRw8xlzfJPLXZxAg2tbbIBGp/nE2Kol1GfbMOJnoH+tcb/A==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
@@ -22025,6 +22034,11 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thinking-orbs@0.2.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   throat@5.0.0: {}
 


### PR DESCRIPTION
More polishing for remix. Adds:
<img width="350" height="71" alt="Screenshot 2026-08-06 at 9 50 47 PM" src="https://github.com/user-attachments/assets/ad39cde1-8ee0-4cd1-b65c-47df2278af1c" />
<img width="371" height="195" alt="Screenshot 2026-08-06 at 9 50 58 PM" src="https://github.com/user-attachments/assets/62d479c0-a37a-4f97-ba1d-532fbdf943bf" />

And some nice animations.