### PR TITLE
feat: Apps page on the panel home screen + in-chat connect cards

### DIFF
--- a/apps/electron/src/renderer/panel.html
+++ b/apps/electron/src/renderer/panel.html
@@ -5,7 +5,7 @@
     <title>Freestyle</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
+      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://logos.composio.dev; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
     />
   </head>
 

--- a/apps/electron/src/renderer/src/components/connect-suggestions.tsx
+++ b/apps/electron/src/renderer/src/components/connect-suggestions.tsx
@@ -1,4 +1,12 @@
-import { ConnectorLogo } from "@renderer/components/connected-apps";
+import {
+  ApiKeyForm,
+  ConnectorLogo,
+  DEFAULT_AUTH_FIELDS,
+} from "@renderer/components/connected-apps";
+import {
+  type ConnectorAuthField,
+  disconnectToolkit,
+} from "@renderer/lib/connectors";
 import { useConnectorConnect } from "@renderer/lib/use-connector-connect";
 import type React from "react";
 import { useState } from "react";
@@ -9,6 +17,8 @@ type Suggestion = {
   logo?: string;
   description?: string;
   status?: string | null;
+  authMode?: string;
+  authFields?: ConnectorAuthField[];
 };
 
 function parseSuggestions(output: unknown): Suggestion[] {
@@ -33,8 +43,10 @@ export function ConnectSuggestions({
   output: unknown;
 }): React.JSX.Element | null {
   const suggestions = parseSuggestions(output);
-  const { connect, phases, error } = useConnectorConnect();
+  const { connect, connectWithCredentials, cancel, phases, error } =
+    useConnectorConnect();
   const [dismissed, setDismissed] = useState<ReadonlySet<string>>(new Set());
+  const [keyFormSlug, setKeyFormSlug] = useState<string | null>(null);
   const visible = suggestions.filter((item) => !dismissed.has(item.slug));
   if (visible.length === 0) return null;
 
@@ -42,10 +54,11 @@ export function ConnectSuggestions({
     <div className="tavern-connect-cards">
       {visible.map((suggestion) => {
         const phase = phases[suggestion.slug];
+        const apiKey = suggestion.authMode === "api_key";
         return (
           <div
             key={suggestion.slug}
-            className={`tavern-connect-card${phase === "connected" ? " is-connected" : ""}`}
+            className={`tavern-connect-card${phase === "connected" ? " is-connected" : ""}${keyFormSlug === suggestion.slug ? " has-keyform" : ""}`}
           >
             <ConnectorLogo name={suggestion.name} logo={suggestion.logo} />
             <div className="tavern-connect-copy">
@@ -68,27 +81,56 @@ export function ConnectSuggestions({
                   type="button"
                   className="tavern-approve-btn tavern-approve-allow"
                   disabled={phase === "opening" || phase === "pending"}
-                  onClick={() => connect(suggestion.slug)}
+                  onClick={() =>
+                    apiKey
+                      ? setKeyFormSlug((current) =>
+                          current === suggestion.slug ? null : suggestion.slug,
+                        )
+                      : connect(suggestion.slug)
+                  }
                 >
                   {phase === "opening"
-                    ? "Opening…"
+                    ? apiKey
+                      ? "Connecting…"
+                      : "Opening…"
                     : phase === "pending"
                       ? "Waiting…"
                       : suggestion.status === "needs_reconnect"
                         ? "Reconnect"
-                        : "Connect"}
+                        : apiKey
+                          ? "Add API key"
+                          : "Connect"}
                 </button>
                 <button
                   type="button"
                   className="tavern-approve-btn"
-                  onClick={() =>
-                    setDismissed((prev) => new Set(prev).add(suggestion.slug))
-                  }
+                  onClick={() => {
+                    // Backing out of an in-flight connect must also clear the
+                    // pending row, or the app sticks at "In progress".
+                    if (phase === "pending" || phase === "opening") {
+                      cancel(suggestion.slug);
+                      void disconnectToolkit(suggestion.slug).catch(() => {});
+                    }
+                    setDismissed((prev) => new Set(prev).add(suggestion.slug));
+                  }}
                 >
-                  Not now
+                  {phase === "pending" ? "Cancel" : "Not now"}
                 </button>
               </div>
             )}
+            {apiKey &&
+            keyFormSlug === suggestion.slug &&
+            phase !== "connected" ? (
+              <div className="tavern-connect-keyform">
+                <ApiKeyForm
+                  fields={suggestion.authFields ?? DEFAULT_AUTH_FIELDS}
+                  busy={phase === "opening"}
+                  onSubmit={(credentials) =>
+                    connectWithCredentials(suggestion.slug, credentials)
+                  }
+                />
+              </div>
+            ) : null}
           </div>
         );
       })}

--- a/apps/electron/src/renderer/src/components/connect-suggestions.tsx
+++ b/apps/electron/src/renderer/src/components/connect-suggestions.tsx
@@ -1,0 +1,102 @@
+import { ConnectorLogo } from "@renderer/components/connected-apps";
+import { useConnectorConnect } from "@renderer/lib/use-connector-connect";
+import type React from "react";
+import { useState } from "react";
+
+type Suggestion = {
+  slug: string;
+  name: string;
+  logo?: string;
+  description?: string;
+  status?: string | null;
+};
+
+function parseSuggestions(output: unknown): Suggestion[] {
+  const list = (output as { suggestions?: unknown } | null)?.suggestions;
+  if (!Array.isArray(list)) return [];
+  return list
+    .filter(
+      (item): item is Suggestion =>
+        !!item &&
+        typeof (item as Suggestion).slug === "string" &&
+        typeof (item as Suggestion).name === "string",
+    )
+    .slice(0, 3);
+}
+
+/** Renders a suggest_connections tool result as connect cards instead of the
+ * generic tool chip. The part is persisted with the message, so the cards
+ * survive reload; dismissal is per-session only. */
+export function ConnectSuggestions({
+  output,
+}: {
+  output: unknown;
+}): React.JSX.Element | null {
+  const suggestions = parseSuggestions(output);
+  const { connect, phases, error } = useConnectorConnect();
+  const [dismissed, setDismissed] = useState<ReadonlySet<string>>(new Set());
+  const visible = suggestions.filter((item) => !dismissed.has(item.slug));
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="tavern-connect-cards">
+      {visible.map((suggestion) => {
+        const phase = phases[suggestion.slug];
+        return (
+          <div
+            key={suggestion.slug}
+            className={`tavern-connect-card${phase === "connected" ? " is-connected" : ""}`}
+          >
+            <ConnectorLogo name={suggestion.name} logo={suggestion.logo} />
+            <div className="tavern-connect-copy">
+              <strong>{suggestion.name}</strong>
+              {phase === "connected" ? (
+                <p>Connected — ask me again and I'll use it.</p>
+              ) : phase === "pending" ? (
+                <p>Finish connecting in your browser…</p>
+              ) : suggestion.description ? (
+                <p>{suggestion.description}</p>
+              ) : null}
+            </div>
+            {phase === "connected" ? (
+              <span className="tavern-connect-done" aria-hidden="true">
+                ✓
+              </span>
+            ) : (
+              <div className="tavern-connect-actions">
+                <button
+                  type="button"
+                  className="tavern-approve-btn tavern-approve-allow"
+                  disabled={phase === "opening" || phase === "pending"}
+                  onClick={() => connect(suggestion.slug)}
+                >
+                  {phase === "opening"
+                    ? "Opening…"
+                    : phase === "pending"
+                      ? "Waiting…"
+                      : suggestion.status === "needs_reconnect"
+                        ? "Reconnect"
+                        : "Connect"}
+                </button>
+                <button
+                  type="button"
+                  className="tavern-approve-btn"
+                  onClick={() =>
+                    setDismissed((prev) => new Set(prev).add(suggestion.slug))
+                  }
+                >
+                  Not now
+                </button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+      {error ? (
+        <p className="tavern-connect-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -1,4 +1,5 @@
 import {
+  type ConnectorAuthField,
   type ConnectorCatalogItem,
   type ConnectorConnection,
   disconnectToolkit,
@@ -54,12 +55,81 @@ export function ConnectorLogo({
   );
 }
 
+export const DEFAULT_AUTH_FIELDS: ConnectorAuthField[] = [
+  { name: "generic_api_key", displayName: "API Key", required: true },
+];
+
+function isSecretField(name: string): boolean {
+  return /key|token|secret|password/i.test(name);
+}
+
+export function ApiKeyForm({
+  fields,
+  busy,
+  onSubmit,
+}: {
+  fields: ConnectorAuthField[];
+  busy: boolean;
+  onSubmit: (credentials: Record<string, string>) => void;
+}): React.JSX.Element {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const ready = fields
+    .filter((field) => field.required)
+    .every((field) => (values[field.name] ?? "").trim().length > 0);
+
+  return (
+    <form
+      className="connector-keyform"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!ready || busy) return;
+        const credentials: Record<string, string> = {};
+        for (const field of fields) {
+          const value = (values[field.name] ?? "").trim();
+          if (value) credentials[field.name] = value;
+        }
+        onSubmit(credentials);
+      }}
+    >
+      {fields.map((field) => (
+        <label key={field.name} className="connector-keyfield">
+          <span>
+            {field.displayName}
+            {field.required ? "" : " (optional)"}
+          </span>
+          <input
+            type={isSecretField(field.name) ? "password" : "text"}
+            value={values[field.name] ?? ""}
+            autoComplete="off"
+            spellCheck={false}
+            onMouseDown={() => window.api.panelRequestFocus()}
+            onChange={(event) =>
+              setValues((current) => ({
+                ...current,
+                [field.name]: event.target.value,
+              }))
+            }
+          />
+          {field.description ? <small>{field.description}</small> : null}
+        </label>
+      ))}
+      <button
+        type="submit"
+        className="connector-action"
+        disabled={!ready || busy}
+      >
+        {busy ? "Connecting…" : "Connect"}
+      </button>
+    </form>
+  );
+}
+
 function connectionCopy(
   connection: ConnectorConnection | null,
   phase: ConnectPhase | undefined,
   description?: string,
 ): string {
-  if (phase === "opening") return "Opening your browser…";
+  if (phase === "opening") return "Connecting…";
   if (phase === "pending" || connection?.status === "pending")
     return "Finish connecting in your browser";
   if (connection?.status === "active")
@@ -117,6 +187,8 @@ function ConnectorCard({
   const connected = connection?.status === "active";
   const pending = phase === "pending" || connection?.status === "pending";
   const reconnect = connection?.status === "needs_reconnect";
+  // API-key apps collect credentials in the detail pane, so Connect opens it.
+  const opensDetail = connector.authMode === "api_key" && !connected;
 
   return (
     <article
@@ -144,14 +216,26 @@ function ConnectorCard({
           ) : null}
         </div>
       </button>
-      <button
-        type="button"
-        className={`connector-action${connected ? " is-secondary" : ""}`}
-        disabled={busy || phase === "opening"}
-        onClick={connected ? onDisconnect : onConnect}
-      >
-        {busy && !connected ? "Opening…" : actionLabel(connection, phase)}
-      </button>
+      <div className="connector-card-actions">
+        <button
+          type="button"
+          className={`connector-action${connected ? " is-secondary" : ""}`}
+          disabled={busy || phase === "opening"}
+          onClick={connected ? onDisconnect : opensDetail ? onOpen : onConnect}
+        >
+          {busy && !connected ? "Opening…" : actionLabel(connection, phase)}
+        </button>
+        {pending || reconnect ? (
+          <button
+            type="button"
+            className="connector-cancel"
+            disabled={busy}
+            onClick={onDisconnect}
+          >
+            {pending ? "Cancel" : "Remove"}
+          </button>
+        ) : null}
+      </div>
     </article>
   );
 }
@@ -179,16 +263,20 @@ function ConnectorDetail({
   busyDisconnect,
   onBack,
   onConnect,
+  onConnectWithKey,
   onDisconnect,
   onUseWorkflow,
+  actionError,
 }: {
   slug: string;
   phase: ConnectPhase | undefined;
   busyDisconnect: boolean;
   onBack: () => void;
   onConnect: () => void;
+  onConnectWithKey: (credentials: Record<string, string>) => void;
   onDisconnect: () => void;
   onUseWorkflow?: (prompt: string) => void;
+  actionError?: string | null;
 }): React.JSX.Element {
   const detailsQuery = useQuery(connectorDetailsQueryOptions(slug));
   const details = detailsQuery.data;
@@ -200,6 +288,12 @@ function ConnectorDetail({
       <button type="button" className="connector-detail-back" onClick={onBack}>
         ‹ Apps
       </button>
+
+      {actionError ? (
+        <div className="connector-error" role="alert">
+          <span>{actionError}</span>
+        </div>
+      ) : null}
 
       {detailsQuery.isLoading ? (
         <ConnectedAppsSkeleton />
@@ -249,17 +343,50 @@ function ConnectorDetail({
             ) : null}
           </div>
 
-          <button
-            type="button"
-            className={`connector-action connector-detail-action${connected ? " is-secondary" : ""}`}
-            disabled={busyDisconnect || phase === "opening"}
-            onClick={connected ? onDisconnect : onConnect}
-          >
-            {actionLabel(connection, phase)}
-          </button>
-          <p className="connector-detail-status">
-            {connectionCopy(connection, phase)}
-          </p>
+          {details.authMode === "api_key" && !connected ? (
+            <div className="connector-detail-keyform">
+              <p className="connector-detail-status">
+                This app connects with an API key from your account. It goes
+                straight to the cloud and is never stored on this device.
+              </p>
+              <ApiKeyForm
+                fields={details.authFields ?? DEFAULT_AUTH_FIELDS}
+                busy={phase === "opening"}
+                onSubmit={onConnectWithKey}
+              />
+            </div>
+          ) : (
+            <div className="connector-detail-actions">
+              <button
+                type="button"
+                className={`connector-action connector-detail-action${connected ? " is-secondary" : ""}`}
+                disabled={busyDisconnect || phase === "opening"}
+                onClick={connected ? onDisconnect : onConnect}
+              >
+                {actionLabel(connection, phase)}
+              </button>
+              {phase === "pending" ||
+              connection?.status === "pending" ||
+              connection?.status === "needs_reconnect" ? (
+                <button
+                  type="button"
+                  className="connector-cancel"
+                  disabled={busyDisconnect}
+                  onClick={onDisconnect}
+                >
+                  {connection?.status === "needs_reconnect" &&
+                  phase !== "pending"
+                    ? "Remove"
+                    : "Cancel"}
+                </button>
+              ) : null}
+            </div>
+          )}
+          {details.authMode === "api_key" && !connected ? null : (
+            <p className="connector-detail-status">
+              {connectionCopy(connection, phase)}
+            </p>
+          )}
 
           {details.workflows.length > 0 ? (
             <div className="connector-detail-section">
@@ -322,6 +449,8 @@ export function ConnectedApps({
   const queryClient = useQueryClient();
   const {
     connect,
+    connectWithCredentials,
+    cancel: cancelConnect,
     phases,
     error: connectError,
     clearError,
@@ -393,6 +522,7 @@ export function ConnectedApps({
     },
   });
   const disconnect = (toolkit: string) => {
+    cancelConnect(toolkit);
     setActionError(null);
     disconnectMutation.mutate(toolkit, {
       onError: (cause) =>
@@ -461,8 +591,13 @@ export function ConnectedApps({
         busyDisconnect={busyDisconnect === detailSlug}
         onBack={() => setDetailSlug(null)}
         onConnect={() => startConnect(detailSlug)}
+        onConnectWithKey={(credentials) => {
+          setActionError(null);
+          connectWithCredentials(detailSlug, credentials);
+        }}
         onDisconnect={() => disconnect(detailSlug)}
         onUseWorkflow={onUseWorkflow}
+        actionError={actionError ?? connectError}
       />
     );
   }
@@ -482,14 +617,6 @@ export function ConnectedApps({
 
   return (
     <section className="connected-apps" aria-busy={browseQuery.isFetching}>
-      <header className="connected-apps-intro">
-        <span>Private by default</span>
-        <p>
-          Connect once. Freestyle can use only your account, and always asks
-          before changing anything outside the app.
-        </p>
-      </header>
-
       <label className="connector-search" htmlFor="connector-search">
         <span aria-hidden="true">⌕</span>
         <input

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -1,39 +1,80 @@
 import {
   type ConnectorCatalogItem,
-  type ConnectorCatalogPage,
-  connectorStatus,
-  connectToolkit,
+  type ConnectorConnection,
   disconnectToolkit,
 } from "@renderer/lib/connectors";
 import {
   connectorCatalogInfiniteQueryOptions,
+  connectorConnectionsQueryOptions,
+  connectorDetailsQueryOptions,
+  connectorSearchQueryOptions,
+  connectorSuggestedQueryOptions,
   queryKeys,
 } from "@renderer/lib/query";
 import {
-  type InfiniteData,
+  type ConnectPhase,
+  useConnectorConnect,
+} from "@renderer/lib/use-connector-connect";
+import {
   useInfiniteQuery,
   useMutation,
+  useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
 import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-const POLL_INTERVAL_MS = 2_000;
-const POLL_TIMEOUT_MS = 5 * 60_000;
-
-function connectionCopy(connector: ConnectorCatalogItem): string {
-  const connection = connector.connection;
-  if (connection?.status === "active")
-    return `${connection.accountLabel ?? "Connected"} · ${connection.toolCount} ${connection.toolCount === 1 ? "tool" : "tools"}`;
-  if (connection?.status === "pending")
-    return "Finish connecting in your browser";
-  if (connection?.status === "needs_reconnect")
-    return "Reconnect to keep using this app";
-  return "Available to Freestyle";
+export function ConnectorLogo({
+  name,
+  logo,
+  large,
+}: {
+  name: string;
+  logo?: string | null;
+  large?: boolean;
+}): React.JSX.Element {
+  const [failed, setFailed] = useState(false);
+  if (!logo || failed)
+    return (
+      <div
+        className={`connector-mark${large ? " is-large" : ""}`}
+        aria-hidden="true"
+      >
+        {name.slice(0, 1)}
+      </div>
+    );
+  return (
+    <img
+      className={`connector-logo${large ? " is-large" : ""}`}
+      src={logo}
+      alt=""
+      draggable={false}
+      onError={() => setFailed(true)}
+    />
+  );
 }
 
-function connectionBadge(connector: ConnectorCatalogItem): string | null {
-  switch (connector.connection?.status) {
+function connectionCopy(
+  connection: ConnectorConnection | null,
+  phase: ConnectPhase | undefined,
+  description?: string,
+): string {
+  if (phase === "opening") return "Opening your browser…";
+  if (phase === "pending" || connection?.status === "pending")
+    return "Finish connecting in your browser";
+  if (connection?.status === "active")
+    return `${connection.accountLabel ?? "Connected"} · ${connection.toolCount} ${connection.toolCount === 1 ? "tool" : "tools"}`;
+  if (connection?.status === "needs_reconnect")
+    return "Reconnect to keep using this app";
+  return description ?? "Available to Freestyle";
+}
+
+function connectionBadge(
+  connection: ConnectorConnection | null,
+  phase: ConnectPhase | undefined,
+): string | null {
+  if (phase === "pending") return "In progress";
+  switch (connection?.status) {
     case "active":
       return "Connected";
     case "pending":
@@ -45,56 +86,71 @@ function connectionBadge(connector: ConnectorCatalogItem): string | null {
   }
 }
 
+function actionLabel(
+  connection: ConnectorConnection | null,
+  phase: ConnectPhase | undefined,
+): string {
+  if (connection?.status === "active") return "Disconnect";
+  if (phase === "opening") return "Opening…";
+  if (phase === "pending" || connection?.status === "pending")
+    return "Open browser";
+  if (connection?.status === "needs_reconnect") return "Reconnect";
+  return "Connect";
+}
+
 function ConnectorCard({
   connector,
+  phase,
   busy,
   onConnect,
   onDisconnect,
+  onOpen,
 }: {
   connector: ConnectorCatalogItem;
+  phase: ConnectPhase | undefined;
   busy: boolean;
   onConnect: () => void;
   onDisconnect: () => void;
+  onOpen: () => void;
 }): React.JSX.Element {
   const connection = connector.connection;
   const connected = connection?.status === "active";
-  const pending = connection?.status === "pending";
+  const pending = phase === "pending" || connection?.status === "pending";
   const reconnect = connection?.status === "needs_reconnect";
-  const badge = connectionBadge(connector);
-  const action = connected
-    ? "Disconnect"
-    : busy
-      ? "Opening…"
-      : pending
-        ? "Open browser"
-        : reconnect
-          ? "Reconnect"
-          : "Connect";
 
   return (
     <article
       className={`connector-card${connected ? " is-connected" : ""}${pending ? " is-pending" : ""}${reconnect ? " needs-reconnect" : ""}`}
     >
-      <div className="connector-mark" aria-hidden="true">
-        {connector.name.slice(0, 1)}
-      </div>
-      <div className="connector-card-copy">
-        <div className="connector-card-heading">
-          <strong>{connector.name}</strong>
-          {badge ? <span className="connector-state">{badge}</span> : null}
+      <button
+        type="button"
+        className="connector-card-open"
+        aria-label={`About ${connector.name}`}
+        onClick={onOpen}
+      >
+        <ConnectorLogo name={connector.name} logo={connector.logo} />
+        <div className="connector-card-copy">
+          <div className="connector-card-heading">
+            <strong>{connector.name}</strong>
+            {connectionBadge(connection, phase) ? (
+              <span className="connector-state">
+                {connectionBadge(connection, phase)}
+              </span>
+            ) : null}
+          </div>
+          <p>{connectionCopy(connection, phase, connector.description)}</p>
+          {connection?.statusReason ? (
+            <p className="connector-reason">{connection.statusReason}</p>
+          ) : null}
         </div>
-        <p>{connectionCopy(connector)}</p>
-        {connection?.statusReason ? (
-          <p className="connector-reason">{connection.statusReason}</p>
-        ) : null}
-      </div>
+      </button>
       <button
         type="button"
         className={`connector-action${connected ? " is-secondary" : ""}`}
-        disabled={busy}
+        disabled={busy || phase === "opening"}
         onClick={connected ? onDisconnect : onConnect}
       >
-        {action}
+        {busy && !connected ? "Opening…" : actionLabel(connection, phase)}
       </button>
     </article>
   );
@@ -117,103 +173,225 @@ function ConnectedAppsSkeleton(): React.JSX.Element {
   );
 }
 
-export function ConnectedApps(): React.JSX.Element {
-  const [query, setQuery] = useState("");
-  const queryClient = useQueryClient();
-  const catalogQuery = useInfiniteQuery(connectorCatalogInfiniteQueryOptions());
-  const catalog = useMemo(
-    () => catalogQuery.data?.pages.flatMap((page) => page.connectors) ?? [],
-    [catalogQuery.data],
+function ConnectorDetail({
+  slug,
+  phase,
+  busyDisconnect,
+  onBack,
+  onConnect,
+  onDisconnect,
+  onUseWorkflow,
+}: {
+  slug: string;
+  phase: ConnectPhase | undefined;
+  busyDisconnect: boolean;
+  onBack: () => void;
+  onConnect: () => void;
+  onDisconnect: () => void;
+  onUseWorkflow?: (prompt: string) => void;
+}): React.JSX.Element {
+  const detailsQuery = useQuery(connectorDetailsQueryOptions(slug));
+  const details = detailsQuery.data;
+  const connection = details?.connection ?? null;
+  const connected = connection?.status === "active";
+
+  return (
+    <section className="connector-detail">
+      <button type="button" className="connector-detail-back" onClick={onBack}>
+        ‹ Apps
+      </button>
+
+      {detailsQuery.isLoading ? (
+        <ConnectedAppsSkeleton />
+      ) : detailsQuery.isError || !details ? (
+        <div className="connector-error" role="alert">
+          <span>That app's details are unavailable right now.</span>
+          <button type="button" onClick={() => void detailsQuery.refetch()}>
+            Try again
+          </button>
+        </div>
+      ) : (
+        <>
+          <header className="connector-detail-head">
+            <ConnectorLogo name={details.name} logo={details.logo} large />
+            <div className="connector-detail-title">
+              <div className="connector-card-heading">
+                <strong>{details.name}</strong>
+                {connectionBadge(connection, phase) ? (
+                  <span className="connector-state">
+                    {connectionBadge(connection, phase)}
+                  </span>
+                ) : null}
+              </div>
+              {details.description ? <p>{details.description}</p> : null}
+            </div>
+          </header>
+
+          <div className="connector-detail-meta">
+            {details.categories?.map((category) => (
+              <span key={category} className="connector-chip">
+                {category}
+              </span>
+            ))}
+            {details.toolsCount ? (
+              <span className="connector-chip is-muted">
+                {details.toolsCount} tools
+              </span>
+            ) : null}
+            {details.appUrl ? (
+              <button
+                type="button"
+                className="connector-chip is-link"
+                onClick={() => void window.api.openExternal(details.appUrl!)}
+              >
+                Website ↗
+              </button>
+            ) : null}
+          </div>
+
+          <button
+            type="button"
+            className={`connector-action connector-detail-action${connected ? " is-secondary" : ""}`}
+            disabled={busyDisconnect || phase === "opening"}
+            onClick={connected ? onDisconnect : onConnect}
+          >
+            {actionLabel(connection, phase)}
+          </button>
+          <p className="connector-detail-status">
+            {connectionCopy(connection, phase)}
+          </p>
+
+          {details.workflows.length > 0 ? (
+            <div className="connector-detail-section">
+              <div className="connector-group-label">
+                <span>Things to try</span>
+              </div>
+              <div className="connector-workflows">
+                {details.workflows.map((workflow) => (
+                  <button
+                    key={workflow.name}
+                    type="button"
+                    className="connector-workflow"
+                    disabled={!onUseWorkflow}
+                    title={workflow.prompt}
+                    onClick={() => onUseWorkflow?.(workflow.prompt)}
+                  >
+                    <strong>{workflow.name}</strong>
+                    <small>{workflow.prompt}</small>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {details.tools.length > 0 ? (
+            <div className="connector-detail-section">
+              <div className="connector-group-label">
+                <span>What it can do</span>
+                <em>{details.tools.length}</em>
+              </div>
+              <ul className="connector-tools">
+                {details.tools.map((tool) => (
+                  <li key={tool.name}>
+                    <strong>
+                      {tool.name}
+                      {tool.readOnly ? (
+                        <span className="connector-tool-ro">read-only</span>
+                      ) : null}
+                    </strong>
+                    {tool.description ? <p>{tool.description}</p> : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </>
+      )}
+    </section>
   );
+}
+
+export function ConnectedApps({
+  onUseWorkflow,
+}: {
+  onUseWorkflow?: (prompt: string) => void;
+}): React.JSX.Element {
+  const [query, setQuery] = useState("");
+  const [search, setSearch] = useState("");
+  const [detailSlug, setDetailSlug] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const {
+    connect,
+    phases,
+    error: connectError,
+    clearError,
+  } = useConnectorConnect();
   const [actionError, setActionError] = useState<string | null>(null);
-  const [pollStartedAt, setPollStartedAt] = useState(0);
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
-  const pending = useMemo(
-    () =>
-      catalog
-        .filter((item) => item.connection?.status === "pending")
-        .map((item) => item.slug),
-    [catalog],
-  );
-  const pendingKey = pending.join(",");
   useEffect(() => {
-    if (!pendingKey) return;
-    const startedAt = pollStartedAt || Date.now();
-    const pendingToolkits = pendingKey.split(",");
-    const timer = window.setInterval(() => {
-      if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
-        window.clearInterval(timer);
-        setActionError(
-          "This connection is still pending. Finish it in your browser, or open it again to restart.",
-        );
-        return;
-      }
-      void Promise.all(
-        pendingToolkits.map((toolkit) => connectorStatus(toolkit)),
-      )
-        .then((statuses) => {
-          queryClient.setQueryData<InfiniteData<ConnectorCatalogPage>>(
-            queryKeys.connectors.catalog,
-            (current) => {
-              if (!current) return current;
-              const statusByToolkit = new Map(
-                pendingToolkits.map((toolkit, index) => [
-                  toolkit,
-                  statuses[index] ?? null,
-                ]),
-              );
-              return {
-                ...current,
-                pages: current.pages.map((page) => ({
-                  ...page,
-                  connectors: page.connectors.map((item) =>
-                    statusByToolkit.has(item.slug)
-                      ? {
-                          ...item,
-                          connection: statusByToolkit.get(item.slug) ?? null,
-                        }
-                      : item,
-                  ),
-                })),
-              };
-            },
-          );
-        })
-        .catch(() => {});
-    }, POLL_INTERVAL_MS);
-    return () => window.clearInterval(timer);
-  }, [pendingKey, pollStartedAt, queryClient]);
+    const timer = window.setTimeout(() => setSearch(query.trim()), 300);
+    return () => window.clearTimeout(timer);
+  }, [query]);
 
-  const connectMutation = useMutation({
-    mutationFn: connectToolkit,
-    onSuccess: async () => {
-      setPollStartedAt(Date.now());
-      await queryClient.invalidateQueries({
-        queryKey: queryKeys.connectors.catalog,
-      });
-    },
-  });
+  const connectionsQuery = useQuery(connectorConnectionsQueryOptions());
+  const suggestedQuery = useQuery(connectorSuggestedQueryOptions());
+  const browseQuery = useInfiniteQuery(connectorCatalogInfiniteQueryOptions());
+  const searchQuery = useQuery(connectorSearchQueryOptions(search));
+
+  const connections = useMemo(
+    () =>
+      (connectionsQuery.data ?? []).filter(
+        (connection) => connection.status !== "disconnected",
+      ),
+    [connectionsQuery.data],
+  );
+  const connectedSlugs = useMemo(
+    () => new Set(connections.map((connection) => connection.toolkitSlug)),
+    [connections],
+  );
+  const connectedItems: ConnectorCatalogItem[] = useMemo(
+    () =>
+      connections.map((connection) => ({
+        slug: connection.toolkitSlug,
+        name: connection.toolkitName,
+        logo: connection.toolkitLogo ?? undefined,
+        connection,
+      })),
+    [connections],
+  );
+  const suggested = useMemo(
+    () =>
+      (suggestedQuery.data ?? []).filter(
+        (item) => !connectedSlugs.has(item.slug),
+      ),
+    [suggestedQuery.data, connectedSlugs],
+  );
+  const suggestedSlugs = useMemo(
+    () => new Set((suggestedQuery.data ?? []).map((item) => item.slug)),
+    [suggestedQuery.data],
+  );
+  const browse = useMemo(
+    () =>
+      (browseQuery.data?.pages.flatMap((page) => page.connectors) ?? []).filter(
+        (item) =>
+          !connectedSlugs.has(item.slug) && !suggestedSlugs.has(item.slug),
+      ),
+    [browseQuery.data, connectedSlugs, suggestedSlugs],
+  );
+  const searchResults = useMemo(
+    () => searchQuery.data?.connectors ?? [],
+    [searchQuery.data],
+  );
+
   const disconnectMutation = useMutation({
     mutationFn: disconnectToolkit,
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: queryKeys.connectors.catalog,
+        queryKey: queryKeys.connectors.all,
       });
     },
   });
-
-  const connect = (toolkit: string) => {
-    setActionError(null);
-    connectMutation.mutate(toolkit, {
-      onError: (cause) =>
-        setActionError(
-          cause instanceof Error
-            ? cause.message
-            : "Could not start that connection.",
-        ),
-    });
-  };
   const disconnect = (toolkit: string) => {
     setActionError(null);
     disconnectMutation.mutate(toolkit, {
@@ -225,65 +403,85 @@ export function ConnectedApps(): React.JSX.Element {
         ),
     });
   };
+  const startConnect = (toolkit: string) => {
+    setActionError(null);
+    connect(toolkit);
+  };
 
-  const normalizedQuery = query.trim().toLowerCase();
+  const searching = search.length > 0;
 
   useEffect(() => {
     const target = loadMoreRef.current;
     if (
       !target ||
-      normalizedQuery ||
-      !catalogQuery.hasNextPage ||
-      catalogQuery.isFetchingNextPage
+      searching ||
+      !browseQuery.hasNextPage ||
+      browseQuery.isFetchingNextPage
     )
       return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry?.isIntersecting) void catalogQuery.fetchNextPage();
+        if (entry?.isIntersecting) void browseQuery.fetchNextPage();
       },
       { rootMargin: "180px" },
     );
     observer.observe(target);
     return () => observer.disconnect();
   }, [
-    catalogQuery.fetchNextPage,
-    catalogQuery.hasNextPage,
-    catalogQuery.isFetchingNextPage,
-    normalizedQuery,
+    browseQuery.fetchNextPage,
+    browseQuery.hasNextPage,
+    browseQuery.isFetchingNextPage,
+    searching,
   ]);
 
-  const matchingCatalog = useMemo(
-    () =>
-      normalizedQuery
-        ? catalog.filter((item) =>
-            `${item.name} ${item.slug}`.toLowerCase().includes(normalizedQuery),
-          )
-        : catalog,
-    [catalog, normalizedQuery],
-  );
-  const connected = matchingCatalog.filter(
-    (item) => item.connection && item.connection.status !== "disconnected",
-  );
-  const available = matchingCatalog.filter(
-    (item) => !item.connection || item.connection.status === "disconnected",
-  );
-  const initialLoading = catalogQuery.isLoading && catalog.length === 0;
+  const initialLoading =
+    (suggestedQuery.isLoading || connectionsQuery.isLoading) &&
+    connectedItems.length === 0 &&
+    suggested.length === 0;
   const error =
     actionError ??
-    (catalogQuery.error instanceof Error
-      ? catalogQuery.error.message
-      : catalogQuery.isError
+    connectError ??
+    (browseQuery.error instanceof Error
+      ? browseQuery.error.message
+      : browseQuery.isError ||
+          suggestedQuery.isError ||
+          connectionsQuery.isError
         ? "Connected apps are unavailable."
         : null);
-  const busyToolkit = connectMutation.isPending
-    ? connectMutation.variables
-    : disconnectMutation.isPending
-      ? disconnectMutation.variables
-      : null;
+  const busyDisconnect = disconnectMutation.isPending
+    ? disconnectMutation.variables
+    : null;
+
+  if (detailSlug) {
+    return (
+      <ConnectorDetail
+        slug={detailSlug}
+        phase={phases[detailSlug]}
+        busyDisconnect={busyDisconnect === detailSlug}
+        onBack={() => setDetailSlug(null)}
+        onConnect={() => startConnect(detailSlug)}
+        onDisconnect={() => disconnect(detailSlug)}
+        onUseWorkflow={onUseWorkflow}
+      />
+    );
+  }
+
+  const renderCards = (items: ConnectorCatalogItem[]) =>
+    items.map((connector) => (
+      <ConnectorCard
+        key={connector.slug}
+        connector={connector}
+        phase={phases[connector.slug]}
+        busy={busyDisconnect === connector.slug}
+        onConnect={() => startConnect(connector.slug)}
+        onDisconnect={() => disconnect(connector.slug)}
+        onOpen={() => setDetailSlug(connector.slug)}
+      />
+    ));
 
   return (
-    <section className="connected-apps" aria-busy={catalogQuery.isFetching}>
+    <section className="connected-apps" aria-busy={browseQuery.isFetching}>
       <header className="connected-apps-intro">
         <span>Private by default</span>
         <p>
@@ -296,9 +494,9 @@ export function ConnectedApps(): React.JSX.Element {
         <span aria-hidden="true">⌕</span>
         <input
           id="connector-search"
-          aria-label="Filter loaded connected apps"
+          aria-label="Search all apps"
           value={query}
-          placeholder="Filter loaded apps"
+          placeholder="Search 1,000+ apps"
           onChange={(event) => setQuery(event.target.value)}
         />
         {query ? (
@@ -315,7 +513,16 @@ export function ConnectedApps(): React.JSX.Element {
       {error ? (
         <div className="connector-error" role="alert">
           <span>{error}</span>
-          <button type="button" onClick={() => void catalogQuery.refetch()}>
+          <button
+            type="button"
+            onClick={() => {
+              setActionError(null);
+              clearError();
+              void browseQuery.refetch();
+              void suggestedQuery.refetch();
+              void connectionsQuery.refetch();
+            }}
+          >
             Try again
           </button>
         </div>
@@ -330,87 +537,83 @@ export function ConnectedApps(): React.JSX.Element {
         </>
       ) : null}
 
-      {!initialLoading && connected.length > 0 ? (
+      {searching ? (
         <div className="connector-group">
           <div className="connector-group-label">
-            <span>Connected</span>
-            <em>{connected.length}</em>
+            <span>Results</span>
+            <em>{searchResults.length}</em>
           </div>
-          {connected.map((connector) => (
-            <ConnectorCard
-              key={connector.slug}
-              connector={connector}
-              busy={busyToolkit === connector.slug}
-              onConnect={() => connect(connector.slug)}
-              onDisconnect={() => disconnect(connector.slug)}
-            />
-          ))}
-        </div>
-      ) : null}
-
-      {!initialLoading && available.length > 0 ? (
-        <div className="connector-group">
-          <div className="connector-group-label">
-            <span>{connected.length > 0 ? "More apps" : "Available apps"}</span>
-            <em>{available.length}</em>
-          </div>
-          {available.map((connector) => (
-            <ConnectorCard
-              key={connector.slug}
-              connector={connector}
-              busy={busyToolkit === connector.slug}
-              onConnect={() => connect(connector.slug)}
-              onDisconnect={() => disconnect(connector.slug)}
-            />
-          ))}
-        </div>
-      ) : null}
-
-      {!initialLoading && matchingCatalog.length === 0 ? (
-        <div className="connector-empty">
-          <strong>
-            {normalizedQuery ? "No apps found" : "No apps are available"}
-          </strong>
-          <p>
-            {normalizedQuery
-              ? "Try a different app name."
-              : "Try again in a moment."}
-          </p>
-          {normalizedQuery ? (
-            <button type="button" onClick={() => setQuery("")}>
-              Clear search
-            </button>
-          ) : null}
-        </div>
-      ) : null}
-
-      {!initialLoading && catalog.length > 0 ? (
-        <div
-          ref={loadMoreRef}
-          className={`connector-load-more${catalogQuery.isFetchingNextPage ? " is-loading" : ""}`}
-          role="status"
-        >
-          {catalogQuery.isFetchingNextPage ? (
-            <>
-              <span className="connector-load-trail" aria-hidden="true">
-                <i />
-                <i />
-                <i />
-              </span>
-              <span className="connector-load-copy">
-                <strong>Finding more apps</strong>
-                <small>Keeping your place in the catalog</small>
-              </span>
-            </>
-          ) : normalizedQuery ? (
-            "Filter applies to apps loaded so far."
-          ) : catalogQuery.hasNextPage ? (
-            "More apps load as you scroll."
+          {searchQuery.isLoading ? (
+            <ConnectedAppsSkeleton />
+          ) : searchResults.length > 0 ? (
+            renderCards(searchResults)
           ) : (
-            "All available apps loaded."
+            <div className="connector-empty">
+              <strong>No apps found</strong>
+              <p>Try a different app name.</p>
+              <button type="button" onClick={() => setQuery("")}>
+                Clear search
+              </button>
+            </div>
           )}
         </div>
-      ) : null}
+      ) : (
+        <>
+          {!initialLoading && connectedItems.length > 0 ? (
+            <div className="connector-group">
+              <div className="connector-group-label">
+                <span>Connected</span>
+                <em>{connectedItems.length}</em>
+              </div>
+              {renderCards(connectedItems)}
+            </div>
+          ) : null}
+
+          {!initialLoading && suggested.length > 0 ? (
+            <div className="connector-group">
+              <div className="connector-group-label">
+                <span>Suggested</span>
+              </div>
+              {renderCards(suggested)}
+            </div>
+          ) : null}
+
+          {!initialLoading && browse.length > 0 ? (
+            <div className="connector-group">
+              <div className="connector-group-label">
+                <span>All apps</span>
+              </div>
+              {renderCards(browse)}
+            </div>
+          ) : null}
+
+          {!initialLoading && browse.length > 0 ? (
+            <div
+              ref={loadMoreRef}
+              className={`connector-load-more${browseQuery.isFetchingNextPage ? " is-loading" : ""}`}
+              role="status"
+            >
+              {browseQuery.isFetchingNextPage ? (
+                <>
+                  <span className="connector-load-trail" aria-hidden="true">
+                    <i />
+                    <i />
+                    <i />
+                  </span>
+                  <span className="connector-load-copy">
+                    <strong>Finding more apps</strong>
+                    <small>Keeping your place in the catalog</small>
+                  </span>
+                </>
+              ) : browseQuery.hasNextPage ? (
+                "More apps load as you scroll — or search to jump straight there."
+              ) : (
+                "All available apps loaded."
+              )}
+            </div>
+          ) : null}
+        </>
+      )}
     </section>
   );
 }

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -2,6 +2,8 @@ import "../overlay.css";
 import "../tavern.css";
 
 import { useChat } from "@ai-sdk/react";
+import { ConnectSuggestions } from "@renderer/components/connect-suggestions";
+import { ConnectedApps } from "@renderer/components/connected-apps";
 import { Markdown } from "@renderer/components/markdown";
 import { NotesTab } from "@renderer/components/notes-tab";
 import { OnboardingGate, useOnboarding } from "@renderer/components/onboarding";
@@ -42,6 +44,7 @@ const TAB_LABELS: Record<PanelTab, string> = {
   history: "History",
   todos: "Todos",
   notes: "Notes",
+  apps: "Apps",
 };
 
 const TAB_PLACEHOLDER: Record<PanelTab, string> = {
@@ -49,6 +52,7 @@ const TAB_PLACEHOLDER: Record<PanelTab, string> = {
   history: "Past conversations land here — pick one to continue it.",
   todos: "Nothing to do yet.",
   notes: "No notes yet.",
+  apps: "Connect the apps you live in, and Freestyle can work them for you.",
 };
 
 function ShikiJson({ value }: { value: unknown }): React.JSX.Element {
@@ -326,6 +330,16 @@ function ChatMessage({
               <div key={`${message.id}-${i}`} className="tavern-msg-assistant">
                 <Markdown text={part.text} />
               </div>
+            );
+          }
+          if (part.type === "tool-suggest_connections") {
+            const tool = part as { state?: string; output?: unknown };
+            if (tool.state !== "output-available") return null;
+            return (
+              <ConnectSuggestions
+                key={`${message.id}-${i}`}
+                output={tool.output}
+              />
             );
           }
           if (part.type.startsWith("tool-")) {
@@ -988,6 +1002,14 @@ function PanelInner({
               onPick={(picked) => {
                 if (picked.id === thread.id) setTab("chat");
                 else onSwitchThread(picked);
+              }}
+            />
+          ) : tab === "apps" ? (
+            <ConnectedApps
+              onUseWorkflow={(prompt) => {
+                setTab("chat");
+                setNotice(null);
+                void sendMessage({ text: prompt });
               }}
             />
           ) : showChat ? (

--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -8,7 +8,6 @@ import {
   resolveLanguageOptions,
 } from "@freestyle-voice/validations";
 import { BrainFiles } from "@renderer/components/brain-files";
-import { ConnectedApps } from "@renderer/components/connected-apps";
 import { NotificationsHistory } from "@renderer/components/notifications-history";
 import { ScheduledTasks } from "@renderer/components/scheduled-tasks";
 import {
@@ -50,7 +49,6 @@ type SettingsPage =
   | "profile"
   | "billing"
   | "brain"
-  | "connectedApps"
   | "notifications"
   | "scheduled"
   | "dictation"
@@ -63,7 +61,6 @@ const PAGE_TITLES: Record<Exclude<SettingsPage, "root">, string> = {
   profile: "Profile",
   billing: "Billing & Usage",
   brain: "Brain",
-  connectedApps: "Connected apps",
   notifications: "Notifications",
   scheduled: "Scheduled",
   dictation: "Dictation",
@@ -1497,8 +1494,6 @@ export function SettingsView({
             newLabel="New file"
             graphable
           />
-        ) : page === "connectedApps" ? (
-          <ConnectedApps />
         ) : page === "scheduled" ? (
           <ScheduledTasks />
         ) : page === "notifications" ? (
@@ -1554,7 +1549,6 @@ export function SettingsView({
         onClick={() => setPage("billing")}
       />
       <NavRow label="Brain" onClick={() => setPage("brain")} />
-      <NavRow label="Connected apps" onClick={() => setPage("connectedApps")} />
       <NavRow label="Scheduled" onClick={() => setPage("scheduled")} />
       <NavRow label="Notifications" onClick={() => setPage("notifications")} />
       <NavRow

--- a/apps/electron/src/renderer/src/lib/auth-context.tsx
+++ b/apps/electron/src/renderer/src/lib/auth-context.tsx
@@ -70,7 +70,7 @@ function useCloudAuthState(): UseCloudAuth {
         if (!user && wasSignedInRef.current) {
           setSessionExpired(true);
           queryClient.removeQueries({
-            queryKey: queryKeys.connectors.catalog,
+            queryKey: queryKeys.connectors.all,
           });
         }
         if (user) setSessionExpired(false);
@@ -161,7 +161,7 @@ function useCloudAuthState(): UseCloudAuth {
         const data = await tokenRes.json();
         if (attempt !== signInAttemptRef.current) return null;
         queryClient.removeQueries({ queryKey: queryKeys.cloud.usage });
-        queryClient.removeQueries({ queryKey: queryKeys.connectors.catalog });
+        queryClient.removeQueries({ queryKey: queryKeys.connectors.all });
         wasSignedInRef.current = true;
         setSessionExpired(false);
         setUser(data.user);
@@ -204,7 +204,7 @@ function useCloudAuthState(): UseCloudAuth {
     setSessionExpired(false);
     setUser(null);
     queryClient.removeQueries({ queryKey: queryKeys.cloud.usage });
-    queryClient.removeQueries({ queryKey: queryKeys.connectors.catalog });
+    queryClient.removeQueries({ queryKey: queryKeys.connectors.all });
   }, [queryClient]);
 
   return {

--- a/apps/electron/src/renderer/src/lib/connectors.test.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.test.ts
@@ -61,4 +61,15 @@ describe("connected-app tool approvals", () => {
       "/api/connectors/catalog?limit=24&cursor=cursor-1",
     );
   });
+
+  it("passes a search query through to the catalog endpoint", async () => {
+    apiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ connectors: [], nextCursor: null })),
+    );
+
+    await listConnectorCatalog({ search: "calendar", limit: 50 });
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/connectors/catalog?limit=50&search=calendar",
+    );
+  });
 });

--- a/apps/electron/src/renderer/src/lib/connectors.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.ts
@@ -19,6 +19,15 @@ export type ConnectorConnection = {
 
 export type ConnectorWorkflow = { name: string; prompt: string };
 
+export type ConnectorAuthMode = "oauth" | "api_key";
+
+export type ConnectorAuthField = {
+  name: string;
+  displayName: string;
+  description?: string;
+  required: boolean;
+};
+
 export type ConnectorCatalogItem = {
   slug: string;
   name: string;
@@ -28,6 +37,8 @@ export type ConnectorCatalogItem = {
   toolsCount?: number;
   triggersCount?: number;
   appUrl?: string;
+  authMode?: ConnectorAuthMode;
+  authFields?: ConnectorAuthField[];
   workflows?: ConnectorWorkflow[];
   connection: ConnectorConnection | null;
 };
@@ -145,6 +156,22 @@ export async function connectToolkit(toolkit: string): Promise<void> {
   const opened = await window.api.openExternal(data.connectUrl);
   if (!opened)
     throw new Error("Could not open your browser to connect this app.");
+}
+
+/** API-key apps skip the browser: the key goes straight to the cloud, which
+ * verifies it with Composio and returns the now-active connection. */
+export async function connectToolkitWithCredentials(
+  toolkit: string,
+  credentials: Record<string, string>,
+): Promise<ConnectorConnection | null> {
+  const data = await responseJson<{ connection: ConnectorConnection | null }>(
+    await apiFetch(`/api/connectors/${encodeURIComponent(toolkit)}/connect`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ credentials }),
+    }),
+  );
+  return data.connection;
 }
 
 export async function connectorStatus(

--- a/apps/electron/src/renderer/src/lib/connectors.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.ts
@@ -17,16 +17,36 @@ export type ConnectorConnection = {
   statusReason: string | null;
 };
 
+export type ConnectorWorkflow = { name: string; prompt: string };
+
 export type ConnectorCatalogItem = {
   slug: string;
   name: string;
   logo?: string;
+  description?: string;
+  categories?: string[];
+  toolsCount?: number;
+  triggersCount?: number;
+  appUrl?: string;
+  workflows?: ConnectorWorkflow[];
   connection: ConnectorConnection | null;
 };
 
 export type ConnectorCatalogPage = {
   connectors: ConnectorCatalogItem[];
   nextCursor: string | null;
+  totalItems?: number | null;
+};
+
+export type ConnectorToolSummary = {
+  name: string;
+  description?: string;
+  readOnly: boolean;
+};
+
+export type ConnectorDetails = ConnectorCatalogItem & {
+  tools: ConnectorToolSummary[];
+  workflows: ConnectorWorkflow[];
 };
 
 export function isConnectorToolName(name: string): boolean {
@@ -76,14 +96,43 @@ async function responseJson<T>(response: Response): Promise<T> {
 export async function listConnectorCatalog({
   cursor,
   limit = 24,
+  search,
 }: {
   cursor?: string;
   limit?: number;
+  search?: string;
 } = {}): Promise<ConnectorCatalogPage> {
   const params = new URLSearchParams({ limit: String(limit) });
   if (cursor) params.set("cursor", cursor);
+  if (search) params.set("search", search);
   return responseJson<ConnectorCatalogPage>(
     await apiFetch(`/api/connectors/catalog?${params.toString()}`),
+  );
+}
+
+export async function listConnectorConnections(): Promise<
+  ConnectorConnection[]
+> {
+  const data = await responseJson<{ connections: ConnectorConnection[] }>(
+    await apiFetch("/api/connectors"),
+  );
+  return data.connections;
+}
+
+export async function listSuggestedConnectors(): Promise<
+  ConnectorCatalogItem[]
+> {
+  const data = await responseJson<{ connectors: ConnectorCatalogItem[] }>(
+    await apiFetch("/api/connectors/suggested"),
+  );
+  return data.connectors;
+}
+
+export async function getConnectorDetails(
+  toolkit: string,
+): Promise<ConnectorDetails> {
+  return responseJson<ConnectorDetails>(
+    await apiFetch(`/api/connectors/${encodeURIComponent(toolkit)}/details`),
   );
 }
 

--- a/apps/electron/src/renderer/src/lib/query.ts
+++ b/apps/electron/src/renderer/src/lib/query.ts
@@ -1,6 +1,12 @@
 import { QueryClient } from "@tanstack/react-query";
 import { getClient } from "./api";
-import { type ConnectorCatalogPage, listConnectorCatalog } from "./connectors";
+import {
+  type ConnectorCatalogPage,
+  getConnectorDetails,
+  listConnectorCatalog,
+  listConnectorConnections,
+  listSuggestedConnectors,
+} from "./connectors";
 import type { AvailableModel } from "./models";
 
 /** Common staleTime for cached queries (1 hour). */
@@ -66,7 +72,12 @@ export const queryKeys = {
   },
 
   connectors: {
+    all: ["connectors"] as const,
     catalog: ["connectors", "catalog"] as const,
+    connections: ["connectors", "connections"] as const,
+    search: (search: string) => ["connectors", "search", search] as const,
+    suggested: ["connectors", "suggested"] as const,
+    details: (slug: string) => ["connectors", "details", slug] as const,
   },
 
   /** Remix practice runs. */
@@ -176,6 +187,46 @@ export function connectorCatalogInfiniteQueryOptions() {
       }),
     getNextPageParam: (lastPage: ConnectorCatalogPage) =>
       lastPage.nextCursor ?? undefined,
+    staleTime: 5 * 60 * 1000,
+    gcTime: ONE_HOUR,
+  };
+}
+
+export function connectorConnectionsQueryOptions() {
+  return {
+    queryKey: queryKeys.connectors.connections,
+    queryFn: listConnectorConnections,
+    staleTime: 5 * 60 * 1000,
+    gcTime: ONE_HOUR,
+  };
+}
+
+export const CONNECTOR_SEARCH_PAGE_SIZE = 50;
+
+export function connectorSearchQueryOptions(search: string) {
+  return {
+    queryKey: queryKeys.connectors.search(search),
+    queryFn: () =>
+      listConnectorCatalog({ search, limit: CONNECTOR_SEARCH_PAGE_SIZE }),
+    staleTime: 5 * 60 * 1000,
+    gcTime: ONE_HOUR,
+    enabled: search.length > 0,
+  };
+}
+
+export function connectorSuggestedQueryOptions() {
+  return {
+    queryKey: queryKeys.connectors.suggested,
+    queryFn: listSuggestedConnectors,
+    staleTime: 5 * 60 * 1000,
+    gcTime: ONE_HOUR,
+  };
+}
+
+export function connectorDetailsQueryOptions(slug: string) {
+  return {
+    queryKey: queryKeys.connectors.details(slug),
+    queryFn: () => getConnectorDetails(slug),
     staleTime: 5 * 60 * 1000,
     gcTime: ONE_HOUR,
   };

--- a/apps/electron/src/renderer/src/lib/use-connector-connect.ts
+++ b/apps/electron/src/renderer/src/lib/use-connector-connect.ts
@@ -1,4 +1,8 @@
-import { connectorStatus, connectToolkit } from "@renderer/lib/connectors";
+import {
+  connectorStatus,
+  connectToolkit,
+  connectToolkitWithCredentials,
+} from "@renderer/lib/connectors";
 import { queryKeys } from "@renderer/lib/query";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -41,6 +45,14 @@ export function useConnectorConnect() {
       active.clear();
     };
   }, []);
+
+  const cancel = useCallback(
+    (slug: string) => {
+      stopPolling(slug);
+      setPhase(slug, null);
+    },
+    [setPhase, stopPolling],
+  );
 
   const connect = useCallback(
     (slug: string) => {
@@ -96,5 +108,40 @@ export function useConnectorConnect() {
     [queryClient, setPhase, stopPolling],
   );
 
-  return { connect, phases, error, clearError: () => setError(null) };
+  const connectWithCredentials = useCallback(
+    (slug: string, credentials: Record<string, string>) => {
+      setError(null);
+      setPhase(slug, "opening");
+      void connectToolkitWithCredentials(slug, credentials)
+        .then((connection) => {
+          if (connection?.status === "active") {
+            setPhase(slug, "connected");
+          } else {
+            setPhase(slug, null);
+            setError("That API key could not be verified.");
+          }
+          void queryClient.invalidateQueries({
+            queryKey: queryKeys.connectors.all,
+          });
+        })
+        .catch((cause) => {
+          setPhase(slug, null);
+          setError(
+            cause instanceof Error
+              ? cause.message
+              : "That API key could not be verified.",
+          );
+        });
+    },
+    [queryClient, setPhase],
+  );
+
+  return {
+    connect,
+    connectWithCredentials,
+    cancel,
+    phases,
+    error,
+    clearError: () => setError(null),
+  };
 }

--- a/apps/electron/src/renderer/src/lib/use-connector-connect.ts
+++ b/apps/electron/src/renderer/src/lib/use-connector-connect.ts
@@ -1,0 +1,100 @@
+import { connectorStatus, connectToolkit } from "@renderer/lib/connectors";
+import { queryKeys } from "@renderer/lib/query";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const POLL_INTERVAL_MS = 2_000;
+const POLL_TIMEOUT_MS = 5 * 60_000;
+
+export type ConnectPhase = "opening" | "pending" | "connected";
+
+/**
+ * One connect-and-poll implementation shared by the Apps page and in-chat
+ * connect cards: open the system browser, then poll the connection status
+ * until it becomes active, times out, or fails.
+ */
+export function useConnectorConnect() {
+  const queryClient = useQueryClient();
+  const [phases, setPhases] = useState<Record<string, ConnectPhase>>({});
+  const [error, setError] = useState<string | null>(null);
+  const timers = useRef<Map<string, number>>(new Map());
+
+  const setPhase = useCallback((slug: string, phase: ConnectPhase | null) => {
+    setPhases((current) => {
+      const next = { ...current };
+      if (phase) next[slug] = phase;
+      else delete next[slug];
+      return next;
+    });
+  }, []);
+
+  const stopPolling = useCallback((slug: string) => {
+    const timer = timers.current.get(slug);
+    if (timer !== undefined) window.clearInterval(timer);
+    timers.current.delete(slug);
+  }, []);
+
+  useEffect(() => {
+    const active = timers.current;
+    return () => {
+      for (const timer of active.values()) window.clearInterval(timer);
+      active.clear();
+    };
+  }, []);
+
+  const connect = useCallback(
+    (slug: string) => {
+      setError(null);
+      setPhase(slug, "opening");
+      void connectToolkit(slug)
+        .then(() => {
+          setPhase(slug, "pending");
+          const startedAt = Date.now();
+          stopPolling(slug);
+          const timer = window.setInterval(() => {
+            if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
+              stopPolling(slug);
+              setPhase(slug, null);
+              setError(
+                "This connection is still pending. Finish it in your browser, or open it again to restart.",
+              );
+              return;
+            }
+            void connectorStatus(slug)
+              .then((connection) => {
+                if (connection?.status === "active") {
+                  stopPolling(slug);
+                  setPhase(slug, "connected");
+                  void queryClient.invalidateQueries({
+                    queryKey: queryKeys.connectors.all,
+                  });
+                } else if (connection?.status === "needs_reconnect") {
+                  stopPolling(slug);
+                  setPhase(slug, null);
+                  setError(
+                    connection.statusReason ??
+                      "That connection could not be completed. Try again.",
+                  );
+                  void queryClient.invalidateQueries({
+                    queryKey: queryKeys.connectors.all,
+                  });
+                }
+              })
+              .catch(() => {});
+          }, POLL_INTERVAL_MS);
+          timers.current.set(slug, timer);
+        })
+        .catch((cause) => {
+          setPhase(slug, null);
+          setError(
+            cause instanceof Error
+              ? cause.message
+              : "Could not start that connection.",
+          );
+        });
+    },
+    [queryClient, setPhase, stopPolling],
+  );
+
+  return { connect, phases, error, clearError: () => setError(null) };
+}

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -3229,3 +3229,268 @@
   font-size: 10.5px;
   color: var(--tavern-mute);
 }
+
+/* ── Apps page v2: logos, detail pane, in-chat connect cards ─────────── */
+
+.connector-card {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.connector-card-open {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.connector-card-open:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+.connector-logo {
+  box-sizing: border-box;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 8px;
+  padding: 4px;
+  background: #fff;
+  object-fit: contain;
+}
+
+.connector-logo.is-large,
+.connector-mark.is-large {
+  width: 44px;
+  height: 44px;
+}
+
+.connector-mark.is-large {
+  font-size: 24px;
+}
+
+.connector-detail {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.connector-detail-back {
+  align-self: flex-start;
+  margin: 0;
+  padding: 2px 6px 2px 0;
+  border: 0;
+  background: none;
+  font-family: var(--tavern-mono);
+  font-size: 11px;
+  color: var(--tavern-robe);
+  cursor: pointer;
+}
+
+.connector-detail-back:hover {
+  color: var(--tavern-lantern);
+}
+
+.connector-detail-head {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+.connector-detail-title p {
+  margin: 3px 0 0;
+  font-size: 12px;
+  color: var(--tavern-robe);
+}
+
+.connector-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.connector-chip {
+  padding: 2px 8px;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 999px;
+  background: var(--tavern-card);
+  font-family: var(--tavern-mono);
+  font-size: 10px;
+  color: var(--tavern-robe);
+}
+
+.connector-chip.is-muted {
+  opacity: 0.75;
+}
+
+.connector-chip.is-link {
+  cursor: pointer;
+}
+
+.connector-chip.is-link:hover {
+  border-color: var(--tavern-lantern);
+  color: var(--tavern-lantern);
+}
+
+.connector-detail-action {
+  align-self: flex-start;
+}
+
+.connector-detail-status {
+  margin: -6px 0 0;
+  font-size: 11px;
+  color: var(--tavern-robe);
+}
+
+.connector-detail-section {
+  display: grid;
+  gap: 8px;
+}
+
+.connector-workflows {
+  display: grid;
+  gap: 6px;
+}
+
+.connector-workflow {
+  display: grid;
+  gap: 2px;
+  padding: 8px 10px;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 10px;
+  background: var(--tavern-card);
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 120ms ease;
+}
+
+.connector-workflow:hover:not(:disabled) {
+  border-color: var(--tavern-lantern);
+}
+
+.connector-workflow:disabled {
+  cursor: default;
+}
+
+.connector-workflow strong {
+  font-size: 12px;
+}
+
+.connector-workflow small {
+  font-size: 11px;
+  color: var(--tavern-robe);
+}
+
+.connector-tools {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.connector-tools li {
+  display: grid;
+  gap: 2px;
+  border-bottom: 1px dashed var(--tavern-rule);
+  padding-bottom: 8px;
+}
+
+.connector-tools li:last-child {
+  border-bottom: 0;
+}
+
+.connector-tools strong {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.connector-tool-ro {
+  padding: 1px 6px;
+  border: 1px solid #9daa7b;
+  border-radius: 999px;
+  font-family: var(--tavern-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4a7c46;
+}
+
+.connector-tools p {
+  margin: 0;
+  font-size: 11px;
+  color: var(--tavern-robe);
+}
+
+.tavern-connect-cards {
+  display: grid;
+  gap: 8px;
+  margin: 4px 0;
+}
+
+.tavern-connect-card {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 10px;
+  padding: 9px;
+  background: color-mix(in srgb, var(--tavern-parchment) 74%, var(--tavern-card));
+}
+
+.tavern-connect-card.is-connected {
+  border-color: #9daa7b;
+}
+
+.tavern-connect-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.tavern-connect-copy strong {
+  font-size: 12px;
+}
+
+.tavern-connect-copy p {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  margin: 0;
+  overflow: hidden;
+  font-size: 11px;
+  color: var(--tavern-robe);
+}
+
+.tavern-connect-actions {
+  display: grid;
+  gap: 4px;
+}
+
+.tavern-connect-done {
+  color: #4a7c46;
+  font-size: 14px;
+}
+
+.tavern-connect-error {
+  margin: 0;
+  font-size: 11px;
+  color: #a04d3c;
+}

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -3494,3 +3494,167 @@
   font-size: 11px;
   color: #a04d3c;
 }
+
+/* ── Experiment: wider panel, two-column app grid ─────────────────────── */
+
+.connector-group {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.connector-group-label,
+.connector-group .connector-skeleton,
+.connector-group .connector-empty {
+  grid-column: 1 / -1;
+}
+
+.connector-card {
+  grid-template-columns: minmax(0, 1fr);
+  align-content: start;
+  row-gap: 8px;
+}
+
+.connector-card .connector-action {
+  width: 100%;
+}
+
+/* ── Cancel/remove for stuck connections ─────────────────────────────── */
+
+.connector-card-actions,
+.connector-detail-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: stretch;
+}
+
+.connector-detail-actions {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.connector-cancel {
+  border: 1px solid var(--tavern-rule);
+  border-radius: 7px;
+  padding: 4px 8px;
+  background: none;
+  color: var(--tavern-robe);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10.5px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.connector-cancel:hover:not(:disabled) {
+  border-color: #a04d3c;
+  color: #a04d3c;
+}
+
+.connector-cancel:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* ── Experiment: quieter connect buttons in app cards ────────────────── */
+
+.connector-card .connector-action {
+  border-color: var(--tavern-rule);
+  background: none;
+  color: var(--tavern-robe);
+  font-weight: 600;
+}
+
+.connector-card .connector-action:hover:not(:disabled) {
+  filter: none;
+  border-color: var(--tavern-lantern);
+  color: var(--tavern-lantern);
+  background: color-mix(in srgb, var(--tavern-lantern) 8%, transparent);
+}
+
+.connector-card.is-connected .connector-action {
+  border-color: transparent;
+  color: var(--tavern-mute);
+}
+
+.connector-card.is-connected .connector-action:hover:not(:disabled) {
+  border-color: var(--tavern-rule);
+  color: #a04d3c;
+  background: none;
+}
+
+.connector-card.needs-reconnect .connector-action {
+  border-color: var(--tavern-lantern);
+  color: var(--tavern-lantern);
+}
+
+/* ── Experiment: tighter cards for the narrower two-column grid ──────── */
+
+.connector-card {
+  padding: 8px;
+}
+
+.connector-card-heading strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── API-key connect form ────────────────────────────────────────────── */
+
+.connector-keyform {
+  display: grid;
+  gap: 8px;
+}
+
+.connector-keyfield {
+  display: grid;
+  gap: 3px;
+}
+
+.connector-keyfield span {
+  font-family: var(--tavern-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--tavern-mute);
+}
+
+.connector-keyfield input {
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 7px;
+  padding: 6px 8px;
+  background: var(--tavern-card);
+  color: inherit;
+  font: inherit;
+  font-size: 12px;
+}
+
+.connector-keyfield input:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: 1px;
+}
+
+.connector-keyfield small {
+  font-size: 10px;
+  color: var(--tavern-mute);
+}
+
+.connector-keyform .connector-action {
+  justify-self: start;
+}
+
+.connector-detail-keyform {
+  display: grid;
+  gap: 8px;
+}
+
+.tavern-connect-keyform {
+  grid-column: 1 / -1;
+  border-top: 1px dashed var(--tavern-rule);
+  padding-top: 8px;
+}

--- a/apps/electron/src/shared/panel.ts
+++ b/apps/electron/src/shared/panel.ts
@@ -1,4 +1,10 @@
-export const PANEL_TABS = ["chat", "history", "todos", "notes"] as const;
+export const PANEL_TABS = [
+  "chat",
+  "history",
+  "todos",
+  "notes",
+  "apps",
+] as const;
 export type PanelTab = (typeof PANEL_TABS)[number];
 
 // 380px of bubble + 7px of hard shadow.

--- a/apps/electron/src/shared/panel.ts
+++ b/apps/electron/src/shared/panel.ts
@@ -7,8 +7,8 @@ export const PANEL_TABS = [
 ] as const;
 export type PanelTab = (typeof PANEL_TABS)[number];
 
-// 380px of bubble + 7px of hard shadow.
-export const PANEL_WIDTH = 387;
+// 390px of bubble + 7px of hard shadow.
+export const PANEL_WIDTH = 397;
 export const PANEL_HEIGHT = 624;
 export const PANEL_GAP = 10;
 export const COMPANION_CLEARANCE = 84;


### PR DESCRIPTION
Implements the desktop half of the Connected Apps v2 spec (plan H9JWSKWJbmGBjHD1). Pairs with freestyle-voice/cloud#126, which adds the endpoints and the suggest_connections agent tool this consumes.

## Apps tab on the home screen
- Connected apps move out of Settings into a top-level **Apps** tab next to Chat/History/Todos/Notes.
- Three sections: **Connected** (from the connections endpoint), **Suggested** (~12 curated flagship apps), and **All apps** behind the search box.
- Search is now server-side (debounced `?search=`) across the full ~1,200-app catalog — the old "filter applies to apps loaded so far" client-side filter is gone. Infinite scroll remains for browsing.
- Real logos from Composio's CDN with the old monogram as fallback (panel CSP gains `img-src https://logos.composio.dev`).
- Tapping a card opens a detail pane: logo, description, category chips, website link, example workflows (tapping one seeds the chat), and the full tool list with read-only tags — what Freestyle can actually do before the user grants OAuth.

## In-chat connect cards
- New `ConnectSuggestions` renderer for `tool-suggest_connections` message parts: logo + description cards with Connect / Not now, replacing the generic tool chip. Cards persist with the message and flip to "Connected — ask me again and I'll use it." when OAuth completes.
- New shared `useConnectorConnect` hook (system-browser handoff + 2s status polling + query invalidation) used by both the Apps page and chat cards, replacing the page-local polling implementation.

Tests: 57 passing, typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)