### PR TITLE
feat: 1/10 Instrument the proposal loop (desktop)

### DIFF
--- a/apps/electron/src/renderer/src/components/connect-suggestions.tsx
+++ b/apps/electron/src/renderer/src/components/connect-suggestions.tsx
@@ -3,13 +3,14 @@ import {
   ConnectorLogo,
   DEFAULT_AUTH_FIELDS,
 } from "@renderer/components/connected-apps";
+import { captureSuggestion } from "@renderer/lib/analytics";
 import {
   type ConnectorAuthField,
   disconnectToolkit,
 } from "@renderer/lib/connectors";
 import { useConnectorConnect } from "@renderer/lib/use-connector-connect";
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type Suggestion = {
   slug: string;
@@ -47,7 +48,35 @@ export function ConnectSuggestions({
     useConnectorConnect();
   const [dismissed, setDismissed] = useState<ReadonlySet<string>>(new Set());
   const [keyFormSlug, setKeyFormSlug] = useState<string | null>(null);
+  const shownRef = useRef<string | null>(null);
+  const connectedRef = useRef<ReadonlySet<string>>(new Set());
   const visible = suggestions.filter((item) => !dismissed.has(item.slug));
+
+  useEffect(() => {
+    if (suggestions.length === 0) return;
+    const signature = suggestions.map((item) => item.slug).join(",");
+    if (shownRef.current === signature) return;
+    shownRef.current = signature;
+    captureSuggestion("shown", "chat_connect", {
+      slugs: suggestions.map((item) => item.slug),
+    });
+  }, [suggestions]);
+
+  useEffect(() => {
+    for (const item of suggestions) {
+      if (
+        phases[item.slug] !== "connected" ||
+        connectedRef.current.has(item.slug)
+      )
+        continue;
+      connectedRef.current = new Set(connectedRef.current).add(item.slug);
+      captureSuggestion("accepted", "chat_connect", {
+        slug: item.slug,
+        outcome: "connected",
+      });
+    }
+  }, [phases, suggestions]);
+
   if (visible.length === 0) return null;
 
   return (
@@ -81,13 +110,20 @@ export function ConnectSuggestions({
                   type="button"
                   className="tavern-approve-btn tavern-approve-allow"
                   disabled={phase === "opening" || phase === "pending"}
-                  onClick={() =>
-                    apiKey
-                      ? setKeyFormSlug((current) =>
-                          current === suggestion.slug ? null : suggestion.slug,
-                        )
-                      : connect(suggestion.slug)
-                  }
+                  onClick={() => {
+                    captureSuggestion("accepted", "chat_connect", {
+                      slug: suggestion.slug,
+                      outcome: "started",
+                      authMode: suggestion.authMode ?? "oauth",
+                    });
+                    if (apiKey) {
+                      setKeyFormSlug((current) =>
+                        current === suggestion.slug ? null : suggestion.slug,
+                      );
+                    } else {
+                      connect(suggestion.slug);
+                    }
+                  }}
                 >
                   {phase === "opening"
                     ? apiKey
@@ -111,6 +147,10 @@ export function ConnectSuggestions({
                       cancel(suggestion.slug);
                       void disconnectToolkit(suggestion.slug).catch(() => {});
                     }
+                    captureSuggestion("dismissed", "chat_connect", {
+                      slug: suggestion.slug,
+                      wasPending: phase === "pending" || phase === "opening",
+                    });
                     setDismissed((prev) => new Set(prev).add(suggestion.slug));
                   }}
                 >

--- a/apps/electron/src/renderer/src/components/notification.tsx
+++ b/apps/electron/src/renderer/src/components/notification.tsx
@@ -1,6 +1,7 @@
 import "../overlay.css";
 import "../tavern.css";
 
+import { capture } from "@renderer/lib/analytics";
 import { initApiBase } from "@renderer/lib/api";
 import { installGlobalErrorHandlers } from "@renderer/lib/report-error";
 import type React from "react";
@@ -71,6 +72,7 @@ function NotificationStack(): React.JSX.Element | null {
   const [items, setItems] = useState<NotificationItem[]>([]);
   const [expanded, setExpanded] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
+  const seenRef = useRef(new Set<string>());
 
   const load = useCallback((): void => {
     void window.api
@@ -85,18 +87,33 @@ function NotificationStack(): React.JSX.Element | null {
     return () => off?.();
   }, [load]);
 
+  useEffect(() => {
+    for (const item of items) {
+      if (seenRef.current.has(item.id)) continue;
+      seenRef.current.add(item.id);
+      capture("notification_shown", { surface: "bubble", kind: item.kind });
+    }
+  }, [items]);
+
   useLayoutEffect(() => {
     const height = rootRef.current?.offsetHeight ?? 0;
     if (height > 0) window.api.notificationSetHeight(height + 8);
     if (items.length <= 1) setExpanded(false);
   }, [items]);
 
+  const ageOf = (id: string): number | null => {
+    const item = items.find((n) => n.id === id);
+    return item ? Date.now() - item.createdAt : null;
+  };
+
   const dismiss = (id: string): void => {
+    capture("notification_dismissed", { surface: "bubble", ageMs: ageOf(id) });
     setItems((prev) => prev.filter((n) => n.id !== id));
     window.api.notificationDismiss(id);
   };
 
   const open = (id: string): void => {
+    capture("notification_opened", { surface: "bubble", ageMs: ageOf(id) });
     setItems((prev) => prev.filter((n) => n.id !== id));
     window.api.notificationOpen(id);
   };

--- a/apps/electron/src/renderer/src/components/onboarding.tsx
+++ b/apps/electron/src/renderer/src/components/onboarding.tsx
@@ -1,6 +1,7 @@
 import "../onboarding.css";
 
 import { ConnectorLogo } from "@renderer/components/connected-apps";
+import { capture } from "@renderer/lib/analytics";
 import { apiFetch } from "@renderer/lib/api";
 import { readBrainFile, writeBrainFile } from "@renderer/lib/brain-fs";
 import type { ConnectorCatalogItem } from "@renderer/lib/connectors";
@@ -416,6 +417,7 @@ export function OnboardingGate({
     setBeat(next);
     setLineIdx(0);
     persist(next);
+    capture("onboarding_beat", { beat: next, index: index + 1 });
   }, [beat, persist]);
 
   const advance = useCallback((): void => {
@@ -526,6 +528,7 @@ export function OnboardingGate({
 
   const skip = (): void => {
     if (skipping) return;
+    capture("onboarding_skipped", { beat, index: BEATS.indexOf(beat) });
     setSkipping(true);
     if (!todoStarted.current && task.trim()) {
       todoStarted.current = true;
@@ -550,9 +553,15 @@ export function OnboardingGate({
   };
 
   const complete = useCallback((): void => {
+    capture("onboarding_completed", {
+      hasTask: task.trim().length > 0,
+      trade: trade.trim() || null,
+      connected: [...activeSlugs],
+      automations: [...applied],
+    });
     window.api.spriteEvent({ kind: "turn", phase: "done" });
     onDone(task.trim());
-  }, [onDone, task]);
+  }, [onDone, task, trade, activeSlugs, applied]);
 
   // Enter anywhere is Next: finishes the typing line, steps the scene, and
   // advances the beat — including the receipt CTA. Buttons keep their native

--- a/apps/electron/src/renderer/src/components/opener-cards.tsx
+++ b/apps/electron/src/renderer/src/components/opener-cards.tsx
@@ -3,7 +3,7 @@ import {
   ConnectorLogo,
   DEFAULT_AUTH_FIELDS,
 } from "@renderer/components/connected-apps";
-import { capture } from "@renderer/lib/analytics";
+import { capture, captureSuggestion } from "@renderer/lib/analytics";
 import { starterPrompts } from "@renderer/lib/onboarding-core";
 import {
   applyOpenerTemplate,
@@ -73,8 +73,14 @@ export function OpenerCards({
 
   const applyTemplate = useMutation({
     mutationFn: applyOpenerTemplate,
-    onSuccess: (_result, templateId) => {
+    onSuccess: (result, templateId) => {
       setApplied((prev) => new Set(prev).add(templateId));
+      capture("automation_applied", {
+        surface: "opener",
+        templateId,
+        applied: result.applied.length,
+        skipped: result.skipped.map((entry) => entry.reason),
+      });
     },
   });
 
@@ -91,8 +97,10 @@ export function OpenerCards({
     const signature = query.data.cards.map((card) => card.id).join(",");
     if (reportedFor.current === signature) return;
     reportedFor.current = signature;
-    capture("opener_rendered", {
+    captureSuggestion("shown", "opener", {
       cards: query.data.cards.map((card) => card.id),
+      categories: query.data.cards.map((card) => card.category),
+      todos: query.data.todos.length,
     });
   }, [query.data, cards.length]);
 
@@ -131,13 +139,20 @@ export function OpenerCards({
   const dismiss = (card: OpenerCard): void => {
     dismissOpener(card.id);
     setDismissTick((tick) => tick + 1);
-    capture("opener_dismissed", { id: card.id, category: card.category });
+    captureSuggestion("dismissed", "opener", {
+      id: card.id,
+      category: card.category,
+      kind: card.kind,
+    });
   };
 
   const refresh = (): void => {
     for (const card of cards) dismissOpener(card.id);
     setDismissTick((tick) => tick + 1);
-    capture("opener_refreshed", { ids: cards.map((card) => card.id) });
+    capture("suggestion_refreshed", {
+      surface: "opener",
+      ids: cards.map((card) => card.id),
+    });
     void queryClient.invalidateQueries({ queryKey: queryKeys.openers });
   };
 
@@ -155,9 +170,10 @@ export function OpenerCards({
                 className="tavern-opener-launch"
                 disabled={busy}
                 onClick={() => {
-                  capture("opener_tapped", {
+                  captureSuggestion("accepted", "opener", {
                     id: "todo:launch",
                     category: "do_now",
+                    kind: "todo",
                   });
                   onPrompt(`I want you to help me do this: ${todo}`);
                 }}
@@ -178,9 +194,10 @@ export function OpenerCards({
               className="tavern-opener"
               disabled={busy}
               onClick={() => {
-                capture("opener_tapped", {
+                captureSuggestion("accepted", "opener", {
                   id: card.id,
                   category: card.category,
+                  kind: card.kind,
                 });
                 onPrompt(prompt);
               }}
@@ -217,9 +234,10 @@ export function OpenerCards({
                     className="tavern-approve-btn tavern-approve-allow"
                     disabled={phase === "opening" || phase === "pending"}
                     onClick={() => {
-                      capture("opener_tapped", {
+                      captureSuggestion("accepted", "opener", {
                         id: card.id,
                         category: card.category,
+                        kind: card.kind,
                       });
                       if (apiKey) {
                         setKeyFormSlug((current) =>
@@ -283,9 +301,10 @@ export function OpenerCards({
                     className="tavern-approve-btn tavern-approve-allow"
                     disabled={isApplying}
                     onClick={() => {
-                      capture("opener_tapped", {
+                      captureSuggestion("accepted", "opener", {
                         id: card.id,
                         category: card.category,
+                        kind: card.kind,
                       });
                       applyTemplate.mutate(templateId);
                     }}

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -19,6 +19,7 @@ import {
   describeAgentAction,
   executeAgentTool,
 } from "@renderer/lib/agent-tools";
+import { capture } from "@renderer/lib/analytics";
 import { apiFetch, initApiBase } from "@renderer/lib/api";
 import { CloudAuthProvider, useCloudAuth } from "@renderer/lib/auth-context";
 import { composerAction } from "@renderer/lib/composer-action";
@@ -808,6 +809,7 @@ function PanelInner({
   };
 
   const resolveApproval = (call: AgentToolCall, allowed: boolean): void => {
+    capture("approval_resolved", { tool: call.toolName, allowed });
     setApprovals((prev) =>
       prev.filter((a) => a.toolCallId !== call.toolCallId),
     );
@@ -996,6 +998,7 @@ function PanelInner({
               aria-selected={!settingsOpen && tab === id}
               className="tavern-tab"
               onClick={() => {
+                capture("panel_tab_opened", { tab: id });
                 setSettingsOpen(false);
                 setTab(id);
               }}

--- a/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
+++ b/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
@@ -1,4 +1,5 @@
 import { DataSkeleton } from "@renderer/components/data-skeleton";
+import { capture } from "@renderer/lib/analytics";
 import { writeBrainFile } from "@renderer/lib/brain-fs";
 import {
   type ScheduledTaskView,
@@ -26,6 +27,11 @@ export function ScheduledTasks(): React.JSX.Element {
 
   const toggle = (task: ScheduledTaskView): void => {
     const next = !task.enabled;
+    capture("scheduled_task_toggled", {
+      enabled: next,
+      task: task.name,
+      hasRun: task.lastRun !== null,
+    });
     setBusy(task.path);
     queryClient.setQueryData<ScheduledTaskView[]>(
       queryKeys.brain.scheduledTasks,

--- a/apps/electron/src/renderer/src/lib/analytics.ts
+++ b/apps/electron/src/renderer/src/lib/analytics.ts
@@ -12,6 +12,16 @@ import { apiFetch } from "@renderer/lib/api";
  *
  * Fire-and-forget: failures never interrupt the UI.
  */
+export type SuggestionSurface = "opener" | "chat_connect" | "capability";
+
+export function captureSuggestion(
+  phase: "shown" | "accepted" | "dismissed",
+  surface: SuggestionSurface,
+  properties?: Record<string, unknown>,
+): void {
+  capture(`suggestion_${phase}`, { surface, ...properties });
+}
+
 export function capture(
   event: string,
   properties?: Record<string, unknown>,


### PR DESCRIPTION
**Stack position: 1 of 10.** Base is `deep-code-audit` (#591). Paired with freestyle-voice/cloud#135 — merge that one too or the Worker half of the funnel stays dark.

Fixes finding **C1** from the audit.

## The problem

The renderer emitted six analytics events in total — four on opener cards, two on the sprite waking and sleeping. That was the entire companion-era instrumentation. The in-chat connect cards, which the system prompt pushes hardest ("hunt for chances to connect apps"), emitted nothing at all. So suggestion acceptance rate — the number the product spec names as the one that decides whether the thesis is right — was not computable.

The desktop server's own events are all pre-pivot: transcription, vocabulary, models, history.

## What this does

Adds `captureSuggestion(phase, surface, props)` so both proposal surfaces report under one schema and can be compared:

- **`suggestion_shown` / `_accepted` / `_dismissed`**, tagged `surface: "opener" | "chat_connect"`
- Opener events renamed from `opener_*` (4 days old, low continuity cost) and enriched with card kind and category
- Connect cards now report shown, accepted at *both* stages (`started` on tap, `connected` on OAuth completion — the gap between them is the drop-off you want), and dismissed with whether a connect was in flight

Plus the surrounding funnel:

| Event | Properties |
|---|---|
| `notification_shown` / `_opened` / `_dismissed` | surface, kind, ageMs at action |
| `onboarding_beat` | beat, index |
| `onboarding_skipped` | beat, index — where people bail |
| `onboarding_completed` | hasTask, trade, connected, automations |
| `approval_resolved` | tool, allowed |
| `automation_applied` | templateId, applied, skipped reasons |
| `scheduled_task_toggled` | enabled, task, hasRun |
| `panel_tab_opened` | tab |

Everything routes through the existing `/api/telemetry` → server-side `capture()` path, so it honours `telemetry_enabled`, `DO_NOT_TRACK`, production-gating and device-id attribution unchanged. No PostHog SDK enters the renderer.

## Testing

- `pnpm typecheck` clean (node + web)
- `pnpm test` — 65 passed, 12 files
- Biome formatted

**To verify by hand:** run with `FREESTYLE_ANALYTICS_DEV=1`, open the panel, tap an opener and a connect card, and confirm `suggestion_accepted` arrives with the right `surface`.