### PR TITLE
feat: Simplify the empty-chat openers (desktop)

### DIFF
--- a/apps/electron/src/renderer/src/components/opener-cards.tsx
+++ b/apps/electron/src/renderer/src/components/opener-cards.tsx
@@ -18,6 +18,10 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
 
+/** Two at a time. Dismissing one reveals the next the server already sent. */
+const VISIBLE_CARDS = 2;
+const VISIBLE_TODOS = 3;
+
 function FallbackStarters({
   busy,
   onPrompt,
@@ -40,6 +44,58 @@ function FallbackStarters({
           </button>
         ))}
       </div>
+    </div>
+  );
+}
+
+function OpenerRow({
+  label,
+  logo,
+  logoName,
+  busy,
+  onRun,
+  onDismiss,
+  children,
+}: {
+  label: string;
+  logo?: string | undefined;
+  logoName?: string | undefined;
+  busy: boolean;
+  onRun: () => void;
+  onDismiss: () => void;
+  children?: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <div className="tavern-opener-row">
+      <div className="tavern-opener-line">
+        <button
+          type="button"
+          className="tavern-opener"
+          disabled={busy}
+          onClick={onRun}
+        >
+          {logoName ? (
+            <ConnectorLogo name={logoName} logo={logo} />
+          ) : (
+            <span className="tavern-opener-mark" aria-hidden="true">
+              ✦
+            </span>
+          )}
+          <span className="tavern-opener-title">{label}</span>
+          <span className="tavern-opener-go" aria-hidden="true">
+            →
+          </span>
+        </button>
+        <button
+          type="button"
+          className="tavern-opener-x"
+          aria-label={`Dismiss: ${label}`}
+          onClick={onDismiss}
+        >
+          ×
+        </button>
+      </div>
+      {children}
     </div>
   );
 }
