### PR TITLE
feat: 6/10 Wake the corner up (desktop)

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -3122,8 +3122,14 @@ ipcMain.on("sprite:event", (event, ev: unknown) => {
 });
 
 const NOTIFICATION_POLL_MS = 20_000;
+/** How long an unread bubble sits open before it collapses to the
+ *  companion's suggestion glow. It stays unread either way. */
+const NOTIFICATION_COLLAPSE_MS = 30_000;
 let notificationPollTimer: NodeJS.Timeout | null = null;
+let notificationCollapseTimer: NodeJS.Timeout | null = null;
+let notificationHovered = false;
 const notifiedIds = new Set<string>();
+const collapsedIds = new Set<string>();
 
 interface DesktopNotification {
   id: string;
@@ -3169,16 +3175,53 @@ async function postNotification(
   }
 }
 
+function clearCollapseTimer(): void {
+  if (!notificationCollapseTimer) return;
+  clearTimeout(notificationCollapseTimer);
+  notificationCollapseTimer = null;
+}
+
+function scheduleCollapse(ids: string[]): void {
+  clearCollapseTimer();
+  if (ids.length === 0) return;
+  notificationCollapseTimer = setTimeout(() => {
+    notificationCollapseTimer = null;
+    if (notificationHovered) {
+      scheduleCollapse(ids);
+      return;
+    }
+    for (const id of ids) collapsedIds.add(id);
+    hideNotifications();
+    setCompanionState("suggestion");
+  }, NOTIFICATION_COLLAPSE_MS);
+  notificationCollapseTimer.unref();
+}
+
 async function refreshNotifications(): Promise<void> {
   const items = await fetchNotifications();
   if (items.length === 0) {
+    clearCollapseTimer();
+    collapsedIds.clear();
     hideNotifications();
     notifyRendererChanged();
+    if (!panelBusy) setCompanionState("idle");
     return;
   }
 
-  showNotifications();
   notifyRendererChanged();
+
+  // A bubble the user neither opened nor dismissed used to float over their
+  // desktop until the 14-day server TTL. It now folds into the companion's
+  // glow, which keeps the item unread without holding the screen.
+  const live = items.filter((n) => !collapsedIds.has(n.id));
+  if (live.length === 0) {
+    hideNotifications();
+    setCompanionState("suggestion");
+  } else {
+    showNotifications();
+    setCompanionState("suggestion");
+    scheduleCollapse(live.map((n) => n.id));
+  }
 
   const fresh = items.filter(
     (n) => n.seenAt === null && !notifiedIds.has(n.id),
@@ -3191,6 +3234,12 @@ async function refreshNotifications(): Promise<void> {
     note.on("click", () => void openNotification(item.id));
     note.show();
   }
+  // The companion reacts to work that finished while the panel was closed;
+  // without this the sprite sleeps through the product's whole point.
+  companionWindow?.webContents.send("companion:sprite-event", {
+    kind: "emote",
+    emotion: "proud",
+  });
   await postNotification("/seen", { ids: fresh.map((n) => n.id) });
 }
 
@@ -3247,6 +3296,10 @@ ipcMain.on("notifications:open", (_event, id: unknown) => {
 ipcMain.on("notifications:set-height", (_event, height: unknown) => {
   if (typeof height !== "number") return;
   setNotificationHeight(height);
+});
+
+ipcMain.on("notifications:hover", (_event, hovering: unknown) => {
+  notificationHovered = hovering === true;
 });
 
 ipcMain.on("agent:turn-finished", (_event, payload: unknown) => {
@@ -3364,7 +3417,12 @@ ipcMain.on("panel:set-busy", (event, busy: unknown) => {
   const next = busy === true;
   // The corner sprite mirrors the agent loop: this is what puts Jeb at his
   // laptop (and Spark into its breathing state) while a turn runs.
-  if (next !== panelBusy) setCompanionState(next ? "working" : "idle");
+  // Falling out of a run must not clear a pending suggestion glow.
+  if (next !== panelBusy) {
+    setCompanionState(
+      next ? "working" : collapsedIds.size > 0 ? "suggestion" : "idle",
+    );
+  }
   panelBusy = next;
   if (panelBusy) cancelPanelHide();
 });

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -74,6 +74,7 @@ declare global {
       notificationDismiss: (id: string) => void;
       notificationOpen: (id: string) => void;
       notificationSetHeight: (height: number) => void;
+      notificationSetHovered: (hovering: boolean) => void;
       onNotificationsChanged: (callback: () => void) => () => void;
       agentTurnFinished: (payload: {
         threadId: string;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -137,6 +137,8 @@ const api = {
     ipcRenderer.send("notifications:open", id),
   notificationSetHeight: (height: number): void =>
     ipcRenderer.send("notifications:set-height", height),
+  notificationSetHovered: (hovering: boolean): void =>
+    ipcRenderer.send("notifications:hover", hovering),
   onNotificationsChanged: (callback: () => void): (() => void) => {
     const handler = (): void => callback();
     ipcRenderer.on("notifications:changed", handler);

--- a/apps/electron/src/renderer/src/components/notification.tsx
+++ b/apps/electron/src/renderer/src/components/notification.tsx
@@ -123,7 +123,12 @@ function NotificationStack(): React.JSX.Element | null {
   const shown = expanded ? items : items.slice(0, 1);
 
   return (
-    <div className="tavern tavern-bub-stack" ref={rootRef}>
+    <div
+      className="tavern tavern-bub-stack"
+      ref={rootRef}
+      onMouseEnter={() => window.api.notificationSetHovered(true)}
+      onMouseLeave={() => window.api.notificationSetHovered(false)}
+    >
       {shown.map((item, index) => (
         <NotificationCard
           key={item.id}

--- a/apps/electron/src/renderer/src/sprites/stage.tsx
+++ b/apps/electron/src/renderer/src/sprites/stage.tsx
@@ -82,6 +82,9 @@ export function SpriteStage({
 
   useEffect(() => {
     performerRef.current?.handle({ kind: "thinking", on: state === "working" });
+    if (state === "suggestion") {
+      performerRef.current?.handle({ kind: "emote", emotion: "proud" });
+    }
   }, [state]);
 
   useEffect(() => {


### PR DESCRIPTION
**Stack position: 6 of 10.** Base is `proposal/05-live-tool-progress` (#596). Desktop only.

Fixes audit findings **A9**, **B9**, **B10**.

## The problem

`CompanionState` includes `"suggestion"`. `spark.tsx` implements it in full — brighter satellites, an amber halo through two box-shadow rings. **Nothing in the codebase ever sent it.** `setCompanionState` had exactly one call site, toggling `working`/`idle` on panel busy-ness. The product's one ambient, non-interrupting proactive signal existed and was dark.

Meanwhile `refreshNotifications` called `showNotifications()` whenever `items.length > 0`, and only hid when the list emptied. With a 14-day server TTL, a brief you neither opened nor dismissed sat over your desktop indefinitely — on every workspace, over full-screen apps.

And the sprite emitter only runs inside a mounted panel, so scheduled runs — the product's most differentiated moment — produced no reaction at all.

## What this does

- **A pending notification puts the companion into `"suggestion"`.** ~5 lines, and the glow was already written.
- **The bubble collapses after 30s unmoused** into that glow. The item stays unread, undismissed and reachable in the stack; it just stops holding the screen. This gives you two urgency tiers instead of one: interrupt, then ambient.
- **Hovering defers the collapse** via a new `notifications:hover` IPC, so it can't vanish mid-read.
- **Falling out of a run no longer clears a pending glow** — `panelSetBusy(false)` now checks for collapsed notifications before going idle.
- **A notification arriving emits a sprite beat**, so the character reacts to background work.
- **Sheet sprites react to `"suggestion"` too** — previously `stage.tsx` only mapped `working`.

## Testing

- `pnpm typecheck` clean (node + web)
- `pnpm test` — 69 passed
- Biome formatted

**To verify by hand:** trigger a notification, leave the bubble alone for 30s, and confirm it folds into a glowing Spark with the item still in the stack when you hover. Hover it before 30s and it should stay put.