### PR TITLE
feat: Add Remix connected apps settings

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -41,6 +41,7 @@
     "hono": "^4.12.22",
     "react-markdown": "^9.1.0",
     "remark-gfm": "^4.0.0",
+    "shiki": "^3.23.0",
     "three": "0.185.1",
     "three-spritetext": "^1.10.0"
   },

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -1,0 +1,202 @@
+import {
+  type ConnectorCatalogItem,
+  connectorStatus,
+  connectToolkit,
+  disconnectToolkit,
+  listConnectorCatalog,
+} from "@renderer/lib/connectors";
+import type React from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+const POLL_INTERVAL_MS = 2_000;
+const POLL_TIMEOUT_MS = 5 * 60_000;
+
+function ConnectorCard({
+  connector,
+  busy,
+  onConnect,
+  onDisconnect,
+}: {
+  connector: ConnectorCatalogItem;
+  busy: boolean;
+  onConnect: () => void;
+  onDisconnect: () => void;
+}): React.JSX.Element {
+  const connection = connector.connection;
+  const connected = connection?.status === "active";
+  const pending = connection?.status === "pending";
+  const reconnect = connection?.status === "needs_reconnect";
+  return (
+    <div className="tavern-set-card">
+      <div className="tavern-set-card-title">{connector.name}</div>
+      <div className="tavern-set-card-sub">
+        {connected
+          ? `${connection.accountLabel ?? "Connected"} · ${connection.toolCount} tools`
+          : pending
+            ? "Waiting for approval in your browser…"
+            : reconnect
+              ? "Connection needs to be renewed"
+              : "Available to Remix"}
+      </div>
+      {connection?.statusReason ? (
+        <p className="tavern-set-hint">{connection.statusReason}</p>
+      ) : null}
+      <div className="tavern-set-seg">
+        {connected ? (
+          <button
+            type="button"
+            className="tavern-set-seg-btn"
+            disabled={busy}
+            onClick={onDisconnect}
+          >
+            Disconnect
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="tavern-set-seg-btn is-on"
+            disabled={busy || pending}
+            onClick={onConnect}
+          >
+            {busy ? "Opening…" : reconnect ? "Reconnect" : "Connect"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ConnectedApps(): React.JSX.Element {
+  const [query, setQuery] = useState("");
+  const [catalog, setCatalog] = useState<ConnectorCatalogItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyToolkit, setBusyToolkit] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setCatalog(await listConnectorCatalog(query));
+      setError(null);
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "Connected apps are unavailable.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [query]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => void load(), 150);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+
+  const pending = useMemo(
+    () =>
+      catalog
+        .filter((item) => item.connection?.status === "pending")
+        .map((item) => item.slug),
+    [catalog],
+  );
+  useEffect(() => {
+    if (pending.length === 0) return;
+    const startedAt = Date.now();
+    const timer = window.setInterval(() => {
+      if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
+        window.clearInterval(timer);
+        return;
+      }
+      void Promise.all(pending.map((toolkit) => connectorStatus(toolkit)))
+        .then(() => void load())
+        .catch(() => {});
+    }, POLL_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [load, pending]);
+
+  const connect = async (toolkit: string) => {
+    setBusyToolkit(toolkit);
+    try {
+      await connectToolkit(toolkit);
+      await load();
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "Could not start that connection.",
+      );
+    } finally {
+      setBusyToolkit(null);
+    }
+  };
+  const disconnect = async (toolkit: string) => {
+    setBusyToolkit(toolkit);
+    try {
+      await disconnectToolkit(toolkit);
+      await load();
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "Could not disconnect that app.",
+      );
+    } finally {
+      setBusyToolkit(null);
+    }
+  };
+
+  const connected = catalog.filter(
+    (item) => item.connection && item.connection.status !== "disconnected",
+  );
+  const available = catalog.filter(
+    (item) => !item.connection || item.connection.status === "disconnected",
+  );
+  return (
+    <>
+      <p className="tavern-set-hint is-lead">
+        Connect an app once, then Remix can use only your account. You approve
+        every action that changes data outside Freestyle.
+      </p>
+      <input
+        className="tavern-set-input"
+        value={query}
+        placeholder="Search connected apps"
+        aria-label="Search connected apps"
+        onChange={(event) => setQuery(event.target.value)}
+      />
+      {error ? <p className="tavern-set-hint">{error}</p> : null}
+      {loading ? (
+        <p className="tavern-set-hint">Loading connected apps…</p>
+      ) : null}
+      {connected.length > 0 ? (
+        <div className="tavern-set-section">Connected</div>
+      ) : null}
+      {connected.map((connector) => (
+        <ConnectorCard
+          key={connector.slug}
+          connector={connector}
+          busy={busyToolkit === connector.slug}
+          onConnect={() => void connect(connector.slug)}
+          onDisconnect={() => void disconnect(connector.slug)}
+        />
+      ))}
+      {available.length > 0 ? (
+        <div className="tavern-set-section">Available</div>
+      ) : null}
+      {available.map((connector) => (
+        <ConnectorCard
+          key={connector.slug}
+          connector={connector}
+          busy={busyToolkit === connector.slug}
+          onConnect={() => void connect(connector.slug)}
+          onDisconnect={() => void disconnect(connector.slug)}
+        />
+      ))}
+      {!loading && catalog.length === 0 ? (
+        <p className="tavern-set-hint">No connected apps match that search.</p>
+      ) : null}
+    </>
+  );
+}

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -1,13 +1,22 @@
 import {
   type ConnectorCatalogItem,
+  type ConnectorCatalogPage,
   connectorStatus,
   connectToolkit,
   disconnectToolkit,
 } from "@renderer/lib/connectors";
-import { connectorCatalogQueryOptions, queryKeys } from "@renderer/lib/query";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  connectorCatalogInfiniteQueryOptions,
+  queryKeys,
+} from "@renderer/lib/query";
+import {
+  type InfiniteData,
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 import type React from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 const POLL_INTERVAL_MS = 2_000;
 const POLL_TIMEOUT_MS = 5 * 60_000;
@@ -111,10 +120,14 @@ function ConnectedAppsSkeleton(): React.JSX.Element {
 export function ConnectedApps(): React.JSX.Element {
   const [query, setQuery] = useState("");
   const queryClient = useQueryClient();
-  const catalogQuery = useQuery(connectorCatalogQueryOptions());
-  const catalog = catalogQuery.data ?? [];
+  const catalogQuery = useInfiniteQuery(connectorCatalogInfiniteQueryOptions());
+  const catalog = useMemo(
+    () => catalogQuery.data?.pages.flatMap((page) => page.connectors) ?? [],
+    [catalogQuery.data],
+  );
   const [actionError, setActionError] = useState<string | null>(null);
   const [pollStartedAt, setPollStartedAt] = useState(0);
+  const loadMoreRef = useRef<HTMLDivElement>(null);
 
   const pending = useMemo(
     () =>
@@ -140,7 +153,7 @@ export function ConnectedApps(): React.JSX.Element {
         pendingToolkits.map((toolkit) => connectorStatus(toolkit)),
       )
         .then((statuses) => {
-          queryClient.setQueryData<ConnectorCatalogItem[]>(
+          queryClient.setQueryData<InfiniteData<ConnectorCatalogPage>>(
             queryKeys.connectors.catalog,
             (current) => {
               if (!current) return current;
@@ -150,14 +163,20 @@ export function ConnectedApps(): React.JSX.Element {
                   statuses[index] ?? null,
                 ]),
               );
-              return current.map((item) =>
-                statusByToolkit.has(item.slug)
-                  ? {
-                      ...item,
-                      connection: statusByToolkit.get(item.slug) ?? null,
-                    }
-                  : item,
-              );
+              return {
+                ...current,
+                pages: current.pages.map((page) => ({
+                  ...page,
+                  connectors: page.connectors.map((item) =>
+                    statusByToolkit.has(item.slug)
+                      ? {
+                          ...item,
+                          connection: statusByToolkit.get(item.slug) ?? null,
+                        }
+                      : item,
+                  ),
+                })),
+              };
             },
           );
         })
@@ -208,6 +227,32 @@ export function ConnectedApps(): React.JSX.Element {
   };
 
   const normalizedQuery = query.trim().toLowerCase();
+
+  useEffect(() => {
+    const target = loadMoreRef.current;
+    if (
+      !target ||
+      normalizedQuery ||
+      !catalogQuery.hasNextPage ||
+      catalogQuery.isFetchingNextPage
+    )
+      return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) void catalogQuery.fetchNextPage();
+      },
+      { rootMargin: "180px" },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [
+    catalogQuery.fetchNextPage,
+    catalogQuery.hasNextPage,
+    catalogQuery.isFetchingNextPage,
+    normalizedQuery,
+  ]);
+
   const matchingCatalog = useMemo(
     () =>
       normalizedQuery
@@ -251,9 +296,9 @@ export function ConnectedApps(): React.JSX.Element {
         <span aria-hidden="true">⌕</span>
         <input
           id="connector-search"
-          aria-label="Search connected apps"
+          aria-label="Filter loaded connected apps"
           value={query}
-          placeholder="Search apps"
+          placeholder="Filter loaded apps"
           onChange={(event) => setQuery(event.target.value)}
         />
         {query ? (
@@ -336,6 +381,23 @@ export function ConnectedApps(): React.JSX.Element {
               Clear search
             </button>
           ) : null}
+        </div>
+      ) : null}
+
+      {!initialLoading && catalog.length > 0 ? (
+        <div ref={loadMoreRef} className="connector-load-more" role="status">
+          {catalogQuery.isFetchingNextPage ? (
+            <>
+              <span className="connector-load-spinner" aria-hidden="true" />
+              Loading more apps…
+            </>
+          ) : normalizedQuery ? (
+            "Filter applies to apps loaded so far."
+          ) : catalogQuery.hasNextPage ? (
+            "More apps load as you scroll."
+          ) : (
+            "All available apps loaded."
+          )}
         </div>
       ) : null}
     </section>

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -3,10 +3,11 @@ import {
   connectorStatus,
   connectToolkit,
   disconnectToolkit,
-  listConnectorCatalog,
 } from "@renderer/lib/connectors";
+import { connectorCatalogQueryOptions, queryKeys } from "@renderer/lib/query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type React from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const POLL_INTERVAL_MS = 2_000;
 const POLL_TIMEOUT_MS = 5 * 60_000;
@@ -109,34 +110,11 @@ function ConnectedAppsSkeleton(): React.JSX.Element {
 
 export function ConnectedApps(): React.JSX.Element {
   const [query, setQuery] = useState("");
-  const [catalog, setCatalog] = useState<ConnectorCatalogItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [busyToolkit, setBusyToolkit] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const catalogQuery = useQuery(connectorCatalogQueryOptions());
+  const catalog = catalogQuery.data ?? [];
+  const [actionError, setActionError] = useState<string | null>(null);
   const [pollStartedAt, setPollStartedAt] = useState(0);
-
-  // The catalog is deliberately fetched once and searched locally. This keeps
-  // typing instant in the compact panel and avoids replacing the list with a
-  // loading state for every keystroke.
-  const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      setCatalog(await listConnectorCatalog());
-      setError(null);
-    } catch (cause) {
-      setError(
-        cause instanceof Error
-          ? cause.message
-          : "Connected apps are unavailable.",
-      );
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
 
   const pending = useMemo(
     () =>
@@ -153,7 +131,7 @@ export function ConnectedApps(): React.JSX.Element {
     const timer = window.setInterval(() => {
       if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
         window.clearInterval(timer);
-        setError(
+        setActionError(
           "This connection is still pending. Finish it in your browser, or open it again to restart.",
         );
         return;
@@ -161,61 +139,72 @@ export function ConnectedApps(): React.JSX.Element {
       void Promise.all(
         pendingToolkits.map((toolkit) => connectorStatus(toolkit)),
       )
-        .then((statuses) =>
-          setCatalog((current) => {
-            const statusByToolkit = new Map(
-              pendingToolkits.map((toolkit, index) => [
-                toolkit,
-                statuses[index] ?? null,
-              ]),
-            );
-            return current.map((item) =>
-              statusByToolkit.has(item.slug)
-                ? {
-                    ...item,
-                    connection: statusByToolkit.get(item.slug) ?? null,
-                  }
-                : item,
-            );
-          }),
-        )
+        .then((statuses) => {
+          queryClient.setQueryData<ConnectorCatalogItem[]>(
+            queryKeys.connectors.catalog,
+            (current) => {
+              if (!current) return current;
+              const statusByToolkit = new Map(
+                pendingToolkits.map((toolkit, index) => [
+                  toolkit,
+                  statuses[index] ?? null,
+                ]),
+              );
+              return current.map((item) =>
+                statusByToolkit.has(item.slug)
+                  ? {
+                      ...item,
+                      connection: statusByToolkit.get(item.slug) ?? null,
+                    }
+                  : item,
+              );
+            },
+          );
+        })
         .catch(() => {});
     }, POLL_INTERVAL_MS);
     return () => window.clearInterval(timer);
-  }, [pendingKey, pollStartedAt]);
+  }, [pendingKey, pollStartedAt, queryClient]);
 
-  const connect = async (toolkit: string) => {
-    setBusyToolkit(toolkit);
-    setError(null);
-    try {
-      await connectToolkit(toolkit);
+  const connectMutation = useMutation({
+    mutationFn: connectToolkit,
+    onSuccess: async () => {
       setPollStartedAt(Date.now());
-      await load();
-    } catch (cause) {
-      setError(
-        cause instanceof Error
-          ? cause.message
-          : "Could not start that connection.",
-      );
-    } finally {
-      setBusyToolkit(null);
-    }
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.connectors.catalog,
+      });
+    },
+  });
+  const disconnectMutation = useMutation({
+    mutationFn: disconnectToolkit,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.connectors.catalog,
+      });
+    },
+  });
+
+  const connect = (toolkit: string) => {
+    setActionError(null);
+    connectMutation.mutate(toolkit, {
+      onError: (cause) =>
+        setActionError(
+          cause instanceof Error
+            ? cause.message
+            : "Could not start that connection.",
+        ),
+    });
   };
-  const disconnect = async (toolkit: string) => {
-    setBusyToolkit(toolkit);
-    setError(null);
-    try {
-      await disconnectToolkit(toolkit);
-      await load();
-    } catch (cause) {
-      setError(
-        cause instanceof Error
-          ? cause.message
-          : "Could not disconnect that app.",
-      );
-    } finally {
-      setBusyToolkit(null);
-    }
+  const disconnect = (toolkit: string) => {
+    setActionError(null);
+    disconnectMutation.mutate(toolkit, {
+      onError: (cause) =>
+        setActionError(
+          cause instanceof Error
+            ? cause.message
+            : "Could not disconnect that app.",
+        ),
+    });
   };
 
   const normalizedQuery = query.trim().toLowerCase();
@@ -234,10 +223,22 @@ export function ConnectedApps(): React.JSX.Element {
   const available = matchingCatalog.filter(
     (item) => !item.connection || item.connection.status === "disconnected",
   );
-  const initialLoading = loading && catalog.length === 0;
+  const initialLoading = catalogQuery.isLoading && catalog.length === 0;
+  const error =
+    actionError ??
+    (catalogQuery.error instanceof Error
+      ? catalogQuery.error.message
+      : catalogQuery.isError
+        ? "Connected apps are unavailable."
+        : null);
+  const busyToolkit = connectMutation.isPending
+    ? connectMutation.variables
+    : disconnectMutation.isPending
+      ? disconnectMutation.variables
+      : null;
 
   return (
-    <section className="connected-apps" aria-busy={loading}>
+    <section className="connected-apps" aria-busy={catalogQuery.isFetching}>
       <header className="connected-apps-intro">
         <span>Private by default</span>
         <p>
@@ -269,7 +270,7 @@ export function ConnectedApps(): React.JSX.Element {
       {error ? (
         <div className="connector-error" role="alert">
           <span>{error}</span>
-          <button type="button" onClick={() => void load()}>
+          <button type="button" onClick={() => void catalogQuery.refetch()}>
             Try again
           </button>
         </div>
@@ -295,8 +296,8 @@ export function ConnectedApps(): React.JSX.Element {
               key={connector.slug}
               connector={connector}
               busy={busyToolkit === connector.slug}
-              onConnect={() => void connect(connector.slug)}
-              onDisconnect={() => void disconnect(connector.slug)}
+              onConnect={() => connect(connector.slug)}
+              onDisconnect={() => disconnect(connector.slug)}
             />
           ))}
         </div>
@@ -313,8 +314,8 @@ export function ConnectedApps(): React.JSX.Element {
               key={connector.slug}
               connector={connector}
               busy={busyToolkit === connector.slug}
-              onConnect={() => void connect(connector.slug)}
-              onDisconnect={() => void disconnect(connector.slug)}
+              onConnect={() => connect(connector.slug)}
+              onDisconnect={() => disconnect(connector.slug)}
             />
           ))}
         </div>

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -55,10 +55,16 @@ function ConnectorCard({
           <button
             type="button"
             className="tavern-set-seg-btn is-on"
-            disabled={busy || pending}
+            disabled={busy}
             onClick={onConnect}
           >
-            {busy ? "Opening…" : reconnect ? "Reconnect" : "Connect"}
+            {busy
+              ? "Opening…"
+              : pending
+                ? "Open browser again"
+                : reconnect
+                  ? "Reconnect"
+                  : "Connect"}
           </button>
         )}
       </div>
@@ -72,6 +78,7 @@ export function ConnectedApps(): React.JSX.Element {
   const [loading, setLoading] = useState(true);
   const [busyToolkit, setBusyToolkit] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pollStartedAt, setPollStartedAt] = useState(0);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -101,25 +108,51 @@ export function ConnectedApps(): React.JSX.Element {
         .map((item) => item.slug),
     [catalog],
   );
+  const pendingKey = pending.join(",");
   useEffect(() => {
-    if (pending.length === 0) return;
-    const startedAt = Date.now();
+    if (!pendingKey) return;
+    const startedAt = pollStartedAt || Date.now();
+    const pendingToolkits = pendingKey.split(",");
     const timer = window.setInterval(() => {
       if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
         window.clearInterval(timer);
+        setError(
+          "This connection is still pending. Finish it in your browser, or open the browser again to restart.",
+        );
         return;
       }
-      void Promise.all(pending.map((toolkit) => connectorStatus(toolkit)))
-        .then(() => void load())
+      void Promise.all(
+        pendingToolkits.map((toolkit) => connectorStatus(toolkit)),
+      )
+        .then((statuses) =>
+          setCatalog((current) => {
+            const statusByToolkit = new Map(
+              pendingToolkits.map((toolkit, index) => [
+                toolkit,
+                statuses[index] ?? null,
+              ]),
+            );
+            return current.map((item) =>
+              statusByToolkit.has(item.slug)
+                ? {
+                    ...item,
+                    connection: statusByToolkit.get(item.slug) ?? null,
+                  }
+                : item,
+            );
+          }),
+        )
         .catch(() => {});
     }, POLL_INTERVAL_MS);
     return () => window.clearInterval(timer);
-  }, [load, pending]);
+  }, [pendingKey, pollStartedAt]);
 
   const connect = async (toolkit: string) => {
     setBusyToolkit(toolkit);
+    setError(null);
     try {
       await connectToolkit(toolkit);
+      setPollStartedAt(Date.now());
       await load();
     } catch (cause) {
       setError(
@@ -133,6 +166,7 @@ export function ConnectedApps(): React.JSX.Element {
   };
   const disconnect = async (toolkit: string) => {
     setBusyToolkit(toolkit);
+    setError(null);
     try {
       await disconnectToolkit(toolkit);
       await load();
@@ -156,8 +190,8 @@ export function ConnectedApps(): React.JSX.Element {
   return (
     <>
       <p className="tavern-set-hint is-lead">
-        Connect an app once, then Remix can use only your account. You approve
-        every action that changes data outside Freestyle.
+        Connect an app once, then Freestyle can use only your account. You
+        approve every action that changes data outside Freestyle.
       </p>
       <input
         className="tavern-set-input"

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -29,7 +29,7 @@ function connectionCopy(connector: ConnectorCatalogItem): string {
     return "Finish connecting in your browser";
   if (connection?.status === "needs_reconnect")
     return "Reconnect to keep using this app";
-  return "Available to Remix";
+  return "Available to Freestyle";
 }
 
 function connectionBadge(connector: ConnectorCatalogItem): string | null {

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -11,6 +11,30 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 const POLL_INTERVAL_MS = 2_000;
 const POLL_TIMEOUT_MS = 5 * 60_000;
 
+function connectionCopy(connector: ConnectorCatalogItem): string {
+  const connection = connector.connection;
+  if (connection?.status === "active")
+    return `${connection.accountLabel ?? "Connected"} · ${connection.toolCount} ${connection.toolCount === 1 ? "tool" : "tools"}`;
+  if (connection?.status === "pending")
+    return "Finish connecting in your browser";
+  if (connection?.status === "needs_reconnect")
+    return "Reconnect to keep using this app";
+  return "Available to Remix";
+}
+
+function connectionBadge(connector: ConnectorCatalogItem): string | null {
+  switch (connector.connection?.status) {
+    case "active":
+      return "Connected";
+    case "pending":
+      return "In progress";
+    case "needs_reconnect":
+      return "Needs attention";
+    default:
+      return null;
+  }
+}
+
 function ConnectorCard({
   connector,
   busy,
@@ -26,48 +50,59 @@ function ConnectorCard({
   const connected = connection?.status === "active";
   const pending = connection?.status === "pending";
   const reconnect = connection?.status === "needs_reconnect";
+  const badge = connectionBadge(connector);
+  const action = connected
+    ? "Disconnect"
+    : busy
+      ? "Opening…"
+      : pending
+        ? "Open browser"
+        : reconnect
+          ? "Reconnect"
+          : "Connect";
+
   return (
-    <div className="tavern-set-card">
-      <div className="tavern-set-card-title">{connector.name}</div>
-      <div className="tavern-set-card-sub">
-        {connected
-          ? `${connection.accountLabel ?? "Connected"} · ${connection.toolCount} tools`
-          : pending
-            ? "Waiting for approval in your browser…"
-            : reconnect
-              ? "Connection needs to be renewed"
-              : "Available to Remix"}
+    <article
+      className={`connector-card${connected ? " is-connected" : ""}${pending ? " is-pending" : ""}${reconnect ? " needs-reconnect" : ""}`}
+    >
+      <div className="connector-mark" aria-hidden="true">
+        {connector.name.slice(0, 1)}
       </div>
-      {connection?.statusReason ? (
-        <p className="tavern-set-hint">{connection.statusReason}</p>
-      ) : null}
-      <div className="tavern-set-seg">
-        {connected ? (
-          <button
-            type="button"
-            className="tavern-set-seg-btn"
-            disabled={busy}
-            onClick={onDisconnect}
-          >
-            Disconnect
-          </button>
-        ) : (
-          <button
-            type="button"
-            className="tavern-set-seg-btn is-on"
-            disabled={busy}
-            onClick={onConnect}
-          >
-            {busy
-              ? "Opening…"
-              : pending
-                ? "Open browser again"
-                : reconnect
-                  ? "Reconnect"
-                  : "Connect"}
-          </button>
-        )}
+      <div className="connector-card-copy">
+        <div className="connector-card-heading">
+          <strong>{connector.name}</strong>
+          {badge ? <span className="connector-state">{badge}</span> : null}
+        </div>
+        <p>{connectionCopy(connector)}</p>
+        {connection?.statusReason ? (
+          <p className="connector-reason">{connection.statusReason}</p>
+        ) : null}
       </div>
+      <button
+        type="button"
+        className={`connector-action${connected ? " is-secondary" : ""}`}
+        disabled={busy}
+        onClick={connected ? onDisconnect : onConnect}
+      >
+        {action}
+      </button>
+    </article>
+  );
+}
+
+function ConnectedAppsSkeleton(): React.JSX.Element {
+  return (
+    <div className="connector-skeleton" aria-hidden="true">
+      {["first", "second", "third"].map((key) => (
+        <div key={key} className="connector-skeleton-row">
+          <span className="connector-skeleton-mark" />
+          <span className="connector-skeleton-copy">
+            <i />
+            <i />
+          </span>
+          <span className="connector-skeleton-action" />
+        </div>
+      ))}
     </div>
   );
 }
@@ -80,10 +115,13 @@ export function ConnectedApps(): React.JSX.Element {
   const [error, setError] = useState<string | null>(null);
   const [pollStartedAt, setPollStartedAt] = useState(0);
 
+  // The catalog is deliberately fetched once and searched locally. This keeps
+  // typing instant in the compact panel and avoids replacing the list with a
+  // loading state for every keystroke.
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      setCatalog(await listConnectorCatalog(query));
+      setCatalog(await listConnectorCatalog());
       setError(null);
     } catch (cause) {
       setError(
@@ -94,11 +132,10 @@ export function ConnectedApps(): React.JSX.Element {
     } finally {
       setLoading(false);
     }
-  }, [query]);
+  }, []);
 
   useEffect(() => {
-    const timer = window.setTimeout(() => void load(), 150);
-    return () => window.clearTimeout(timer);
+    void load();
   }, [load]);
 
   const pending = useMemo(
@@ -117,7 +154,7 @@ export function ConnectedApps(): React.JSX.Element {
       if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
         window.clearInterval(timer);
         setError(
-          "This connection is still pending. Finish it in your browser, or open the browser again to restart.",
+          "This connection is still pending. Finish it in your browser, or open it again to restart.",
         );
         return;
       }
@@ -181,56 +218,125 @@ export function ConnectedApps(): React.JSX.Element {
     }
   };
 
-  const connected = catalog.filter(
+  const normalizedQuery = query.trim().toLowerCase();
+  const matchingCatalog = useMemo(
+    () =>
+      normalizedQuery
+        ? catalog.filter((item) =>
+            `${item.name} ${item.slug}`.toLowerCase().includes(normalizedQuery),
+          )
+        : catalog,
+    [catalog, normalizedQuery],
+  );
+  const connected = matchingCatalog.filter(
     (item) => item.connection && item.connection.status !== "disconnected",
   );
-  const available = catalog.filter(
+  const available = matchingCatalog.filter(
     (item) => !item.connection || item.connection.status === "disconnected",
   );
+  const initialLoading = loading && catalog.length === 0;
+
   return (
-    <>
-      <p className="tavern-set-hint is-lead">
-        Connect an app once, then Freestyle can use only your account. You
-        approve every action that changes data outside Freestyle.
-      </p>
-      <input
-        className="tavern-set-input"
-        value={query}
-        placeholder="Search connected apps"
-        aria-label="Search connected apps"
-        onChange={(event) => setQuery(event.target.value)}
-      />
-      {error ? <p className="tavern-set-hint">{error}</p> : null}
-      {loading ? (
-        <p className="tavern-set-hint">Loading connected apps…</p>
-      ) : null}
-      {connected.length > 0 ? (
-        <div className="tavern-set-section">Connected</div>
-      ) : null}
-      {connected.map((connector) => (
-        <ConnectorCard
-          key={connector.slug}
-          connector={connector}
-          busy={busyToolkit === connector.slug}
-          onConnect={() => void connect(connector.slug)}
-          onDisconnect={() => void disconnect(connector.slug)}
+    <section className="connected-apps" aria-busy={loading}>
+      <header className="connected-apps-intro">
+        <span>Private by default</span>
+        <p>
+          Connect once. Freestyle can use only your account, and always asks
+          before changing anything outside the app.
+        </p>
+      </header>
+
+      <label className="connector-search" htmlFor="connector-search">
+        <span aria-hidden="true">⌕</span>
+        <input
+          id="connector-search"
+          aria-label="Search connected apps"
+          value={query}
+          placeholder="Search apps"
+          onChange={(event) => setQuery(event.target.value)}
         />
-      ))}
-      {available.length > 0 ? (
-        <div className="tavern-set-section">Available</div>
+        {query ? (
+          <button
+            type="button"
+            aria-label="Clear app search"
+            onClick={() => setQuery("")}
+          >
+            ×
+          </button>
+        ) : null}
+      </label>
+
+      {error ? (
+        <div className="connector-error" role="alert">
+          <span>{error}</span>
+          <button type="button" onClick={() => void load()}>
+            Try again
+          </button>
+        </div>
       ) : null}
-      {available.map((connector) => (
-        <ConnectorCard
-          key={connector.slug}
-          connector={connector}
-          busy={busyToolkit === connector.slug}
-          onConnect={() => void connect(connector.slug)}
-          onDisconnect={() => void disconnect(connector.slug)}
-        />
-      ))}
-      {!loading && catalog.length === 0 ? (
-        <p className="tavern-set-hint">No connected apps match that search.</p>
+
+      {initialLoading ? (
+        <>
+          <p className="connector-loading-copy" role="status">
+            Finding your apps…
+          </p>
+          <ConnectedAppsSkeleton />
+        </>
       ) : null}
-    </>
+
+      {!initialLoading && connected.length > 0 ? (
+        <div className="connector-group">
+          <div className="connector-group-label">
+            <span>Connected</span>
+            <em>{connected.length}</em>
+          </div>
+          {connected.map((connector) => (
+            <ConnectorCard
+              key={connector.slug}
+              connector={connector}
+              busy={busyToolkit === connector.slug}
+              onConnect={() => void connect(connector.slug)}
+              onDisconnect={() => void disconnect(connector.slug)}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {!initialLoading && available.length > 0 ? (
+        <div className="connector-group">
+          <div className="connector-group-label">
+            <span>{connected.length > 0 ? "More apps" : "Available apps"}</span>
+            <em>{available.length}</em>
+          </div>
+          {available.map((connector) => (
+            <ConnectorCard
+              key={connector.slug}
+              connector={connector}
+              busy={busyToolkit === connector.slug}
+              onConnect={() => void connect(connector.slug)}
+              onDisconnect={() => void disconnect(connector.slug)}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {!initialLoading && matchingCatalog.length === 0 ? (
+        <div className="connector-empty">
+          <strong>
+            {normalizedQuery ? "No apps found" : "No apps are available"}
+          </strong>
+          <p>
+            {normalizedQuery
+              ? "Try a different app name."
+              : "Try again in a moment."}
+          </p>
+          {normalizedQuery ? (
+            <button type="button" onClick={() => setQuery("")}>
+              Clear search
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
   );
 }

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -385,11 +385,22 @@ export function ConnectedApps(): React.JSX.Element {
       ) : null}
 
       {!initialLoading && catalog.length > 0 ? (
-        <div ref={loadMoreRef} className="connector-load-more" role="status">
+        <div
+          ref={loadMoreRef}
+          className={`connector-load-more${catalogQuery.isFetchingNextPage ? " is-loading" : ""}`}
+          role="status"
+        >
           {catalogQuery.isFetchingNextPage ? (
             <>
-              <span className="connector-load-spinner" aria-hidden="true" />
-              Loading more apps…
+              <span className="connector-load-trail" aria-hidden="true">
+                <i />
+                <i />
+                <i />
+              </span>
+              <span className="connector-load-copy">
+                <strong>Finding more apps</strong>
+                <small>Keeping your place in the catalog</small>
+              </span>
             </>
           ) : normalizedQuery ? (
             "Filter applies to apps loaded so far."

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -20,6 +20,7 @@ import { seedMessageFor, starterPrompts } from "@renderer/lib/onboarding-core";
 import { createQueryClient } from "@renderer/lib/query";
 import { installGlobalErrorHandlers } from "@renderer/lib/report-error";
 import { useSpriteEmitter } from "@renderer/lib/sprite-emitter";
+import { toolPresentation } from "@renderer/lib/tool-presentation";
 import { SpriteBadge } from "@renderer/sprites/badge";
 import { type CompanionForm, DEFAULT_COMPANION_FORM } from "@shared/companion";
 import { PANEL_TABS, type PanelTab } from "@shared/panel";
@@ -48,36 +49,6 @@ const TAB_PLACEHOLDER: Record<PanelTab, string> = {
   notes: "No notes yet.",
 };
 
-const TOOL_LABELS: Record<string, string> = {
-  "tool-current_time": "checked the time",
-  "tool-web_search": "searched the web",
-  "tool-image_search": "searched for images",
-  "tool-get_context": "looked at your screen",
-  "tool-read_document": "read the document",
-  "tool-get_clipboard": "read your clipboard",
-  "tool-set_clipboard": "updated your clipboard",
-  "tool-paste": "pasted at your cursor",
-  "tool-Bash": "ran a command",
-  "tool-Read": "read a file",
-  "tool-Write": "wrote a file",
-  "tool-Edit": "edited a file",
-  "tool-Glob": "listed files",
-  "tool-Grep": "searched files",
-  "tool-brain_read": "recalled from its brain",
-  "tool-brain_write": "wrote to its brain",
-  "tool-brain_edit": "updated its brain",
-  "tool-brain_glob": "browsed its brain",
-  "tool-brain_search": "searched its brain",
-  "tool-brain_delete": "forgot something",
-  "tool-emote": "emoted",
-};
-
-function toolLabel(partType: string): string {
-  return (
-    TOOL_LABELS[partType] ?? partType.replace(/^tool-/, "").replace(/_/g, " ")
-  );
-}
-
 function toolJson(value: unknown): string {
   try {
     const dump = JSON.stringify(value, null, 1) ?? "";
@@ -97,37 +68,82 @@ function ToolChip({
   output: unknown;
 }): React.JSX.Element {
   const [open, setOpen] = useState(false);
+  const presentation = toolPresentation(partType);
+  const hasInput =
+    input !== undefined &&
+    input !== null &&
+    (typeof input !== "object" || Object.keys(input).length > 0);
+  const hasOutput =
+    output !== undefined &&
+    output !== null &&
+    (typeof output !== "object" ||
+      Object.keys(output).some((key) => key !== "ok"));
+  const canExpand = hasInput || hasOutput;
+  const activity = (
+    <>
+      <span className="tavern-tool-mark" aria-hidden="true">
+        ◆
+      </span>
+      <span className="tavern-tool-copy">
+        <strong>{presentation.title}</strong>
+        {presentation.detail ? <small>{presentation.detail}</small> : null}
+      </span>
+      <span className="tavern-tool-state">
+        <i aria-hidden="true" /> Done
+      </span>
+      {canExpand ? (
+        <span className="tavern-tool-caret" aria-hidden="true">
+          {open ? "▾" : "▸"}
+        </span>
+      ) : null}
+    </>
+  );
+
+  if (!canExpand) {
+    return <div className="tavern-tool tavern-tool-static">{activity}</div>;
+  }
+
   return (
     <div className="tavern-tool">
       <button
         type="button"
-        className="tavern-msg-tool tavern-tool-toggle"
+        className="tavern-tool-toggle"
         onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
       >
-        <i className="tavern-tool-spark">◆</i> {toolLabel(partType)}{" "}
-        {open ? "▾" : "▸"}
+        {activity}
       </button>
       {open ? (
         <div className="tavern-tool-detail">
-          {input !== undefined && Object.keys(input as object).length > 0 ? (
+          {hasInput ? (
             <>
-              <span className="tavern-tool-heading">Input</span>
+              <span className="tavern-tool-heading">Request</span>
               <pre className="tavern-tool-block">{toolJson(input)}</pre>
             </>
           ) : null}
-          <span className="tavern-tool-heading">Output</span>
-          <pre className="tavern-tool-block">{toolJson(output)}</pre>
+          {hasOutput ? (
+            <>
+              <span className="tavern-tool-heading">Result</span>
+              <pre className="tavern-tool-block">{toolJson(output)}</pre>
+            </>
+          ) : null}
         </div>
       ) : null}
     </div>
   );
 }
 
+function isPlaceholderText(text: string): boolean {
+  return text.trim() === "...";
+}
+
 function messageText(message: UIMessage): string {
   return message.parts
-    .filter((part) => part.type === "text")
-    .map((part) => part.text)
-    .filter(Boolean)
+    .flatMap((part) =>
+      part.type === "text" && !isPlaceholderText(part.text) && part.text
+        ? [part.text]
+        : [],
+    )
     .join("\n\n");
 }
 
@@ -276,7 +292,7 @@ function ChatMessage({
       <div className="tavern-msg-assistant-content">
         {message.parts.map((part, i) => {
           if (part.type === "text") {
-            if (!part.text) return null;
+            if (!part.text || isPlaceholderText(part.text)) return null;
             return (
               <div key={`${message.id}-${i}`} className="tavern-msg-assistant">
                 <Markdown text={part.text} />
@@ -612,11 +628,7 @@ function PanelInner({
       if (finished.length === 0) return;
       const last = finished[finished.length - 1];
       if (last?.role !== "assistant") return;
-      const text = last.parts
-        .filter((p) => p.type === "text")
-        .map((p) => (p as { text: string }).text)
-        .join(" ")
-        .trim();
+      const text = messageText(last);
       if (!text) return;
       window.api.agentTurnFinished({
         threadId: thread.id,

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -20,6 +20,7 @@ import { seedMessageFor, starterPrompts } from "@renderer/lib/onboarding-core";
 import { createQueryClient } from "@renderer/lib/query";
 import { installGlobalErrorHandlers } from "@renderer/lib/report-error";
 import { useSpriteEmitter } from "@renderer/lib/sprite-emitter";
+import { highlightToolJson, toolJson } from "@renderer/lib/tool-json";
 import { toolPresentation } from "@renderer/lib/tool-presentation";
 import { SpriteBadge } from "@renderer/sprites/badge";
 import { type CompanionForm, DEFAULT_COMPANION_FORM } from "@shared/companion";
@@ -49,13 +50,40 @@ const TAB_PLACEHOLDER: Record<PanelTab, string> = {
   notes: "No notes yet.",
 };
 
-function toolJson(value: unknown): string {
-  try {
-    const dump = JSON.stringify(value, null, 1) ?? "";
-    return dump.length > 2_000 ? `${dump.slice(0, 2_000)}\n…` : dump;
-  } catch {
-    return String(value);
+function ShikiJson({ value }: { value: unknown }): React.JSX.Element {
+  const source = toolJson(value);
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setHtml(null);
+    void highlightToolJson(source)
+      .then((highlighted) => {
+        if (active) setHtml(highlighted);
+      })
+      .catch(() => {
+        // A readable, unhighlighted JSON block remains available on failure.
+      });
+    return () => {
+      active = false;
+    };
+  }, [source]);
+
+  if (!html) {
+    return (
+      <pre className="tavern-tool-code">
+        <code>{source}</code>
+      </pre>
+    );
   }
+
+  return (
+    <div
+      className="tavern-tool-code"
+      // Shiki renders escaped source code; tool-json.test.ts guards this contract.
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
 }
 
 function ToolChip({
@@ -118,13 +146,13 @@ function ToolChip({
           {hasInput ? (
             <>
               <span className="tavern-tool-heading">Request</span>
-              <pre className="tavern-tool-block">{toolJson(input)}</pre>
+              <ShikiJson value={input} />
             </>
           ) : null}
           {hasOutput ? (
             <>
               <span className="tavern-tool-heading">Result</span>
-              <pre className="tavern-tool-block">{toolJson(output)}</pre>
+              <ShikiJson value={output} />
             </>
           ) : null}
         </div>

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -123,46 +123,196 @@ function ToolChip({
   );
 }
 
-function ChatMessage({ message }: { message: UIMessage }): React.JSX.Element {
+function messageText(message: UIMessage): string {
+  return message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function MessageActions({
+  role,
+  copied,
+  disabled,
+  onCopy,
+  onEdit,
+  onRegenerate,
+}: {
+  role: UIMessage["role"];
+  copied: boolean;
+  disabled: boolean;
+  onCopy: () => void;
+  onEdit?: () => void;
+  onRegenerate?: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="tavern-msg-actions">
+      <button
+        type="button"
+        className={`tavern-msg-action${copied ? " is-copied" : ""}`}
+        onClick={onCopy}
+        aria-label={copied ? "Message copied" : "Copy message"}
+        title={copied ? "Copied" : "Copy message"}
+      >
+        <span aria-hidden="true">{copied ? "✓" : "⧉"}</span>
+      </button>
+      {role === "user" && onEdit ? (
+        <button
+          type="button"
+          className="tavern-msg-action"
+          disabled={disabled}
+          onClick={onEdit}
+          aria-label="Edit and resend message"
+          title="Edit and resend"
+        >
+          <span aria-hidden="true">✎</span>
+        </button>
+      ) : null}
+      {role === "assistant" && onRegenerate ? (
+        <button
+          type="button"
+          className="tavern-msg-action"
+          disabled={disabled}
+          onClick={onRegenerate}
+          aria-label="Regenerate response"
+          title="Regenerate response"
+        >
+          <span aria-hidden="true">↻</span>
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function ChatMessage({
+  message,
+  copied,
+  disabled,
+  editing,
+  editDraft,
+  onCopy,
+  onEdit,
+  onEditDraftChange,
+  onCancelEdit,
+  onResendEdit,
+  onRegenerate,
+}: {
+  message: UIMessage;
+  copied: boolean;
+  disabled: boolean;
+  editing: boolean;
+  editDraft: string;
+  onCopy: () => void;
+  onEdit: () => void;
+  onEditDraftChange: (text: string) => void;
+  onCancelEdit: () => void;
+  onResendEdit: () => void;
+  onRegenerate: () => void;
+}): React.JSX.Element {
+  const text = messageText(message);
+  const editInputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (editing) editInputRef.current?.focus();
+  }, [editing]);
+
   if (message.role === "user") {
-    const text = message.parts
-      .filter((p) => p.type === "text")
-      .map((p) => p.text)
-      .join("");
-    return <div className="tavern-msg-user">{text}</div>;
+    return (
+      <div className="tavern-msg tavern-msg-user-wrap">
+        {editing ? (
+          <div className="tavern-msg-edit">
+            <textarea
+              className="tavern-msg-edit-input"
+              value={editDraft}
+              rows={2}
+              ref={editInputRef}
+              aria-label="Edit message"
+              onMouseDown={() => window.api.panelRequestFocus()}
+              onChange={(event) => onEditDraftChange(event.target.value)}
+              onKeyDown={(event) => {
+                if (
+                  event.key === "Enter" &&
+                  !event.shiftKey &&
+                  !event.nativeEvent.isComposing
+                ) {
+                  event.preventDefault();
+                  onResendEdit();
+                }
+              }}
+            />
+            <div className="tavern-msg-edit-actions">
+              <button type="button" onClick={onCancelEdit}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="is-primary"
+                disabled={!editDraft.trim() || disabled}
+                onClick={onResendEdit}
+              >
+                Send again
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="tavern-msg-user">{text}</div>
+            <MessageActions
+              role={message.role}
+              copied={copied}
+              disabled={disabled}
+              onCopy={onCopy}
+              onEdit={onEdit}
+            />
+          </>
+        )}
+      </div>
+    );
   }
 
   return (
-    <>
-      {message.parts.map((part, i) => {
-        if (part.type === "text") {
-          if (!part.text) return null;
-          return (
-            <div key={`${message.id}-${i}`} className="tavern-msg-assistant">
-              <Markdown text={part.text} />
-            </div>
-          );
-        }
-        if (part.type.startsWith("tool-")) {
-          const tool = part as {
-            state?: string;
-            input?: unknown;
-            output?: { ok?: boolean; reason?: string };
-          };
-          if (tool.state !== "output-available") return null;
-          if (tool.output?.ok === false) return null;
-          return (
-            <ToolChip
-              key={`${message.id}-${i}`}
-              partType={part.type}
-              input={tool.input}
-              output={tool.output}
-            />
-          );
-        }
-        return null;
-      })}
-    </>
+    <div className="tavern-msg tavern-msg-assistant-wrap">
+      <div className="tavern-msg-assistant-content">
+        {message.parts.map((part, i) => {
+          if (part.type === "text") {
+            if (!part.text) return null;
+            return (
+              <div key={`${message.id}-${i}`} className="tavern-msg-assistant">
+                <Markdown text={part.text} />
+              </div>
+            );
+          }
+          if (part.type.startsWith("tool-")) {
+            const tool = part as {
+              state?: string;
+              input?: unknown;
+              output?: { ok?: boolean; reason?: string };
+            };
+            if (tool.state !== "output-available") return null;
+            if (tool.output?.ok === false) return null;
+            return (
+              <ToolChip
+                key={`${message.id}-${i}`}
+                partType={part.type}
+                input={tool.input}
+                output={tool.output}
+              />
+            );
+          }
+          return null;
+        })}
+      </div>
+      {text ? (
+        <MessageActions
+          role={message.role}
+          copied={copied}
+          disabled={disabled}
+          onCopy={onCopy}
+          onRegenerate={onRegenerate}
+        />
+      ) : null}
+    </div>
   );
 }
 
@@ -432,6 +582,9 @@ function PanelInner({
 
   const [notice, setNotice] = useState<string | null>(null);
   const [approvals, setApprovals] = useState<AgentToolCall[]>([]);
+  const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
+  const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const bodyRef = useRef<HTMLDivElement>(null);
   const dictationBaseRef = useRef<string | null>(null);
@@ -450,7 +603,7 @@ function PanelInner({
     [thread.id],
   );
 
-  const { messages, sendMessage, status, addToolOutput } = useChat({
+  const { messages, sendMessage, regenerate, status, addToolOutput } = useChat({
     id: thread.id,
     messages: thread.messages,
     transport,
@@ -511,6 +664,57 @@ function PanelInner({
     setNotice(null);
     setDraft("");
     void sendMessage({ text });
+  };
+
+  const copyMessage = (message: UIMessage): void => {
+    const text = messageText(message);
+    if (!text) return;
+    void window.api
+      .remixSetClipboard(text)
+      .then((result) => {
+        if (!result.ok) throw new Error("copy-failed");
+        setCopiedMessageId(message.id);
+        window.setTimeout(
+          () =>
+            setCopiedMessageId((current) =>
+              current === message.id ? null : current,
+            ),
+          1_500,
+        );
+      })
+      .catch(() => setNotice("Could not copy that message."));
+  };
+
+  const startEditingMessage = (message: UIMessage): void => {
+    const text = messageText(message);
+    if (message.role !== "user" || !text || busy || approvals.length > 0)
+      return;
+    setEditingMessageId(message.id);
+    setEditDraft(text);
+  };
+
+  const cancelEditingMessage = (): void => {
+    setEditingMessageId(null);
+    setEditDraft("");
+  };
+
+  const resendEditedMessage = (): void => {
+    const text = editDraft.trim();
+    if (!editingMessageId || !text || busy || approvals.length > 0) return;
+    const messageId = editingMessageId;
+    cancelEditingMessage();
+    setNotice(null);
+    void sendMessage({ text, messageId }).catch(() => {
+      setNotice("Could not resend that message.");
+    });
+  };
+
+  const regenerateMessage = (message: UIMessage): void => {
+    if (message.role !== "assistant" || busy || approvals.length > 0) return;
+    setNotice(null);
+    void regenerate({ messageId: message.id }).catch(() => {
+      setNotice("Could not regenerate that response.");
+    });
   };
 
   const resolveApproval = (call: AgentToolCall, allowed: boolean): void => {
@@ -741,7 +945,20 @@ function PanelInner({
           ) : showChat ? (
             <>
               {messages.map((m) => (
-                <ChatMessage key={m.id} message={m} />
+                <ChatMessage
+                  key={m.id}
+                  message={m}
+                  copied={copiedMessageId === m.id}
+                  disabled={pinned}
+                  editing={editingMessageId === m.id}
+                  editDraft={editDraft}
+                  onCopy={() => copyMessage(m)}
+                  onEdit={() => startEditingMessage(m)}
+                  onEditDraftChange={setEditDraft}
+                  onCancelEdit={cancelEditingMessage}
+                  onResendEdit={resendEditedMessage}
+                  onRegenerate={() => regenerateMessage(m)}
+                />
               ))}
               {approvals.map((call) => (
                 <div key={call.toolCallId} className="tavern-approve">

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -483,7 +483,7 @@ function PanelInner({
       }
       const output =
         tier === "free"
-          ? await executeAgentTool(call)
+          ? await executeAgentTool(call, thread.id)
           : { ok: false, reason: `unknown tool: ${call.toolName}` };
       addToolOutput({
         tool: toolCall.toolName,
@@ -518,7 +518,9 @@ function PanelInner({
       prev.filter((a) => a.toolCallId !== call.toolCallId),
     );
     void (async () => {
-      const output = allowed ? await executeAgentTool(call) : DECLINED_OUTPUT;
+      const output = allowed
+        ? await executeAgentTool(call, thread.id)
+        : DECLINED_OUTPUT;
       addToolOutput({
         tool: call.toolName,
         toolCallId: call.toolCallId,

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -16,6 +16,7 @@ import {
 } from "@renderer/lib/agent-tools";
 import { apiFetch, initApiBase } from "@renderer/lib/api";
 import { CloudAuthProvider, useCloudAuth } from "@renderer/lib/auth-context";
+import { composerAction } from "@renderer/lib/composer-action";
 import { seedMessageFor, starterPrompts } from "@renderer/lib/onboarding-core";
 import { createQueryClient } from "@renderer/lib/query";
 import { installGlobalErrorHandlers } from "@renderer/lib/report-error";
@@ -647,54 +648,56 @@ function PanelInner({
     [thread.id],
   );
 
-  const { messages, sendMessage, regenerate, status, addToolOutput } = useChat({
-    id: thread.id,
-    messages: thread.messages,
-    transport,
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-    onFinish: ({ messages: finished }) => {
-      if (finished.length === 0) return;
-      const last = finished[finished.length - 1];
-      if (last?.role !== "assistant") return;
-      const text = messageText(last);
-      if (!text) return;
-      window.api.agentTurnFinished({
-        threadId: thread.id,
-        excerpt: text.slice(0, 140),
-      });
-    },
-    onToolCall: async ({ toolCall }) => {
-      const call: AgentToolCall = {
-        toolName: toolCall.toolName,
-        toolCallId: toolCall.toolCallId,
-        input: toolCall.input,
-      };
-      const tier = await agentToolTier(call);
-      if (tier === "confirmed") {
-        setApprovals((prev) => [...prev, call]);
-        return;
-      }
-      const output =
-        tier === "free"
-          ? await executeAgentTool(call, thread.id)
-          : { ok: false, reason: `unknown tool: ${call.toolName}` };
-      addToolOutput({
-        tool: toolCall.toolName,
-        toolCallId: toolCall.toolCallId,
-        output,
-      });
-    },
-    onError: (err) => {
-      setNotice(
-        err.message.includes("cloud_auth_required") ||
-          err.message.includes("401")
-          ? "Sign in to Freestyle Cloud to chat."
-          : err.message,
-      );
-    },
-  });
+  const { messages, sendMessage, regenerate, stop, status, addToolOutput } =
+    useChat({
+      id: thread.id,
+      messages: thread.messages,
+      transport,
+      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+      onFinish: ({ messages: finished }) => {
+        if (finished.length === 0) return;
+        const last = finished[finished.length - 1];
+        if (last?.role !== "assistant") return;
+        const text = messageText(last);
+        if (!text) return;
+        window.api.agentTurnFinished({
+          threadId: thread.id,
+          excerpt: text.slice(0, 140),
+        });
+      },
+      onToolCall: async ({ toolCall }) => {
+        const call: AgentToolCall = {
+          toolName: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          input: toolCall.input,
+        };
+        const tier = await agentToolTier(call);
+        if (tier === "confirmed") {
+          setApprovals((prev) => [...prev, call]);
+          return;
+        }
+        const output =
+          tier === "free"
+            ? await executeAgentTool(call, thread.id)
+            : { ok: false, reason: `unknown tool: ${call.toolName}` };
+        addToolOutput({
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          output,
+        });
+      },
+      onError: (err) => {
+        setNotice(
+          err.message.includes("cloud_auth_required") ||
+            err.message.includes("401")
+            ? "Sign in to Freestyle Cloud to chat."
+            : err.message,
+        );
+      },
+    });
 
   const busy = status === "submitted" || status === "streaming";
+  const action = composerAction(status);
 
   useSpriteEmitter(messages, approvals.length, busy);
 
@@ -704,6 +707,11 @@ function PanelInner({
     setNotice(null);
     setDraft("");
     void sendMessage({ text });
+  };
+
+  const stopGeneration = (): void => {
+    if (!busy) return;
+    stop();
   };
 
   const copyMessage = (message: UIMessage): void => {
@@ -1083,11 +1091,12 @@ function PanelInner({
             />
             <button
               type="button"
-              className="tavern-btn tavern-btn-send"
-              aria-label="Send"
-              onClick={send}
+              className={`tavern-btn tavern-btn-send${action === "stop" ? " is-stop" : ""}`}
+              aria-label={action === "stop" ? "Stop generating" : "Send"}
+              title={action === "stop" ? "Stop generating" : "Send"}
+              onClick={action === "stop" ? stopGeneration : send}
             >
-              ↑
+              {action === "stop" ? "■" : "↑"}
             </button>
           </div>
         ) : null}

--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -1538,11 +1538,7 @@ export function SettingsView({
         onClick={() => setPage("billing")}
       />
       <NavRow label="Brain" onClick={() => setPage("brain")} />
-      <NavRow
-        label="Connected apps"
-        detail="Freestyle"
-        onClick={() => setPage("connectedApps")}
-      />
+      <NavRow label="Connected apps" onClick={() => setPage("connectedApps")} />
       <NavRow label="Scheduled" onClick={() => setPage("scheduled")} />
       <NavRow label="Notifications" onClick={() => setPage("notifications")} />
       <NavRow

--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -1538,7 +1538,11 @@ export function SettingsView({
         onClick={() => setPage("billing")}
       />
       <NavRow label="Brain" onClick={() => setPage("brain")} />
-      <NavRow label="Connected apps" detail="Freestyle" onClick={() => setPage("connectedApps")} />
+      <NavRow
+        label="Connected apps"
+        detail="Freestyle"
+        onClick={() => setPage("connectedApps")}
+      />
       <NavRow label="Scheduled" onClick={() => setPage("scheduled")} />
       <NavRow label="Notifications" onClick={() => setPage("notifications")} />
       <NavRow

--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -8,6 +8,7 @@ import {
   resolveLanguageOptions,
 } from "@freestyle-voice/validations";
 import { BrainFiles } from "@renderer/components/brain-files";
+import { ConnectedApps } from "@renderer/components/connected-apps";
 import { NotificationsHistory } from "@renderer/components/notifications-history";
 import { ScheduledTasks } from "@renderer/components/scheduled-tasks";
 import {
@@ -49,6 +50,7 @@ type SettingsPage =
   | "profile"
   | "billing"
   | "brain"
+  | "connectedApps"
   | "notifications"
   | "scheduled"
   | "dictation"
@@ -61,6 +63,7 @@ const PAGE_TITLES: Record<Exclude<SettingsPage, "root">, string> = {
   profile: "Profile",
   billing: "Billing & Usage",
   brain: "Brain",
+  connectedApps: "Connected apps",
   notifications: "Notifications",
   scheduled: "Scheduled",
   dictation: "Dictation",
@@ -1478,6 +1481,8 @@ export function SettingsView({
             newLabel="New file"
             graphable
           />
+        ) : page === "connectedApps" ? (
+          <ConnectedApps />
         ) : page === "scheduled" ? (
           <ScheduledTasks />
         ) : page === "notifications" ? (
@@ -1533,6 +1538,7 @@ export function SettingsView({
         onClick={() => setPage("billing")}
       />
       <NavRow label="Brain" onClick={() => setPage("brain")} />
+      <NavRow label="Connected apps" detail="Freestyle" onClick={() => setPage("connectedApps")} />
       <NavRow label="Scheduled" onClick={() => setPage("scheduled")} />
       <NavRow label="Notifications" onClick={() => setPage("notifications")} />
       <NavRow

--- a/apps/electron/src/renderer/src/lib/agent-tools.test.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@shared/sprite-events", () => ({
+  parseSpriteEmotion: vi.fn(),
+}));
+
+import { agentToolTier } from "./agent-tools";
+
+describe("agent tool approval tiers", () => {
+  const call = (toolName: string) => ({
+    toolName,
+    toolCallId: "call-1",
+    input: {},
+  });
+
+  it("runs read-only local tools without asking", async () => {
+    await expect(agentToolTier(call("Read"))).resolves.toBe("free");
+    await expect(agentToolTier(call("Glob"))).resolves.toBe("free");
+    await expect(agentToolTier(call("Grep"))).resolves.toBe("free");
+  });
+
+  it("runs only explicitly read-only connected-app tools without asking", async () => {
+    await expect(
+      agentToolTier(
+        call("connector__gmail__ro_474d41494c5f46455443485f454d41494c53"),
+      ),
+    ).resolves.toBe("free");
+    await expect(
+      agentToolTier(call("connector__gmail__474d41494c5f53454")),
+    ).resolves.toBe("confirmed");
+  });
+});

--- a/apps/electron/src/renderer/src/lib/agent-tools.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.ts
@@ -1,6 +1,7 @@
 import { apiFetch } from "@renderer/lib/api";
 import {
   approveConnectorAction,
+  connectorToolActionName,
   executeConnectorAction,
   isConnectorToolName,
 } from "@renderer/lib/connectors";
@@ -74,7 +75,7 @@ export function describeAgentAction(call: AgentToolCall): string {
   const input = (call.input ?? {}) as Record<string, unknown>;
   if (isConnectorToolName(call.toolName)) {
     const action =
-      call.toolName.split("__").at(-1)?.replace(/_/g, " ").toLowerCase() ??
+      connectorToolActionName(call.toolName).replace(/_/g, " ").toLowerCase() ||
       "connected-app action";
     return `Use a connected app to ${action}.`;
   }

--- a/apps/electron/src/renderer/src/lib/agent-tools.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.ts
@@ -1,4 +1,9 @@
 import { apiFetch } from "@renderer/lib/api";
+import {
+  approveConnectorAction,
+  executeConnectorAction,
+  isConnectorToolName,
+} from "@renderer/lib/connectors";
 import { parseSpriteEmotion } from "@shared/sprite-events";
 
 export type AgentToolTier = "free" | "confirmed";
@@ -41,6 +46,7 @@ export async function agentToolTier(
 ): Promise<AgentToolTier | null> {
   const input = (call.input ?? {}) as Record<string, unknown>;
   void input;
+  if (isConnectorToolName(call.toolName)) return "confirmed";
   switch (call.toolName) {
     case "current_time":
     case "get_context":
@@ -66,6 +72,12 @@ export async function agentToolTier(
 
 export function describeAgentAction(call: AgentToolCall): string {
   const input = (call.input ?? {}) as Record<string, unknown>;
+  if (isConnectorToolName(call.toolName)) {
+    const action =
+      call.toolName.split("__").at(-1)?.replace(/_/g, " ").toLowerCase() ??
+      "connected-app action";
+    return `Use a connected app to ${action}.`;
+  }
   switch (call.toolName) {
     case "set_clipboard": {
       const text = str(input, "text");
@@ -112,6 +124,7 @@ async function runOsTool(
 
 export async function executeAgentTool(
   call: AgentToolCall,
+  threadId?: string,
 ): Promise<Record<string, unknown>> {
   const input = (call.input ?? {}) as Record<string, unknown>;
   const badArgs = (expected: string): Record<string, unknown> => ({
@@ -122,6 +135,20 @@ export async function executeAgentTool(
   });
 
   try {
+    if (isConnectorToolName(call.toolName)) {
+      if (!threadId) return { ok: false, reason: "missing-thread" };
+      const approval = await approveConnectorAction({
+        threadId,
+        toolName: call.toolName,
+        input,
+      });
+      return await executeConnectorAction({
+        approvalToken: approval.approvalToken,
+        threadId,
+        toolName: call.toolName,
+        input,
+      });
+    }
     switch (call.toolName) {
       case "current_time": {
         const now = new Date();

--- a/apps/electron/src/renderer/src/lib/agent-tools.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.ts
@@ -4,6 +4,7 @@ import {
   connectorToolActionName,
   executeConnectorAction,
   isConnectorToolName,
+  isReadOnlyConnectorToolName,
 } from "@renderer/lib/connectors";
 import { parseSpriteEmotion } from "@shared/sprite-events";
 
@@ -47,7 +48,8 @@ export async function agentToolTier(
 ): Promise<AgentToolTier | null> {
   const input = (call.input ?? {}) as Record<string, unknown>;
   void input;
-  if (isConnectorToolName(call.toolName)) return "confirmed";
+  if (isConnectorToolName(call.toolName))
+    return isReadOnlyConnectorToolName(call.toolName) ? "free" : "confirmed";
   switch (call.toolName) {
     case "current_time":
     case "get_context":
@@ -61,10 +63,11 @@ export async function agentToolTier(
     case "Bash":
       return bashIsReadOnly(str(input, "command")) ? "free" : "confirmed";
     case "Read":
-    case "Write":
-    case "Edit":
     case "Glob":
     case "Grep":
+      return "free";
+    case "Write":
+    case "Edit":
       return "confirmed";
     default:
       return null;

--- a/apps/electron/src/renderer/src/lib/auth-context.tsx
+++ b/apps/electron/src/renderer/src/lib/auth-context.tsx
@@ -67,7 +67,12 @@ function useCloudAuthState(): UseCloudAuth {
         })
         .catch(() => null);
       if (reached) {
-        if (!user && wasSignedInRef.current) setSessionExpired(true);
+        if (!user && wasSignedInRef.current) {
+          setSessionExpired(true);
+          queryClient.removeQueries({
+            queryKey: queryKeys.connectors.catalog,
+          });
+        }
         if (user) setSessionExpired(false);
         wasSignedInRef.current = !!user;
         setUser(user);
@@ -80,7 +85,7 @@ function useCloudAuthState(): UseCloudAuth {
     } finally {
       refreshInFlightRef.current = null;
     }
-  }, []);
+  }, [queryClient]);
 
   const refresh = useCallback(
     async (): Promise<CloudUser | null> => (await refreshInternal()).user,
@@ -156,6 +161,7 @@ function useCloudAuthState(): UseCloudAuth {
         const data = await tokenRes.json();
         if (attempt !== signInAttemptRef.current) return null;
         queryClient.removeQueries({ queryKey: queryKeys.cloud.usage });
+        queryClient.removeQueries({ queryKey: queryKeys.connectors.catalog });
         wasSignedInRef.current = true;
         setSessionExpired(false);
         setUser(data.user);
@@ -198,6 +204,7 @@ function useCloudAuthState(): UseCloudAuth {
     setSessionExpired(false);
     setUser(null);
     queryClient.removeQueries({ queryKey: queryKeys.cloud.usage });
+    queryClient.removeQueries({ queryKey: queryKeys.connectors.catalog });
   }, [queryClient]);
 
   return {

--- a/apps/electron/src/renderer/src/lib/composer-action.test.ts
+++ b/apps/electron/src/renderer/src/lib/composer-action.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { composerAction } from "./composer-action";
+
+describe("composerAction", () => {
+  it("shows stop while an answer is being submitted or streamed", () => {
+    expect(composerAction("submitted")).toBe("stop");
+    expect(composerAction("streaming")).toBe("stop");
+  });
+
+  it("shows send once the generation is no longer active", () => {
+    expect(composerAction("ready")).toBe("send");
+    expect(composerAction("error")).toBe("send");
+  });
+});

--- a/apps/electron/src/renderer/src/lib/composer-action.ts
+++ b/apps/electron/src/renderer/src/lib/composer-action.ts
@@ -1,0 +1,3 @@
+export function composerAction(status: string): "send" | "stop" {
+  return status === "submitted" || status === "streaming" ? "stop" : "send";
+}

--- a/apps/electron/src/renderer/src/lib/connectors.test.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { isConnectorToolName } from "./connectors";
+
+describe("connected-app tool approvals", () => {
+  it("requires confirmation before a connector action can execute", async () => {
+    expect(
+      isConnectorToolName("connector__connection_1__GMAIL_SEND_EMAIL"),
+    ).toBe(true);
+  });
+
+  it("does not mistake malformed tool names for connector actions", async () => {
+    expect(isConnectorToolName("connector__broken")).toBe(false);
+  });
+});

--- a/apps/electron/src/renderer/src/lib/connectors.test.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { connectorToolActionName, isConnectorToolName } from "./connectors";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+
+vi.mock("@renderer/lib/api", () => ({ apiFetch }));
+
+import {
+  connectorToolActionName,
+  isConnectorToolName,
+  listConnectorCatalog,
+} from "./connectors";
 
 describe("connected-app tool approvals", () => {
+  beforeEach(() => vi.clearAllMocks());
+
   it("requires confirmation before a connector action can execute", async () => {
     expect(
       isConnectorToolName("connector__connection_1__GMAIL_SEND_EMAIL"),
@@ -16,5 +27,21 @@ describe("connected-app tool approvals", () => {
     expect(
       connectorToolActionName("connector__connection_1__474d41494c5f534554"),
     ).toBe("GMAIL_SET");
+  });
+
+  it("requests a bounded connector catalog page using the opaque cursor", async () => {
+    apiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ connectors: [], nextCursor: "cursor-2" })),
+    );
+
+    await expect(
+      listConnectorCatalog({ cursor: "cursor-1", limit: 24 }),
+    ).resolves.toEqual({
+      connectors: [],
+      nextCursor: "cursor-2",
+    });
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/connectors/catalog?limit=24&cursor=cursor-1",
+    );
   });
 });

--- a/apps/electron/src/renderer/src/lib/connectors.test.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.test.ts
@@ -7,6 +7,7 @@ vi.mock("@renderer/lib/api", () => ({ apiFetch }));
 import {
   connectorToolActionName,
   isConnectorToolName,
+  isReadOnlyConnectorToolName,
   listConnectorCatalog,
 } from "./connectors";
 
@@ -23,10 +24,26 @@ describe("connected-app tool approvals", () => {
     expect(isConnectorToolName("connector__broken")).toBe(false);
   });
 
+  it("identifies only server-marked read-only connector tools", () => {
+    expect(
+      isReadOnlyConnectorToolName(
+        "connector__gmail__ro_474d41494c5f46455443485f454d41494c53",
+      ),
+    ).toBe(true);
+    expect(
+      isReadOnlyConnectorToolName("connector__gmail__474d41494c5f53454"),
+    ).toBe(false);
+  });
+
   it("keeps the approval copy readable for collision-safe tool names", () => {
     expect(
       connectorToolActionName("connector__connection_1__474d41494c5f534554"),
     ).toBe("GMAIL_SET");
+    expect(
+      connectorToolActionName(
+        "connector__gmail__ro_474d41494c5f46455443485f454d41494c53",
+      ),
+    ).toBe("GMAIL_FETCH_EMAILS");
   });
 
   it("requests a bounded connector catalog page using the opaque cursor", async () => {

--- a/apps/electron/src/renderer/src/lib/connectors.test.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isConnectorToolName } from "./connectors";
+import { connectorToolActionName, isConnectorToolName } from "./connectors";
 
 describe("connected-app tool approvals", () => {
   it("requires confirmation before a connector action can execute", async () => {
@@ -10,5 +10,11 @@ describe("connected-app tool approvals", () => {
 
   it("does not mistake malformed tool names for connector actions", async () => {
     expect(isConnectorToolName("connector__broken")).toBe(false);
+  });
+
+  it("keeps the approval copy readable for collision-safe tool names", () => {
+    expect(
+      connectorToolActionName("connector__connection_1__474d41494c5f534554"),
+    ).toBe("GMAIL_SET");
   });
 });

--- a/apps/electron/src/renderer/src/lib/connectors.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.ts
@@ -24,6 +24,11 @@ export type ConnectorCatalogItem = {
   connection: ConnectorConnection | null;
 };
 
+export type ConnectorCatalogPage = {
+  connectors: ConnectorCatalogItem[];
+  nextCursor: string | null;
+};
+
 export function isConnectorToolName(name: string): boolean {
   return /^connector__[a-zA-Z0-9_-]+__[a-zA-Z0-9_]+$/.test(name);
 }
@@ -63,13 +68,18 @@ async function responseJson<T>(response: Response): Promise<T> {
   return payload as T;
 }
 
-export async function listConnectorCatalog(
-  query = "",
-): Promise<ConnectorCatalogItem[]> {
-  const data = await responseJson<{ connectors: ConnectorCatalogItem[] }>(
-    await apiFetch(`/api/connectors/catalog?q=${encodeURIComponent(query)}`),
+export async function listConnectorCatalog({
+  cursor,
+  limit = 24,
+}: {
+  cursor?: string;
+  limit?: number;
+} = {}): Promise<ConnectorCatalogPage> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (cursor) params.set("cursor", cursor);
+  return responseJson<ConnectorCatalogPage>(
+    await apiFetch(`/api/connectors/catalog?${params.toString()}`),
   );
-  return data.connectors;
 }
 
 export async function connectToolkit(toolkit: string): Promise<void> {

--- a/apps/electron/src/renderer/src/lib/connectors.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.ts
@@ -1,0 +1,113 @@
+import { apiFetch } from "@renderer/lib/api";
+
+export type ConnectorStatus =
+  | "pending"
+  | "active"
+  | "needs_reconnect"
+  | "disconnected";
+
+export type ConnectorConnection = {
+  id: string;
+  toolkitSlug: string;
+  toolkitName: string;
+  toolkitLogo: string | null;
+  accountLabel: string | null;
+  toolCount: number;
+  status: ConnectorStatus;
+  statusReason: string | null;
+};
+
+export type ConnectorCatalogItem = {
+  slug: string;
+  name: string;
+  logo?: string;
+  connection: ConnectorConnection | null;
+};
+
+export function isConnectorToolName(name: string): boolean {
+  return /^connector__[a-zA-Z0-9_-]+__[a-zA-Z0-9_]+$/.test(name);
+}
+
+async function responseJson<T>(response: Response): Promise<T> {
+  const payload = (await response.json().catch(() => null)) as
+    | { error?: string }
+    | T
+    | null;
+  if (!response.ok)
+    throw new Error(
+      (payload as { error?: string } | null)?.error ??
+        "Connected apps are unavailable.",
+    );
+  return payload as T;
+}
+
+export async function listConnectorCatalog(
+  query = "",
+): Promise<ConnectorCatalogItem[]> {
+  const data = await responseJson<{ connectors: ConnectorCatalogItem[] }>(
+    await apiFetch(`/api/connectors/catalog?q=${encodeURIComponent(query)}`),
+  );
+  return data.connectors;
+}
+
+export async function connectToolkit(toolkit: string): Promise<void> {
+  const data = await responseJson<{ connectUrl: string }>(
+    await apiFetch(`/api/connectors/${encodeURIComponent(toolkit)}/connect`, {
+      method: "POST",
+    }),
+  );
+  const opened = await window.api.openExternal(data.connectUrl);
+  if (!opened)
+    throw new Error("Could not open your browser to connect this app.");
+}
+
+export async function connectorStatus(
+  toolkit: string,
+): Promise<ConnectorConnection | null> {
+  const data = await responseJson<{ connection: ConnectorConnection | null }>(
+    await apiFetch(`/api/connectors/${encodeURIComponent(toolkit)}/status`),
+  );
+  return data.connection;
+}
+
+export async function disconnectToolkit(toolkit: string): Promise<void> {
+  await responseJson(
+    await apiFetch(
+      `/api/connectors/${encodeURIComponent(toolkit)}/disconnect`,
+      { method: "POST" },
+    ),
+  );
+}
+
+export async function approveConnectorAction(input: {
+  threadId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+}): Promise<{ approvalToken: string }> {
+  return responseJson(
+    await apiFetch("/api/connectors/approve", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    }),
+  );
+}
+
+export async function executeConnectorAction(input: {
+  approvalToken: string;
+  threadId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+}): Promise<Record<string, unknown>> {
+  const data = await responseJson<{
+    ok: true;
+    output: Record<string, unknown>;
+  }>(
+    await apiFetch("/api/connectors/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    }),
+  );
+  return data.output;
+}

--- a/apps/electron/src/renderer/src/lib/connectors.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.ts
@@ -30,12 +30,17 @@ export type ConnectorCatalogPage = {
 };
 
 export function isConnectorToolName(name: string): boolean {
-  return /^connector__[a-zA-Z0-9_-]+__[a-zA-Z0-9_]+$/.test(name);
+  return /^connector__[a-zA-Z0-9_-]+__(?:ro_)?[a-zA-Z0-9_]+$/.test(name);
+}
+
+/** A read-only marker is added server-side from Composio's tool metadata. */
+export function isReadOnlyConnectorToolName(name: string): boolean {
+  return /^connector__[a-zA-Z0-9_-]+__ro_[a-zA-Z0-9_]+$/.test(name);
 }
 
 /** Decode the collision-safe Cloud tool suffix for human approval copy. */
 export function connectorToolActionName(toolName: string): string {
-  const encoded = toolName.split("__").at(-1) ?? "";
+  const encoded = (toolName.split("__").at(-1) ?? "").replace(/^ro_/, "");
   if (/^(?:[0-9a-f]{2})+$/i.test(encoded)) {
     try {
       return new TextDecoder().decode(

--- a/apps/electron/src/renderer/src/lib/connectors.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.ts
@@ -28,16 +28,38 @@ export function isConnectorToolName(name: string): boolean {
   return /^connector__[a-zA-Z0-9_-]+__[a-zA-Z0-9_]+$/.test(name);
 }
 
+/** Decode the collision-safe Cloud tool suffix for human approval copy. */
+export function connectorToolActionName(toolName: string): string {
+  const encoded = toolName.split("__").at(-1) ?? "";
+  if (/^(?:[0-9a-f]{2})+$/i.test(encoded)) {
+    try {
+      return new TextDecoder().decode(
+        Uint8Array.from(encoded.match(/.{2}/g) ?? [], (byte) =>
+          parseInt(byte, 16),
+        ),
+      );
+    } catch {
+      // Fall through to the opaque name below. The server still validates it.
+    }
+  }
+  return encoded;
+}
+
 async function responseJson<T>(response: Response): Promise<T> {
   const payload = (await response.json().catch(() => null)) as
     | { error?: string }
     | T
     | null;
-  if (!response.ok)
-    throw new Error(
-      (payload as { error?: string } | null)?.error ??
-        "Connected apps are unavailable.",
-    );
+  if (!response.ok) {
+    const error = (payload as { error?: string } | null)?.error;
+    const friendlyError =
+      error === "cloud_auth_required"
+        ? "Sign in to Freestyle before connecting an app."
+        : error === "connected_apps_unavailable"
+          ? "Connected apps are temporarily unavailable. Please try again."
+          : error;
+    throw new Error(friendlyError ?? "Connected apps are unavailable.");
+  }
   return payload as T;
 }
 

--- a/apps/electron/src/renderer/src/lib/query.ts
+++ b/apps/electron/src/renderer/src/lib/query.ts
@@ -1,5 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 import { getClient } from "./api";
+import { type ConnectorCatalogItem, listConnectorCatalog } from "./connectors";
 import type { AvailableModel } from "./models";
 
 /** Common staleTime for cached queries (1 hour). */
@@ -62,6 +63,10 @@ export const queryKeys = {
     all: ["vocabulary"] as const,
     list: (page: number, search: string) =>
       ["vocabulary", page, search] as const,
+  },
+
+  connectors: {
+    catalog: ["connectors", "catalog"] as const,
   },
 
   /** Remix practice runs. */
@@ -150,6 +155,20 @@ export function dismissedNotificationsQueryOptions() {
       if (!res.ok) throw new Error("Failed to load dismissed notifications");
       return (await res.json()) as string[];
     },
+  };
+}
+
+/**
+ * Connected-app catalog and status snapshot. Keep it warm across Settings
+ * navigation, but refresh after five minutes so lifecycle changes made outside
+ * the desktop app do not remain hidden for the full default cache lifetime.
+ */
+export function connectorCatalogQueryOptions() {
+  return {
+    queryKey: queryKeys.connectors.catalog,
+    queryFn: (): Promise<ConnectorCatalogItem[]> => listConnectorCatalog(),
+    staleTime: 5 * 60 * 1000,
+    gcTime: ONE_HOUR,
   };
 }
 

--- a/apps/electron/src/renderer/src/lib/query.ts
+++ b/apps/electron/src/renderer/src/lib/query.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 import { getClient } from "./api";
-import { type ConnectorCatalogItem, listConnectorCatalog } from "./connectors";
+import { type ConnectorCatalogPage, listConnectorCatalog } from "./connectors";
 import type { AvailableModel } from "./models";
 
 /** Common staleTime for cached queries (1 hour). */
@@ -163,10 +163,19 @@ export function dismissedNotificationsQueryOptions() {
  * navigation, but refresh after five minutes so lifecycle changes made outside
  * the desktop app do not remain hidden for the full default cache lifetime.
  */
-export function connectorCatalogQueryOptions() {
+export const CONNECTOR_CATALOG_PAGE_SIZE = 24;
+
+export function connectorCatalogInfiniteQueryOptions() {
   return {
     queryKey: queryKeys.connectors.catalog,
-    queryFn: (): Promise<ConnectorCatalogItem[]> => listConnectorCatalog(),
+    initialPageParam: null as string | null,
+    queryFn: ({ pageParam }: { pageParam: string | null }) =>
+      listConnectorCatalog({
+        cursor: pageParam ?? undefined,
+        limit: CONNECTOR_CATALOG_PAGE_SIZE,
+      }),
+    getNextPageParam: (lastPage: ConnectorCatalogPage) =>
+      lastPage.nextCursor ?? undefined,
     staleTime: 5 * 60 * 1000,
     gcTime: ONE_HOUR,
   };

--- a/apps/electron/src/renderer/src/lib/tool-json.test.ts
+++ b/apps/electron/src/renderer/src/lib/tool-json.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { highlightToolJson } from "./tool-json";
+
+describe("highlightToolJson", () => {
+  it("returns Shiki-highlighted and escaped JSON", async () => {
+    const html = await highlightToolJson(
+      JSON.stringify({ query: "<script>", unread: true }, null, 1),
+    );
+
+    expect(html).toContain('class="shiki');
+    expect(html).toContain("<span");
+    expect(html).toContain("&#x3C;script>");
+    expect(html).not.toContain("<script>");
+  });
+});

--- a/apps/electron/src/renderer/src/lib/tool-json.ts
+++ b/apps/electron/src/renderer/src/lib/tool-json.ts
@@ -1,13 +1,27 @@
-import { createHighlighterCore } from "shiki/core";
-import json from "shiki/dist/langs/json.mjs";
-import vitesseLight from "shiki/dist/themes/vitesse-light.mjs";
-import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+type JsonHighlighter = {
+  codeToHtml(
+    source: string,
+    options: { lang: "json"; theme: "vitesse-light" },
+  ): string;
+};
 
-const highlighter = createHighlighterCore({
-  engine: createJavaScriptRegexEngine(),
-  langs: [json],
-  themes: [vitesseLight],
-});
+let highlighter: Promise<JsonHighlighter> | undefined;
+
+function getHighlighter(): Promise<JsonHighlighter> {
+  highlighter ??= Promise.all([
+    import("shiki/core"),
+    import("shiki/engine/javascript"),
+    import("shiki/dist/langs/json.mjs"),
+    import("shiki/dist/themes/vitesse-light.mjs"),
+  ]).then(async ([core, engine, language, theme]) =>
+    core.createHighlighterCore({
+      engine: engine.createJavaScriptRegexEngine(),
+      langs: [language.default],
+      themes: [theme.default],
+    }),
+  );
+  return highlighter;
+}
 
 export function toolJson(value: unknown): string {
   try {
@@ -20,7 +34,7 @@ export function toolJson(value: unknown): string {
 
 /** Highlight untrusted tool JSON through Shiki, which HTML-escapes the source. */
 export function highlightToolJson(source: string): Promise<string> {
-  return highlighter.then((instance) =>
+  return getHighlighter().then((instance) =>
     instance.codeToHtml(source, { lang: "json", theme: "vitesse-light" }),
   );
 }

--- a/apps/electron/src/renderer/src/lib/tool-json.ts
+++ b/apps/electron/src/renderer/src/lib/tool-json.ts
@@ -1,0 +1,26 @@
+import { createHighlighterCore } from "shiki/core";
+import json from "shiki/dist/langs/json.mjs";
+import vitesseLight from "shiki/dist/themes/vitesse-light.mjs";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+
+const highlighter = createHighlighterCore({
+  engine: createJavaScriptRegexEngine(),
+  langs: [json],
+  themes: [vitesseLight],
+});
+
+export function toolJson(value: unknown): string {
+  try {
+    const dump = JSON.stringify(value, null, 1) ?? "";
+    return dump.length > 2_000 ? `${dump.slice(0, 2_000)}\n…` : dump;
+  } catch {
+    return String(value);
+  }
+}
+
+/** Highlight untrusted tool JSON through Shiki, which HTML-escapes the source. */
+export function highlightToolJson(source: string): Promise<string> {
+  return highlighter.then((instance) =>
+    instance.codeToHtml(source, { lang: "json", theme: "vitesse-light" }),
+  );
+}

--- a/apps/electron/src/renderer/src/lib/tool-presentation.test.ts
+++ b/apps/electron/src/renderer/src/lib/tool-presentation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { toolPresentation } from "./tool-presentation";
+
+describe("toolPresentation", () => {
+  it("turns an encoded connected-app tool name into human-readable activity", () => {
+    expect(
+      toolPresentation(
+        "tool-connector__gmail__474d41494c5f46455443485f454d41494c53",
+      ),
+    ).toEqual({
+      title: "Used Gmail",
+      detail: "Fetch emails",
+    });
+  });
+
+  it("uses the companion's existing plain-language labels for local tools", () => {
+    expect(toolPresentation("tool-web_search")).toEqual({
+      title: "Searched the web",
+      detail: undefined,
+    });
+  });
+});

--- a/apps/electron/src/renderer/src/lib/tool-presentation.ts
+++ b/apps/electron/src/renderer/src/lib/tool-presentation.ts
@@ -1,0 +1,87 @@
+import {
+  connectorToolActionName,
+  isConnectorToolName,
+} from "@renderer/lib/connectors";
+
+const TOOL_LABELS: Record<string, string> = {
+  "tool-current_time": "Checked the time",
+  "tool-web_search": "Searched the web",
+  "tool-image_search": "Searched for images",
+  "tool-get_context": "Looked at your screen",
+  "tool-read_document": "Read the document",
+  "tool-get_clipboard": "Read your clipboard",
+  "tool-set_clipboard": "Updated your clipboard",
+  "tool-paste": "Pasted at your cursor",
+  "tool-Bash": "Ran a command",
+  "tool-Read": "Read a file",
+  "tool-Write": "Wrote a file",
+  "tool-Edit": "Edited a file",
+  "tool-Glob": "Listed files",
+  "tool-Grep": "Searched files",
+  "tool-brain_read": "Recalled a memory",
+  "tool-brain_write": "Saved a memory",
+  "tool-brain_edit": "Updated a memory",
+  "tool-brain_glob": "Browsed memories",
+  "tool-brain_search": "Searched memories",
+  "tool-brain_delete": "Forgot a memory",
+  "tool-emote": "Changed expression",
+};
+
+const APP_NAMES: Record<string, string> = {
+  gmail: "Gmail",
+  github: "GitHub",
+  google_drive: "Google Drive",
+  google_calendar: "Google Calendar",
+  slack: "Slack",
+  notion: "Notion",
+};
+
+function sentence(value: string): string {
+  return value ? `${value[0].toUpperCase()}${value.slice(1)}` : value;
+}
+
+function words(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function appName(slug: string): string {
+  return (
+    APP_NAMES[slug] ??
+    slug
+      .split(/[-_]/)
+      .filter(Boolean)
+      .map((word) => sentence(word))
+      .join(" ")
+  );
+}
+
+/** The short, user-facing label for an AI SDK tool part. */
+export function toolPresentation(partType: string): {
+  title: string;
+  detail: string | undefined;
+} {
+  const name = partType.replace(/^tool-/, "");
+  if (isConnectorToolName(name)) {
+    const [, toolkitSlug = "connected app"] = name.split("__");
+    const action = words(connectorToolActionName(name)).replace(
+      new RegExp(
+        `^${toolkitSlug.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&").replace(/[-_]/g, " ")}\\s*`,
+        "i",
+      ),
+      "",
+    );
+    return {
+      title: `Used ${appName(toolkitSlug)}`,
+      detail: action ? sentence(action) : undefined,
+    };
+  }
+
+  return {
+    title: TOOL_LABELS[partType] ?? sentence(words(name)),
+    detail: undefined,
+  };
+}

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1565,10 +1565,12 @@
 }
 
 .tavern-set-input {
+  box-sizing: border-box;
   font: inherit;
   font-size: 12.5px;
   flex: 1;
   min-width: 0;
+  max-width: 100%;
   width: 100%;
   padding: 6px 9px;
   border-radius: 8px;
@@ -1580,6 +1582,363 @@
 .tavern-set-input:focus {
   outline: none;
   border-color: var(--tavern-lantern);
+}
+
+.connected-apps {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 13px;
+}
+
+.connected-apps-intro {
+  display: grid;
+  gap: 4px;
+}
+
+.connected-apps-intro > span {
+  font-family: var(--tavern-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--tavern-lantern);
+}
+
+.connected-apps-intro p {
+  margin: 0;
+  color: var(--tavern-mute);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.connector-search {
+  box-sizing: border-box;
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 9px;
+  padding: 0 9px;
+  background: color-mix(in srgb, var(--tavern-card) 88%, white);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.connector-search:focus-within {
+  border-color: var(--tavern-lantern);
+  box-shadow: 0 0 0 2px #d98e2b24;
+}
+
+.connector-search > span {
+  color: var(--tavern-mute);
+  font-family: var(--tavern-mono);
+  font-size: 16px;
+  line-height: 1;
+}
+
+.connector-search input {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--tavern-ink);
+  font: inherit;
+  font-size: 12px;
+  padding: 9px 0;
+}
+
+.connector-search input::placeholder {
+  color: var(--tavern-mute);
+}
+
+.connector-search button {
+  width: 19px;
+  height: 19px;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 50%;
+  padding: 0;
+  background: var(--tavern-wash);
+  color: var(--tavern-mute);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+}
+
+.connector-group {
+  display: grid;
+  gap: 7px;
+}
+
+.connector-group-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--tavern-mute);
+  font-family: var(--tavern-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.connector-group-label em {
+  border-radius: 999px;
+  padding: 1px 6px;
+  background: var(--tavern-wash);
+  color: var(--tavern-mute);
+  font-style: normal;
+  letter-spacing: 0;
+}
+
+.connector-card {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 10px;
+  padding: 9px;
+  background: color-mix(in srgb, var(--tavern-parchment) 74%, var(--tavern-card));
+  transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
+}
+
+.connector-card:hover {
+  border-color: color-mix(in srgb, var(--tavern-lantern) 55%, var(--tavern-rule));
+  background: var(--tavern-parchment);
+  transform: translateY(-1px);
+}
+
+.connector-card.is-connected {
+  border-color: #9daa7b;
+}
+
+.connector-card.needs-reconnect {
+  border-color: color-mix(in srgb, var(--tavern-lantern) 70%, var(--tavern-rule));
+}
+
+.connector-mark {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 8px;
+  background: var(--tavern-card);
+  color: var(--tavern-robe);
+  font-family: var(--tavern-px);
+  font-size: 17px;
+  line-height: 1;
+}
+
+.is-connected .connector-mark {
+  border-color: #9daa7b;
+  color: #4a7c46;
+}
+
+.connector-card-copy {
+  min-width: 0;
+}
+
+.connector-card-heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.connector-card-heading strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+}
+
+.connector-state {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 1px 5px;
+  background: #dce5cd;
+  color: #4a7c46;
+  font-size: 8.5px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.is-pending .connector-state {
+  background: var(--tavern-wash);
+  color: var(--tavern-mute);
+}
+
+.needs-reconnect .connector-state {
+  background: #f4d9ae;
+  color: #9d6016;
+}
+
+.connector-card-copy p {
+  overflow: hidden;
+  margin: 2px 0 0;
+  color: var(--tavern-mute);
+  font-size: 10.5px;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connector-card-copy .connector-reason {
+  color: #9d6016;
+}
+
+.connector-action {
+  flex: 0 0 auto;
+  border: 1px solid var(--tavern-lantern);
+  border-radius: 7px;
+  padding: 5px 8px;
+  background: var(--tavern-lantern);
+  color: var(--tavern-card);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10.5px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.connector-action:hover:not(:disabled) {
+  filter: brightness(0.94);
+}
+
+.connector-action.is-secondary {
+  border-color: var(--tavern-rule);
+  background: var(--tavern-card);
+  color: var(--tavern-mute);
+}
+
+.connector-action:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.connector-error {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  border: 1px solid #d8ae83;
+  border-radius: 8px;
+  padding: 7px 8px;
+  background: #f8e6cb;
+  color: #89521c;
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.connector-error button,
+.connector-empty button {
+  flex: 0 0 auto;
+  border: 0;
+  padding: 0;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-size: 10.5px;
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+.connector-loading-copy {
+  margin: 0;
+  color: var(--tavern-mute);
+  font-size: 11px;
+}
+
+.connector-skeleton {
+  display: grid;
+  gap: 7px;
+}
+
+.connector-skeleton-row {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) 56px;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 10px;
+  padding: 9px;
+  background: var(--tavern-parchment);
+}
+
+.connector-skeleton-mark,
+.connector-skeleton-copy i,
+.connector-skeleton-action {
+  display: block;
+  border-radius: 6px;
+  background: linear-gradient(90deg, var(--tavern-wash) 25%, #f8efd9 50%, var(--tavern-wash) 75%);
+  background-size: 200% 100%;
+  animation: connector-shimmer 1.35s ease-in-out infinite;
+}
+
+.connector-skeleton-mark {
+  width: 32px;
+  height: 32px;
+}
+
+.connector-skeleton-copy {
+  display: grid;
+  gap: 5px;
+}
+
+.connector-skeleton-copy i:first-child {
+  width: 68%;
+  height: 9px;
+}
+
+.connector-skeleton-copy i:last-child {
+  width: 92%;
+  height: 7px;
+}
+
+.connector-skeleton-action {
+  width: 56px;
+  height: 24px;
+}
+
+@keyframes connector-shimmer {
+  to { background-position: -200% 0; }
+}
+
+.connector-empty {
+  display: grid;
+  justify-items: start;
+  gap: 3px;
+  border: 1px dashed var(--tavern-rule);
+  border-radius: 10px;
+  padding: 13px;
+  color: var(--tavern-mute);
+}
+
+.connector-empty strong {
+  color: var(--tavern-ink);
+  font-size: 12px;
+}
+
+.connector-empty p {
+  margin: 0;
+  font-size: 11px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .connector-card { transition: none; }
+  .connector-card:hover { transform: none; }
+  .connector-skeleton-mark,
+  .connector-skeleton-copy i,
+  .connector-skeleton-action { animation: none; }
 }
 
 .tavern-set-saved {

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1072,6 +1072,12 @@
   border-color: var(--tavern-ink);
 }
 
+.tavern-btn-send.is-stop {
+  background: var(--tavern-rust);
+  border-color: var(--tavern-rust);
+  font-size: 11px;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .tavern *,
   .tavern {

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -658,19 +658,6 @@
   font-weight: 700;
 }
 
-.tavern-msg-tool {
-  align-self: flex-start;
-  font-size: 11px;
-  color: var(--tavern-mute);
-}
-
-.tavern-tool-spark {
-  font-family: var(--tavern-px);
-  font-style: normal;
-  font-size: 12px;
-  color: var(--tavern-lantern);
-}
-
 .tavern-thinking {
   color: var(--tavern-mute);
 }
@@ -1317,32 +1304,112 @@
   align-self: stretch;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  width: min(100%, 300px);
+  overflow: hidden;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--tavern-wash) 60%, var(--tavern-parchment));
+  color: var(--tavern-ink);
+}
+
+.tavern-tool-static {
+  display: grid;
+  grid-template-columns: 21px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 7px;
+  min-height: 45px;
+  padding: 7px 9px;
 }
 
 .tavern-tool-toggle {
   font: inherit;
-  font-size: 11px;
+  display: grid;
+  grid-template-columns: 21px minmax(0, 1fr) auto 10px;
+  align-items: center;
+  gap: 7px;
+  min-height: 45px;
   text-align: left;
-  align-self: flex-start;
-  background: none;
+  width: 100%;
+  padding: 7px 9px;
+  background: transparent;
   border: none;
-  padding: 0;
   cursor: pointer;
-  color: var(--tavern-mute);
+  color: var(--tavern-ink);
 }
 
 .tavern-tool-toggle:hover {
-  color: var(--tavern-ink);
+  background: color-mix(in srgb, var(--tavern-lantern) 9%, transparent);
+}
+
+.tavern-tool-toggle:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: -2px;
+}
+
+.tavern-tool-mark {
+  display: grid;
+  width: 21px;
+  height: 21px;
+  place-items: center;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 6px;
+  background: var(--tavern-parchment);
+  color: var(--tavern-lantern);
+  font-family: var(--tavern-px);
+  font-size: 10px;
+}
+
+.tavern-tool-copy {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
+}
+
+.tavern-tool-copy strong,
+.tavern-tool-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tavern-tool-copy strong {
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+.tavern-tool-copy small {
+  color: var(--tavern-mute);
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.tavern-tool-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--tavern-mute);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.tavern-tool-state i {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #779d5c;
+}
+
+.tavern-tool-caret {
+  color: var(--tavern-mute);
+  font-size: 10px;
 }
 
 .tavern-tool-detail {
   display: flex;
   flex-direction: column;
-  gap: 3px;
-  border-left: 2px solid var(--tavern-rule);
-  padding-left: 9px;
-  margin-left: 2px;
+  gap: 4px;
+  border-top: 1px solid var(--tavern-rule);
+  padding: 8px 9px 9px;
 }
 
 .tavern-tool-heading {

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1869,14 +1869,53 @@
   text-align: center;
 }
 
-.connector-load-spinner {
-  width: 12px;
-  height: 12px;
-  flex: 0 0 auto;
-  border: 2px solid var(--tavern-rule);
-  border-top-color: var(--tavern-lantern);
+.connector-load-more.is-loading {
+  min-height: 52px;
+  justify-content: flex-start;
+  padding: 8px 12px;
+  border: 1px dashed #d8ba88;
+  border-radius: 10px;
+  background:
+    linear-gradient(90deg, #fff8e9 0%, #f9edd8 48%, #fff8e9 100%);
+  background-size: 180% 100%;
+  animation: connector-load-wash 2.5s ease-in-out infinite;
+}
+
+.connector-load-trail {
+  display: flex;
+  width: 35px;
+  flex: 0 0 35px;
+  align-items: center;
+  gap: 4px;
+}
+
+.connector-load-trail i {
+  display: block;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
-  animation: connector-spin 700ms linear infinite;
+  background: var(--tavern-lantern);
+  box-shadow: 0 1px 0 #fff6e4 inset;
+  animation: connector-load-step 1.15s ease-in-out infinite;
+}
+
+.connector-load-trail i:nth-child(2) { animation-delay: 120ms; }
+.connector-load-trail i:nth-child(3) { animation-delay: 240ms; }
+
+.connector-load-copy {
+  display: grid;
+  gap: 1px;
+  text-align: left;
+}
+
+.connector-load-copy strong {
+  color: var(--tavern-ink);
+  font-size: 11px;
+}
+
+.connector-load-copy small {
+  color: var(--tavern-mute);
+  font-size: 9.5px;
 }
 
 .connector-skeleton {
@@ -1934,8 +1973,13 @@
   to { background-position: -200% 0; }
 }
 
-@keyframes connector-spin {
-  to { transform: rotate(1turn); }
+@keyframes connector-load-step {
+  0%, 55%, 100% { opacity: .3; transform: translateY(0) scale(.72); }
+  22% { opacity: 1; transform: translateY(-3px) scale(1); }
+}
+
+@keyframes connector-load-wash {
+  50% { background-position: -80% 0; }
 }
 
 .connector-empty {
@@ -1964,7 +2008,8 @@
   .connector-skeleton-mark,
   .connector-skeleton-copy i,
   .connector-skeleton-action,
-  .connector-load-spinner { animation: none; }
+  .connector-load-more.is-loading,
+  .connector-load-trail i { animation: none; }
 }
 
 .tavern-set-saved {

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -430,10 +430,26 @@
   gap: 3px;
   min-height: 22px;
   color: var(--tavern-mute);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
 }
 
 .tavern-msg-user-wrap .tavern-msg-actions {
   justify-content: flex-end;
+}
+
+.tavern-msg:hover .tavern-msg-actions,
+.tavern-msg:focus-within .tavern-msg-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (hover: none) {
+  .tavern-msg-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 .tavern-msg-action {

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1858,6 +1858,27 @@
   font-size: 11px;
 }
 
+.connector-load-more {
+  display: flex;
+  min-height: 24px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  color: var(--tavern-mute);
+  font-size: 10.5px;
+  text-align: center;
+}
+
+.connector-load-spinner {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
+  border: 2px solid var(--tavern-rule);
+  border-top-color: var(--tavern-lantern);
+  border-radius: 50%;
+  animation: connector-spin 700ms linear infinite;
+}
+
 .connector-skeleton {
   display: grid;
   gap: 7px;
@@ -1913,6 +1934,10 @@
   to { background-position: -200% 0; }
 }
 
+@keyframes connector-spin {
+  to { transform: rotate(1turn); }
+}
+
 .connector-empty {
   display: grid;
   justify-items: start;
@@ -1938,7 +1963,8 @@
   .connector-card:hover { transform: none; }
   .connector-skeleton-mark,
   .connector-skeleton-copy i,
-  .connector-skeleton-action { animation: none; }
+  .connector-skeleton-action,
+  .connector-load-spinner { animation: none; }
 }
 
 .tavern-set-saved {

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1320,7 +1320,7 @@
   align-self: stretch;
   display: flex;
   flex-direction: column;
-  width: min(100%, 300px);
+  width: 100%;
   overflow: hidden;
   border: 1px solid var(--tavern-rule);
   border-radius: 9px;
@@ -1436,9 +1436,9 @@
   color: var(--tavern-mute);
 }
 
-.tavern-tool-block {
+.tavern-tool-code,
+.tavern-tool-code pre.shiki {
   margin: 0;
-  font: inherit;
   font-size: 11px;
   line-height: 1.5;
   background: var(--tavern-wash);
@@ -1448,6 +1448,17 @@
   overflow-wrap: break-word;
   max-height: 180px;
   overflow-y: auto;
+}
+
+.tavern-tool-code pre.shiki {
+  padding: 0;
+  background: transparent !important;
+  color: inherit !important;
+}
+
+.tavern-tool-code code {
+  font-family: var(--tavern-mono);
+  font-size: inherit;
 }
 
 .tavern-set-row {

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -390,8 +390,6 @@
 }
 
 .tavern-msg-user {
-  align-self: flex-end;
-  max-width: 85%;
   background: var(--tavern-wash);
   border: 2px solid var(--tavern-ink);
   border-radius: 11px 11px 4px 11px;
@@ -402,8 +400,132 @@
 }
 
 .tavern-msg-assistant {
-  align-self: stretch;
   overflow-wrap: break-word;
+}
+
+.tavern-msg {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.tavern-msg-user-wrap {
+  align-self: flex-end;
+  width: min(85%, 100%);
+  justify-items: end;
+}
+
+.tavern-msg-assistant-wrap {
+  align-self: stretch;
+}
+
+.tavern-msg-assistant-content {
+  display: grid;
+  gap: 8px;
+}
+
+.tavern-msg-actions {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  min-height: 22px;
+  color: var(--tavern-mute);
+}
+
+.tavern-msg-user-wrap .tavern-msg-actions {
+  justify-content: flex-end;
+}
+
+.tavern-msg-action {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-family: var(--tavern-mono);
+  font-size: 13px;
+  line-height: 1;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.tavern-msg-action:hover:not(:disabled) {
+  border-color: var(--tavern-rule);
+  background: var(--tavern-wash);
+  color: var(--tavern-ink);
+}
+
+.tavern-msg-action.is-copied {
+  color: #4a7c46;
+}
+
+.tavern-msg-action:disabled {
+  cursor: default;
+  opacity: .42;
+}
+
+.tavern-msg-action:focus-visible,
+.tavern-msg-edit-actions button:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: 2px;
+}
+
+.tavern-msg-edit {
+  width: 100%;
+  border: 1px solid var(--tavern-lantern);
+  border-radius: 10px;
+  padding: 7px;
+  background: var(--tavern-card);
+  box-shadow: 2px 2px 0 #d98e2b33;
+}
+
+.tavern-msg-edit-input {
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  min-height: 45px;
+  resize: vertical;
+  border: 0;
+  outline: 0;
+  padding: 2px 3px 6px;
+  background: transparent;
+  color: var(--tavern-ink);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.tavern-msg-edit-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 5px;
+}
+
+.tavern-msg-edit-actions button {
+  border: 1px solid var(--tavern-rule);
+  border-radius: 6px;
+  padding: 4px 7px;
+  background: var(--tavern-parchment);
+  color: var(--tavern-ink);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.tavern-msg-edit-actions button.is-primary {
+  border-color: var(--tavern-lantern);
+  background: var(--tavern-lantern);
+  color: var(--tavern-card);
+}
+
+.tavern-msg-edit-actions button:disabled {
+  cursor: default;
+  opacity: .5;
 }
 
 .tavern-md {

--- a/apps/server/src/routes/agent.ts
+++ b/apps/server/src/routes/agent.ts
@@ -9,6 +9,11 @@ const log = createAppLogger("agent");
 
 const agentRequestSchema = z.object({
   messages: z.array(z.record(z.string(), z.unknown())).min(1),
+  // DefaultChatTransport sends `id`; the renderer also supplies the stable
+  // thread id explicitly. Preserve either form so Cloud can bind approval
+  // grants to the same thread that will execute them.
+  id: z.string().min(1).max(100).optional(),
+  threadId: z.string().min(1).max(100).optional(),
   // The seeded turn right after onboarding — forwarded so the cloud can
   // append its one-turn system-prompt addendum.
   firstTurn: z.boolean().optional(),
@@ -23,7 +28,7 @@ const agentRoute = new Hono().post(
   "/",
   zValidator("json", agentRequestSchema),
   async (c) => {
-    const { messages, firstTurn } = c.req.valid("json");
+    const { messages, firstTurn, id, threadId } = c.req.valid("json");
 
     const token = getSessionToken();
     if (!token) return c.json({ error: "cloud_auth_required" }, 401);
@@ -38,6 +43,7 @@ const agentRoute = new Hono().post(
         },
         body: JSON.stringify({
           messages,
+          ...(threadId || id ? { threadId: threadId ?? id } : {}),
           ...(firstTurn ? { firstTurn: true } : {}),
         }),
         signal: c.req.raw.signal,

--- a/apps/server/src/routes/connectors.ts
+++ b/apps/server/src/routes/connectors.ts
@@ -1,0 +1,57 @@
+import { createAppLogger } from "@freestyle-voice/utils";
+import { Hono } from "hono";
+import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
+import { getSessionToken, invalidateSession } from "../lib/sessions.js";
+
+const log = createAppLogger("connectors-proxy");
+
+/**
+ * The desktop renderer speaks only to its local Freestyle server. This proxy
+ * adds the server-owned Cloud bearer token, preserving the boundary that keeps
+ * provider tokens, callback state, and Cloud credentials out of Electron.
+ */
+const connectors = new Hono().all("/*", async (c) => {
+  const token = getSessionToken();
+  if (!token) return c.json({ error: "cloud_auth_required" }, 401);
+
+  const requestUrl = new URL(c.req.url);
+  const suffix = requestUrl.pathname.replace(/^\/api\/connectors/, "");
+  const upstreamUrl = `${freestyleCloudUrl()}/v2/connectors${suffix}${requestUrl.search}`;
+  const method = c.req.method;
+  try {
+    const upstream = await fetch(upstreamUrl, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(method === "GET" || method === "HEAD"
+          ? {}
+          : {
+              "Content-Type":
+                c.req.header("content-type") ?? "application/json",
+            }),
+      },
+      ...(method === "GET" || method === "HEAD"
+        ? {}
+        : { body: await c.req.raw.arrayBuffer() }),
+      signal: c.req.raw.signal,
+    });
+    if (upstream.status === 401) {
+      invalidateSession();
+      return c.json({ error: "cloud_auth_required" }, 401);
+    }
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: {
+        "Content-Type":
+          upstream.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch (error) {
+    log.error(
+      `Connector cloud request failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return c.json({ error: "connected_apps_unavailable" }, 502);
+  }
+});
+
+export default connectors;

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -13,6 +13,7 @@ import auth from "./auth.js";
 import billing from "./billing.js";
 import brainRoute from "./brain.js";
 import configRoute from "./config.js";
+import connectorsRoute from "./connectors.js";
 import dictionary from "./dictionary.js";
 import dismissedNotifications from "./dismissed-notifications.js";
 import eventsRoute from "./events.js";
@@ -65,6 +66,7 @@ const apiRouter = new Hono()
   })
   .route("/settings", settings)
   .route("/config", configRoute)
+  .route("/connectors", connectorsRoute)
   .route("/auth", auth)
   .route("/models", models)
   .route("/transcribe", transcribe)

--- a/apps/server/tests/connectors.test.ts
+++ b/apps/server/tests/connectors.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, it } from "vitest";
+import createApp from "../src/index.js";
+import { clearSession } from "../src/lib/sessions.js";
+
+const app = createApp();
+
+afterEach(() => clearSession());
+
+describe("connector proxy", () => {
+  it("requires the server-owned Freestyle Cloud session", async () => {
+    const response = await app.request("/api/connectors");
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "cloud_auth_required",
+    });
+  });
+});

--- a/apps/server/tests/connectors.test.ts
+++ b/apps/server/tests/connectors.test.ts
@@ -1,10 +1,14 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import createApp from "../src/index.js";
-import { clearSession } from "../src/lib/sessions.js";
+import { freestyleCloudUrl } from "../src/lib/freestyle-cloud.js";
+import { clearSession, setSession } from "../src/lib/sessions.js";
 
 const app = createApp();
 
-afterEach(() => clearSession());
+afterEach(() => {
+  clearSession();
+  vi.unstubAllGlobals();
+});
 
 describe("connector proxy", () => {
   it("requires the server-owned Freestyle Cloud session", async () => {
@@ -13,6 +17,36 @@ describe("connector proxy", () => {
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toEqual({
       error: "cloud_auth_required",
+    });
+  });
+
+  it("forwards the stable chat thread id to Cloud", async () => {
+    setSession({
+      token: "cloud-session",
+      user: { id: "user-1", email: "user@example.com" },
+      host: freestyleCloudUrl(),
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("stream", {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/agent", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "transport-chat-id",
+        threadId: "stable-thread-id",
+        messages: [{ id: "message-1", role: "user", parts: [] }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(request.body as string)).toMatchObject({
+      threadId: "stable-thread-id",
     });
   });
 });

--- a/docs/superpowers/specs/2026-08-13-remix-connected-apps-design.md
+++ b/docs/superpowers/specs/2026-08-13-remix-connected-apps-design.md
@@ -1,0 +1,163 @@
+# Remix connected apps
+
+**Status:** Approved design, pending implementation-plan review  
+**Date:** 2026-08-13  
+**Scope:** Freestyle desktop (`apps/electron`) and Freestyle Cloud (`cloud/apps/server`)
+
+## Goal
+
+Let a signed-in Freestyle user connect third-party apps from the desktop client
+and use those apps as tools in Remix. Provider OAuth credentials remain with
+Composio. Freestyle Cloud stores only opaque connection references and owns all
+access decisions, so one user's connector data and MCP gateway can never be
+used by another user.
+
+## Non-goals
+
+- Standalone desktop automations or connector-triggered workflows.
+- Sharing connections between users, organizations, or desktop installations.
+- Arbitrary custom MCP endpoints in v1.
+- Multiple simultaneously active accounts for the same toolkit.
+- Letting the renderer, the model, or the embedded desktop server handle
+  provider access or refresh tokens.
+
+## Chosen approach
+
+Freestyle Cloud is the connector control plane and Remix tool host. It uses the
+Composio server SDK with the Freestyle Cloud service credential. The desktop is
+a signed-in management UI only.
+
+For each Remix run, Cloud builds a short-lived Composio MCP session scoped to
+the authenticated Cloud user and to that user's active connection records. Its
+tools are exposed to the existing Remix server-tool factory. Tool definitions
+are namespaced by toolkit and restricted to a persisted allow-list.
+
+## Ownership and isolation
+
+The authenticated Cloud identity (`c.get("user").id`) is the only owner key.
+Every connector read and write filters by this value on the server. The desktop
+does not send a user ID, a connection ID owned by another user, an MCP URL, or
+credentials as authority.
+
+The persisted connection record includes:
+
+- `id`: server-generated opaque identifier.
+- `user_id`: required FK to `users.id`, with a composite unique index on
+  `(user_id, toolkit_slug)`.
+- `toolkit_slug`, display metadata, and a selected-tool allow-list.
+- Composio's opaque connected-account ID; never OAuth access or refresh tokens.
+- `status`: `pending`, `active`, `needs_reconnect`, or `disconnected`.
+- timestamps and non-secret status reason.
+
+The callback state is a separate short-lived, single-use record bound to the
+same user, toolkit, connection, and Cloud callback URL. It expires promptly and
+contains no provider token. Composio remains the token store.
+
+Composio MCP session identity is `freestyle-user:${user.id}`. Session creation
+also passes only the account IDs loaded from that user's active connection
+records. This is defense in depth: row-level ownership filters prevent mixed
+accounts before the session is assembled, and the Composio session cannot
+discover another user's accounts.
+
+## Cloud API
+
+All connector endpoints sit behind Cloud's existing authenticated middleware.
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /v2/connectors/catalog` | Searchable Composio toolkit catalog, with the caller's redacted status. |
+| `GET /v2/connectors` | Caller-owned connection list only. |
+| `POST /v2/connectors/:toolkit/connect` | Create/reuse a pending record, create a bound OAuth state, and return a browser URL. |
+| `GET /v2/connectors/:toolkit/status` | Poll the caller's redacted state during OAuth. |
+| `GET /v2/connectors/callback` | Verify state, reconcile Composio's connected account, and activate the caller's record. |
+| `POST /v2/connectors/:toolkit/disconnect` | Mark disconnected, delete/revoke the Composio connected account when supported, and invalidate cached tools. |
+
+Webhooks from Composio are verified with a configured secret. Credential-expiry
+events locate the opaque account reference, transition its owner record to
+`needs_reconnect`, and invalidate the connection/tool cache. Remix ignores
+non-active records.
+
+## Desktop experience
+
+Add a **Connected apps** section to desktop Settings:
+
+- Fetch the catalog from Cloud and show a searchable list split into Connected
+  and Available.
+- **Connect** calls Cloud and opens the returned OAuth URL with Electron's
+  system-browser handoff. The renderer receives neither callback credentials
+  nor state secrets.
+- While an attempt is pending, poll only the toolkit's redacted status and
+  update the card on success, expiry, or reconnect-needed state.
+- A connected card shows connector name, account label when Composio supplies
+  one, enabled tool count, health, Reconnect, and Disconnect.
+- v1 permits one active account per toolkit per user. Connecting a new account
+  replaces the existing account after successful authorization.
+
+## Remix gateway and approval
+
+The existing `remixServerTools` factory gains an authenticated connector tool
+source. On each run it loads only the caller's active records, resolves a
+short-lived Composio MCP session, and registers its filtered/namespaced tools.
+The system prompt advertises connector tools only when they are present.
+
+Tool metadata classifies calls as read-only or mutating. Read-only calls execute
+on Cloud. A mutating call does not execute immediately: it returns a pending
+approval representation to the Remix UI. The desktop displays the exact
+connector, action, and validated arguments. Approval creates a short-lived,
+single-use token bound to the Cloud user, conversation, connection, tool name,
+and normalized arguments. Cloud executes the action only when all bindings
+match; changing any bound value requires a fresh approval. Rejection or expiry
+does not execute the action.
+
+Provider error details, MCP URLs, OAuth state, and secrets are never passed to
+the model or renderer. User-facing errors explain whether the connector needs
+reconnection, is unavailable, or needs a fresh approval.
+
+## Failure handling
+
+- OAuth callback state expiry/consumption: show retryable Connect state.
+- Denied OAuth: retain no active account; show connection was not completed.
+- Expired/invalid account or verified webhook: mark `needs_reconnect`, omit
+  tools from subsequent runs, and expose Reconnect in Settings.
+- Composio outage/session failure: omit connector tools for the current turn;
+  do not fail editing or web-search tools.
+- Disconnect: immediately invalidate session/tool caches and remove the
+  connection from later runs, even if upstream deletion is best-effort.
+
+## Security requirements
+
+- Cloud service credentials and webhook secrets are deployment secrets.
+- Composio is the OAuth token custodian. D1 never stores OAuth tokens.
+- All remote callback/webhook inputs are signature/state validated and replay
+  protected.
+- Tool arguments validate against the actual MCP tool schema before pending
+  approval and again before execution.
+- Logs and Sentry metadata redact OAuth state, Composio session headers,
+  connected-account IDs where they could be sensitive, and tool arguments that
+  may contain user data.
+
+## Tests
+
+- Route tests cover catalog/list/connect/status/disconnect ownership: user A
+  cannot inspect or change user B's records, status, pending state, approvals,
+  or tools.
+- Unit tests cover callback state expiry, one-time use, callback ownership,
+  active/reconnect/disconnected transitions, and cache invalidation.
+- Gateway tests prove the MCP session receives only active account IDs for the
+  authenticated user and only each connection's allow-listed tools.
+- Remix tests cover read-only execution, pending write approval, approved
+  execution, rejection, and approval expiry/argument mismatch.
+- Renderer tests cover catalog, loading/error/pending/reconnect cards, the
+  browser handoff, and disconnect refresh.
+- Manual smoke test with two Cloud users connected to the same provider proves
+  that each user's Remix tools return only their own provider data.
+
+## Rollout
+
+1. Deploy Cloud schema and APIs behind a `COMPOSIO_API_KEY` availability check.
+2. Deploy desktop management UI; users without configured Cloud connectors see
+   a clear unavailable state.
+3. Enable connector tools for Remix after the approval UI and two-user isolation
+   smoke test pass.
+4. Add webhooks and operational alerts before broad enablement; expired accounts
+   degrade to reconnect rather than runtime failures.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.1
+      shiki:
+        specifier: ^3.23.0
+        version: 3.23.0
       three:
         specifier: 0.185.1
         version: 0.185.1


### PR DESCRIPTION
## Summary
- add Connected apps settings with search, OAuth browser handoff, status polling, reconnect, and disconnect
- proxy all connector requests through the local desktop server so Cloud session credentials stay out of the renderer
- route connector writes through Remix's existing confirmation card before Cloud executes the approved MCP action

Depends on freestyle-voice/cloud#122.

## Verification
- pnpm --filter @freestyle-voice/server test
- pnpm --filter @freestyle-voice/electron test
- pnpm --filter @freestyle-voice/electron typecheck
- pnpm --filter @freestyle-voice/server build
- pnpm --filter @freestyle-voice/electron build