### PR TITLE
feat: Onboarding v2: six beats, connect-to-automate, receipt handoff

### DIFF
--- a/apps/electron/src/renderer/src/components/onboarding.tsx
+++ b/apps/electron/src/renderer/src/components/onboarding.tsx
@@ -353,7 +353,7 @@ export function OnboardingGate({
   const connectionsQuery = useQuery(connectorConnectionsQueryOptions());
   const suggestedQuery = useQuery(connectorSuggestedQueryOptions());
   const suggested = useMemo(
-    () => suggestedQuery.data ?? [],
+    () => suggestedQuery.data?.connectors ?? [],
     [suggestedQuery.data],
   );
 

--- a/apps/electron/src/renderer/src/components/onboarding.tsx
+++ b/apps/electron/src/renderer/src/components/onboarding.tsx
@@ -1,13 +1,22 @@
+import "../onboarding.css";
+
+import { ConnectorLogo } from "@renderer/components/connected-apps";
 import { apiFetch } from "@renderer/lib/api";
 import { readBrainFile, writeBrainFile } from "@renderer/lib/brain-fs";
+import type { ConnectorCatalogItem } from "@renderer/lib/connectors";
 import {
+  AUTOMATION_LABELS,
   BEATS,
   type BeatId,
   beatLines,
+  CALENDAR_TEMPLATE_IDS,
   EASTER_EGGS,
+  EMAIL_TEMPLATE_IDS,
   firstNameOf,
   handoffCta,
   jobPlaceholder,
+  ONBOARDING_CALENDAR_APPS,
+  ONBOARDING_EMAIL_APPS,
   ONBOARDING_KEY,
   type OnboardingSaved,
   PROFILE_INDEX_LINE,
@@ -18,12 +27,21 @@ import {
   SKIP_LINE,
   TRADE_CHIPS,
 } from "@renderer/lib/onboarding-core";
+import {
+  connectorConnectionsQueryOptions,
+  connectorSuggestedQueryOptions,
+} from "@renderer/lib/query";
+import { applyAutomationTemplates } from "@renderer/lib/scheduled-templates";
+import {
+  type ConnectPhase,
+  useConnectorConnect,
+} from "@renderer/lib/use-connector-connect";
 import { useUpdateProfileFields } from "@renderer/lib/use-profile";
-import { SpriteBadge } from "@renderer/sprites/badge";
 import type { CloudUser } from "@shared/cloud-user";
 import type { SpriteId } from "@shared/sprites";
+import { useQuery } from "@tanstack/react-query";
 import type React from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 function persistSaved(state: OnboardingSaved): void {
   void apiFetch(`/api/settings/${ONBOARDING_KEY}`, {
@@ -77,7 +95,7 @@ export function useOnboarding(enabled: boolean): {
       } else if (parsed) {
         setStatus("show");
       } else if (threads.length > 0) {
-        const grandfathered: OnboardingSaved = { v: 1, done: true };
+        const grandfathered: OnboardingSaved = { v: 2, done: true };
         persistSaved(grandfathered);
         setSaved(grandfathered);
         setStatus("done");
@@ -93,9 +111,11 @@ export function useOnboarding(enabled: boolean): {
   const markDone = useCallback((task: string): void => {
     setSaved((prev) => {
       const next: OnboardingSaved = {
-        v: 1,
+        v: 2,
         done: true,
         task: task.trim(),
+        ...(prev?.connected?.length ? { connected: prev.connected } : {}),
+        ...(prev?.automations?.length ? { automations: prev.automations } : {}),
         ...(prev?.replayed ? { replayed: true } : {}),
       };
       persistSaved(next);
@@ -105,7 +125,7 @@ export function useOnboarding(enabled: boolean): {
   }, []);
 
   const replay = useCallback((): void => {
-    const next: OnboardingSaved = { v: 1, done: false, replayed: true };
+    const next: OnboardingSaved = { v: 2, done: false, replayed: true };
     persistSaved(next);
     setSaved(next);
     setStatus("show");
@@ -114,7 +134,7 @@ export function useOnboarding(enabled: boolean): {
   return { status, saved, markDone, replay };
 }
 
-/** The list beat's real write: the user's own sentence onto their own list. */
+/** The goal's real write: the user's own sentence onto their own list. */
 async function seedTodo(quest: string): Promise<void> {
   const todos = await readBrainFile("todos.md");
   if (todos?.includes(quest)) return;
@@ -122,7 +142,7 @@ async function seedTodo(quest: string): Promise<void> {
   await writeBrainFile("todos.md", `${base}- [ ] ${quest}\n`);
 }
 
-/** The brain beat's real write: the profile page plus its index line. */
+/** The profile's real write: the profile page plus its index line. */
 async function seedProfile(name: string, trade: string): Promise<void> {
   await writeBrainFile(PROFILE_PATH, profileMarkdown(name, trade));
   const index = await readBrainFile("BRAIN.md");
@@ -176,146 +196,123 @@ function useTypewriter(text: string): {
   return { shown: text.slice(0, count), typing: count < text.length, finish };
 }
 
-/* Pixel-accurate miniatures of the real tabs — onboarding doubles as a map
-   of the product, so these echo the panel's own patterns, not new ones. */
+const APP_FALLBACK_NAMES: Record<string, string> = {
+  gmail: "Gmail",
+  outlook: "Outlook",
+  googlecalendar: "Google Calendar",
+};
 
-function MiniTabs({ active }: { active: string }): React.JSX.Element {
+function ConnectStage({
+  apps,
+  templates,
+  suggested,
+  activeSlugs,
+  phases,
+  applied,
+  onConnect,
+}: {
+  apps: readonly string[];
+  templates: readonly string[];
+  suggested: ConnectorCatalogItem[];
+  activeSlugs: ReadonlySet<string>;
+  phases: Record<string, ConnectPhase>;
+  applied: ReadonlySet<string>;
+  onConnect: (slug: string) => void;
+}): React.JSX.Element {
+  const anyConnected = apps.some((slug) => activeSlugs.has(slug));
   return (
-    <div className="tavern-onb-mtabs">
-      {["Chat", "History", "Todos", "Notes"].map((tab) => (
-        <span
-          key={tab}
-          className={`tavern-onb-mtab${tab === active ? " is-on" : ""}`}
-        >
-          {tab}
-        </span>
-      ))}
+    <div className="tavern-onb-connect">
+      <div className="tavern-onb-apps">
+        {apps.map((slug) => {
+          const item = suggested.find((entry) => entry.slug === slug);
+          const name = item?.name ?? APP_FALLBACK_NAMES[slug] ?? slug;
+          const connected = activeSlugs.has(slug);
+          const phase = phases[slug];
+          return (
+            <div
+              key={slug}
+              className={`tavern-onb-app${connected ? " is-on" : ""}`}
+            >
+              <ConnectorLogo name={name} logo={item?.logo} />
+              <span className="tavern-onb-app-name">{name}</span>
+              {connected ? (
+                <span className="tavern-onb-app-done">Connected ✓</span>
+              ) : (
+                <button
+                  type="button"
+                  className="tavern-onb-cta is-small"
+                  disabled={phase === "opening" || phase === "pending"}
+                  onClick={() => onConnect(slug)}
+                >
+                  {phase === "opening"
+                    ? "Opening…"
+                    : phase === "pending"
+                      ? "In browser…"
+                      : "Connect"}
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <ul className="tavern-onb-autos">
+        {templates.map((id) => (
+          <li key={id} className={applied.has(id) ? "is-set" : ""}>
+            <i>{applied.has(id) ? "✓" : "◇"}</i>
+            {AUTOMATION_LABELS[id] ?? id}
+          </li>
+        ))}
+      </ul>
+      {anyConnected && templates.some((id) => !applied.has(id)) ? (
+        <span className="tavern-onb-writing">setting up…</span>
+      ) : null}
     </div>
   );
 }
 
-function MiniTodos({
+function ReceiptStage({
+  connectedNames,
+  automations,
   quest,
-  seeded,
+  hasTask,
 }: {
+  connectedNames: string[];
+  automations: string[];
   quest: string;
-  seeded: boolean;
+  hasTask: boolean;
 }): React.JSX.Element {
   return (
-    <div className="tavern-onb-mini">
-      <MiniTabs active="Todos" />
-      <div className="tavern-onb-mbody">
-        {seeded ? (
-          <div className="tavern-onb-mtodo">
-            <span className="tavern-onb-mcheck" />
-            <span className="tavern-onb-mtodo-main">{quest}</span>
-          </div>
+    <div className="tavern-onb-receipt">
+      <div className="tavern-onb-bigq">
+        On <i>watch.</i>
+      </div>
+      <ul className="tavern-onb-rlist">
+        {connectedNames.length > 0 ? (
+          <li>
+            <b>Connected</b>
+            <span>{connectedNames.join(" · ")}</span>
+          </li>
         ) : (
-          <span className="tavern-onb-writing">writing…</span>
+          <li className="is-dim">
+            <b>Connected</b>
+            <span>nothing yet — the Apps tab is always there</span>
+          </li>
         )}
-        <div className="tavern-onb-mtodo is-done">
-          <span className="tavern-onb-mcheck is-on" />
-          <span>Meet Jeb</span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function MiniNotes({
-  name,
-  trade,
-  seeded,
-}: {
-  name: string;
-  trade: string;
-  seeded: boolean;
-}): React.JSX.Element {
-  return (
-    <div className="tavern-onb-mini">
-      <MiniTabs active="Notes" />
-      <div className="tavern-onb-mbody">
-        <div className="tavern-onb-mnote">
-          <b>Profile</b>
-          {seeded ? (
-            <i>
-              {name}
-              {trade ? ` — ${trade.toLowerCase()}` : ""}. Captured during
-              onboarding.
-            </i>
-          ) : (
-            <i className="tavern-onb-writing">writing…</i>
-          )}
-        </div>
-        <div className="tavern-onb-mnote is-dim">
-          <b>Notes</b>
-          <i>anything worth keeping lands here</i>
-        </div>
-        <div className="tavern-onb-mnote is-dim">
-          <b>Skills</b>
-          <i>teach me once, I do it your way every time</i>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function MiniApproval(): React.JSX.Element {
-  return (
-    <div className="tavern-onb-mini">
-      <MiniTabs active="Chat" />
-      <div className="tavern-onb-mbody">
-        <div className="tavern-onb-muser">What ended the Edo period?</div>
-        <div className="tavern-onb-mtool">
-          <i>◆</i> read your screen ▸
-        </div>
-        <div className="tavern-onb-mappr">
-          <span className="tavern-onb-mappr-t">
-            jeb wants to type at your cursor
-          </span>
-          <span>“The Meiji Restoration — 1868.”</span>
-          <span className="tavern-onb-mabtn">
-            <span className="is-go">Allow</span>
-            <span>Don't allow</span>
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function MiniSearch(): React.JSX.Element {
-  return (
-    <div className="tavern-onb-mini">
-      <MiniTabs active="Chat" />
-      <div className="tavern-onb-mbody">
-        <div className="tavern-onb-muser">Latest news in Austin?</div>
-        <div className="tavern-onb-mtool">
-          <i>◆</i> searched the web ▸
-        </div>
-        <span>
-          “City breaks ground on new transit line.”{" "}
-          <i className="tavern-onb-msrc">Austin Chronicle, this morning.</i>
-        </span>
-      </div>
-    </div>
-  );
-}
-
-function DeskMiniature({
-  spriteForm,
-}: {
-  spriteForm: SpriteId;
-}): React.JSX.Element {
-  return (
-    <div className="tavern-onb-desk">
-      <div className="tavern-onb-deskwin">
-        <i />
-      </div>
-      <div className="tavern-onb-deskjeb">
-        <SpriteBadge form={spriteForm} size={64} />
-      </div>
-      <span className="tavern-onb-deskhome">← home</span>
+        {automations.length > 0 ? (
+          <li>
+            <b>Automations</b>
+            <span>
+              {automations.map((id) => AUTOMATION_LABELS[id] ?? id).join(" · ")}
+            </span>
+          </li>
+        ) : null}
+        {hasTask ? (
+          <li>
+            <b>First job</b>
+            <span>{quest}</span>
+          </li>
+        ) : null}
+      </ul>
     </div>
   );
 }
@@ -331,29 +328,62 @@ export function OnboardingGate({
   saved: OnboardingSaved | null;
   onDone: (task: string) => void;
 }): React.JSX.Element {
+  void spriteForm;
   const [beat, setBeat] = useState<BeatId>(() =>
-    saved?.beat && BEATS.includes(saved.beat) ? saved.beat : "welcome",
+    saved?.beat && BEATS.includes(saved.beat) ? saved.beat : "name",
   );
   const [lineIdx, setLineIdx] = useState(0);
   const [name, setName] = useState(saved?.name ?? user.name ?? "");
   const [trade, setTrade] = useState(saved?.trade ?? "");
   const [task, setTask] = useState(saved?.task ?? "");
-  const [todoSeeded, setTodoSeeded] = useState(false);
-  const [profileSeeded, setProfileSeeded] = useState(false);
+  const [applied, setApplied] = useState<ReadonlySet<string>>(
+    () => new Set(saved?.automations ?? []),
+  );
   const [skipping, setSkipping] = useState(false);
   const [egg, setEgg] = useState<string | null>(null);
   const eggIdx = useRef(0);
   const eggTimer = useRef<number | null>(null);
   const todoStarted = useRef(false);
   const profileStarted = useRef(false);
-  const traveled = useRef(false);
+  const emailApplying = useRef(false);
+  const calendarApplying = useRef(false);
   const updateProfile = useUpdateProfileFields();
+
+  const { connect, phases } = useConnectorConnect();
+  const connectionsQuery = useQuery(connectorConnectionsQueryOptions());
+  const suggestedQuery = useQuery(connectorSuggestedQueryOptions());
+  const suggested = useMemo(
+    () => suggestedQuery.data ?? [],
+    [suggestedQuery.data],
+  );
+
+  const activeSlugs = useMemo(() => {
+    const slugs = new Set(
+      (connectionsQuery.data ?? [])
+        .filter((connection) => connection.status === "active")
+        .map((connection) => connection.toolkitSlug),
+    );
+    for (const [slug, phase] of Object.entries(phases)) {
+      if (phase === "connected") slugs.add(slug);
+    }
+    return slugs;
+  }, [connectionsQuery.data, phases]);
+
+  const beatIndex = BEATS.indexOf(beat);
+  const emailConnected = ONBOARDING_EMAIL_APPS.some((slug) =>
+    activeSlugs.has(slug),
+  );
+  const calendarConnected = ONBOARDING_CALENDAR_APPS.some((slug) =>
+    activeSlugs.has(slug),
+  );
 
   const scene = beatLines(beat, {
     name,
     trade,
     task,
     accountName: user.name,
+    emailConnected,
+    calendarConnected,
   });
   const lastIdx = scene.lines.length - 1;
   const atLastLine = lineIdx >= lastIdx;
@@ -367,24 +397,25 @@ export function OnboardingGate({
   const persist = useCallback(
     (nextBeat: BeatId): void => {
       persistSaved({
-        v: 1,
+        v: 2,
         done: false,
         beat: nextBeat,
         name: name.trim(),
         trade: trade.trim(),
         task: task.trim(),
+        connected: [...activeSlugs].filter((slug) =>
+          [...ONBOARDING_EMAIL_APPS, ...ONBOARDING_CALENDAR_APPS].includes(
+            slug as (typeof ONBOARDING_EMAIL_APPS)[number],
+          ),
+        ),
+        automations: [...applied],
         ...(saved?.replayed ? { replayed: true } : {}),
       });
     },
-    [name, trade, task, saved],
+    [name, trade, task, activeSlugs, applied, saved],
   );
 
-  const beatDone =
-    beat === "name"
-      ? name.trim().length > 0
-      : beat === "list"
-        ? todoSeeded
-        : beat !== "ledger" || profileSeeded;
+  const beatDone = beat !== "name" || name.trim().length > 0;
 
   const advanceBeat = useCallback((): void => {
     const index = BEATS.indexOf(beat);
@@ -405,77 +436,82 @@ export function OnboardingGate({
       setLineIdx((prev) => prev + 1);
       return;
     }
-    if (beatDone && beat !== "handoff") advanceBeat();
+    if (beatDone && beat !== "receipt") advanceBeat();
   }, [skipping, typing, finish, atLastLine, beatDone, beat, advanceBeat]);
 
-  // Welcome flourish from the real corner sprite.
+  // Opening flourish from the real corner sprite.
   useEffect(() => {
-    if (beat === "welcome") {
+    if (beat === "name") {
       window.api.spriteEvent({ kind: "emote", emotion: "proud" });
     }
   }, [beat]);
 
-  // The list beat: the user's sentence lands on their real list while Jeb
-  // types. Reads the entry render's closure and keys on the beat alone —
-  // re-running on render identities would clear the timer behind the guard.
+  // Automations follow connections: once the flow has reached the matching
+  // beat and an app in the group is active, the templates are applied
+  // server-side. Idempotent there, so replays and re-renders are safe.
+  useEffect(() => {
+    if (beatIndex < BEATS.indexOf("inbox")) return;
+    if (!emailConnected || emailApplying.current) return;
+    if (EMAIL_TEMPLATE_IDS.every((id) => applied.has(id))) return;
+    emailApplying.current = true;
+    void applyAutomationTemplates([...EMAIL_TEMPLATE_IDS])
+      .then((result) => {
+        window.api.spriteEvent({ kind: "emote", emotion: "proud" });
+        setApplied((prev) => {
+          const next = new Set(prev);
+          for (const entry of result.applied) next.add(entry.id);
+          for (const entry of result.skipped)
+            if (entry.reason === "exists") next.add(entry.id);
+          return next;
+        });
+      })
+      .catch(() => {
+        emailApplying.current = false;
+      });
+  }, [beatIndex, emailConnected, applied]);
+
+  useEffect(() => {
+    if (beatIndex < BEATS.indexOf("compass")) return;
+    if (!calendarConnected || calendarApplying.current) return;
+    if (CALENDAR_TEMPLATE_IDS.every((id) => applied.has(id))) return;
+    calendarApplying.current = true;
+    void applyAutomationTemplates([...CALENDAR_TEMPLATE_IDS])
+      .then((result) => {
+        window.api.spriteEvent({ kind: "emote", emotion: "proud" });
+        setApplied((prev) => {
+          const next = new Set(prev);
+          for (const entry of result.applied) next.add(entry.id);
+          for (const entry of result.skipped)
+            if (entry.reason === "exists") next.add(entry.id);
+          return next;
+        });
+      })
+      .catch(() => {
+        calendarApplying.current = false;
+      });
+  }, [beatIndex, calendarConnected, applied]);
+
+  // The receipt does the quiet writes: the goal onto the real list, the
+  // profile into the brain. Keys on the beat alone, same contract as v1.
   // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   useEffect(() => {
-    if (beat !== "list" || todoStarted.current) return;
-    todoStarted.current = true;
-    window.api.spriteEvent({ kind: "thinking", on: true });
-    const delay = prefersReducedMotion() ? 0 : 700;
-    const t = window.setTimeout(() => {
-      void seedTodo(questFor(task))
+    if (beat !== "receipt") return;
+    if (!todoStarted.current && task.trim()) {
+      todoStarted.current = true;
+      void seedTodo(questFor(task)).catch(() => {});
+    }
+    if (!profileStarted.current) {
+      profileStarted.current = true;
+      void seedProfile(firstNameOf(name) ? name.trim() : "friend", trade.trim())
         .catch(() => {})
         .then(() => {
-          window.api.spriteEvent({ kind: "thinking", on: false });
-          window.api.spriteEvent({ kind: "emote", emotion: "proud" });
-          setTodoSeeded(true);
+          if (trade.trim()) {
+            updateProfile
+              .mutateAsync({ jobTitle: trade.trim() })
+              .catch(() => {});
+          }
         });
-    }, delay);
-    return () => window.clearTimeout(t);
-  }, [beat]);
-
-  // The brain beat: the profile page is written for real, plus the prefill.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: same contract as the list beat
-  useEffect(() => {
-    if (beat !== "ledger" || profileStarted.current) return;
-    profileStarted.current = true;
-    void seedProfile(firstNameOf(name) ? name.trim() : "friend", trade.trim())
-      .catch(() => {})
-      .then(() => {
-        if (trade.trim()) {
-          updateProfile.mutateAsync({ jobTitle: trade.trim() }).catch(() => {});
-        }
-        window.api.spriteEvent({ kind: "emote", emotion: "proud" });
-        setProfileSeeded(true);
-      });
-  }, [beat]);
-
-  // The corner beat: the real sprite makes the trip home while the stage
-  // shows the desktop miniature.
-  useEffect(() => {
-    if (beat !== "corner" || traveled.current) return;
-    traveled.current = true;
-    // No cleanup on either timer: the end event must land even if the user
-    // advances before the dash finishes, or the sprite is stranded mid-travel.
-    window.setTimeout(() => {
-      window.api.spriteEvent({
-        kind: "travel",
-        phase: "start",
-        travelKind: "dash",
-        direction: "left",
-      });
-    }, 400);
-    window.setTimeout(() => {
-      window.api.spriteEvent({
-        kind: "travel",
-        phase: "end",
-        travelKind: "dash",
-        direction: "left",
-      });
-      window.api.spriteEvent({ kind: "emote", emotion: "proud" });
-    }, 1300);
+    }
   }, [beat]);
 
   useEffect(() => {
@@ -512,7 +548,7 @@ export function OnboardingGate({
   }, [onDone, task]);
 
   // Enter anywhere is Next: finishes the typing line, steps the scene, and
-  // advances the beat — including the handoff CTA. Buttons keep their native
+  // advances the beat — including the receipt CTA. Buttons keep their native
   // Enter activation (handling it here too would double-fire), and the
   // gating lives in advance()/beatDone, so a blocked beat just holds.
   useEffect(() => {
@@ -520,7 +556,7 @@ export function OnboardingGate({
       if (e.key !== "Enter" || e.isComposing || skipping) return;
       if ((e.target as HTMLElement | null)?.tagName === "BUTTON") return;
       e.preventDefault();
-      if (beat === "handoff" && atLastLine && !typing) {
+      if (beat === "receipt" && atLastLine && !typing) {
         complete();
         return;
       }
@@ -531,6 +567,31 @@ export function OnboardingGate({
   }, [skipping, beat, atLastLine, typing, complete, advance]);
 
   const inputReady = atLastLine && !typing && !skipping;
+  const connectedNames = useMemo(() => {
+    const wanted = new Set([
+      ...ONBOARDING_EMAIL_APPS,
+      ...ONBOARDING_CALENDAR_APPS,
+    ]);
+    return [...activeSlugs]
+      .filter((slug) => wanted.has(slug as never))
+      .map(
+        (slug) =>
+          suggested.find((entry) => entry.slug === slug)?.name ??
+          APP_FALLBACK_NAMES[slug] ??
+          slug,
+      );
+  }, [activeSlugs, suggested]);
+
+  const nextLabel =
+    beat === "inbox"
+      ? emailConnected
+        ? "Next ▸"
+        : "Later ▸"
+      : beat === "compass"
+        ? calendarConnected
+          ? "Next ▸"
+          : "Later ▸"
+        : "Next ▸";
 
   return (
     <div className="tavern-onb" data-beat={beat} data-line={lineIdx}>
@@ -555,30 +616,25 @@ export function OnboardingGate({
       </div>
 
       <div className="tavern-onb-stage">
-        {beat === "welcome" ? (
+        {beat === "name" ? (
           <>
             <div className="tavern-onb-bigq">
-              Someone's at
+              Nothing slips
               <br />
-              the <i>door.</i>
+              past <i>Jeb.</i>
             </div>
-            <p className="tavern-onb-sub">
-              A ronin has moved into the corner of your screen. He'd like a word
-              before you put him to work.
-            </p>
+            {inputReady ? (
+              <input
+                className="tavern-onb-in"
+                value={name}
+                maxLength={80}
+                placeholder="Your name"
+                // biome-ignore lint/a11y/noAutofocus: the input is the beat's whole point
+                autoFocus
+                onChange={(e) => setName(e.target.value)}
+              />
+            ) : null}
           </>
-        ) : null}
-
-        {beat === "name" && inputReady ? (
-          <input
-            className="tavern-onb-in"
-            value={name}
-            maxLength={80}
-            placeholder="Your name"
-            // biome-ignore lint/a11y/noAutofocus: the input is the beat's whole point
-            autoFocus
-            onChange={(e) => setName(e.target.value)}
-          />
         ) : null}
 
         {beat === "trade" && inputReady ? (
@@ -607,12 +663,36 @@ export function OnboardingGate({
           </>
         ) : null}
 
-        {beat === "job" && inputReady ? (
+        {beat === "inbox" && !skipping ? (
+          <ConnectStage
+            apps={ONBOARDING_EMAIL_APPS}
+            templates={EMAIL_TEMPLATE_IDS}
+            suggested={suggested}
+            activeSlugs={activeSlugs}
+            phases={phases}
+            applied={applied}
+            onConnect={connect}
+          />
+        ) : null}
+
+        {beat === "compass" && !skipping ? (
+          <ConnectStage
+            apps={ONBOARDING_CALENDAR_APPS}
+            templates={CALENDAR_TEMPLATE_IDS}
+            suggested={suggested}
+            activeSlugs={activeSlugs}
+            phases={phases}
+            applied={applied}
+            onConnect={connect}
+          />
+        ) : null}
+
+        {beat === "goal" && inputReady ? (
           <>
             <div className="tavern-onb-bigq">
-              One thing you
+              One thing,
               <br />
-              need <i>done.</i>
+              today or <i>tomorrow.</i>
             </div>
             <input
               className="tavern-onb-in"
@@ -626,46 +706,13 @@ export function OnboardingGate({
           </>
         ) : null}
 
-        {beat === "list" && !skipping ? (
-          <MiniTodos quest={questFor(task)} seeded={todoSeeded} />
-        ) : null}
-
-        {beat === "ledger" && !skipping ? (
-          <MiniNotes
-            name={firstNameOf(name) || "friend"}
-            trade={trade.trim()}
-            seeded={profileSeeded}
+        {beat === "receipt" && !skipping ? (
+          <ReceiptStage
+            connectedNames={connectedNames}
+            automations={[...applied]}
+            quest={questFor(task)}
+            hasTask={task.trim().length > 0}
           />
-        ) : null}
-
-        {beat === "blade" && !skipping ? <MiniApproval /> : null}
-
-        {beat === "road" && !skipping ? <MiniSearch /> : null}
-
-        {beat === "corner" && !skipping ? (
-          <DeskMiniature spriteForm={spriteForm} />
-        ) : null}
-
-        {beat === "handoff" && !skipping ? (
-          <>
-            <div className="tavern-onb-bigq">
-              No bowing,
-              <br />
-              thank the <i>gods.</i>
-            </div>
-            {task.trim() ? (
-              <div className="tavern-onb-mini">
-                <div className="tavern-onb-mbody">
-                  <div className="tavern-onb-mtodo">
-                    <span className="tavern-onb-mcheck" />
-                    <span className="tavern-onb-mtodo-main">
-                      {questFor(task)}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            ) : null}
-          </>
         ) : null}
       </div>
 
@@ -686,13 +733,7 @@ export function OnboardingGate({
           type="button"
           className="tavern-onb-saytext"
           onClick={() => {
-            if (
-              !skipping &&
-              (typing ||
-                !atLastLine ||
-                !["name", "trade", "job", "handoff"].includes(beat))
-            )
-              advance();
+            if (!skipping && (typing || !atLastLine)) advance();
           }}
         >
           {shown}
@@ -705,7 +746,7 @@ export function OnboardingGate({
 
       <div className="tavern-onb-foot2">
         <span />
-        {beat === "handoff" && atLastLine ? (
+        {beat === "receipt" && atLastLine ? (
           <button
             type="button"
             className="tavern-onb-cta"
@@ -721,7 +762,7 @@ export function OnboardingGate({
             disabled={typing || skipping || (atLastLine && !beatDone)}
             onClick={advance}
           >
-            {atLastLine ? "Next ▸" : "▸"}
+            {atLastLine ? nextLabel : "▸"}
           </button>
         )}
       </div>

--- a/apps/electron/src/renderer/src/lib/onboarding-core.test.ts
+++ b/apps/electron/src/renderer/src/lib/onboarding-core.test.ts
@@ -151,7 +151,7 @@ describe("beat script", () => {
     ).toContain("watched");
     expect(
       beatLines("compass", { ...ctx, emailConnected: false }).lines[0],
-    ).toContain("offer stands");
+    ).toContain("Suit yourself");
     expect(
       beatLines("goal", { ...ctx, calendarConnected: true }).lines[0],
     ).toContain("watch set");

--- a/apps/electron/src/renderer/src/lib/onboarding-core.test.ts
+++ b/apps/electron/src/renderer/src/lib/onboarding-core.test.ts
@@ -17,16 +17,38 @@ import {
 } from "./onboarding-core";
 
 describe("parseSaved", () => {
-  it("round-trips a valid state", () => {
-    const state = { v: 1, done: false, beat: "job", name: "Matt", task: "" };
+  it("round-trips a valid v2 state", () => {
+    const state = {
+      v: 2,
+      done: false,
+      beat: "goal",
+      name: "Matt",
+      task: "",
+      connected: ["gmail"],
+      automations: ["morning-inbox-brief"],
+    };
     expect(parseSaved(JSON.stringify(state))).toEqual(state);
+  });
+
+  it("drops an unknown saved beat so the flow restarts cleanly", () => {
+    const state = { v: 2, done: false, beat: "blade" };
+    expect(parseSaved(JSON.stringify(state))?.beat).toBeUndefined();
+  });
+
+  it("migrates a completed v1 save and restarts a mid-flow one", () => {
+    expect(
+      parseSaved(JSON.stringify({ v: 1, done: true, task: "old task" })),
+    ).toEqual({ v: 2, done: true, task: "old task" });
+    expect(
+      parseSaved(JSON.stringify({ v: 1, done: false, beat: "job" })),
+    ).toBeNull();
   });
 
   it("rejects garbage, wrong versions, and empty values", () => {
     expect(parseSaved(undefined)).toBeNull();
     expect(parseSaved("")).toBeNull();
     expect(parseSaved("not json")).toBeNull();
-    expect(parseSaved(JSON.stringify({ v: 2, done: true }))).toBeNull();
+    expect(parseSaved(JSON.stringify({ v: 3, done: true }))).toBeNull();
   });
 });
 
@@ -114,9 +136,9 @@ describe("beat script", () => {
     accountName: null,
   };
 
-  it("runs welcome-first, handoff-last", () => {
-    expect(BEATS[0]).toBe("welcome");
-    expect(BEATS[BEATS.length - 1]).toBe("handoff");
+  it("runs name-first, receipt-last", () => {
+    expect(BEATS[0]).toBe("name");
+    expect(BEATS[BEATS.length - 1]).toBe("receipt");
   });
 
   it("has lines for every beat", () => {
@@ -127,25 +149,40 @@ describe("beat script", () => {
     }
   });
 
+  it("leads with the value prop", () => {
+    expect(beatLines("name", ctx).lines[0]).toContain("slips");
+  });
+
   it("opens the trade beat with the name reaction", () => {
     expect(beatLines("trade", ctx).lines[0]).toContain("Matt");
   });
 
-  it("opens the job beat with the trade reaction", () => {
-    expect(beatLines("job", ctx).lines[0]).toContain("smith");
+  it("opens the inbox beat with the trade reaction", () => {
+    expect(beatLines("inbox", ctx).lines[0]).toContain("smith");
   });
 
-  it("tunes the job placeholder to the picked trade", () => {
+  it("acknowledges connections in the compass and goal beats", () => {
+    expect(
+      beatLines("compass", { ...ctx, emailConnected: true }).lines[0],
+    ).toContain("watched");
+    expect(
+      beatLines("compass", { ...ctx, emailConnected: false }).lines[0],
+    ).toContain("offer stands");
+    expect(
+      beatLines("goal", { ...ctx, calendarConnected: true }).lines[0],
+    ).toContain("watch set");
+  });
+
+  it("tunes the goal placeholder to the picked trade", () => {
     expect(jobPlaceholder("Engineer")).toContain("login bug");
     expect(jobPlaceholder("Teacher")).toContain("Grade the essays");
     expect(jobPlaceholder("Beekeeper")).toContain("Figure out my taxes");
     expect(jobPlaceholder("")).toContain("Figure out my taxes");
   });
 
-  it("swaps to no-task fallbacks when the job was skipped", () => {
+  it("swaps to no-task fallbacks when the goal was skipped", () => {
     const empty = { ...ctx, task: "" };
-    expect(beatLines("list", empty).lines.join(" ")).toContain("empty for now");
-    expect(beatLines("handoff", empty).lines.join(" ")).toContain("sharpening");
+    expect(beatLines("receipt", empty).lines.join(" ")).toContain("improvise");
   });
 });
 

--- a/apps/electron/src/renderer/src/lib/onboarding-core.test.ts
+++ b/apps/electron/src/renderer/src/lib/onboarding-core.test.ts
@@ -13,7 +13,6 @@ import {
   questFor,
   seedMessageFor,
   starterPrompts,
-  tradeReaction,
 } from "./onboarding-core";
 
 describe("parseSaved", () => {
@@ -91,21 +90,6 @@ describe("nameReaction", () => {
   });
 });
 
-describe("tradeReaction", () => {
-  it("has a bespoke line for every chip", () => {
-    expect(tradeReaction("Consultant")).toContain("hired blade");
-    expect(tradeReaction("Between things")).toContain("eleven years");
-  });
-
-  it("quotes custom trades back", () => {
-    expect(tradeReaction("Beekeeper")).toContain('"Beekeeper."');
-  });
-
-  it("handles an empty trade", () => {
-    expect(tradeReaction("  ")).toContain("watching what you ask");
-  });
-});
-
 describe("jobReaction", () => {
   it("calls short tasks blunt", () => {
     expect(jobReaction("Reply to Sam")).toContain("Blunt");
@@ -157,8 +141,8 @@ describe("beat script", () => {
     expect(beatLines("trade", ctx).lines[0]).toContain("Matt");
   });
 
-  it("opens the inbox beat with the trade reaction", () => {
-    expect(beatLines("inbox", ctx).lines[0]).toContain("smith");
+  it("goes straight to the mail pitch after the trade", () => {
+    expect(beatLines("inbox", ctx).lines[0]).toContain("Hook up your mail");
   });
 
   it("acknowledges connections in the compass and goal beats", () => {

--- a/apps/electron/src/renderer/src/lib/onboarding-core.ts
+++ b/apps/electron/src/renderer/src/lib/onboarding-core.ts
@@ -266,7 +266,7 @@ export function beatLines(beat: BeatId, ctx: BeatContext): BeatScene {
     case "inbox":
       return {
         lines: [
-          "Now the real work. Hook up your mail and I'll stand watch: a brief every weekday morning, and a word when something important is about to slip.",
+          "Now the real work. Hook up your mail and I'll stand watch. A daily brief of your inbox every weekday morning, and a reminder when something important is about to slip.",
         ],
         hint: "Your mail stays yours. I read; I never send.",
       };
@@ -275,7 +275,7 @@ export function beatLines(beat: BeatId, ctx: BeatContext): BeatScene {
         lines: [
           ctx.emailConnected
             ? "Good. The inbox is watched. Calendar next: mornings I'll lay your day out, and before meetings I'll hand you what you need walking in."
-            : "Suit yourself; the offer stands. Calendar, then: mornings I'll lay your day out, and before meetings I'll hand you what you need walking in.",
+            : "Suit yourself. Calendar then. Mornings I'll lay your day out, and before meetings I'll hand you what you need walking in.",
         ],
       };
     case "goal":

--- a/apps/electron/src/renderer/src/lib/onboarding-core.ts
+++ b/apps/electron/src/renderer/src/lib/onboarding-core.ts
@@ -75,35 +75,6 @@ export const TRADE_CHIPS = [
   "Between things",
 ] as const;
 
-const TRADE_REACTIONS: Record<string, string> = {
-  Engineer:
-    "A smith. You build the things everyone else swings around all day.",
-  Designer:
-    "You decide how a thing feels before anyone touches it. Closer to swordwork than you'd think.",
-  Founder: "A daimyo with no army yet. I've served worse odds.",
-  Product: "You pick which hill we take. Fine. I'll carry the map.",
-  Writer:
-    "Words. Careful with those. They cut both directions, and they don't stop when you do.",
-  Student:
-    "Training, then. Everyone's a student. Mine ran forty years and I still lost twice.",
-  Researcher:
-    "You chase the truth for a living. Slow work. Honest work. I like it.",
-  Marketer: "You decide where the eyes go. Half of any battle is exactly that.",
-  Consultant: "A hired blade. Ha. We'll get along.",
-  Operations:
-    "You keep the machine breathing while other people take the bow. Noted.",
-  Sales: "You talk people into things. So did every general worth remembering.",
-  Teacher:
-    "You sharpen other people. Better job than mine. Nobody writes songs about it.",
-  Finance:
-    "You count what's real. Somebody has to, or the camp starves by spring.",
-  Healthcare:
-    "You put people back together. I only ever did the other thing. Respect.",
-  Law: "Rules as weapons. Grim discipline. Still a discipline.",
-  "Between things":
-    "Between things. So was I, for eleven years. It ends. Sit down.",
-};
-
 /** The Job's placeholder examples, tuned to the trade they just picked. */
 const JOB_EXAMPLES: Record<string, [string, string, string]> = {
   Engineer: ["Fix the login bug", "Review Sam's PR", "Write the deploy script"],
@@ -248,17 +219,6 @@ export function nameReaction(
   return `${first}. Good name. Short enough to shout across a room.`;
 }
 
-export function tradeReaction(trade: string): string {
-  const trimmed = trade.trim();
-  if (!trimmed) {
-    return "Nothing? Fine. I'll work out what you do by watching what you ask.";
-  }
-  return (
-    TRADE_REACTIONS[trimmed] ??
-    `"${trimmed}." Never heard of it. You'll teach me.`
-  );
-}
-
 export function jobReaction(task: string): string {
   const trimmed = task.trim();
   if (!trimmed) {
@@ -306,7 +266,6 @@ export function beatLines(beat: BeatId, ctx: BeatContext): BeatScene {
     case "inbox":
       return {
         lines: [
-          tradeReaction(ctx.trade),
           "Now the real work. Hook up your mail and I'll stand watch: a brief every weekday morning, and a word when something important is about to slip.",
         ],
         hint: "Your mail stays yours. I read; I never send.",

--- a/apps/electron/src/renderer/src/lib/onboarding-core.ts
+++ b/apps/electron/src/renderer/src/lib/onboarding-core.ts
@@ -24,18 +24,36 @@ export function starterPrompts(): string[] {
 }
 
 export const BEATS = [
-  "welcome",
   "name",
   "trade",
-  "job",
-  "list",
-  "ledger",
-  "blade",
-  "road",
-  "corner",
-  "handoff",
+  "inbox",
+  "compass",
+  "goal",
+  "receipt",
 ] as const;
 export type BeatId = (typeof BEATS)[number];
+
+/** Connect-beat rosters and the automations each connection unlocks. Slugs
+ * and template ids mirror the cloud's SUGGESTED_TOOLKITS / AUTOMATION_TEMPLATES. */
+export const ONBOARDING_EMAIL_APPS = ["gmail", "outlook"] as const;
+export const ONBOARDING_CALENDAR_APPS = ["googlecalendar", "outlook"] as const;
+export const EMAIL_TEMPLATE_IDS = [
+  "morning-inbox-brief",
+  "inbox-slip-watch",
+  "friday-wrap",
+] as const;
+export const CALENDAR_TEMPLATE_IDS = [
+  "plan-my-day",
+  "meeting-prep-nudge",
+] as const;
+
+export const AUTOMATION_LABELS: Record<string, string> = {
+  "morning-inbox-brief": "Morning inbox brief · weekdays 8am",
+  "inbox-slip-watch": "Slip watch · weekdays 1pm",
+  "friday-wrap": "Friday wrap · 4pm",
+  "plan-my-day": "Plan my day · weekdays 7:30am",
+  "meeting-prep-nudge": "Meeting prep nudges · before meetings",
+};
 
 /** Ordered by likely population — the panel renders as many as fit. */
 export const TRADE_CHIPS = [
@@ -140,12 +158,16 @@ export function jobPlaceholder(trade: string): string {
 }
 
 export interface OnboardingSaved {
-  v: 1;
+  v: 2;
   done: boolean;
   beat?: BeatId;
   name?: string;
   trade?: string;
   task?: string;
+  /** Toolkit slugs connected during the flow. */
+  connected?: string[];
+  /** Automation template ids created during the flow. */
+  automations?: string[];
   /** A settings-triggered rerun — never seed a second thread from it. */
   replayed?: boolean;
 }
@@ -153,8 +175,30 @@ export interface OnboardingSaved {
 export function parseSaved(value: string | undefined): OnboardingSaved | null {
   if (!value) return null;
   try {
-    const parsed = JSON.parse(value) as OnboardingSaved;
-    return parsed && parsed.v === 1 ? parsed : null;
+    const parsed = JSON.parse(value) as {
+      v?: number;
+      done?: boolean;
+      task?: string;
+      replayed?: boolean;
+    };
+    if (!parsed) return null;
+    if (parsed.v === 2) {
+      const saved = parsed as OnboardingSaved;
+      // A saved beat from a different flow version restarts cleanly.
+      if (saved.beat && !BEATS.includes(saved.beat))
+        return { ...saved, beat: undefined };
+      return saved;
+    }
+    // v1 completions stay completed; a v1 mid-flow save restarts the new flow.
+    if (parsed.v === 1 && parsed.done === true) {
+      return {
+        v: 2,
+        done: true,
+        ...(parsed.task ? { task: parsed.task } : {}),
+        ...(parsed.replayed ? { replayed: true } : {}),
+      };
+    }
+    return null;
   } catch {
     return null;
   }
@@ -233,6 +277,8 @@ export interface BeatContext {
   trade: string;
   task: string;
   accountName?: string | null;
+  emailConnected?: boolean;
+  calendarConnected?: boolean;
 }
 
 export interface BeatScene {
@@ -241,19 +287,13 @@ export interface BeatScene {
 }
 
 export function beatLines(beat: BeatId, ctx: BeatContext): BeatScene {
-  const first = firstNameOf(ctx.name) || "friend";
   const task = ctx.task.trim();
   switch (beat) {
-    case "welcome":
-      return {
-        lines: [
-          "I'm Jeb. Wandering samurai, retired. Sixty-one duels, two regrets, and now this corner of your screen.",
-        ],
-      };
     case "name":
       return {
         lines: [
-          "Before anything else, a name. I don't take work from strangers.",
+          "I'm Jeb. Retired samurai, current corner of your screen. My job is simple: nothing important slips past you.",
+          "First, a name. I don't take work from strangers.",
         ],
         hint: "Whatever you'd actually answer to.",
       };
@@ -263,54 +303,37 @@ export function beatLines(beat: BeatId, ctx: BeatContext): BeatScene {
           `${nameReaction(ctx.name, ctx.accountName)} And your trade? Mine was swords and dramatic staring.`,
         ],
       };
-    case "job":
+    case "inbox":
       return {
         lines: [
           tradeReaction(ctx.trade),
-          "What are you actually trying to get done today? One thing. The one that'll still be bothering you at supper.",
+          "Now the real work. Hook up your mail and I'll stand watch: a brief every weekday morning, and a word when something important is about to slip.",
+        ],
+        hint: "Your mail stays yours. I read; I never send.",
+      };
+    case "compass":
+      return {
+        lines: [
+          ctx.emailConnected
+            ? "Good. The inbox is watched. Calendar next: mornings I'll lay your day out, and before meetings I'll hand you what you need walking in."
+            : "Suit yourself; the offer stands. Calendar, then: mornings I'll lay your day out, and before meetings I'll hand you what you need walking in.",
         ],
       };
-    case "list":
+    case "goal":
+      return {
+        lines: [
+          ctx.calendarConnected ? "That's the watch set." : "Fair enough.",
+          "Last thing. What's one thing you want done today or tomorrow? Just one.",
+        ],
+      };
+    case "receipt":
       return {
         lines: [
           jobReaction(task),
           task
-            ? "Put it on your list already. I add things, break the big ones into steps, and check them off. And I read this before everything I say, so you'll never explain it twice."
-            : "Your list is empty for now. I add things, break the big ones into steps, and check them off. And I read this before everything I say, so you'll never explain it twice.",
+            ? "It's on your list and I've opened a thread on it. Here's the watch as it stands."
+            : "Then we improvise. Here's the watch as it stands.",
         ],
-      };
-    case "ledger":
-      return {
-        lines: [
-          "I keep a brain: memories, notes, skills. All yours to read, edit, or erase.",
-        ],
-      };
-    case "blade":
-      return {
-        lines: [
-          "Highlight anything and just ask. I read your screen, and with your go-ahead I type the answer right at your cursor.",
-        ],
-      };
-    case "road":
-      return {
-        lines: [
-          "And I learned how to use a computer. Impressive, I know. I search the web when I don't know something, and I tell you exactly where the answer came from.",
-          "Try me later: ask for the latest news in your city. I'll have it before your tea cools.",
-        ],
-      };
-    case "corner":
-      return {
-        lines: [
-          "I don't live in this window. That's home. Hover me whenever you need me. Ignore me until you don't.",
-        ],
-      };
-    case "handoff":
-      return {
-        lines: task
-          ? ["I've already opened a thread on it. Let's get it off your list."]
-          : [
-              `I've been sharpening this thing for a week with nothing to cut, ${first}.`,
-            ],
       };
   }
 }

--- a/apps/electron/src/renderer/src/lib/scheduled-templates.ts
+++ b/apps/electron/src/renderer/src/lib/scheduled-templates.ts
@@ -1,0 +1,52 @@
+import { apiFetch } from "@renderer/lib/api";
+
+export type AutomationTemplate = {
+  id: string;
+  name: string;
+  schedule: string;
+  toolkits: string[];
+  cron: string | null;
+};
+
+export type ApplyTemplatesResult = {
+  applied: Array<{ id: string; path: string; name: string }>;
+  skipped: Array<{ id: string; reason: string }>;
+};
+
+async function responseJson<T>(response: Response): Promise<T> {
+  const payload = (await response.json().catch(() => null)) as
+    | T
+    | { error?: string }
+    | null;
+  if (!response.ok) {
+    const error = (payload as { error?: string } | null)?.error;
+    throw new Error(
+      error === "cloud_auth_required"
+        ? "Sign in to Freestyle first."
+        : (error ?? "Scheduled tasks are unavailable."),
+    );
+  }
+  return payload as T;
+}
+
+export async function listAutomationTemplates(): Promise<AutomationTemplate[]> {
+  const data = await responseJson<{ templates: AutomationTemplate[] }>(
+    await apiFetch("/api/scheduled/templates"),
+  );
+  return data.templates;
+}
+
+export async function applyAutomationTemplates(
+  templates: string[],
+): Promise<ApplyTemplatesResult> {
+  return responseJson<ApplyTemplatesResult>(
+    await apiFetch("/api/scheduled/templates/apply", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        templates,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }),
+    }),
+  );
+}

--- a/apps/electron/src/renderer/src/onboarding.css
+++ b/apps/electron/src/renderer/src/onboarding.css
@@ -1,0 +1,120 @@
+/* Onboarding v2 stages: connect beats and the receipt. Base onboarding
+   styles (.tavern-onb-*) live in tavern.css; this file only adds the new
+   stage pieces. */
+
+.tavern-onb-connect {
+  display: grid;
+  gap: 10px;
+  width: 100%;
+}
+
+.tavern-onb-apps {
+  display: grid;
+  gap: 7px;
+}
+
+.tavern-onb-app {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 10px;
+  padding: 8px 9px;
+  background: var(--tavern-card);
+}
+
+.tavern-onb-app.is-on {
+  border-color: #9daa7b;
+}
+
+.tavern-onb-app-name {
+  overflow: hidden;
+  font-size: 12.5px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tavern-onb-app-done {
+  color: #4a7c46;
+  font-family: var(--tavern-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+.tavern-onb-cta.is-small {
+  padding: 5px 10px;
+  font-size: 10.5px;
+}
+
+.tavern-onb-autos {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+  padding: 0 2px;
+  list-style: none;
+}
+
+.tavern-onb-autos li {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  color: var(--tavern-mute);
+  font-family: var(--tavern-mono);
+  font-size: 10.5px;
+}
+
+.tavern-onb-autos li i {
+  font-style: normal;
+  color: var(--tavern-rule);
+}
+
+.tavern-onb-autos li.is-set {
+  color: var(--tavern-robe);
+}
+
+.tavern-onb-autos li.is-set i {
+  color: #4a7c46;
+}
+
+.tavern-onb-receipt {
+  display: grid;
+  gap: 12px;
+  width: 100%;
+}
+
+.tavern-onb-rlist {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tavern-onb-rlist li {
+  display: grid;
+  gap: 2px;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 10px;
+  padding: 8px 10px;
+  background: var(--tavern-card);
+}
+
+.tavern-onb-rlist li.is-dim {
+  opacity: 0.75;
+}
+
+.tavern-onb-rlist b {
+  color: var(--tavern-lantern);
+  font-family: var(--tavern-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tavern-onb-rlist span {
+  font-size: 12px;
+  line-height: 1.4;
+}

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -25,6 +25,7 @@ import outputRoute from "./output.js";
 import pluginsRoute from "./plugins.js";
 import postProcessRoute from "./post-process-route.js";
 import pricing from "./pricing.js";
+import scheduledRoute from "./scheduled.js";
 import settings from "./settings.js";
 import streamRoute from "./stream.js";
 import transcribe, { transcribePreWarmRoute } from "./transcribe.js";
@@ -67,6 +68,7 @@ const apiRouter = new Hono()
   .route("/settings", settings)
   .route("/config", configRoute)
   .route("/connectors", connectorsRoute)
+  .route("/scheduled", scheduledRoute)
   .route("/auth", auth)
   .route("/models", models)
   .route("/transcribe", transcribe)

--- a/apps/server/src/routes/scheduled.ts
+++ b/apps/server/src/routes/scheduled.ts
@@ -1,0 +1,57 @@
+import { createAppLogger } from "@freestyle-voice/utils";
+import { Hono } from "hono";
+import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
+import { getSessionToken, invalidateSession } from "../lib/sessions.js";
+
+const log = createAppLogger("scheduled-proxy");
+
+/**
+ * Same boundary as the connectors proxy: the renderer talks only to the local
+ * server, which adds the Cloud bearer token for /v2/scheduled endpoints
+ * (automation templates during onboarding, and any future scheduled surface).
+ */
+const scheduled = new Hono().all("/*", async (c) => {
+  const token = getSessionToken();
+  if (!token) return c.json({ error: "cloud_auth_required" }, 401);
+
+  const requestUrl = new URL(c.req.url);
+  const suffix = requestUrl.pathname.replace(/^\/api\/scheduled/, "");
+  const upstreamUrl = `${freestyleCloudUrl()}/v2/scheduled${suffix}${requestUrl.search}`;
+  const method = c.req.method;
+  try {
+    const upstream = await fetch(upstreamUrl, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(method === "GET" || method === "HEAD"
+          ? {}
+          : {
+              "Content-Type":
+                c.req.header("content-type") ?? "application/json",
+            }),
+      },
+      ...(method === "GET" || method === "HEAD"
+        ? {}
+        : { body: await c.req.raw.arrayBuffer() }),
+      signal: c.req.raw.signal,
+    });
+    if (upstream.status === 401) {
+      invalidateSession();
+      return c.json({ error: "cloud_auth_required" }, 401);
+    }
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: {
+        "Content-Type":
+          upstream.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch (error) {
+    log.error(
+      `Scheduled cloud request failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return c.json({ error: "scheduled_unavailable" }, 502);
+  }
+});
+
+export default scheduled;


### PR DESCRIPTION
Implements the redesign in `docs/onboarding-flow-map.md`: the intro now sells and sets up the "nothing important slips past you" value prop. Pairs with freestyle-voice/cloud d9341d5 (automation templates + read-only connector tools for scheduled runs), which must deploy first.

## The flow
`name → trade → inbox → compass → goal → receipt` (was ten beats; welcome folds into name, the teaching miniatures are cut).

- **inbox**: Gmail/Outlook connect cards with the automation preview (Morning inbox brief · Slip watch · Friday wrap). Connecting applies the templates server-side; the checklist flips live. `Later ▸` skips.
- **compass**: Google Calendar/Outlook with Plan-my-day + meeting-prep nudges. Outlook connected in the inbox beat covers this one with no second OAuth.
- **goal**: "One thing, today or tomorrow" — written to todos.md.
- **receipt**: what's now on watch (connected apps, automations with schedules, first job), then the seeded chat handoff unchanged.

## Mechanics
- Shared `useConnectorConnect` is lifted to the gate so OAuth completing beats later still applies templates and shows on the receipt.
- Template application goes through a new `/api/scheduled` local-server proxy → `POST /v2/scheduled/templates/apply` (idempotent, timezone-aware, requires an active matching connection).
- Saved state bumps to `v:2` (`connected`, `automations`); completed v1 saves migrate, mid-flow v1 saves restart. Skip-flush behavior for the todo/profile writes is unchanged.
- New stage styles in `onboarding.css` — `tavern.css` untouched.

Tests: 61 electron + 400 local-server passing; typecheck + biome clean.

Deploy order: cloud worker first (templates endpoints + scheduled-run connector tools), then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)