### PR TITLE
feat: Readable fallback for agent stream errors

### DIFF
--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -736,11 +736,13 @@ function PanelInner({
         });
       },
       onError: (err) => {
+        const message = typeof err.message === "string" ? err.message : "";
         setNotice(
-          err.message.includes("cloud_auth_required") ||
-            err.message.includes("401")
+          message.includes("cloud_auth_required") || message.includes("401")
             ? "Sign in to Freestyle Cloud to chat."
-            : err.message,
+            : message && message !== "[object Object]"
+              ? message
+              : "That didn't go through. Try again.",
         );
       },
     });


### PR DESCRIPTION
Pairs with freestyle-voice/cloud#132. When an agent turn fails with an object-shaped error, the chat notice showed literal `[object Object]`. The notice now falls back to "That didn't go through. Try again." for non-string or unreadable messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)