### PR TITLE
perf(usage): send ?fresh=1 on post-checkout usage reads

### DIFF
--- a/apps/electron/src/renderer/src/lib/use-cloud-usage.ts
+++ b/apps/electron/src/renderer/src/lib/use-cloud-usage.ts
@@ -115,7 +115,12 @@ export function useCloudUsage(signedIn: boolean): UseCloudUsageResult {
   const query = useQuery({
     queryKey: queryKeys.cloud.usage,
     queryFn: async () => {
-      const res = await getClient().api.usage.$get();
+      // While a checkout is pending, ask the cloud to bypass its plan cache
+      // (`?fresh=1`) so the upgrade is detected on the next poll instead of
+      // after the cache TTL. Regular reads omit it and use the cached path.
+      const res = await getClient().api.usage.$get({
+        query: checkoutStatus === "pending" ? { fresh: "1" } : {},
+      });
       if (!res.ok) throw new Error(`Failed to fetch usage (${res.status})`);
       return (await res.json()) as CloudUsageBalance;
     },

--- a/apps/mobile/src/app/(app)/billing.tsx
+++ b/apps/mobile/src/app/(app)/billing.tsx
@@ -5,6 +5,7 @@ import { ActivityIndicator, StyleSheet, View } from "react-native";
 
 import { ThemedView } from "@/components/themed-view";
 import { useTheme } from "@/hooks/use-theme";
+import { fetchCloudUsage } from "@/lib/cloud/usage";
 
 /**
  * Deep-link landing route for `freestyle://billing` — the return URL used by
@@ -20,7 +21,15 @@ export default function BillingScreen() {
   const theme = useTheme();
 
   useEffect(() => {
-    void queryClient.invalidateQueries({ queryKey: ["cloud-usage"] });
+    // Fetch fresh (bypass the cloud plan cache) since we just returned from a
+    // checkout/portal — the plan may have just changed. Best-effort: a failed
+    // refresh shouldn't block the bounce back to Profile.
+    void queryClient
+      .fetchQuery({
+        queryKey: ["cloud-usage"],
+        queryFn: () => fetchCloudUsage({ fresh: true }),
+      })
+      .catch(() => {});
     router.replace("/(app)/profile");
   }, [queryClient, router]);
 

--- a/apps/mobile/src/app/(app)/profile.tsx
+++ b/apps/mobile/src/app/(app)/profile.tsx
@@ -56,20 +56,35 @@ export default function ProfileScreen() {
 
   const { data: usage, isLoading: usageLoading } = useQuery({
     queryKey: ["cloud-usage"],
-    queryFn: fetchCloudUsage,
+    queryFn: () => fetchCloudUsage(),
     enabled: signedIn,
     retry: 1,
   });
 
-  const refreshUsage = useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey: ["cloud-usage"] });
-  }, [queryClient]);
+  // Refresh the cached usage/plan. Pass `fresh` after a checkout so the cloud
+  // bypasses its plan cache and the upgrade is reflected immediately; a plain
+  // refresh (e.g. on org switch) uses the cached path.
+  const refreshUsage = useCallback(
+    (opts: { fresh?: boolean } = {}) => {
+      if (opts.fresh) {
+        void queryClient
+          .fetchQuery({
+            queryKey: ["cloud-usage"],
+            queryFn: () => fetchCloudUsage({ fresh: true }),
+          })
+          .catch(() => {});
+        return;
+      }
+      void queryClient.invalidateQueries({ queryKey: ["cloud-usage"] });
+    },
+    [queryClient],
+  );
 
   const onUpgrade = useCallback(async () => {
     setBusy(true);
     try {
       await startProCheckout(false); // monthly for beta; annual toggle optional later
-      refreshUsage();
+      refreshUsage({ fresh: true });
     } catch (e) {
       Alert.alert(
         "Checkout unavailable",
@@ -84,7 +99,7 @@ export default function ProfileScreen() {
     setBusy(true);
     try {
       await openBillingPortal();
-      refreshUsage();
+      refreshUsage({ fresh: true });
     } catch (e) {
       Alert.alert(
         "Portal unavailable",

--- a/apps/mobile/src/lib/cloud/usage.ts
+++ b/apps/mobile/src/lib/cloud/usage.ts
@@ -16,10 +16,17 @@ export interface CloudUsageBalance {
   unlimited: boolean;
 }
 
-export async function fetchCloudUsage(): Promise<CloudUsageBalance> {
+export async function fetchCloudUsage(
+  opts: { fresh?: boolean } = {},
+): Promise<CloudUsageBalance> {
   // Auth + 401 handling live in the shared client; usage keeps the 10s budget.
-  return cloud.json<CloudUsageBalance>("/usage", {
-    method: "GET",
-    timeoutMs: 10_000,
-  });
+  // `fresh` bypasses the cloud's plan cache — set it on the post-checkout
+  // refresh so an upgrade shows up right away instead of after the cache TTL.
+  return cloud.json<CloudUsageBalance>(
+    opts.fresh ? "/usage?fresh=1" : "/usage",
+    {
+      method: "GET",
+      timeoutMs: 10_000,
+    },
+  );
 }

--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -452,14 +452,24 @@ export async function postProcessWithFreestyleCloud(opts: {
 /**
  * Fetch the current usage balance from Freestyle Cloud.
  * Returns remaining credits, limit, total consumed, and window reset time.
+ *
+ * Pass `fresh` to bypass the cloud's region-local plan cache — the desktop app
+ * sets it while polling right after Stripe Checkout so a plan upgrade shows up
+ * on the next poll instead of after the cache TTL. Regular reads omit it and
+ * get the cached (fast) path.
  */
 export async function fetchCloudUsage(
   token: string,
+  opts: { fresh?: boolean } = {},
 ): Promise<CloudUsageBalance> {
-  return cloudJson<CloudUsageBalance>("/usage", token, {
-    method: "GET",
-    signal: AbortSignal.timeout(10_000),
-  });
+  return cloudJson<CloudUsageBalance>(
+    opts.fresh ? "/usage?fresh=1" : "/usage",
+    token,
+    {
+      method: "GET",
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/routes/usage.ts
+++ b/apps/server/src/routes/usage.ts
@@ -1,29 +1,45 @@
 import { createAppLogger } from "@freestyle-voice/utils";
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
+import { z } from "zod";
 import { formatError } from "../lib/format-error.js";
 import { fetchCloudUsage } from "../lib/freestyle-cloud.js";
 import { getSessionToken } from "../lib/sessions.js";
 
 const log = createAppLogger("usage");
 
-const usage = new Hono().get("/", async (c) => {
-  const token = getSessionToken();
-  if (!token) {
-    return c.json({ error: "Not signed in to Freestyle Cloud" }, 401);
-  }
-  try {
-    const balance = await fetchCloudUsage(token);
-    return c.json(balance);
-  } catch (err) {
-    log.warn(`failed to fetch cloud usage: ${formatError(err)}`);
-    return c.json(
-      {
-        error: "Failed to fetch usage",
-        detail: err instanceof Error ? err.message : String(err),
-      },
-      502,
-    );
-  }
-});
+/**
+ * `fresh=1` forces the cloud to bypass its region-local plan cache. The
+ * renderer sets it only while polling right after Stripe Checkout so an upgrade
+ * is detected on the next poll; all other reads omit it for the cached path.
+ */
+const usageQuerySchema = z.object({ fresh: z.literal("1").optional() });
+
+const usage = new Hono().get(
+  "/",
+  zValidator("query", usageQuerySchema),
+  async (c) => {
+    const token = getSessionToken();
+    if (!token) {
+      return c.json({ error: "Not signed in to Freestyle Cloud" }, 401);
+    }
+    try {
+      // Forward the caller's `?fresh=1` (set by the post-checkout poll) so the
+      // cloud bypasses its plan cache and reports an upgrade immediately.
+      const { fresh } = c.req.valid("query");
+      const balance = await fetchCloudUsage(token, { fresh: fresh === "1" });
+      return c.json(balance);
+    } catch (err) {
+      log.warn(`failed to fetch cloud usage: ${formatError(err)}`);
+      return c.json(
+        {
+          error: "Failed to fetch usage",
+          detail: err instanceof Error ? err.message : String(err),
+        },
+        502,
+      );
+    }
+  },
+);
 
 export default usage;


### PR DESCRIPTION
## Why

Companion to cloud PR **freestyle-voice/cloud#115**, which stops `GET /usage` from bypassing the plan cache on every poll (that unconditional bypass was the dominant cost on the 7.7k-req/wk endpoint). The cloud now serves the plan from its region-local cache by default and only bypasses it on `?fresh=1`.

This PR makes the clients send `?fresh=1` **only** on the reads that must observe a plan change immediately (right after Stripe Checkout / billing portal). Every other usage read uses the cached fast path.

> [!NOTE]
> Without this change, a plan upgrade could take up to the cloud's 60s plan-cache TTL to appear. With it, the post-checkout poll/refresh sees the flip immediately, and routine polls get the cheaper cached read.

## Changes

### Desktop
- `fetchCloudUsage(token, { fresh })` (`apps/server/.../freestyle-cloud.ts`) appends `?fresh=1` to the cloud path.
- The local `GET /api/usage` route (`apps/server/.../routes/usage.ts`) now validates a `fresh` query param (`zValidator`) and forwards it to `fetchCloudUsage`.
- `useCloudUsage` (`apps/electron/.../use-cloud-usage.ts`) sends `?fresh=1` **only while a checkout is pending** (the existing poll loop); all other reads omit it.

### Mobile
- `fetchCloudUsage({ fresh })` (`apps/mobile/.../lib/cloud/usage.ts`) appends `?fresh=1`.
- The post-checkout / post-portal refreshes fetch fresh: `profile.tsx` `onUpgrade`/`onManage` and the `freestyle://billing` deep-link return (`billing.tsx`). Ordinary refreshes (e.g. org switch) stay on the cached path.

## Verification
- `biome check` — clean on all changed files
- `apps/server` `tsc --emitDeclarationOnly` — clean
- `apps/electron` `npm run typecheck` (node + web) — clean (validates the RPC `$get({ query })` against the server's `AppType`)
- `apps/mobile` `tsc --noEmit` — no new errors (one pre-existing unrelated error in `settings/index.tsx` remains on `main`)