### PR TITLE
fix(analytics): bind events to the cloud user on every launch

### DIFF
--- a/apps/server/src/lib/posthog.ts
+++ b/apps/server/src/lib/posthog.ts
@@ -60,11 +60,53 @@ function getClient(): PostHog {
   _client.register({
     app_version: process.env.FREESTYLE_APP_VERSION ?? "unknown",
     environment: getEnvironment(),
+    os: process.platform,
   });
   return _client;
 }
 
 let _deviceId: string | null = null;
+
+const DEVICE_ID_KEY = "posthog_device_id";
+const LINKED_USER_KEY = "posthog_linked_user_id";
+
+function readSetting(key: string): string | null {
+  try {
+    const row = getDb()
+      .prepare("SELECT value FROM settings WHERE key = ?")
+      .get(key) as { value: string } | undefined;
+    return row?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSetting(key: string, value: string): void {
+  try {
+    getDb()
+      .prepare(
+        `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, datetime('now'))
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')`,
+      )
+      .run(key, value);
+  } catch {
+    // Analytics bookkeeping must never break the app.
+  }
+}
+
+/**
+ * Start a fresh anonymous identity for this machine.
+ *
+ * Called when a different account signs in. The device id is the anonymous
+ * handle we link to a user, so reusing it across accounts would weld two
+ * people into one PostHog person.
+ */
+export function rotateDeviceId(): string {
+  const next = crypto.randomUUID();
+  _deviceId = next;
+  writeSetting(DEVICE_ID_KEY, next);
+  return next;
+}
 
 export function getDeviceId(): string {
   if (_deviceId) return _deviceId;
@@ -105,17 +147,70 @@ export interface CloudIdentity {
   name?: string | null;
 }
 
+/**
+ * Bind this process's events to a cloud user.
+ *
+ * Must run on every launch that has a session, not only at sign-in: without it
+ * `activeDistinctId()` falls back to the device id while the Worker attributes
+ * the same person to `user.id`, and the two halves of a retention chart stop
+ * describing the same population.
+ *
+ * The anonymous handle is linked forward exactly once per account. A different
+ * account on the same machine rotates the device id first, so the previous
+ * user's anonymous history is never merged into the new one.
+ */
 export function identifyCloudUser(user: CloudIdentity): void {
   _userDistinctId = user.id;
   try {
+    const linked = readSetting(LINKED_USER_KEY);
+    const isFirstLink = linked === null;
+    const isAccountSwitch = linked !== null && linked !== user.id;
+
+    if (isAccountSwitch) rotateDeviceId();
+    if (linked !== user.id) writeSetting(LINKED_USER_KEY, user.id);
+
     if (!isEnabled()) return;
-    const client = getClient();
-    // Merge the prior anonymous (device) person into the identified user.
-    client.alias({ distinctId: user.id, alias: getDeviceId() });
-    client.identify({
+    getClient().identify({
       distinctId: user.id,
-      properties: { email: user.email, name: user.name ?? undefined },
+      // $anon_distinct_id is the supported replacement for alias(): it merges
+      // the pre-sign-in device person into this user, once.
+      ...(isFirstLink
+        ? { properties: { $anon_distinct_id: getDeviceId() } }
+        : {}),
     });
+    setPersonProperties({
+      email: user.email,
+      ...(user.name ? { name: user.name } : {}),
+    });
+  } catch {
+    // Never let analytics errors affect the app
+  }
+}
+
+/**
+ * Durable traits on the person, not the event. Safe to call repeatedly; only
+ * send values that actually changed.
+ */
+export function setPersonProperties(properties: Record<string, unknown>): void {
+  try {
+    if (!isEnabled()) return;
+    getClient().capture({
+      distinctId: activeDistinctId(),
+      event: "$set",
+      properties: { $set: properties },
+    });
+  } catch {
+    // Never let analytics errors affect the app
+  }
+}
+
+/** Attach a property to every subsequent event from this process. */
+export function registerSuperProperties(
+  properties: Record<string, string | number | boolean>,
+): void {
+  try {
+    if (!isEnabled()) return;
+    getClient().register(properties);
   } catch {
     // Never let analytics errors affect the app
   }

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -58,8 +58,12 @@ const auth = new Hono()
     }
     return next();
   })
+  // Called on every launch, so this is where a returning user's identity is
+  // re-established. Without it, events after a restart attribute to the device
+  // id while the cloud attributes the same person to their user id.
   .get("/status", async (c) => {
     const { user, verified } = await validateSession();
+    if (user) identifyCloudUser(user);
     return c.json({ authenticated: !!user, user, verified });
   })
   .post("/device/code", async (c) => {


### PR DESCRIPTION
**Merge this first.** Until it lands, every retention and person-level number is measuring a blend of two populations, and adding events on top only produces more data at the same accuracy.

## The defect

`identifyCloudUser()` had exactly two call sites: completing the device-flow sign-in, and renaming yourself in Settings. **Neither runs on app launch.** So after a relaunch `_userDistinctId` is null, desktop events attribute to `getDeviceId()`, and every Worker event attributes to the cloud `user.id`. Any chart mixing the two sees two different people.

Second defect, same area: the PostHog device id never rotates. The app already knows a different account has signed in — `resetSyncedPreferencesForAccount()` scrubs the previous account's preferences for exactly this case — but the analytics identity is left alone, so `alias()` welds both users into one person.

## What changed

- **`GET /auth/status` identifies when a session exists.** The desktop already calls it on every launch, so identity is re-established before the first event of a session. One line, and it is the whole fix for the main defect.
- **`alias()` → `identify()` with `$anon_distinct_id`.** The supported merge primitive rather than the legacy one, and the link is made *once per account* (tracked in `posthog_linked_user_id`) instead of on every sign-in.
- **A different account rotates the device id first**, so the previous user's anonymous history is never merged into the new one.
- Adds `setPersonProperties` and `registerSuperProperties` for durable traits, and stamps `os` on every event.

## Testing

- `pnpm typecheck` clean (electron + server)
- `pnpm test` — 80 passed
- Biome clean

**To verify by hand:** sign in, quit, relaunch, then trigger any event with `FREESTYLE_ANALYTICS_DEV=1`. Its `distinct_id` should be the cloud user id, not a UUID. Then sign out, sign in as a second account, and confirm the two produce different persons.

## Environment

None needed. The desktop's project key is compiled in; `FREESTYLE_ANALYTICS_DEV=1` emits in dev, `DO_NOT_TRACK=1` and the in-app telemetry toggle disable it.