### PR TITLE
feat: 2/10 Quiet hours, and stop promising a ping per run (desktop)

### DIFF
--- a/apps/electron/src/renderer/src/components/notifications-history.tsx
+++ b/apps/electron/src/renderer/src/components/notifications-history.tsx
@@ -1,10 +1,17 @@
 import { DataSkeleton } from "@renderer/components/data-skeleton";
 import {
+  DEFAULT_QUIET_HOURS,
   NotificationHistoryError,
   type NotificationHistoryRow,
+  type QuietHours,
+  setQuietHours,
 } from "@renderer/lib/notifications";
-import { notificationHistoryQueryOptions } from "@renderer/lib/query";
-import { useQuery } from "@tanstack/react-query";
+import {
+  notificationHistoryQueryOptions,
+  queryKeys,
+  quietHoursQueryOptions,
+} from "@renderer/lib/query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type React from "react";
 
 function when(ts: number): string {
@@ -29,6 +36,86 @@ function statusOf(row: NotificationHistoryRow): {
   if (row.expiresAt !== null && row.expiresAt <= Date.now())
     return { label: "Expired", tone: "is-expired" };
   return { label: "Unread", tone: "is-unread" };
+}
+
+const HOUR_OPTIONS = Array.from({ length: 24 }, (_, hour) => ({
+  value: String(hour),
+  label: `${String(hour).padStart(2, "0")}:00`,
+}));
+
+export function QuietHoursSettings(): React.JSX.Element | null {
+  const queryClient = useQueryClient();
+  const quietQuery = useQuery(quietHoursQueryOptions());
+  const quiet = quietQuery.data;
+
+  if (quiet === undefined) return null;
+
+  const save = (next: QuietHours): void => {
+    queryClient.setQueryData(queryKeys.notifications.quietHours, next);
+    void setQuietHours(next).catch(() => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.notifications.quietHours,
+      });
+    });
+  };
+
+  return (
+    <>
+      <div className="tavern-set-row is-static">
+        <span className="tavern-set-label">Quiet hours</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={quiet !== null}
+          className={`tavern-set-switch${quiet !== null ? " is-on" : ""}`}
+          onClick={() => save(quiet === null ? DEFAULT_QUIET_HOURS : null)}
+        >
+          <span className="tavern-set-knob" />
+        </button>
+      </div>
+      {quiet !== null ? (
+        <>
+          <div className="tavern-set-row is-static">
+            <span className="tavern-set-label">From</span>
+            <select
+              className="tavern-set-select"
+              value={String(quiet.start)}
+              aria-label="Quiet hours start"
+              onChange={(e) =>
+                save({ ...quiet, start: Number(e.target.value) })
+              }
+            >
+              {HOUR_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="tavern-set-row is-static">
+            <span className="tavern-set-label">Until</span>
+            <select
+              className="tavern-set-select"
+              value={String(quiet.end)}
+              aria-label="Quiet hours end"
+              onChange={(e) => save({ ...quiet, end: Number(e.target.value) })}
+            >
+              {HOUR_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
+      ) : null}
+      <p className="tavern-set-hint">
+        {quiet === null
+          ? "Freestyle can reach you at any hour."
+          : "Scheduled tasks still run and still write to your history — they just won't interrupt you in this window."}
+      </p>
+    </>
+  );
 }
 
 export function NotificationsHistory(): React.JSX.Element {

--- a/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
+++ b/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
@@ -78,8 +78,8 @@ export function ScheduledTasks(): React.JSX.Element {
   return (
     <>
       <p className="tavern-set-hint is-lead">
-        These run on their own, even with this app closed. Every run sends you a
-        notification.
+        These run on their own, even with this app closed. They only notify you
+        when there's something worth knowing — every run is saved either way.
       </p>
       {tasks.map((task) => (
         <div

--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -7,7 +7,10 @@ import {
   normalizeLanguageList,
   resolveLanguageOptions,
 } from "@freestyle-voice/validations";
-import { NotificationsHistory } from "@renderer/components/notifications-history";
+import {
+  NotificationsHistory,
+  QuietHoursSettings,
+} from "@renderer/components/notifications-history";
 import { ScheduledTasks } from "@renderer/components/scheduled-tasks";
 import {
   acceleratorsEqual,
@@ -1508,7 +1511,11 @@ export function SettingsView({
         ) : page === "scheduled" ? (
           <ScheduledTasks />
         ) : page === "notifications" ? (
-          <NotificationsHistory />
+          <>
+            <QuietHoursSettings />
+            <SectionLabel>History</SectionLabel>
+            <NotificationsHistory />
+          </>
         ) : page === "dictation" ? (
           <DictationPage value={value} setSetting={setSetting} />
         ) : page === "talk" ? (

--- a/apps/electron/src/renderer/src/lib/notifications.ts
+++ b/apps/electron/src/renderer/src/lib/notifications.ts
@@ -37,3 +37,28 @@ export async function listNotificationHistory(): Promise<
     throw new NotificationHistoryError("unreachable");
   }
 }
+
+export type QuietHours = { start: number; end: number } | null;
+
+export const DEFAULT_QUIET_HOURS: QuietHours = { start: 21, end: 7 };
+
+export async function getQuietHours(): Promise<QuietHours> {
+  try {
+    const response = await apiFetch("/api/notifications/preferences");
+    if (!response.ok) return DEFAULT_QUIET_HOURS;
+    const data = (await response.json()) as { quietHours?: QuietHours };
+    return data.quietHours === undefined
+      ? DEFAULT_QUIET_HOURS
+      : data.quietHours;
+  } catch {
+    return DEFAULT_QUIET_HOURS;
+  }
+}
+
+export async function setQuietHours(quietHours: QuietHours): Promise<void> {
+  await apiFetch("/api/notifications/preferences", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ quietHours }),
+  });
+}

--- a/apps/electron/src/renderer/src/lib/query.ts
+++ b/apps/electron/src/renderer/src/lib/query.ts
@@ -9,7 +9,7 @@ import {
   listSuggestedConnectors,
 } from "./connectors";
 import type { AvailableModel } from "./models";
-import { listNotificationHistory } from "./notifications";
+import { getQuietHours, listNotificationHistory } from "./notifications";
 import {
   getLatestThread,
   getThread,
@@ -94,7 +94,10 @@ export const queryKeys = {
     list: ["threads", "list"] as const,
     detail: (id: string) => ["threads", "detail", id] as const,
   },
-  notifications: { history: ["notifications", "history"] as const },
+  notifications: {
+    history: ["notifications", "history"] as const,
+    quietHours: ["notifications", "quiet-hours"] as const,
+  },
   brain: {
     all: ["brain"] as const,
     files: (root: string) => ["brain", "files", root] as const,
@@ -287,6 +290,14 @@ export function threadHistoryInfiniteQueryOptions() {
     queryFn: ({ pageParam }: { pageParam: number | null }) =>
       listThreads({ cursor: pageParam ?? undefined }),
     getNextPageParam: (page: ThreadPage) => page.nextCursor ?? undefined,
+  };
+}
+
+export function quietHoursQueryOptions() {
+  return {
+    queryKey: queryKeys.notifications.quietHours,
+    queryFn: getQuietHours,
+    staleTime: ONE_HOUR,
   };
 }
 

--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -707,14 +707,28 @@ export async function unlinkCloudAccount(
  * served by the cloud's root `/profile` route — distinct from the org-scoped
  * member profile below).
  */
+export interface CloudUserProfile {
+  timezone?: string;
+  quietHours?: { start: number; end: number } | null;
+}
+
 export async function putCloudUserProfile(
   token: string,
-  data: { timezone: string },
+  data: CloudUserProfile,
 ): Promise<void> {
   await cloudJson<{ success?: boolean }>("/profile", token, {
     method: "PUT",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(data),
+    signal: AbortSignal.timeout(PROFILE_REQUEST_TIMEOUT_MS),
+  });
+}
+
+export async function getCloudUserProfile(
+  token: string,
+): Promise<CloudUserProfile> {
+  return cloudJson<CloudUserProfile>("/profile", token, {
+    method: "GET",
     signal: AbortSignal.timeout(PROFILE_REQUEST_TIMEOUT_MS),
   });
 }

--- a/apps/server/src/routes/notifications.ts
+++ b/apps/server/src/routes/notifications.ts
@@ -2,13 +2,19 @@ import { createAppLogger } from "@freestyle-voice/utils";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
-import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
+import {
+  freestyleCloudUrl,
+  getCloudUserProfile,
+  putCloudUserProfile,
+} from "../lib/freestyle-cloud.js";
 import { drainNotificationOutbox } from "../lib/notifications/outbox.js";
 import * as store from "../lib/notifications/store.js";
 import { notificationTransport } from "../lib/notifications/transport.js";
 import { getSessionToken, invalidateSession } from "../lib/sessions.js";
 
 const log = createAppLogger("notifications");
+
+export const DEFAULT_QUIET_HOURS = { start: 21, end: 7 } as const;
 
 const createSchema = z.object({
   kind: z.enum(["thread", "info"]).default("thread"),
@@ -46,8 +52,44 @@ async function forwardHistory(): Promise<{ status: number; payload: unknown }> {
   }
 }
 
+const quietHoursSchema = z.object({
+  quietHours: z
+    .object({
+      start: z.number().int().min(0).max(23),
+      end: z.number().int().min(0).max(23),
+    })
+    .nullable(),
+});
+
 const notificationsRoute = new Hono()
   .get("/", (c) => c.json({ notifications: store.listActive() }))
+  .get("/preferences", async (c) => {
+    const token = getSessionToken();
+    if (!token) return c.json({ quietHours: DEFAULT_QUIET_HOURS });
+    try {
+      const profile = await getCloudUserProfile(token);
+      return c.json({
+        quietHours:
+          profile.quietHours === undefined
+            ? DEFAULT_QUIET_HOURS
+            : profile.quietHours,
+      });
+    } catch {
+      return c.json({ quietHours: DEFAULT_QUIET_HOURS });
+    }
+  })
+  .put("/preferences", zValidator("json", quietHoursSchema), async (c) => {
+    const token = getSessionToken();
+    if (!token)
+      return c.json({ ok: false, reason: "cloud_auth_required" }, 401);
+    try {
+      await putCloudUserProfile(token, c.req.valid("json"));
+      return c.json({ ok: true });
+    } catch (err) {
+      log.error(`Quiet hours update failed: ${err}`);
+      return c.json({ ok: false, reason: "cloud-unreachable" }, 502);
+    }
+  })
   .get("/history", async (c) => {
     const local = store
       .listActive()


### PR DESCRIPTION
**Stack position: 2 of 10.** Base is `proposal/01-instrumentation` (#592). Pairs with freestyle-voice/cloud#136 — that PR carries the actual behaviour change; this one is the control surface and the honest copy.

Fixes audit finding **B6** and the copy half of **B1**.

## The problem

The Notifications page in Settings was a read-only log. There was no setting anywhere for when notifications may arrive, whether the OS banner fires, or how many can stack. The only volume control was switching a task off entirely.

Meanwhile the Scheduled page stated the old behaviour as a feature: *"Every run sends you a notification."*

## What this does

- **Quiet hours** on the Notifications settings page: an on/off switch plus From/Until hour pickers, defaulting to 21:00–07:00. Stored in the cloud user profile so the Worker enforces it at the point notifications are created, not just locally
- `GET`/`PUT /api/notifications/preferences` on the embedded server, proxying to the cloud `/profile` blob — keeps the invariant that the session token never reaches the renderer
- Copy fix on Scheduled: *"They only notify you when there's something worth knowing — every run is saved either way."*
- The quiet-hours hint states the important reassurance explicitly: tasks still run and still write to history, they just don't interrupt

## Testing

- `pnpm typecheck` clean (node + web, electron + server)
- `pnpm test` — 65 passed
- Biome formatted

**To verify by hand:** Settings → Notifications, toggle quiet hours and change the window; reopen the panel and confirm it round-trips. Signed out, the page falls back to the default window rather than erroring.