### PR TITLE
feat: 4/10 Stop suggesting things the agent can't do (desktop)

### DIFF
--- a/apps/electron/src/renderer/src/lib/onboarding-core.test.ts
+++ b/apps/electron/src/renderer/src/lib/onboarding-core.test.ts
@@ -184,12 +184,14 @@ describe("the handoff", () => {
 });
 
 describe("after onboarding", () => {
-  it("offers the three hero starters", () => {
-    expect(starterPrompts()).toEqual([
-      "Summarize what's on my screen",
-      "Rewrite what I'm looking at",
-      "Look this up and keep it short",
-    ]);
+  it("offers starters the current tool set can actually run", () => {
+    const prompts = starterPrompts();
+    expect(prompts).toHaveLength(3);
+    // Screen and cursor tools are disabled; a starter that needs them sends
+    // the user straight into a refusal.
+    for (const prompt of prompts) {
+      expect(prompt).not.toMatch(/on my screen|looking at|highlighted/i);
+    }
   });
 
   it("writes a profile without the retired focus field", () => {

--- a/apps/electron/src/renderer/src/lib/onboarding-core.ts
+++ b/apps/electron/src/renderer/src/lib/onboarding-core.ts
@@ -16,12 +16,13 @@ export const EASTER_EGGS = [
   "Keep poking and I'll start a ledger on that too.",
 ] as const;
 
-/** The hero workflows, in showcase order — only shown when no task was given. */
+/** Last-resort starters when the suggestions request fails. Every one must be
+ * something the current tool set can actually do. */
 export function starterPrompts(): string[] {
   return [
-    "Summarize what's on my screen",
-    "Rewrite what I'm looking at",
     "Look this up and keep it short",
+    "Help me draft a message I've been putting off",
+    "Remember something about how I work",
   ];
 }
 


### PR DESCRIPTION
**Stack position: 4 of 10.** Base is `main`. Pairs with freestyle-voice/cloud#138 (the do-now backfill), which is unaffected by the change below.

Fixes audit finding **A5**.

> **Scope changed on request.** This PR originally also added a `SuggestionStrip` — one suggestion pinned above the composer, to fix **A1** (opener cards only render on an empty thread, so past the first conversation the discovery surface is invisible). That's been pulled out for now and this PR is just the A5 fix. See *What was removed* below.

## The problem

`starterPrompts()` is the fallback the panel renders when the suggestions request fails. Two of its three entries — "Summarize what's on my screen" and "Rewrite what I'm looking at" — depend on `get_context` and `read_document`, which are commented out of `AGENT_CLIENT_TOOLS`.

So the *error* path handed users a suggested prompt that produces a refusal. The one moment the product is already not working is the moment it advertised a capability it doesn't have.

## What this does

Replaces all three with prompts the current tool set can honour: a web lookup, a draft, and teaching the brain something.

The test asserted the three exact strings. It now asserts the property that matters — no starter may reference screen or cursor context — so this can't regress silently the next time the copy changes. If the screen tools are restored, that assertion is the thing to revisit.

## What was removed

The `SuggestionStrip` component, its mount in `panel.tsx`, its CSS, and the `"strip"` analytics surface are all gone; `panel.tsx` is byte-identical to `main` again.

**A1 is therefore still open.** Opener cards continue to render only on an empty thread, and the panel boots into the latest one — so a returning user still won't see suggestions unless they press `＋ New`. PR 8's capability screen is reached from the openers, so it inherits the same limitation.

## Testing

- `pnpm typecheck` clean (node + web)
- `pnpm test` — 76 passed
- Biome clean