### PR TITLE
fix(electron): keep Right Alt distinct from Alt when recording hotkeys

### DIFF
--- a/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.test.ts
+++ b/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  type HotkeyCombo,
+  latchFromCapturedCombo,
+  nextRightModifierLatch,
+} from "./use-hotkey-recorder";
+
+const EMPTY: HotkeyCombo = { modifiers: [], key: null };
+
+describe("latchFromCapturedCombo", () => {
+  it("latches a solo right-side modifier", () => {
+    expect(latchFromCapturedCombo({ modifiers: [], key: "RightAlt" })).toBe(
+      "RightAlt",
+    );
+    expect(latchFromCapturedCombo({ modifiers: [], key: "RightControl" })).toBe(
+      "RightControl",
+    );
+  });
+
+  it("does not latch a right-side modifier held as part of a chord", () => {
+    expect(
+      latchFromCapturedCombo({ modifiers: ["Control"], key: "RightAlt" }),
+    ).toBeNull();
+  });
+
+  it("clears the latch for ordinary keys", () => {
+    expect(latchFromCapturedCombo({ modifiers: [], key: "Space" })).toBeNull();
+    expect(latchFromCapturedCombo({ modifiers: ["Alt"], key: "U" })).toBeNull();
+  });
+});
+
+// On Windows the native binary reports Right Alt as RECORD_KEY:RightAlt while
+// the focused settings window independently sees a DOM AltRight keydown. The
+// two arrive in either order, so the latch must survive both interleavings —
+// otherwise the hotkey saves as generic "Alt" and both Alt keys trigger it.
+describe("Right Alt capture on Windows (native + DOM race)", () => {
+  it("latches RightAlt when the DOM event lands first", () => {
+    let latch = nextRightModifierLatch(null, EMPTY, {
+      rightToken: "RightAlt",
+      modifierCount: 1,
+      genericModifiers: ["Alt"],
+      explicitLeft: false,
+    });
+    expect(latch).toBe("RightAlt");
+
+    latch = latchFromCapturedCombo({ modifiers: [], key: "RightAlt" });
+    expect(latch).toBe("RightAlt");
+  });
+
+  it("latches RightAlt when the native capture lands first", () => {
+    let latch = latchFromCapturedCombo({ modifiers: [], key: "RightAlt" });
+    expect(latch).toBe("RightAlt");
+
+    // Draft already carries the collapsed generic modifier by now.
+    latch = nextRightModifierLatch(
+      latch,
+      { modifiers: ["Alt"], key: null },
+      {
+        rightToken: "RightAlt",
+        modifierCount: 1,
+        genericModifiers: ["Alt"],
+        explicitLeft: false,
+      },
+    );
+    expect(latch).toBe("RightAlt");
+  });
+
+  it("leaves left Alt unlatched so it saves as generic Alt", () => {
+    const latch = nextRightModifierLatch(null, EMPTY, {
+      rightToken: null,
+      modifierCount: 1,
+      genericModifiers: ["Alt"],
+      explicitLeft: true,
+    });
+    expect(latch).toBeNull();
+  });
+});

--- a/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
+++ b/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
@@ -305,6 +305,21 @@ export function nextRightModifierLatch(
   return null;
 }
 
+/**
+ * Latch value implied by a captured combo from the native recorder.
+ *
+ * The Windows binary reports Right Alt/Ctrl/Shift/Super as `RECORD_KEY:` — a
+ * captured key — rather than as a modifiers update, so this is the only signal
+ * that identifies the side. `normalizeCapturedCombo` collapses the token to its
+ * generic modifier in the draft; the latch is what restores "RightAlt" on save.
+ * Only a solo press latches: with other modifiers already held this is a chord,
+ * which saves as the generic accelerator.
+ */
+export function latchFromCapturedCombo(captured: HotkeyCombo): string | null {
+  if (!captured.key || captured.modifiers.length > 0) return null;
+  return RIGHT_MODIFIER_TO_GENERIC[captured.key] ? captured.key : null;
+}
+
 export function comboDisplayKeys(combo: HotkeyCombo): string[] {
   const keys = combo.modifiers.map(keyDisplayLabel);
   if (combo.key) keys.push(keyDisplayLabel(combo.key));
@@ -535,7 +550,10 @@ export function useHotkeyRecorder(
     });
 
     const removeCaptured = window.api.onHotkeyRecordCaptured((combo) => {
-      rightModifierLatchRef.current = null;
+      // A captured side-specific modifier definitively identifies the side, so
+      // latch it rather than clearing. Any other captured key is a real key and
+      // clears the latch.
+      rightModifierLatchRef.current = latchFromCapturedCombo(combo);
       updateDraftCombo((current) => normalizeCapturedCombo(current, combo));
     });
 


### PR DESCRIPTION
## Summary

Fixes #560 

On Windows, recording **Right Alt** as the dictation hotkey saved plain `Alt`, which fires on both Alt keys. Since Windows already *defaults* to `RightAlt`, this only surfaced after rebinding — the shipped default worked, but re-recording Right Alt could not reproduce it, so there was no way back to the default.

**Cause.** The two native binaries report right-side modifiers through different channels, and the recorder only tracked the side on one of them:

- macOS emits `RIGHT_MOD_DOWN:RightOption`, which arrives as a *modifiers update* and runs through `nextRightModifierLatch`.
- Windows emits `RECORD_KEY:RightAlt`, which main wraps as a *captured combo* instead — and the captured handler cleared the right-modifier latch unconditionally.

`normalizeCapturedCombo` then collapses `RightAlt` to the generic `Alt` in the draft (intentional, so chords like `Right Alt + U` still work), but the latch it just cleared was the only thing that would have restored `RightAlt` on save. The C binary was never at fault — it distinguishes `VK_LMENU` from `VK_RMENU` correctly; the wrong accelerator simply never reached it.

**Fix.** Extract `latchFromCapturedCombo` — a captured key that is itself a side-specific modifier now *sets* the latch rather than clearing it. Ordinary keys still clear it, and a right modifier captured alongside other held modifiers stays a chord and does not latch. Right Ctrl, Right Shift and Right Super on Windows had the identical problem and are fixed by the same change.

With the settings window focused, the DOM keydown and the native IPC event both fire for one press in nondeterministic order, so the latch has to be idempotent either way: DOM-first sets it and the native capture confirms it; native-first sets it and the DOM path preserves it via the `rightToken === previousLatch` branch. Both interleavings are covered by the new tests.

**Note:** this corrects only what recording *writes*, so an already-saved `Alt` stays until the hotkey is re-recorded once.

## Testing

- New test cases in `use-hotkey-recorder.test.ts` covering solo Right Alt capture, the chord case, and both DOM/native interleavings — `pnpm --filter @freestyle-voice/electron test` → 11 passed.
- `pnpm biome check` on the touched files → clean. (A repo-wide run also reports pre-existing formatting diagnostics in `biome.json`, `package.json`, `turbo.json` and `skills-lock.json` that are unrelated to this branch and untouched here.)
- `pnpm --filter @freestyle-voice/electron typecheck:web` → clean.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
- [x] Ran `pnpm biome check .` (lint + formatting)
- [x] Ran `pnpm --filter @freestyle-voice/electron typecheck:web` (if touching the app)
