### PR TITLE
fix(electron): keep brain cache coherent

### DIFF
--- a/apps/electron/src/renderer/src/lib/brain-fs.test.ts
+++ b/apps/electron/src/renderer/src/lib/brain-fs.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiFetch = vi.fn();
+
+vi.mock("@renderer/lib/api", () => ({ apiFetch }));
+
+function jsonResponse(payload: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(payload), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("brain file cache", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    vi.resetModules();
+  });
+
+  it("updates cached contents and invalidates cached lists after a raw write", async () => {
+    apiFetch
+      .mockResolvedValueOnce(jsonResponse({ ok: true, text: "old" }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ok: true,
+          files: [{ path: "notes/a.md", size: 3, modified: 1 }],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const {
+      fsCall,
+      listBrainFiles,
+      peekBrainFile,
+      peekBrainFiles,
+      readBrainFile,
+    } = await import("./brain-fs");
+
+    await readBrainFile("notes/a.md");
+    await listBrainFiles();
+    await fsCall("write", { path: "notes/a.md", text: "new" });
+
+    expect(peekBrainFile("notes/a.md")).toBe("new");
+    expect(peekBrainFiles()).toBeUndefined();
+  });
+
+  it("removes cached contents and invalidates cached lists after a raw delete", async () => {
+    apiFetch
+      .mockResolvedValueOnce(jsonResponse({ ok: true, text: "old" }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ok: true,
+          files: [{ path: "notes/a.md", size: 3, modified: 1 }],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const {
+      fsCall,
+      listBrainFiles,
+      peekBrainFile,
+      peekBrainFiles,
+      readBrainFile,
+    } = await import("./brain-fs");
+
+    await readBrainFile("notes/a.md");
+    await listBrainFiles();
+    await fsCall("delete", { path: "notes/a.md" });
+
+    expect(peekBrainFile("notes/a.md")).toBeUndefined();
+    expect(peekBrainFiles()).toBeUndefined();
+  });
+
+  it("evicts the oldest read when more than 100 files are cached", async () => {
+    apiFetch.mockImplementation(async (_path: string, init?: RequestInit) => {
+      const { path } = JSON.parse(String(init?.body)) as { path: string };
+      return jsonResponse({ ok: true, text: path });
+    });
+
+    const { peekBrainFile, readBrainFile } = await import("./brain-fs");
+
+    for (let index = 0; index <= 100; index += 1) {
+      await readBrainFile(`notes/${index}.md`);
+    }
+
+    expect(peekBrainFile("notes/0.md")).toBeUndefined();
+    expect(peekBrainFile("notes/100.md")).toBe("notes/100.md");
+  });
+});

--- a/apps/electron/src/renderer/src/lib/brain-fs.ts
+++ b/apps/electron/src/renderer/src/lib/brain-fs.ts
@@ -10,6 +10,7 @@ const GET_ROUTES = new Set(["list", "graph", "export"]);
 
 /** In-memory TTL so tab remounts don't flash "Loading…" while Cloudflare refetches. */
 const CACHE_TTL_MS = 60_000;
+const MAX_READ_CACHE_ENTRIES = 100;
 
 type CacheEntry<T> = { value: T; at: number };
 
@@ -20,7 +21,20 @@ function isFresh(at: number): boolean {
   return Date.now() - at < CACHE_TTL_MS;
 }
 
+function pruneReadCache(): void {
+  for (const [path, entry] of readCache) {
+    if (!isFresh(entry.at)) readCache.delete(path);
+  }
+  while (readCache.size >= MAX_READ_CACHE_ENTRIES) {
+    const oldestPath = readCache.keys().next().value;
+    if (oldestPath === undefined) return;
+    readCache.delete(oldestPath);
+  }
+}
+
 function putRead(path: string, text: string): void {
+  readCache.delete(path);
+  pruneReadCache();
   readCache.set(path, { value: text, at: Date.now() });
 }
 
@@ -35,7 +49,11 @@ function dropRead(path: string): void {
 /** Sync cache peek — `undefined` means miss (not yet fetched / expired). */
 export function peekBrainFile(path: string): string | undefined {
   const hit = readCache.get(path);
-  if (!hit || !isFresh(hit.at)) return undefined;
+  if (!hit) return undefined;
+  if (!isFresh(hit.at)) {
+    readCache.delete(path);
+    return undefined;
+  }
   return hit.value;
 }
 
@@ -63,7 +81,23 @@ export async function fsCall(
           }),
     });
     if (!res.ok) return null;
-    return (await res.json()) as Record<string, unknown>;
+    const payload = (await res.json()) as Record<string, unknown>;
+    if (payload.ok === true && route === "write") {
+      const path = body.path;
+      const text = body.text;
+      if (typeof path === "string" && typeof text === "string") {
+        putRead(path, text);
+        invalidateList();
+      }
+    }
+    if (payload.ok === true && route === "delete") {
+      const path = body.path;
+      if (typeof path === "string") {
+        dropRead(path);
+        invalidateList();
+      }
+    }
+    return payload;
   } catch {
     return null;
   }
