### PR TITLE
feat: 8/10 One screen answering "what can you do?" (desktop)

### DIFF
--- a/apps/electron/src/renderer/src/components/capabilities.tsx
+++ b/apps/electron/src/renderer/src/components/capabilities.tsx
@@ -1,0 +1,109 @@
+import { capture, captureSuggestion } from "@renderer/lib/analytics";
+import { apiFetch } from "@renderer/lib/api";
+import { applyOpenerTemplate } from "@renderer/lib/openers";
+import type React from "react";
+import { useEffect, useState } from "react";
+
+interface CapabilityItem {
+  id: string;
+  title: string;
+  subtitle: string;
+  prompt?: string;
+  templateId?: string;
+  toolkitSlug?: string;
+  locked?: boolean;
+}
+
+interface CapabilityGroup {
+  id: string;
+  title: string;
+  blurb: string;
+  items: CapabilityItem[];
+}
+
+export function Capabilities({
+  onPrompt,
+  onOpenApps,
+}: {
+  onPrompt: (text: string) => void;
+  onOpenApps: () => void;
+}): React.JSX.Element {
+  const [groups, setGroups] = useState<CapabilityGroup[] | null>(null);
+  const [applied, setApplied] = useState<ReadonlySet<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    void apiFetch("/api/suggestions/capabilities")
+      .then(async (res) =>
+        res.ok
+          ? ((await res.json()) as { groups: CapabilityGroup[] }).groups
+          : [],
+      )
+      .catch(() => [])
+      .then((next) => {
+        if (cancelled) return;
+        setGroups(next);
+        capture("capabilities_opened", {
+          groups: next.map((group) => group.id),
+          items: next.reduce((total, group) => total + group.items.length, 0),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (groups === null) return <div className="tavern-empty">Loading…</div>;
+  if (groups.length === 0)
+    return (
+      <div className="tavern-empty">
+        Couldn't load this right now. Ask in chat instead.
+      </div>
+    );
+
+  const run = (item: CapabilityItem): void => {
+    captureSuggestion("accepted", "capability", { id: item.id });
+    if (item.locked && item.toolkitSlug) {
+      onOpenApps();
+      return;
+    }
+    if (item.templateId) {
+      const templateId = item.templateId;
+      setApplied((prev) => new Set(prev).add(templateId));
+      capture("automation_applied", { surface: "capability", templateId });
+      void applyOpenerTemplate(templateId).catch(() => {});
+      return;
+    }
+    if (item.prompt) onPrompt(item.prompt);
+  };
+
+  return (
+    <>
+      <p className="tavern-set-hint is-lead">
+        Everything Freestyle can do for you. Tap one to run it.
+      </p>
+      {groups.map((group) => (
+        <div key={group.id} className="tavern-cap-group">
+          <div className="tavern-cap-head">
+            <span className="tavern-cap-title">{group.title}</span>
+            <span className="tavern-cap-blurb">{group.blurb}</span>
+          </div>
+          {group.items.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={`tavern-cap${item.locked ? " is-locked" : ""}`}
+              onClick={() => run(item)}
+            >
+              <span className="tavern-cap-item-title">
+                {item.title}
+                {item.templateId && applied.has(item.templateId) ? " ✓" : ""}
+              </span>
+              <span className="tavern-cap-item-sub">{item.subtitle}</span>
+            </button>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+}

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -1,9 +1,12 @@
+import { capture } from "@renderer/lib/analytics";
 import {
   type ConnectorAuthField,
+  type ConnectorAutomation,
   type ConnectorCatalogItem,
   type ConnectorConnection,
   disconnectToolkit,
 } from "@renderer/lib/connectors";
+import { applyOpenerTemplate } from "@renderer/lib/openers";
 import {
   connectorCatalogInfiniteQueryOptions,
   connectorConnectionsQueryOptions,
@@ -257,6 +260,54 @@ function ConnectedAppsSkeleton(): React.JSX.Element {
   );
 }
 
+function AutomationRow({
+  automation,
+  disabled,
+}: {
+  automation: ConnectorAutomation;
+  disabled: boolean;
+}): React.JSX.Element {
+  const [state, setState] = useState<"idle" | "busy" | "on" | "error">("idle");
+
+  const turnOn = (): void => {
+    setState("busy");
+    capture("automation_applied", {
+      surface: "apps",
+      templateId: automation.id,
+    });
+    void applyOpenerTemplate(automation.id)
+      .then((result) => setState(result.applied.length > 0 ? "on" : "error"))
+      .catch(() => setState("error"));
+  };
+
+  return (
+    <div className="connector-workflow is-static">
+      <strong>{automation.name}</strong>
+      <small>
+        {state === "on"
+          ? "On. Manage it in Settings \u2192 Scheduled."
+          : state === "error"
+            ? "Couldn't set that up. Ask in chat instead."
+            : `Runs ${automation.schedule}. Only notifies when it matters.`}
+      </small>
+      {state === "on" ? null : (
+        <button
+          type="button"
+          className="connector-action connector-workflow-action"
+          disabled={disabled || state === "busy"}
+          onClick={turnOn}
+        >
+          {state === "busy"
+            ? "Setting up\u2026"
+            : disabled
+              ? "Connect first"
+              : "Turn on"}
+        </button>
+      )}
+    </div>
+  );
+}
+
 function ConnectorDetail({
   slug,
   phase,
@@ -388,24 +439,41 @@ function ConnectorDetail({
             </p>
           )}
 
-          {details.workflows.length > 0 ? (
+          {(details.plays ?? []).length > 0 ? (
             <div className="connector-detail-section">
               <div className="connector-group-label">
-                <span>Things to try</span>
+                <span>Try it now</span>
               </div>
               <div className="connector-workflows">
-                {details.workflows.map((workflow) => (
+                {(details.plays ?? []).map((play) => (
                   <button
-                    key={workflow.name}
+                    key={play.name}
                     type="button"
                     className="connector-workflow"
                     disabled={!onUseWorkflow}
-                    title={workflow.prompt}
-                    onClick={() => onUseWorkflow?.(workflow.prompt)}
+                    title={play.prompt}
+                    onClick={() => onUseWorkflow?.(play.prompt)}
                   >
-                    <strong>{workflow.name}</strong>
-                    <small>{workflow.prompt}</small>
+                    <strong>{play.name}</strong>
+                    <small>{play.description}</small>
                   </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {(details.automations ?? []).length > 0 ? (
+            <div className="connector-detail-section">
+              <div className="connector-group-label">
+                <span>Run it on a schedule</span>
+              </div>
+              <div className="connector-workflows">
+                {(details.automations ?? []).map((automation) => (
+                  <AutomationRow
+                    key={automation.id}
+                    automation={automation}
+                    disabled={!connected}
+                  />
                 ))}
               </div>
             </div>

--- a/apps/electron/src/renderer/src/components/opener-cards.tsx
+++ b/apps/electron/src/renderer/src/components/opener-cards.tsx
@@ -47,9 +47,11 @@ function FallbackStarters({
 export function OpenerCards({
   busy,
   onPrompt,
+  onShowAll,
 }: {
   busy: boolean;
   onPrompt: (text: string) => void;
+  onShowAll?: () => void;
 }): React.JSX.Element {
   const queryClient = useQueryClient();
   const {
@@ -335,9 +337,20 @@ export function OpenerCards({
           Couldn't set that up. Try again, or ask Freestyle in chat.
         </p>
       ) : null}
-      <button type="button" className="tavern-opener-more" onClick={refresh}>
-        Show me different
-      </button>
+      <div className="tavern-opener-foot">
+        <button type="button" className="tavern-opener-more" onClick={refresh}>
+          Show me different
+        </button>
+        {onShowAll ? (
+          <button
+            type="button"
+            className="tavern-opener-more"
+            onClick={onShowAll}
+          >
+            See everything ↗
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -3,6 +3,7 @@ import "../tavern.css";
 
 import { useChat } from "@ai-sdk/react";
 import { BrainFiles } from "@renderer/components/brain-files";
+import { Capabilities } from "@renderer/components/capabilities";
 import { ConnectSuggestions } from "@renderer/components/connect-suggestions";
 import { ConnectedApps } from "@renderer/components/connected-apps";
 import { Markdown } from "@renderer/components/markdown";
@@ -760,6 +761,7 @@ function PanelInner({
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [capabilitiesOpen, setCapabilitiesOpen] = useState(false);
   const bodyRef = useRef<HTMLDivElement>(null);
   const dictationBaseRef = useRef<string | null>(null);
 
@@ -1097,6 +1099,7 @@ function PanelInner({
               onClick={() => {
                 capture("panel_tab_opened", { tab: id });
                 setSettingsOpen(false);
+                setCapabilitiesOpen(false);
                 setTab(id);
               }}
             >
@@ -1118,7 +1121,28 @@ function PanelInner({
         </div>
 
         <div className="tavern-body" role="tabpanel" ref={bodyRef}>
-          {settingsOpen ? (
+          {capabilitiesOpen ? (
+            <>
+              <button
+                type="button"
+                className="tavern-file-back"
+                onClick={() => setCapabilitiesOpen(false)}
+              >
+                ← What Freestyle can do
+              </button>
+              <Capabilities
+                onPrompt={(text) => {
+                  setCapabilitiesOpen(false);
+                  setNotice(null);
+                  void sendMessage({ text });
+                }}
+                onOpenApps={() => {
+                  setCapabilitiesOpen(false);
+                  setTab("apps");
+                }}
+              />
+            </>
+          ) : settingsOpen ? (
             <SettingsView
               onClose={() => setSettingsOpen(false)}
               onOpenThread={(threadId) => {
@@ -1220,6 +1244,7 @@ function PanelInner({
           ) : chatActive ? (
             <OpenerCards
               busy={busy}
+              onShowAll={() => setCapabilitiesOpen(true)}
               onPrompt={(text) => {
                 setNotice(null);
                 void sendMessage({ text });
@@ -1231,7 +1256,7 @@ function PanelInner({
           {notice ? <p className="tavern-notice">{notice}</p> : null}
         </div>
 
-        {chatActive && !settingsOpen ? (
+        {chatActive && !settingsOpen && !capabilitiesOpen ? (
           <div className="tavern-composer">
             <textarea
               id="panel-composer"

--- a/apps/electron/src/renderer/src/lib/connectors.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.ts
@@ -55,9 +55,23 @@ export type ConnectorToolSummary = {
   readOnly: boolean;
 };
 
+export type ConnectorPlay = {
+  name: string;
+  description: string;
+  prompt: string;
+};
+
+export type ConnectorAutomation = {
+  id: string;
+  name: string;
+  schedule: string;
+};
+
 export type ConnectorDetails = ConnectorCatalogItem & {
   tools: ConnectorToolSummary[];
   workflows: ConnectorWorkflow[];
+  plays?: ConnectorPlay[];
+  automations?: ConnectorAutomation[];
 };
 
 export function isConnectorToolName(name: string): boolean {

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1138,6 +1138,85 @@
   cursor: default;
 }
 
+.tavern-opener-foot {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.tavern-cap-group {
+  margin-top: 14px;
+}
+
+.tavern-cap-head {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin-bottom: 6px;
+}
+
+.tavern-cap-title {
+  font-family: var(--tavern-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--tavern-mute);
+}
+
+.tavern-cap-blurb {
+  font-size: 11.5px;
+  color: var(--tavern-mute);
+}
+
+.tavern-cap {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  padding: 8px 10px;
+  margin-top: 5px;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 9px;
+  background: var(--tavern-card);
+  cursor: pointer;
+}
+
+.tavern-cap:hover {
+  border-color: var(--tavern-ink);
+}
+
+.tavern-cap:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: 2px;
+}
+
+.tavern-cap.is-locked {
+  opacity: 0.68;
+}
+
+.tavern-cap-item-title {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--tavern-ink);
+}
+
+.tavern-cap-item-sub {
+  font-size: 11.5px;
+  color: var(--tavern-mute);
+}
+
+.connector-workflow.is-static {
+  cursor: default;
+}
+
+.connector-workflow-action {
+  margin-top: 6px;
+  align-self: flex-start;
+}
+
 .tavern-sched-actions {
   display: flex;
   gap: 6px;


### PR DESCRIPTION
**Stack position: 8 of 10.** Base is `proposal/07-automation-controls` (#598). Pairs with freestyle-voice/cloud#140 — the capabilities endpoint and the plays/automations split live there.

Fixes audit findings **A11** and **A6**.

## The problem

Onboarding teaches name, trade, two connects and one goal, then hands over. After that the only way to find out what the product can do is to guess into a composer whose placeholder reads "Ask anything" — the exact failure mode the company doc identifies in every other chat product. Meanwhile the Apps tab knows the full tool list for every connected app and shows it only to someone who drills into a specific app's detail view.

And the one surface that tried to teach — "Things to try" — sent schedule-shaped prompts, so tapping a demo subscribed you to a daily notification.

## What this does

**Capabilities screen.** Groups (*For founders* / *Anytime* / *With your apps* / *On a schedule*), one tap runs any row. Locked rows — an app play with no connection — route to the Apps tab rather than failing in chat. Reached from **"See everything ↗"** beside "Show me different" on the openers, so it sits exactly where someone who doesn't know what to ask is already looking.

**Apps detail** now shows **"Try it now"** (act-now prompts) and **"Run it on a schedule"** (a real Turn on button that applies the template) as separate sections, reading `plays` / `automations` with `?? []` fallbacks so an un-migrated cloud degrades to empty rather than crashing.

Both surfaces report under PR 1's schema (`surface: "capability"` / `"apps"`), so you can see which one actually teaches.

## Testing

- `pnpm typecheck` clean (node + web)
- `pnpm test` — 69 passed
- Biome formatted

**To verify by hand:** open the panel on an empty chat → "See everything ↗". Tap an Anytime row and it should send. Tap a locked app row and it should land you on Apps. Then open a connected app's detail and confirm the two sections are distinct, and that Turn on creates a task under Settings → Scheduled rather than sending a chat message.