### PR TITLE
feat(analytics): instrument the desktop surfaces

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -391,6 +391,39 @@ function serverClient() {
   return hc<AppType>(getServerBaseUrl(), { headers: getServerAuthHeaders() });
 }
 
+/**
+ * Emit a product event from the main process.
+ *
+ * Goes through the server's /api/telemetry so it inherits the telemetry
+ * opt-out, DO_NOT_TRACK, production gating and identity that every other
+ * event already honors. Fire-and-forget.
+ */
+function captureMain(
+  event: string,
+  properties?: Record<string, unknown>,
+): void {
+  void fetch(`${getServerBaseUrl()}/api/telemetry`, {
+    method: "POST",
+    headers: {
+      ...getServerAuthHeaders(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ event, ...(properties ? { properties } : {}) }),
+  }).catch(() => {});
+}
+
+/** Durable traits on the person: the sprite in use, launch-at-login. */
+function capturePerson(properties: Record<string, unknown>): void {
+  void fetch(`${getServerBaseUrl()}/api/telemetry/person`, {
+    method: "POST",
+    headers: {
+      ...getServerAuthHeaders(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ properties }),
+  }).catch(() => {});
+}
+
 /** Relay a main-process pipeline event to the current server target with auth. */
 function relayServerEvent(event: Parameters<typeof relayEvent>[1]): void {
   relayEvent(getServerBaseUrl(), event, getServerAuthHeaders());
@@ -1495,7 +1528,7 @@ function createTray(): void {
   }
 
   tray.on("click", () => {
-    openPanel({ focusComposer: true });
+    openPanel({ focusComposer: true, trigger: "tray" });
   });
 }
 
@@ -1586,7 +1619,7 @@ if (!gotTheLock) {
 }
 
 app.on("second-instance", () => {
-  openPanel({ focusComposer: true });
+  openPanel({ focusComposer: true, trigger: "tray" });
 });
 
 // This method will be called when Electron has finished