@@ -85,22 +119,12 @@ export async function writeBrainFile(
   text: string,
 ): Promise<boolean> {
   const res = await fsCall("write", { path, text });
-  const ok = res?.ok === true;
-  if (ok) {
-    putRead(path, text);
-    invalidateList();
-  }
-  return ok;
+  return res?.ok === true;
 }
 
 export async function deleteBrainFile(path: string): Promise<boolean> {
   const res = await fsCall("delete", { path });
-  const ok = res?.ok === true;
-  if (ok) {
-    dropRead(path);
-    invalidateList();
-  }
-  return ok;
+  return res?.ok === true;
 }
 
 export async function listBrainFiles(prefix?: string): Promise<BrainFile[]> {

--- a/docs/superpowers/plans/2026-08-12-brain-cache-safety.md
+++ b/docs/superpowers/plans/2026-08-12-brain-cache-safety.md
@@ -1,0 +1,93 @@
+# Brain Cache Safety Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent Brain Files edits from serving stale Todos or Notes data, while keeping the renderer's short-lived cache bounded.
+
+**Architecture:** Keep cache lifecycle ownership in `brain-fs.ts`. Successful raw `write` and `delete` calls update or invalidate the shared cache, so both specialized tabs and the Settings file editor behave consistently. Bound cached file contents with deterministic oldest-entry eviction.
+
+**Tech Stack:** TypeScript, Vitest, Electron renderer.
+
+## Global Constraints
+
+- Preserve the 60-second warm-cache behavior added in PR #572.
+- Do not alter the Brain API contract or UI behavior beyond cache freshness.
+- Tests must exercise `brain-fs.ts` behavior with the network boundary mocked.
+
+---
+
+### Task 1: Cover cache mutation and retention behavior
+
+**Files:**
+- Create: `apps/electron/src/renderer/src/lib/brain-fs.test.ts`
+- Modify: `apps/electron/src/renderer/src/lib/brain-fs.ts`
+
+**Interfaces:**
+- Consumes: `fsCall(route, body)`, `readBrainFile(path)`, `listBrainFiles()`, `peekBrainFile(path)`, and `peekBrainFiles()`.
+- Produces: regression coverage for cache invalidation and bounded read retention.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it("updates cached file contents and invalidates cached lists after a raw write", async () => {
+  await readBrainFile("notes/a.md");
+  await listBrainFiles();
+  await fsCall("write", { path: "notes/a.md", text: "new" });
+  expect(peekBrainFile("notes/a.md")).toBe("new");
+  expect(peekBrainFiles()).toBeUndefined();
+});
+
+it("evicts the oldest cached read when the cache reaches its capacity", async () => {
+  // Read one more unique path than the defined cache capacity.
+  expect(peekBrainFile("notes/0.md")).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run the targeted test file and verify it fails**
+
+Run: `pnpm --filter @freestyle-voice/electron exec vitest run src/renderer/src/lib/brain-fs.test.ts`
+
+Expected: FAIL because raw writes do not update cached contents or invalidate the list, and the read cache has no capacity bound.
+
+- [ ] **Step 3: Implement the smallest shared cache lifecycle changes**
+
+```ts
+// On a successful fsCall("write"), refresh that path and invalidate the list.
+// On a successful fsCall("delete"), remove that path and invalidate the list.
+// Before adding a new read, evict the oldest entry when the read cache is full.
+```
+
+- [ ] **Step 4: Run the targeted test file and verify it passes**
+
+Run: `pnpm --filter @freestyle-voice/electron exec vitest run src/renderer/src/lib/brain-fs.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/electron/src/renderer/src/lib/brain-fs.ts apps/electron/src/renderer/src/lib/brain-fs.test.ts docs/superpowers/plans/2026-08-12-brain-cache-safety.md
+git commit -m "fix(electron): keep brain cache coherent"
+```
+
+### Task 2: Validate the renderer change
+
+**Files:**
+- Modify: `apps/electron/src/renderer/src/lib/brain-fs.ts`
+- Test: `apps/electron/src/renderer/src/lib/brain-fs.test.ts`
+
+**Interfaces:**
+- Consumes: completed Task 1 cache contract.
+- Produces: type-safe, formatted renderer code with all Electron tests passing.
+
+- [ ] **Step 1: Run focused and package tests**
+
+Run: `pnpm --filter @freestyle-voice/electron test`
+
+Expected: PASS with no failing test files.
+
+- [ ] **Step 2: Run formatting and renderer typecheck**
+
+Run: `pnpm exec biome check apps/electron/src/renderer/src/lib/brain-fs.ts apps/electron/src/renderer/src/lib/brain-fs.test.ts && pnpm --filter @freestyle-voice/electron typecheck:web`
+
+Expected: both commands exit 0.


### PR DESCRIPTION
## Summary

- centralize Brain Files cache updates and invalidation for raw writes and deletes
- prune expired reads and cap retained file contents at 100 entries
- add regression coverage for write, delete, and bounded retention

## Validation

- `pnpm test`
- `pnpm --filter @freestyle-voice/electron typecheck:web`
- `pnpm exec biome check apps/electron/src/renderer/src/lib/brain-fs.ts apps/electron/src/renderer/src/lib/brain-fs.test.ts`
