### PR TITLE
feat(hotkey): show key names alongside symbols where the key is taught

### DIFF
--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -285,7 +285,7 @@ function HotkeyRow({
           className="tavern-set-keys"
           onClick={() => recorder.startRecording()}
         >
-          {formatAcceleratorKeys(accel).map((k) => (
+          {formatAcceleratorKeys(accel, { verbose: true }).map((k) => (
             <kbd key={k} className="tavern-kbd">
               {k}
             </kbd>

--- a/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.test.ts
+++ b/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Verbose key labels, on both platforms.
+ *
+ * Written after a review found the first attempt produced "Right ⌘ Right
+ * Command" and "Ctrl Control": it composed symbol + word and used a substring
+ * guard that missed the "Right " prefix and the Ctrl/Control mismatch. The
+ * table below is the contract, so a future refactor that reintroduces
+ * composition fails here instead of in someone's onboarding.
+ */
+async function loadWith(isMac: boolean) {
+  vi.resetModules();
+  vi.doMock("@renderer/lib/platform", () => ({
+    IS_MAC: isMac,
+    IS_WINDOWS: !isMac,
+    IS_LINUX: false,
+    PLATFORM: isMac ? "darwin" : "win32",
+  }));
+  return import("./use-hotkey-recorder");
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("keyDisplayLabel verbose", () => {
+  it("names macOS modifiers without duplicating the Right prefix", async () => {
+    const { keyDisplayLabel } = await loadWith(true);
+    const v = (k: string) => keyDisplayLabel(k, { verbose: true });
+
+    expect(v("Fn")).toBe("🌐 Fn");
+    expect(v("Command")).toBe("⌘ Command");
+    expect(v("Alt")).toBe("⌥ Option");
+    expect(v("Control")).toBe("⌃ Control");
+    expect(v("Shift")).toBe("⇧ Shift");
+
+    expect(v("RightCommand")).toBe("⌘ Right Command");
+    expect(v("RightControl")).toBe("⌃ Right Control");
+    expect(v("RightAlt")).toBe("⌥ Right Option");
+    expect(v("RightShift")).toBe("⇧ Right Shift");
+  });
+
+  it("leaves Windows and Linux labels alone", async () => {
+    const { keyDisplayLabel } = await loadWith(false);
+    for (const key of ["Control", "Command", "Alt", "Shift", "Fn", "Space"]) {
+      expect(keyDisplayLabel(key, { verbose: true })).toBe(
+        keyDisplayLabel(key),
+      );
+    }
+    // The pairing is a macOS affordance; these already read as words.
+    expect(keyDisplayLabel("Control", { verbose: true })).toBe("Ctrl");
+  });
+
+  it("leaves non-modifier keys as their symbol on macOS", async () => {
+    const { keyDisplayLabel } = await loadWith(true);
+    // ␣ and ⎋ are the established legends, and their names are ordinary words
+    // that would need translating. Only modifier legends get a name.
+    expect(keyDisplayLabel("Space", { verbose: true })).toBe("␣");
+    expect(keyDisplayLabel("Escape", { verbose: true })).toBe("⎋");
+    expect(keyDisplayLabel("Right", { verbose: true })).toBe("→");
+    expect(keyDisplayLabel("A", { verbose: true })).toBe("A");
+  });
+
+  it("is unchanged when verbose is not asked for", async () => {
+    const { keyDisplayLabel } = await loadWith(true);
+    expect(keyDisplayLabel("Fn")).toBe("🌐");
+    expect(keyDisplayLabel("Command")).toBe("⌘");
+    expect(keyDisplayLabel("RightCommand")).toBe("Right ⌘");
+  });
+
+  it("threads the option through a whole accelerator", async () => {
+    const { formatAcceleratorKeys } = await loadWith(true);
+    expect(formatAcceleratorKeys("Fn", { verbose: true })).toEqual(["🌐 Fn"]);
+    expect(
+      formatAcceleratorKeys("Control+Alt+Space", { verbose: true }),
+    ).toEqual(["⌃ Control", "⌥ Option", "␣"]);
+    // `.map` would pass the index as the second argument; the wrappers in
+    // comboDisplayKeys exist to stop that turning into a silent verbose call.
+    expect(formatAcceleratorKeys("Control+Alt+Space")).toEqual(["⌃", "⌥", "␣"]);
+  });
+});

--- a/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
+++ b/apps/electron/src/renderer/src/hooks/use-hotkey-recorder.ts
@@ -221,12 +221,56 @@ export function acceleratorToCombo(accel: string): HotkeyCombo {
   };
 }
 
-export function keyDisplayLabel(key: string): string {
+/**
+ * macOS modifier legends paired with their names, for the places that teach a
+ * shortcut rather than just recall it.
+ *
+ * A symbol only helps if it matches what's printed on the key in front of you.
+ * The globe is on Apple keyboards; the same key on a Logitech reads "fn", and
+ * anyone on a Mac mini, Mac Studio or Mac Pro brings their own keyboard. The
+ * app can't tell which you have: an Fn press arrives as
+ * `CGEventFlags.maskSecondaryFn` from either.
+ *
+ * macOS-only and modifiers-only, deliberately. Windows and Linux already
+ * resolve modifiers to words, so there is nothing to add. Keys like Space and
+ * Escape keep their bare symbol: those glyphs *are* the convention, and their
+ * names are ordinary English that would need translating, unlike a modifier
+ * legend stamped on the hardware.
+ *
+ * Written out in full rather than composed from symbol + word. Composing them
+ * needs a rule for the "Right " prefix, and the obvious rule produces
+ * "Right ⌘ Right Command".
+ */
+const MAC_VERBOSE_MODIFIERS: Record<string, string> = {
+  Control: "⌃ Control",
+  Command: "⌘ Command",
+  Alt: "⌥ Option",
+  Shift: "⇧ Shift",
+  Fn: "🌐 Fn",
+  RightControl: "⌃ Right Control",
+  RightCommand: "⌘ Right Command",
+  RightAlt: "⌥ Right Option",
+  RightOption: "⌥ Right Option",
+  RightShift: "⇧ Right Shift",
+};
+
+function keySymbolLabel(key: string): string {
   if (IS_MAC && MAC_MOD_SYMBOLS[key]) return MAC_MOD_SYMBOLS[key];
   if (IS_MAC && MAC_RIGHT_MOD_SYMBOLS[key]) return MAC_RIGHT_MOD_SYMBOLS[key];
   if (!IS_MAC && OTHER_MOD_LABELS[key]) return OTHER_MOD_LABELS[key];
   if (KEY_SYMBOLS[key]) return KEY_SYMBOLS[key];
   return key;
+}
+
+export function keyDisplayLabel(
+  key: string,
+  options?: { verbose?: boolean },
+): string {
+  if (options?.verbose && IS_MAC) {
+    const named = MAC_VERBOSE_MODIFIERS[key];
+    if (named) return named;
+  }
+  return keySymbolLabel(key);
 }
 
 // ---------------------------------------------------------------------------
@@ -305,14 +349,22 @@ export function nextRightModifierLatch(
   return null;
 }
 
-export function comboDisplayKeys(combo: HotkeyCombo): string[] {
-  const keys = combo.modifiers.map(keyDisplayLabel);
-  if (combo.key) keys.push(keyDisplayLabel(combo.key));
+export function comboDisplayKeys(
+  combo: HotkeyCombo,
+  options?: { verbose?: boolean },
+): string[] {
+  // Explicit arrow, not a bare reference: `.map` passes the index as the
+  // second argument, which would land in `options`.
+  const keys = combo.modifiers.map((m) => keyDisplayLabel(m, options));
+  if (combo.key) keys.push(keyDisplayLabel(combo.key, options));
   return keys;
 }
 
-export function formatAcceleratorKeys(accel: string): string[] {
-  return comboDisplayKeys(acceleratorToCombo(accel));
+export function formatAcceleratorKeys(
+  accel: string,
+  options?: { verbose?: boolean },
+): string[] {
+  return comboDisplayKeys(acceleratorToCombo(accel), options);
 }
 
 export function formatAccelerator(accel: string): string {


### PR DESCRIPTION
Closes #566.

The dictation hotkey is shown as a symbol alone. On macOS the default is Fn, which renders as
a bare globe emoji: no word next to it, no tooltip. It appears that way in Settings and in the
recorder.

## Why a symbol isn't enough here

The globe is printed on Apple keyboards. On a Logitech the same key reads **fn**, and anyone
on a Mac mini, Mac Studio or Mac Pro brings their own keyboard. So the app names a key that
doesn't appear on their hardware.

It can't detect which keyboard you have, either. An Fn press arrives as
`CGEventFlags.maskSecondaryFn` from both. Getting make and model would mean enumerating HID
devices and then guessing whether a globe is printed on the key, which means maintaining a
list of Apple models that is wrong for everything else. Naming the key costs nothing and never
goes stale.

## The change

`keyDisplayLabel` takes a `verbose` option returning the symbol paired with its name, so
`🌐 Fn` and `⌘ Command`. `settings-view` passes it when rendering the hotkey badge.

macOS modifiers only. The table is written out in full rather than composed from symbol plus
word: composition has no good rule for the `Right ` prefix, giving `Right ⌘ Right Command`,
and `Ctrl` versus `Control` collides the same way on Windows. Space, Escape and the arrows
keep their bare symbol, since those glyphs are the convention and their names are ordinary
English that belongs in the locale files.

Threaded through `comboDisplayKeys` and `formatAcceleratorKeys`, with explicit arrows at the
`.map` call sites so the array index can't land in the new argument. There's a table test over
both platforms covering every token in the symbol maps.

Rebased onto the new UI from #570. Typecheck, Biome, knip and `vitest run` clean.
