### PR TITLE
feat: Minimalist openers: real todos with launch, slimmer suggestion rows

### DIFF
--- a/apps/electron/src/renderer/src/components/opener-cards.tsx
+++ b/apps/electron/src/renderer/src/components/opener-cards.tsx
@@ -116,10 +116,15 @@ export function OpenerCards({
     queryClient,
   ]);
 
-  if (query.isError || (query.isSuccess && query.data.cards.length === 0)) {
+  const todos = query.data?.todos ?? [];
+
+  if (
+    query.isError ||
+    (query.isSuccess && query.data.cards.length === 0 && todos.length === 0)
+  ) {
     return <FallbackStarters busy={busy} onPrompt={onPrompt} />;
   }
-  if (!query.data || cards.length === 0) {
+  if (!query.data || (cards.length === 0 && todos.length === 0)) {
     return <div className="tavern-openers" aria-busy="true" />;
   }
 
@@ -138,6 +143,31 @@ export function OpenerCards({
 
   return (
     <div className="tavern-openers">
+      {todos.length > 0 ? (
+        <div className="tavern-opener-todos">
+          <span className="tavern-openers-label">On your list</span>
+          {todos.map((todo) => (
+            <div key={todo} className="tavern-opener-todo">
+              <i aria-hidden="true">◇</i>
+              <span className="tavern-opener-todo-text">{todo}</span>
+              <button
+                type="button"
+                className="tavern-opener-launch"
+                disabled={busy}
+                onClick={() => {
+                  capture("opener_tapped", {
+                    id: "todo:launch",
+                    category: "do_now",
+                  });
+                  onPrompt(`I want you to help me do this: ${todo}`);
+                }}
+              >
+                launch ↗
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
       {cards.map((card) => {
         if (card.kind === "prompt" && card.action.prompt) {
           const prompt = card.action.prompt;

--- a/apps/electron/src/renderer/src/lib/openers.ts
+++ b/apps/electron/src/renderer/src/lib/openers.ts
@@ -27,6 +27,8 @@ export type OpenerCard = {
 export type OpenersResponse = {
   greeting: string;
   cards: OpenerCard[];
+  /** First open items from todos.md, list order, already truncated. */
+  todos: string[];
   ttlSeconds: number;
 };
 
@@ -75,6 +77,7 @@ async function fetchOpenersOnce(exclude: string[]): Promise<OpenersResponse> {
   const data = (await res.json()) as {
     greeting?: unknown;
     cards?: unknown;
+    todos?: unknown;
     ttlSeconds?: unknown;
   };
   const cards = Array.isArray(data.cards)
@@ -85,6 +88,9 @@ async function fetchOpenersOnce(exclude: string[]): Promise<OpenersResponse> {
   return {
     greeting: typeof data.greeting === "string" ? data.greeting : "",
     cards,
+    todos: Array.isArray(data.todos)
+      ? data.todos.filter((item): item is string => typeof item === "string")
+      : [],
     ttlSeconds: typeof data.ttlSeconds === "number" ? data.ttlSeconds : 21_600,
   };
 }
@@ -95,7 +101,11 @@ export async function fetchOpeners(): Promise<OpenersResponse> {
   // Dismissing enough cards can exhaust a finite pool (connect/automate
   // rankings). Suggestions must always come back, so a dry result resets the
   // session's dismissals and refetches the full set.
-  if (result.cards.length === 0 && exclude.length > 0) {
+  if (
+    result.cards.length === 0 &&
+    result.todos.length === 0 &&
+    exclude.length > 0
+  ) {
     resetOpenerDismissals();
     return fetchOpenersOnce([]);
   }

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -3616,3 +3616,74 @@
   border-top: 1px dashed var(--tavern-rule);
   padding-top: 8px;
 }
+
+/* ── Minimalist openers: todo rows + tighter cards ───────────────────── */
+
+.tavern-openers-label {
+  font-family: var(--tavern-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--tavern-mute);
+}
+
+.tavern-opener-todos {
+  display: grid;
+  gap: 3px;
+  margin-bottom: 4px;
+}
+
+.tavern-opener-todo {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  padding: 2px 1px;
+}
+
+.tavern-opener-todo i {
+  color: var(--tavern-lantern);
+  font-size: 10px;
+  font-style: normal;
+}
+
+.tavern-opener-todo-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tavern-opener-launch {
+  border: 0;
+  background: none;
+  padding: 2px 4px;
+  color: var(--tavern-mute);
+  cursor: pointer;
+  font-family: var(--tavern-mono);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.tavern-opener-launch:hover:not(:disabled) {
+  color: var(--tavern-lantern);
+}
+
+.tavern-opener-launch:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.tavern-opener {
+  gap: 2px;
+  padding: 7px 10px;
+}
+
+.tavern-opener-sub {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Pairs with freestyle-voice/cloud's "Slim the opener assembly" PR (deploy cloud first — the `todos` field comes from `/v2/suggestions/home`).

The empty-chat state gets quieter and more useful:

- **Your list first**: top 3 open todos from todos.md as single-line rows (`◇ task … launch ↗`). Launch seeds a thread with "I want you to help me do this: <task>".
- **Suggestions stay but slim down**: one workflow prompt using connected apps, one automation to turn on, one app worth connecting — same smart assembly, now max 3 cards (the do-now prompt card is gone; the real todo list replaced it), tighter padding, one-line subtitles.
- Dismissals, backfill, api-key connect forms, and the starter-prompt fallback all behave as before.

Tests: 61 electron passing, typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)