@@ -1804,6 +1837,7 @@ app.whenReady().then(async () => {
   ipcMain.handle("permissions:request-mic", async () => {
     if (process.platform === "darwin") {
       const granted = await systemPreferences.askForMediaAccess("microphone");
+      captureMain("permission_resolved", { kind: "microphone", granted });
       return granted ? "granted" : "denied";
     }
     if (process.platform === "win32") {
@@ -1819,6 +1853,7 @@ app.whenReady().then(async () => {
   });
 
   ipcMain.on("permissions:open-accessibility", () => {
+    captureMain("permission_prompted", { kind: "accessibility" });
     openAccessibilitySettings();
   });
 
@@ -1931,6 +1966,10 @@ app.whenReady().then(async () => {
   if (readSettings().companionEnabled !== false) {
     createCompanionWindow();
     registerSummonShortcut();
+    capturePerson({
+      companion_form: companionFormSetting(),
+      launch_at_login: app.getLoginItemSettings().openAtLogin,
+    });
     initNotificationWindow({
       spriteForm: () => companionFormSetting(),
       companionBounds: () => {
@@ -3100,6 +3139,11 @@ ipcMain.handle("companion:form", () => companionFormSetting());
 
 ipcMain.on("companion:set-form", (_event, form: string) => {
   const next = parseCompanionForm(form);
+  const previous = companionFormSetting();
+  if (previous !== next) {
+    captureMain("sprite_changed", { from: previous, to: next });
+    capturePerson({ companion_form: next });
+  }
   writeSettings({ companionForm: next });
   const win = companionWindow;
   if (win && !win.isDestroyed()) {
@@ -3253,7 +3297,7 @@ async function openNotification(id: string): Promise<void> {
   } | null;
   await refreshNotifications();
   if (result?.threadId) {
-    openPanel({ focusComposer: false });
+    openPanel({ focusComposer: false, trigger: "notification" });
     const win = panelWindow;
     if (!win || win.isDestroyed()) return;
     const threadId = result.threadId;
@@ -3351,7 +3395,7 @@ ipcMain.on("companion:set-hot-rect", (event, rect: PillHotRect | null) => {
 
 ipcMain.on("companion:hover", (event) => {
   if (event.sender !== companionWindow?.webContents) return;
-  openPanel();
+  openPanel({ trigger: "hover" });
 });
 
 let pendingDictation: { kind: string; text: string } | null = null;
@@ -3376,7 +3420,7 @@ function forwardDictation(
 
 ipcMain.on("panel:open-for-dictation", (event) => {
   if (event.sender !== companionWindow?.webContents) return;
-  openPanel({ focusComposer: true });
+  openPanel({ focusComposer: true, trigger: "dictation" });
 });
 
 ipcMain.on("panel:dictation-partial", (event, text: string) => {
@@ -3511,11 +3555,28 @@ function cancelPanelHide(): void {
   panelHideTimer = null;
 }
 
-function openPanel(opts: { focusComposer?: boolean } = {}): void {
+type PanelTrigger =
+  | "hover"
+  | "hotkey"
+  | "notification"
+  | "dictation"
+  | "tray"
+  | "other";
+
+function openPanel(
+  opts: { focusComposer?: boolean; trigger?: PanelTrigger } = {},
+): void {
   cancelPanelHide();
+  const wasVisible =
+    !!panelWindow && !panelWindow.isDestroyed() && panelWindow.isVisible();
   createPanelWindow();
   const win = panelWindow;
   if (!win || win.isDestroyed()) return;
+  // Only a genuine hidden -> visible transition is an open; re-entry while
+  // already showing (hover re-fires, focus requests) is not.
+  if (!wasVisible) {
+    captureMain("panel_opened", { trigger: opts.trigger ?? "other" });
+  }
   invalidateDictationDisplayRequest(dictationDisplayRequests);
   const cursorDisplay = screen.getDisplayNearestPoint(
     screen.getCursorScreenPoint(),
@@ -3579,7 +3640,7 @@ function registerSummonShortcut(): void {
     const ok = globalShortcut.register(SUMMON_ACCELERATOR, () => {
       const visible = panelWindow?.isVisible() && !panelWindow.isDestroyed();
       if (visible) closePanel();
-      else openPanel({ focusComposer: true });
+      else openPanel({ focusComposer: true, trigger: "hotkey" });
     });
     if (!ok)
       log.warn(`Could not register summon shortcut ${SUMMON_ACCELERATOR}`);

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -705,6 +705,7 @@ function ThreadHistory({
               type="button"
               className={`tavern-thread-row${t.id === currentId ? " is-current" : ""}`}
               onClick={() => {
+                capture("thread_opened", { origin });
                 void queryClient
                   .fetchQuery(threadQueryOptions(t.id))
                   .then((picked) => picked && onPick(picked));
@@ -764,6 +765,8 @@ function PanelInner({
   const [capabilitiesOpen, setCapabilitiesOpen] = useState(false);
   const bodyRef = useRef<HTMLDivElement>(null);
   const dictationBaseRef = useRef<string | null>(null);
+  // Whether the current draft arrived by voice, so message_sent can say so.
+  const dictatedRef = useRef(false);
 
   const transport = useMemo(
     () =>
@@ -846,6 +849,12 @@ function PanelInner({
   const send = (): void => {
     const text = draft.trim();
     if (!text || tab !== "chat" || busy || approvals.length > 0) return;
+    capture("message_sent", {
+      source: dictatedRef.current ? "dictated" : "typed",
+      chars: text.length,
+      threadIsNew: messages.length === 0,
+    });
+    dictatedRef.current = false;
     setNotice(null);
     setDraft("");
     void sendMessage({ text });
@@ -965,6 +974,8 @@ function PanelInner({
         return;
       }
       setNotice(null);
+      if (ev.kind === "partial" || ev.kind === "final")
+        dictatedRef.current = true;
       if (ev.kind === "partial") {
         // Snapshot whatever was typed before this utterance once; every
         // partial then re-renders base + live text, replacing the previous

--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -17,6 +17,7 @@ import {
   formatAcceleratorKeys,
   useHotkeyRecorder,
 } from "@renderer/hooks/use-hotkey-recorder";
+import { capture } from "@renderer/lib/analytics";
 import { apiFetch } from "@renderer/lib/api";
 import { useCloudAuth } from "@renderer/lib/auth-context";
 import { LANGUAGES } from "@renderer/lib/languages";
@@ -830,7 +831,10 @@ function BillingPage(): React.JSX.Element {
             type="button"
             className="tavern-approve-btn tavern-approve-allow"
             disabled={usage.checkoutStatus === "pending"}
-            onClick={() => void usage.startCheckout(period)}
+            onClick={() => {
+              capture("upgrade_clicked", { surface: "settings", period });
+              void usage.startCheckout(period);
+            }}
           >
             {usage.checkoutStatus === "pending"
               ? "Finish in browser…"

--- a/apps/electron/src/renderer/src/lib/brain-fs.ts
+++ b/apps/electron/src/renderer/src/lib/brain-fs.ts
@@ -1,3 +1,4 @@
+import { capture } from "@renderer/lib/analytics";
 import { apiFetch } from "@renderer/lib/api";
 
 export interface BrainFile {
@@ -114,17 +115,28 @@ export async function readBrainFile(path: string): Promise<string | null> {
   return text;
 }
 
+/** Top-level brain folder, so we can report where a write landed without
+ *  ever reporting the path or the contents. */
+function brainFolder(path: string): string {
+  const [head] = path.split("/");
+  return head?.endsWith(".md") ? "root" : (head ?? "root");
+}
+
 export async function writeBrainFile(
   path: string,
   text: string,
 ): Promise<boolean> {
   const res = await fsCall("write", { path, text });
-  return res?.ok === true;
+  const ok = res?.ok === true;
+  if (ok) capture("brain_file_edited", { folder: brainFolder(path) });
+  return ok;
 }
 
 export async function deleteBrainFile(path: string): Promise<boolean> {
   const res = await fsCall("delete", { path });
-  return res?.ok === true;
+  const ok = res?.ok === true;
+  if (ok) capture("brain_file_deleted", { folder: brainFolder(path) });
+  return ok;
 }
 
 export async function listBrainFiles(prefix?: string): Promise<BrainFile[]> {

--- a/apps/electron/src/renderer/src/lib/connectors.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.ts
@@ -1,3 +1,4 @@
+import { capture } from "@renderer/lib/analytics";
 import { apiFetch } from "@renderer/lib/api";
 
 export type ConnectorStatus =
@@ -212,6 +213,7 @@ export async function disconnectToolkit(toolkit: string): Promise<void> {
       { method: "POST" },
     ),
   );
+  capture("connector_disconnected", { toolkit });
 }
 
 export async function approveConnectorAction(input: {

--- a/apps/electron/src/renderer/src/lib/use-connector-connect.ts
+++ b/apps/electron/src/renderer/src/lib/use-connector-connect.ts
@@ -1,3 +1,4 @@
+import { capture } from "@renderer/lib/analytics";
 import {
   connectorStatus,
   connectToolkit,
@@ -22,6 +23,26 @@ export function useConnectorConnect() {
   const [phases, setPhases] = useState<Record<string, ConnectPhase>>({});
   const [error, setError] = useState<string | null>(null);
   const timers = useRef<Map<string, number>>(new Map());
+  // Every connect surface funnels through this hook, so instrumenting here
+  // covers the openers, the in-chat cards and the Apps tab at once.
+  const attempts = useRef<Map<string, { at: number; authMode: string }>>(
+    new Map(),
+  );
+
+  const started = useCallback((slug: string, authMode: string) => {
+    attempts.current.set(slug, { at: Date.now(), authMode });
+    capture("connector_connect_started", { toolkit: slug, authMode });
+  }, []);
+
+  const connected = useCallback((slug: string) => {
+    const attempt = attempts.current.get(slug);
+    attempts.current.delete(slug);
+    capture("connector_connected", {
+      toolkit: slug,
+      authMode: attempt?.authMode ?? "oauth",
+      ...(attempt ? { elapsedMs: Date.now() - attempt.at } : {}),
+    });
+  }, []);
 
   const setPhase = useCallback((slug: string, phase: ConnectPhase | null) => {
     setPhases((current) => {
@@ -58,6 +79,7 @@ export function useConnectorConnect() {
     (slug: string) => {
       setError(null);
       setPhase(slug, "opening");
+      started(slug, "oauth");
       void connectToolkit(slug)
         .then(() => {
           setPhase(slug, "pending");
@@ -77,6 +99,7 @@ export function useConnectorConnect() {
                 if (connection?.status === "active") {
                   stopPolling(slug);
                   setPhase(slug, "connected");
+                  connected(slug);
                   void queryClient.invalidateQueries({
                     queryKey: queryKeys.connectors.all,
                   });
@@ -105,17 +128,19 @@ export function useConnectorConnect() {
           );
         });
     },
-    [queryClient, setPhase, stopPolling],
+    [queryClient, setPhase, stopPolling, started, connected],
   );
 
   const connectWithCredentials = useCallback(
     (slug: string, credentials: Record<string, string>) => {
       setError(null);
       setPhase(slug, "opening");
+      started(slug, "api_key");
       void connectToolkitWithCredentials(slug, credentials)
         .then((connection) => {
           if (connection?.status === "active") {
             setPhase(slug, "connected");
+            connected(slug);
           } else {
             setPhase(slug, null);
             setError("That API key could not be verified.");
@@ -133,7 +158,7 @@ export function useConnectorConnect() {
           );
         });
     },
-    [queryClient, setPhase],
+    [queryClient, setPhase, started, connected],
   );
 
   return {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,6 +8,7 @@ import { logger } from "hono/logger";
 import { requestId } from "hono/request-id";
 import { timeout } from "hono/timeout";
 import { WebSocketServer } from "ws";
+import { recordAppLaunch } from "./lib/app-lifecycle.js";
 import { authMiddleware, setAuthToken } from "./lib/auth.js";
 import { refreshCleanupPromptConfig } from "./lib/editor/prompt-config.js";
 import { formatError } from "./lib/format-error.js";
@@ -247,6 +248,9 @@ export async function startServer(
   // Keep the cloud profile's timezone current so scheduled tasks fire on this
   // machine's clock. No-op when signed out or unchanged; never throws.
   void syncTimezoneToCloud();
+
+  // Install / update / launch, emitted once per process start.
+  recordAppLaunch();
 
   // Flush any preference syncs that were queued while offline in a previous
   // run. No-op when signed out / nothing pending; never throws.

--- a/apps/server/src/lib/app-lifecycle.ts
+++ b/apps/server/src/lib/app-lifecycle.ts
@@ -1,0 +1,56 @@
+import { getDb } from "./db.js";
+import { capture, registerSuperProperties } from "./posthog.js";
+import { getSession } from "./sessions.js";
+
+const VERSION_KEY = "analytics_last_version";
+
+function readSetting(key: string): string | null {
+  try {
+    const row = getDb()
+      .prepare("SELECT value FROM settings WHERE key = ?")
+      .get(key) as { value: string } | undefined;
+    return row?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSetting(key: string, value: string): void {
+  try {
+    getDb()
+      .prepare(
+        `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, datetime('now'))
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')`,
+      )
+      .run(key, value);
+  } catch {
+    // Analytics bookkeeping must never break startup.
+  }
+}
+
+/**
+ * Emit the launch trio once per process start.
+ *
+ * Lives on the server rather than in main because this is where both the
+ * persisted settings table and FREESTYLE_APP_VERSION are already available, so
+ * "is this the first launch" needs no new storage.
+ */
+export function recordAppLaunch(): void {
+  const version = process.env.FREESTYLE_APP_VERSION ?? "unknown";
+  const previous = readSetting(VERSION_KEY);
+
+  registerSuperProperties({ app_version: version });
+
+  if (previous === null) {
+    capture("app_installed", { version });
+  } else if (previous !== version) {
+    capture("app_updated", { from: previous, to: version });
+  }
+  if (previous !== version) writeSetting(VERSION_KEY, version);
+
+  capture("app_launched", {
+    version,
+    signed_in: !!getSession(),
+    first_launch: previous === null,
+  });
+}

--- a/apps/server/src/lib/posthog.ts
+++ b/apps/server/src/lib/posthog.ts
@@ -60,11 +60,53 @@ function getClient(): PostHog {
   _client.register({
     app_version: process.env.FREESTYLE_APP_VERSION ?? "unknown",
     environment: getEnvironment(),
+    os: process.platform,
   });
   return _client;
 }
 
 let _deviceId: string | null = null;
+
+const DEVICE_ID_KEY = "posthog_device_id";
+const LINKED_USER_KEY = "posthog_linked_user_id";
+
+function readSetting(key: string): string | null {
+  try {
+    const row = getDb()
+      .prepare("SELECT value FROM settings WHERE key = ?")
+      .get(key) as { value: string } | undefined;
+    return row?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSetting(key: string, value: string): void {
+  try {
+    getDb()
+      .prepare(
+        `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, datetime('now'))
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')`,
+      )
+      .run(key, value);
+  } catch {
+    // Analytics bookkeeping must never break the app.
+  }
+}
+
+/**
+ * Start a fresh anonymous identity for this machine.
+ *
+ * Called when a different account signs in. The device id is the anonymous
+ * handle we link to a user, so reusing it across accounts would weld two
+ * people into one PostHog person.
+ */
+export function rotateDeviceId(): string {
+  const next = crypto.randomUUID();
+  _deviceId = next;
+  writeSetting(DEVICE_ID_KEY, next);
+  return next;
+}
 
 export function getDeviceId(): string {
   if (_deviceId) return _deviceId;
@@ -105,17 +147,70 @@ export interface CloudIdentity {
   name?: string | null;
 }
 
+/**
+ * Bind this process's events to a cloud user.
+ *
+ * Must run on every launch that has a session, not only at sign-in: without it
+ * `activeDistinctId()` falls back to the device id while the Worker attributes
+ * the same person to `user.id`, and the two halves of a retention chart stop
+ * describing the same population.
+ *
+ * The anonymous handle is linked forward exactly once per account. A different
+ * account on the same machine rotates the device id first, so the previous
+ * user's anonymous history is never merged into the new one.
+ */
 export function identifyCloudUser(user: CloudIdentity): void {
   _userDistinctId = user.id;
   try {
+    const linked = readSetting(LINKED_USER_KEY);
+    const isFirstLink = linked === null;
+    const isAccountSwitch = linked !== null && linked !== user.id;
+
+    if (isAccountSwitch) rotateDeviceId();
+    if (linked !== user.id) writeSetting(LINKED_USER_KEY, user.id);
+
     if (!isEnabled()) return;
-    const client = getClient();
-    // Merge the prior anonymous (device) person into the identified user.
-    client.alias({ distinctId: user.id, alias: getDeviceId() });
-    client.identify({
+    getClient().identify({
       distinctId: user.id,
-      properties: { email: user.email, name: user.name ?? undefined },
+      // $anon_distinct_id is the supported replacement for alias(): it merges
+      // the pre-sign-in device person into this user, once.
+      ...(isFirstLink
+        ? { properties: { $anon_distinct_id: getDeviceId() } }
+        : {}),
     });
+    setPersonProperties({
+      email: user.email,
+      ...(user.name ? { name: user.name } : {}),
+    });
+  } catch {
+    // Never let analytics errors affect the app
+  }
+}
+
+/**
+ * Durable traits on the person, not the event. Safe to call repeatedly; only
+ * send values that actually changed.
+ */
+export function setPersonProperties(properties: Record<string, unknown>): void {
+  try {
+    if (!isEnabled()) return;
+    getClient().capture({
+      distinctId: activeDistinctId(),
+      event: "$set",
+      properties: { $set: properties },
+    });
+  } catch {
+    // Never let analytics errors affect the app
+  }
+}
+
+/** Attach a property to every subsequent event from this process. */
+export function registerSuperProperties(
+  properties: Record<string, string | number | boolean>,
+): void {
+  try {
+    if (!isEnabled()) return;
+    getClient().register(properties);
   } catch {
     // Never let analytics errors affect the app
   }

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -58,8 +58,12 @@ const auth = new Hono()
     }
     return next();
   })
+  // Called on every launch, so this is where a returning user's identity is
+  // re-established. Without it, events after a restart attribute to the device
+  // id while the cloud attributes the same person to their user id.
   .get("/status", async (c) => {
     const { user, verified } = await validateSession();
+    if (user) identifyCloudUser(user);
     return c.json({ authenticated: !!user, user, verified });
   })
   .post("/device/code", async (c) => {

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -5,7 +5,13 @@ import {
 } from "@freestyle-voice/validations";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import { capture, captureException, getDeviceId } from "../lib/posthog.js";
+import { z } from "zod";
+import {
+  capture,
+  captureException,
+  getDeviceId,
+  setPersonProperties,
+} from "../lib/posthog.js";
 import agentRoute from "./agent.js";
 import agentOsRoute from "./agent-os.js";
 import agentThreadsRoute from "./agent-threads.js";
@@ -46,6 +52,19 @@ const apiRouter = new Hono()
     capture(event, properties);
     return c.json({ ok: true });
   })
+  // Durable traits on the person rather than the event: the sprite in use, the
+  // trade picked at onboarding. Same opt-out gate as above.
+  .post(
+    "/telemetry/person",
+    zValidator(
+      "json",
+      z.object({ properties: z.record(z.string(), z.unknown()) }),
+    ),
+    (c) => {
+      setPersonProperties(c.req.valid("json").properties);
+      return c.json({ ok: true });
+    },
+  )
   // Crash/error reports from the renderer (window.onerror, unhandled
   // rejections, React error boundary). Always persisted to the local log file
   // for diagnostics; PostHog reporting is gated by the telemetry opt-out inside

--- a/apps/server/src/routes/usage.ts
+++ b/apps/server/src/routes/usage.ts
@@ -4,6 +4,10 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { formatError } from "../lib/format-error.js";
 import { fetchCloudUsage } from "../lib/freestyle-cloud.js";
+import {
+  registerSuperProperties,
+  setPersonProperties,
+} from "../lib/posthog.js";
 import { getSessionToken } from "../lib/sessions.js";
 
 const log = createAppLogger("usage");
@@ -14,6 +18,17 @@ const log = createAppLogger("usage");
  * is detected on the next poll; all other reads omit it for the cached path.
  */
 const usageQuerySchema = z.object({ fresh: z.literal("1").optional() });
+
+// The plan changes rarely and is wanted on every breakdown, so it rides as a
+// super property rather than being stamped per event by each caller.
+let lastPlan: string | null = null;
+
+function rememberPlan(plan: string): void {
+  if (plan === lastPlan) return;
+  lastPlan = plan;
+  registerSuperProperties({ plan });
+  setPersonProperties({ plan });
+}
 
 const usage = new Hono().get(
   "/",
@@ -28,6 +43,7 @@ const usage = new Hono().get(
       // cloud bypasses its plan cache and reports an upgrade immediately.
       const { fresh } = c.req.valid("query");
       const balance = await fetchCloudUsage(token, { fresh: fresh === "1" });
+      rememberPlan(balance.plan ?? "free");
       return c.json(balance);
     } catch (err) {
       log.warn(`failed to fetch cloud usage: ${formatError(err)}`);


### PR DESCRIPTION
**Stacked on #607.** Merge that first — these events are only trustworthy once identity is.

Implements the desktop half of the telemetry plan. Everything routes through the existing `/api/telemetry` path, so the opt-out, `DO_NOT_TRACK` and production gating are unchanged, and no PostHog SDK enters the renderer or main.

## App lifecycle

Emitted from the **server**, not main, because that is where the settings table and `FREESTYLE_APP_VERSION` already live — so "is this the first launch" needs no new storage.

| Event | Properties |
|---|---|
| `app_installed` | version |
| `app_updated` | from, to |
| `app_launched` | version, signed_in, first_launch |

## Main process

| Event | Properties |
|---|---|
| `panel_opened` | trigger: hover / hotkey / notification / dictation / tray |
| `permission_resolved` | kind, granted |
| `permission_prompted` | kind |
| `sprite_changed` | from, to |

`panel_opened` fires **only on a real hidden → visible transition** — hover re-fires and focus requests while already open are not opens, and counting them would inflate the number that feeds engagement.

## Renderer

| Event | Properties |
|---|---|
| `message_sent` | source (typed / dictated), chars, threadIsNew |
| `connector_connect_started` | toolkit, authMode |
| `connector_connected` | toolkit, authMode, elapsedMs |
| `connector_disconnected` | toolkit |
| `brain_file_edited` / `_deleted` | folder |
| `thread_opened` | origin |
| `upgrade_clicked` | surface, period |

Two choices worth reviewing:

**The connector events are instrumented once in `useConnectorConnect`**, not per surface. All three connect entry points — the openers, the in-chat cards, the Apps tab — funnel through that hook, so this covers them without three copies that could drift.

**`brain_file_edited` reports only the top-level folder** (`memories` / `notes` / `skills` / `scheduled_tasks`), never the path or contents. Same instinct throughout: counts and enums only.

## Person and super properties

- `plan` registered from the usage route whenever it changes — the segmentation nearly every other question wants
- `companion_form` and `launch_at_login` via a new `POST /api/telemetry/person`, which reuses the same opt-out gate

## Testing

- `pnpm typecheck` clean (electron + server)
- `pnpm test` — 80 passed
- Biome clean, including the two dependency warnings this change originally introduced

## Environment

None. Same gating as today.