@@ -90,9 +146,9 @@ export function OpenerCards({
   // filtering here keeps a dismissed card hidden even when the cached query
   // data still contains it.
   const dismissed = new Set(dismissedOpenerIds());
-  const cards = (query.data?.cards ?? []).filter(
-    (card) => !dismissed.has(card.id),
-  );
+  const cards = (query.data?.cards ?? [])
+    .filter((card) => !dismissed.has(card.id))
+    .slice(0, VISIBLE_CARDS);
 
   useEffect(() => {
     if (!query.data || cards.length === 0) return;
@@ -126,7 +182,7 @@ export function OpenerCards({
     queryClient,
   ]);
 
-  const todos = query.data?.todos ?? [];
+  const todos = (query.data?.todos ?? []).slice(0, VISIBLE_TODOS);
 
   if (
     query.isError ||
@@ -148,21 +204,19 @@ export function OpenerCards({
     });
   };
 
-  const refresh = (): void => {
-    for (const card of cards) dismissOpener(card.id);
-    setDismissTick((tick) => tick + 1);
-    capture("suggestion_refreshed", {
-      surface: "opener",
-      ids: cards.map((card) => card.id),
+  const accepted = (card: OpenerCard): void => {
+    captureSuggestion("accepted", "opener", {
+      id: card.id,
+      category: card.category,
+      kind: card.kind,
     });
-    void queryClient.invalidateQueries({ queryKey: queryKeys.openers });
   };
 
   return (
     <div className="tavern-openers">
       {todos.length > 0 ? (
         <div className="tavern-opener-todos">
-          <span className="tavern-openers-label">On your list</span>
+          <span className="tavern-openers-label">Your todos</span>
           {todos.map((todo) => (
             <div key={todo} className="tavern-opener-todo">
               <i aria-hidden="true">◇</i>
@@ -190,87 +244,53 @@ export function OpenerCards({
         if (card.kind === "prompt" && card.action.prompt) {
           const prompt = card.action.prompt;
           return (
-            <button
+            <OpenerRow
               key={card.id}
-              type="button"
-              className="tavern-opener"
-              disabled={busy}
-              onClick={() => {
-                captureSuggestion("accepted", "opener", {
-                  id: card.id,
-                  category: card.category,
-                  kind: card.kind,
-                });
+              label={card.title}
+              busy={busy}
+              onRun={() => {
+                accepted(card);
                 onPrompt(prompt);
               }}
-            >
-              <span className="tavern-opener-title">{card.title}</span>
-              <span className="tavern-opener-sub">{card.subtitle}</span>
-            </button>
+              onDismiss={() => dismiss(card)}
+            />
           );
         }
+
         if (card.kind === "connect" && card.action.toolkitSlug) {
           const slug = card.action.toolkitSlug;
           const name = card.action.toolkitName ?? slug;
           const phase = phases[slug];
           const apiKey = card.action.authMode === "api_key";
+          const label =
+            phase === "connected"
+              ? `${name} connected`
+              : phase === "opening"
+                ? "Opening…"
+                : phase === "pending"
+                  ? "Finish in your browser…"
+                  : apiKey
+                    ? `Add your ${name} API key`
+                    : `Connect ${name}`;
           return (
-            <div key={card.id} className="tavern-opener is-static">
-              <span className="tavern-opener-head">
-                <ConnectorLogo name={name} logo={card.action.toolkitLogo} />
-                <span className="tavern-opener-head-copy">
-                  <span className="tavern-opener-title">{card.title}</span>
-                  <span className="tavern-opener-sub">
-                    {phase === "connected"
-                      ? "Connected — ask and Freestyle will use it."
-                      : phase === "pending"
-                        ? "Finish connecting in your browser…"
-                        : card.subtitle}
-                  </span>
-                </span>
-              </span>
-              {phase === "connected" ? null : (
-                <span className="tavern-opener-actions">
-                  <button
-                    type="button"
-                    className="tavern-approve-btn tavern-approve-allow"
-                    disabled={phase === "opening" || phase === "pending"}
-                    onClick={() => {
-                      captureSuggestion("accepted", "opener", {
-                        id: card.id,
-                        category: card.category,
-                        kind: card.kind,
-                      });
-                      if (apiKey) {
-                        setKeyFormSlug((current) =>
-                          current === slug ? null : slug,
-                        );
-                      } else {
-                        connect(slug);
-                      }
-                    }}
-                  >
-                    {phase === "opening"
-                      ? apiKey
-                        ? "Connecting…"
-                        : "Opening…"
-                      : phase === "pending"
-                        ? "Waiting…"
-                        : apiKey
-                          ? "Add API key"
-                          : `Connect ${name}`}
-                  </button>
-                  <button
-                    type="button"
-                    className="tavern-approve-btn"
-                    onClick={() => dismiss(card)}
-                  >
-                    Not now
-                  </button>
-                </span>
-              )}
+            <OpenerRow
+              key={card.id}
+              label={label}
+              logo={card.action.toolkitLogo}
+              logoName={name}
+              busy={phase === "opening" || phase === "pending"}
+              onRun={() => {
+                accepted(card);
+                if (apiKey) {
+                  setKeyFormSlug((current) => (current === slug ? null : slug));
+                } else {
+                  connect(slug);
+                }
+              }}
+              onDismiss={() => dismiss(card)}
+            >
               {apiKey && keyFormSlug === slug && phase !== "connected" ? (
-                <span className="tavern-connect-keyform">
+                <div className="tavern-opener-keyform">
                   <ApiKeyForm
                     fields={card.action.authFields ?? DEFAULT_AUTH_FIELDS}
                     busy={phase === "opening"}
@@ -278,51 +298,34 @@ export function OpenerCards({
                       connectWithCredentials(slug, credentials)
                     }
                   />
-                </span>
+                </div>
               ) : null}
-            </div>
+            </OpenerRow>
           );
         }
+
         if (card.kind === "apply_template" && card.action.templateId) {
           const templateId = card.action.templateId;
           const isOn = applied.has(templateId);
           const isApplying =
             applyTemplate.isPending && applyTemplate.variables === templateId;
           return (
-            <div key={card.id} className="tavern-opener is-static">
-              <span className="tavern-opener-title">{card.title}</span>
-              <span className="tavern-opener-sub">
-                {isOn
-                  ? "On. Manage it any time in your scheduled tasks."
-                  : card.subtitle}
-              </span>
-              {isOn ? null : (
-                <span className="tavern-opener-actions">
-                  <button
-                    type="button"
-                    className="tavern-approve-btn tavern-approve-allow"
-                    disabled={isApplying}
-                    onClick={() => {
-                      captureSuggestion("accepted", "opener", {
-                        id: card.id,
-                        category: card.category,
-                        kind: card.kind,
-                      });
-                      applyTemplate.mutate(templateId);
-                    }}
-                  >
-                    {isApplying ? "Setting up…" : "Turn on"}
-                  </button>
-                  <button
-                    type="button"
-                    className="tavern-approve-btn"
-                    onClick={() => dismiss(card)}
-                  >
-                    Not now
-                  </button>
-                </span>
-              )}
-            </div>
+            <OpenerRow
+              key={card.id}
+              label={
+                isOn
+                  ? `${card.title} is on`
+                  : isApplying
+                    ? "Setting up…"
+                    : `Turn on ${card.title.toLowerCase()}`
+              }
+              busy={isApplying || isOn}
+              onRun={() => {
+                accepted(card);
+                applyTemplate.mutate(templateId);
+              }}
+              onDismiss={() => dismiss(card)}
+            />
           );
         }
         return null;
@@ -337,20 +340,15 @@ export function OpenerCards({
           Couldn't set that up. Try again, or ask Freestyle in chat.
         </p>
       ) : null}
-      <div className="tavern-opener-foot">
-        <button type="button" className="tavern-opener-more" onClick={refresh}>
-          Show me different
+      {onShowAll ? (
+        <button
+          type="button"
+          className="tavern-opener-more"
+          onClick={onShowAll}
+        >
+          See everything ↗
         </button>
-        {onShowAll ? (
-          <button
-            type="button"
-            className="tavern-opener-more"
-            onClick={onShowAll}
-          >
-            See everything ↗
-          </button>
-        ) : null}
-      </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -3097,59 +3097,97 @@
   text-align: left;
 }
 
-.tavern-opener-head {
+.tavern-opener-row {
+  display: grid;
+  gap: 4px;
+}
+
+.tavern-opener-line {
   display: flex;
-  align-items: center;
-  gap: 9px;
-}
-
-.tavern-opener-head-copy {
-  display: grid;
-  gap: 2px;
-  min-width: 0;
-}
-
-.tavern-opener {
-  display: grid;
-  gap: 3px;
-  font: inherit;
-  text-align: left;
-  padding: 9px 11px;
+  align-items: stretch;
+  gap: 0;
   border: 1px solid var(--tavern-rule);
   border-radius: 10px;
   background: color-mix(in srgb, var(--tavern-parchment) 74%, var(--tavern-card));
+  overflow: hidden;
+}
+
+.tavern-opener {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font: inherit;
+  text-align: left;
+  padding: 8px 10px;
+  border: none;
+  background: none;
   color: var(--tavern-ink);
   cursor: pointer;
 }
 
-.tavern-opener.is-static {
-  cursor: default;
-}
-
-.tavern-opener:not(.is-static):hover:not(:disabled) {
+.tavern-opener-line:hover:has(.tavern-opener:not(:disabled)) {
   border-color: var(--tavern-ink);
   box-shadow: 2px 2px 0 var(--tavern-lantern);
 }
 
 .tavern-opener:disabled {
-  opacity: 0.5;
+  opacity: 0.55;
   cursor: default;
 }
 
+.tavern-opener-mark {
+  color: var(--tavern-lantern);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
 .tavern-opener-title {
+  flex: 1;
+  min-width: 0;
   font-size: 12.5px;
   font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.tavern-opener-sub {
-  font-size: 11px;
-  color: var(--tavern-robe);
+.tavern-opener-go {
+  color: var(--tavern-mute);
+  font-size: 12px;
+  flex-shrink: 0;
 }
 
-.tavern-opener-actions {
-  display: flex;
-  gap: 6px;
-  margin-top: 5px;
+.tavern-opener:hover:not(:disabled) .tavern-opener-go {
+  color: var(--tavern-lantern);
+}
+
+.tavern-opener-x {
+  flex-shrink: 0;
+  padding: 0 9px;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  border: none;
+  border-left: 1px solid var(--tavern-rule);
+  background: none;
+  color: var(--tavern-mute);
+  cursor: pointer;
+}
+
+.tavern-opener-x:hover {
+  color: var(--tavern-ink);
+}
+
+.tavern-opener:focus-visible,
+.tavern-opener-x:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: -2px;
+}
+
+.tavern-opener-keyform {
+  padding: 0 2px;
 }
 
 .tavern-opener-more {
@@ -3830,11 +3868,7 @@
 /* ── Minimalist openers: todo rows + tighter cards ───────────────────── */
 
 .tavern-openers-label {
-  font-family: var(--tavern-mono);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-size: 11.5px;
   color: var(--tavern-mute);
 }
 
@@ -3888,12 +3922,6 @@
 }
 
 .tavern-opener {
-  gap: 2px;
   padding: 7px 10px;
 }
 
-.tavern-opener-sub {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}


### PR DESCRIPTION
Standalone against `main` — no longer stacked on the dark-mode PR, which is closed.

## The problem

The empty chat was carrying a todo list, three stacked cards each with its own CTA row (`Connect Gmail` / `Turn on` plus `Not now`), and two footer links. Too much furniture for a surface that should be glanceable.

## What changed

**Each suggestion is one narrow button that does the thing.** The row *is* the CTA — `✦ Connect Gmail →`, `✦ Turn on morning inbox brief →`, `✦ Find email threads still waiting on you →`. No nested buttons, no subtitle line.

```
Your todos
◇ Finish the deck                    launch ↗
◇ Reply to Sam                       launch ↗
◇ Book the flights                   launch ↗

[ ✦ Connect Gmail                  → ] [×]
[ ✦ Find threads waiting on you    → ] [×]

See everything ↗
```

**Two suggestions instead of three.** Capped client-side, so the server still sends its full set and dismissing one reveals the next without a refetch — the pool is unchanged, just the window onto it.

**Todos capped at three** (the server already sends three; now enforced both ends) and relabelled **"Your todos"** in plain muted text instead of the bold uppercase mono eyebrow.

**"Show me different" removed.** ⚠️ *Judgement call worth checking:* you named "the show more" as part of the clutter, and there were two footer links. I dropped the refresh and kept `See everything ↗`, because that's the only entry point to the capability screen (8/10) — losing it would leave no way to reach it. Say the word if you meant the other one.

## What I deliberately kept

A compact `×` on each row. Dismissal is what feeds `suggestion_dismissed` → the retirement rule in 9/10 that stops re-offering a twice-refused card. Without it that signal goes dark and a card you don't want returns forever. It's one glyph in the existing row, not a second CTA.

API-key connectors still expand their key form beneath the row when tapped.

## Testing

- `pnpm typecheck` clean (node + web)
- `pnpm test` — 80 passed
- Biome clean
- Touches two files only: `opener-cards.tsx` and `tavern.css`. No dark-mode content came along in the rebase — zero `prefers-color-scheme` in the stylesheet, and `overlay.css` / `spark.tsx` / `companion.tsx` / `panel.tsx` are untouched.
- Every colour comes from a token already defined on `main`
- Dead rules removed (`.tavern-opener-head`, `-head-copy`, `-sub`, `-actions`), and the new rows carry their own `:focus-visible` rule

**To check by hand:** empty chat with nothing connected, then with Gmail connected, then tap an API-key app to confirm the form still opens under the row.