### PR TITLE
feat: Profile-driven recommendations refresh + Google avatar rendering

### DIFF
--- a/apps/electron/src/renderer/panel.html
+++ b/apps/electron/src/renderer/panel.html
@@ -5,7 +5,7 @@
     <title>Freestyle</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://logos.composio.dev; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
+      content="default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://logos.composio.dev https://*.googleusercontent.com; media-src 'self' blob: mediastream:; connect-src 'self' ws: wss: http: https:"
     />
   </head>
 

--- a/apps/electron/src/renderer/src/components/onboarding.tsx
+++ b/apps/electron/src/renderer/src/components/onboarding.tsx
@@ -26,6 +26,7 @@ import {
   questFor,
   SKIP_LINE,
   TRADE_CHIPS,
+  TRADE_TO_INDUSTRY,
 } from "@renderer/lib/onboarding-core";
 import {
   connectorConnectionsQueryOptions,
@@ -506,8 +507,12 @@ export function OnboardingGate({
         .catch(() => {})
         .then(() => {
           if (trade.trim()) {
+            const industry = TRADE_TO_INDUSTRY[trade.trim()];
             updateProfile
-              .mutateAsync({ jobTitle: trade.trim() })
+              .mutateAsync({
+                jobTitle: trade.trim(),
+                ...(industry ? { industry } : {}),
+              })
               .catch(() => {});
           }
         });
@@ -541,7 +546,13 @@ export function OnboardingGate({
       // The profile row is the source of truth for role-aware
       // recommendations; a skipped intro must still record the trade.
       if (trade.trim()) {
-        updateProfile.mutateAsync({ jobTitle: trade.trim() }).catch(() => {});
+        const industry = TRADE_TO_INDUSTRY[trade.trim()];
+        updateProfile
+          .mutateAsync({
+            jobTitle: trade.trim(),
+            ...(industry ? { industry } : {}),
+          })
+          .catch(() => {});
       }
     }
     window.setTimeout(() => onDone(task.trim()), 1400);

--- a/apps/electron/src/renderer/src/components/onboarding.tsx
+++ b/apps/electron/src/renderer/src/components/onboarding.tsx
@@ -538,6 +538,11 @@ export function OnboardingGate({
     if (!profileStarted.current && name.trim()) {
       profileStarted.current = true;
       void seedProfile(name.trim(), trade.trim()).catch(() => {});
+      // The profile row is the source of truth for role-aware
+      // recommendations; a skipped intro must still record the trade.
+      if (trade.trim()) {
+        updateProfile.mutateAsync({ jobTitle: trade.trim() }).catch(() => {});
+      }
     }
     window.setTimeout(() => onDone(task.trim()), 1400);
   };

--- a/apps/electron/src/renderer/src/lib/onboarding-core.ts
+++ b/apps/electron/src/renderer/src/lib/onboarding-core.ts
@@ -1,3 +1,5 @@
+import type { Industry } from "@freestyle-voice/validations";
+
 export const ONBOARDING_KEY = "onboarding";
 export const DEFAULT_QUEST = "Ask Jeb to do something for you";
 export const PROFILE_PATH = "memories/profile.md";
@@ -46,6 +48,26 @@ export const CALENDAR_TEMPLATE_IDS = [
   "plan-my-day",
   "meeting-prep-nudge",
 ] as const;
+
+/** Trade chips mapped onto the Settings industry enum, so onboarding fills
+ * the same profile field Settings edits. Chips with no honest industry
+ * (Founder, Operations, "Between things") set none; the jobTitle fallback
+ * covers them. */
+export const TRADE_TO_INDUSTRY: Record<string, Industry> = {
+  Engineer: "software",
+  Designer: "design",
+  Product: "software",
+  Writer: "media",
+  Student: "education",
+  Researcher: "research",
+  Marketer: "marketing",
+  Consultant: "consulting",
+  Sales: "sales",
+  Teacher: "education",
+  Finance: "finance",
+  Healthcare: "healthcare",
+  Law: "legal",
+};
 
 export const AUTOMATION_LABELS: Record<string, string> = {
   "morning-inbox-brief": "Morning inbox brief · weekdays 8am",

--- a/apps/electron/src/renderer/src/lib/use-profile.ts
+++ b/apps/electron/src/renderer/src/lib/use-profile.ts
@@ -93,6 +93,17 @@ export function useUpdateProfileFields() {
           queryKey: queryKeys.vocabulary.all,
         });
       }
+      // Recommendations (Apps-page Suggested section, opener cards) are
+      // role-aware from these same profile fields; refetch them on change.
+      const roleChanged =
+        industryChanged ||
+        (previous?.jobTitle ?? null) !== (profile.jobTitle ?? null);
+      if (roleChanged) {
+        void queryClient.invalidateQueries({
+          queryKey: queryKeys.connectors.suggested,
+        });
+        void queryClient.invalidateQueries({ queryKey: queryKeys.openers });
+      }
     },
   });
 }


### PR DESCRIPTION
Pairs with freestyle-voice/cloud's "member_preferences as recommendation source of truth" PR.

- **Avatar fix**: the panel CSP blocked `lh3.googleusercontent.com`, so Google OAuth profile pictures never rendered in Settings even though the URL flows end to end. `img-src` now allows `https://*.googleusercontent.com`.
- **Recommendations follow the profile**: changing industry or job title invalidates the Apps-page Suggested query and the opener-cards query, so role-aware recommendations refresh immediately.
- **Onboarding skip path**: a typed trade is now written to the profile row (`jobTitle`) on skip, same as on finish — the profile row is the source of truth the cloud now reads.

Tests: 61 electron passing, typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)