### PR TITLE
fix(dictation): serve renderers from app:// and recover stuck transcriptions

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -165,6 +165,7 @@ import {
 } from "./plugins/index";
 import { invalidatePluginViews } from "./plugins/ui-host";
 import { isRemixTargetAllowed } from "./remix-target";
+import { rendererUrl } from "./renderer-url";
 import {
   initSpriteTravel,
   performSyncAction,
@@ -3628,11 +3629,7 @@ function createPanelWindow(): void {
     if (!panelBusy) schedulePanelHide();
   });
 
-  if (is.dev && process.env.ELECTRON_RENDERER_URL) {
-    void panelWindow.loadURL(`${process.env.ELECTRON_RENDERER_URL}/panel.html`);
-  } else {
-    void panelWindow.loadFile(join(__dirname, "../renderer/panel.html"));
-  }
+  void panelWindow.loadURL(rendererUrl("panel.html"));
 }
 
 function cancelPanelHide(): void {
@@ -3792,15 +3789,7 @@ function createCompanionWindow(): void {
     companionWindow?.showInactive();
   });
 
-  if (is.dev && process.env.ELECTRON_RENDERER_URL) {
-    void companionWindow.loadURL(
-      `${process.env.ELECTRON_RENDERER_URL}/companion.html`,
-    );
-  } else {
-    void companionWindow.loadFile(
-      join(__dirname, "../renderer/companion.html"),
-    );
-  }
+  void companionWindow.loadURL(rendererUrl("companion.html"));
 }
 
 function destroyCompanionWindow(): void {

--- a/apps/electron/src/main/notification-window.ts
+++ b/apps/electron/src/main/notification-window.ts
@@ -1,8 +1,8 @@
 import { join } from "node:path";
-import { is } from "@electron-toolkit/utils";
 import { BrowserWindow, screen } from "electron";
 import type { SpriteId } from "../shared/sprites";
 import { SPRITES_INFO } from "../shared/sprites";
+import { rendererUrl } from "./renderer-url";
 
 const WIDTH = 300;
 const DEFAULT_HEIGHT = 140;
@@ -89,11 +89,7 @@ export function createNotificationWindow(): void {
     win = null;
   });
 
-  if (is.dev && process.env.ELECTRON_RENDERER_URL) {
-    void win.loadURL(`${process.env.ELECTRON_RENDERER_URL}/notification.html`);
-  } else {
-    void win.loadFile(join(__dirname, "../renderer/notification.html"));
-  }
+  void win.loadURL(rendererUrl("notification.html"));
 }
 
 export function destroyNotificationWindow(): void {

--- a/apps/electron/src/main/renderer-url.ts
+++ b/apps/electron/src/main/renderer-url.ts
@@ -1,0 +1,8 @@
+import { is } from "@electron-toolkit/utils";
+
+export function rendererUrl(file: string): string {
+  if (is.dev && process.env.ELECTRON_RENDERER_URL) {
+    return `${process.env.ELECTRON_RENDERER_URL}/${file}`;
+  }
+  return `app://renderer/${file}`;
+}

--- a/apps/electron/src/renderer/src/lib/dictation.test.ts
+++ b/apps/electron/src/renderer/src/lib/dictation.test.ts
@@ -146,7 +146,7 @@ describe("DictationController", () => {
   });
 
   it("falls back to REST transcription when no final arrives", async () => {
-    const { controller, phases, composer } = makeController();
+    const { controller, phases, composer, errors } = makeController();
     await flush();
     void controller.start();
     await flush();
@@ -168,8 +168,10 @@ describe("DictationController", () => {
     expect(composer).toEqual(["hello there"]);
     expect(phases.at(-1)).toBe("idle");
     state.streamerCallbacks?.onFinal("late");
+    state.streamerCallbacks?.onError("late transport error");
     await flush();
     expect(composer).toEqual(["hello there"]);
+    expect(errors).toEqual([]);
   });
 
   it("reports a timeout when nothing was recorded", async () => {

--- a/apps/electron/src/renderer/src/lib/dictation.test.ts
+++ b/apps/electron/src/renderer/src/lib/dictation.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type StreamerCallbacks = {
+  onFinal: (text: string) => void;
+  onError: (message: string) => void;
+};
+
+const mocks = vi.hoisted(() => {
+  const state: {
+    acquire: { resolve: (s: unknown) => void } | null;
+    streamerCallbacks: StreamerCallbacks | null;
+  } = { acquire: null, streamerCallbacks: null };
+  return {
+    state,
+    apiFetch: vi.fn(),
+    recorder: {
+      acquireStream: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            state.acquire = { resolve };
+          }),
+      ),
+      releaseStream: vi.fn(),
+    },
+    streamer: {
+      startCapture: vi.fn(async () => {}),
+      commit: vi.fn(),
+      cancel: vi.fn(),
+      destroy: vi.fn(),
+      setContext: vi.fn(),
+      getWavBlob: vi.fn<() => Blob | null>(() => null),
+    },
+  };
+});
+
+vi.mock("@renderer/lib/api", () => ({
+  apiFetch: mocks.apiFetch,
+  getApiBase: () => "http://127.0.0.1:4649",
+  getClient: () => ({
+    api: {
+      output: {
+        hook: { $get: vi.fn(async () => ({ ok: false })) },
+        deliver: { $post: vi.fn(async () => ({ ok: false })) },
+      },
+      "post-process": { $post: vi.fn(async () => ({ ok: false })) },
+    },
+  }),
+  getServerToken: () => "",
+  initApiBase: vi.fn(async () => {}),
+}));
+
+vi.mock("@renderer/lib/level-meter", () => ({
+  LevelMeter: class {
+    attach(): void {}
+    detach(): void {}
+    destroy(): void {}
+  },
+}));
+
+vi.mock("@renderer/lib/recorder", () => ({
+  Recorder: class {
+    acquireStream = mocks.recorder.acquireStream;
+    releaseStream = mocks.recorder.releaseStream;
+  },
+  RecorderSupersededError: class extends Error {},
+}));
+
+vi.mock("@renderer/lib/streamer", () => ({
+  Streamer: class {
+    constructor(_base: string, _token: string, callbacks: StreamerCallbacks) {
+      mocks.state.streamerCallbacks = callbacks;
+    }
+    startCapture = mocks.streamer.startCapture;
+    commit = mocks.streamer.commit;
+    cancel = mocks.streamer.cancel;
+    destroy = mocks.streamer.destroy;
+    setContext = mocks.streamer.setContext;
+    getWavBlob = mocks.streamer.getWavBlob;
+  },
+}));
+
+const { apiFetch, recorder, streamer, state } = mocks;
+
+import { DictationController } from "./dictation";
+
+function makeController() {
+  const phases: string[] = [];
+  const errors: string[] = [];
+  const composer: string[] = [];
+  const controller = new DictationController(
+    {
+      onPhase: (p) => phases.push(p),
+      onPartial: () => {},
+      onComposerText: (t) => composer.push(t),
+      onError: (m) => errors.push(m),
+    },
+    {
+      destination: () => "composer",
+      outputMode: () => "paste",
+      soundEnabled: () => false,
+      audioPlaybackMode: () => "off",
+    },
+  );
+  return { controller, phases, errors, composer };
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+describe("DictationController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    state.acquire = null;
+    state.streamerCallbacks = null;
+    streamer.getWavBlob.mockReturnValue(null);
+    apiFetch.mockReset();
+    (globalThis as { window?: unknown }).window = {
+      api: {
+        getFrontmostApp: async () => null,
+        prepareSystemAudio: async () => {},
+        restoreSystemAudio: async () => {},
+        sendTranscriptionDone: () => {},
+        pasteText: async () => {},
+        copyText: async () => {},
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("returns to idle when the key is released before the mic is acquired", async () => {
+    const { controller, phases } = makeController();
+    await flush();
+    void controller.start();
+    await flush();
+    controller.stop();
+    state.acquire?.resolve({});
+    await flush();
+    expect(streamer.commit).not.toHaveBeenCalled();
+    expect(phases).toEqual(["recording", "idle"]);
+    expect(recorder.releaseStream).toHaveBeenCalled();
+  });
+
+  it("falls back to REST transcription when no final arrives", async () => {
+    const { controller, phases, composer } = makeController();
+    await flush();
+    void controller.start();
+    await flush();
+    state.acquire?.resolve({});
+    await flush();
+    controller.stop();
+    expect(streamer.commit).toHaveBeenCalledTimes(1);
+    streamer.getWavBlob.mockReturnValue(new Blob(["wav"]));
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ cleaned: "hello there" }),
+    });
+    await vi.advanceTimersByTimeAsync(15_000);
+    await flush();
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/transcribe",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(composer).toEqual(["hello there"]);
+    expect(phases.at(-1)).toBe("idle");
+    state.streamerCallbacks?.onFinal("late");
+    await flush();
+    expect(composer).toEqual(["hello there"]);
+  });
+
+  it("reports a timeout when nothing was recorded", async () => {
+    const { controller, errors, phases } = makeController();
+    await flush();
+    void controller.start();
+    await flush();
+    state.acquire?.resolve({});
+    await flush();
+    controller.stop();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(errors).toEqual(["Transcription timed out"]);
+    expect(phases.at(-1)).toBe("idle");
+  });
+
+  it("delivers a streamed final and disarms the watchdog", async () => {
+    const { controller, composer, errors } = makeController();
+    await flush();
+    void controller.start();
+    await flush();
+    state.acquire?.resolve({});
+    await flush();
+    controller.stop();
+    state.streamerCallbacks?.onFinal("streamed text");
+    await flush();
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(composer).toEqual(["streamed text"]);
+    expect(errors).toEqual([]);
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/electron/src/renderer/src/lib/dictation.ts
+++ b/apps/electron/src/renderer/src/lib/dictation.ts
@@ -122,7 +122,11 @@ export class DictationController {
         this.enqueue(text);
       },
       onError: (message) => {
-        this.settleFinal();
+        // A streaming transport can report an error after the watchdog has
+        // already recovered the recording through the REST path. Treat that
+        // as stale just like a late final: the user has their transcript and
+        // should not see a spurious failure card.
+        if (!this.settleFinal()) return;
         this.setPhase("idle");
         this.callbacks.onError(message);
       },

--- a/apps/electron/src/renderer/src/lib/dictation.ts
+++ b/apps/electron/src/renderer/src/lib/dictation.ts
@@ -1,4 +1,5 @@
 import {
+  apiFetch,
   getApiBase,
   getClient,
   getServerToken,
@@ -27,6 +28,8 @@ export interface DictationOptions {
 }
 
 type TonePreset = "start" | "stop";
+
+const TRANSCRIBE_TIMEOUT_MS = 15_000;
 
 const TONE_PRESETS: Record<TonePreset, { freq: number; ms: number }> = {
   start: { freq: 347, ms: 125 },
@@ -86,6 +89,10 @@ export class DictationController {
   private duckPromise: Promise<unknown> | undefined;
   private pending: string[] = [];
   private draining = false;
+  private session = 0;
+  private capturing = false;
+  private awaitingFinals = 0;
+  private transcribeTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     private readonly callbacks: DictationCallbacks,
@@ -110,12 +117,12 @@ export class DictationController {
     this.streamer = new Streamer(getApiBase(), getServerToken(), {
       onPartial: (text) => this.callbacks.onPartial(text),
       onFinal: (text) => {
+        if (!this.settleFinal()) return;
         this.setPhase("idle");
-        const trimmed = text.trim();
-        if (trimmed) this.pending.push(trimmed);
-        void this.drain();
+        this.enqueue(text);
       },
       onError: (message) => {
+        this.settleFinal();
         this.setPhase("idle");
         this.callbacks.onError(message);
       },
@@ -123,6 +130,76 @@ export class DictationController {
       onConfig: () => {},
     });
     return this.streamer;
+  }
+
+  private settleFinal(): boolean {
+    if (this.awaitingFinals === 0) return false;
+    this.awaitingFinals -= 1;
+    if (this.awaitingFinals === 0) this.clearTranscribeWatchdog();
+    return true;
+  }
+
+  private enqueue(text: string): void {
+    const trimmed = text.trim();
+    if (trimmed) this.pending.push(trimmed);
+    void this.drain();
+  }
+
+  private clearTranscribeWatchdog(): void {
+    if (!this.transcribeTimer) return;
+    clearTimeout(this.transcribeTimer);
+    this.transcribeTimer = null;
+  }
+
+  private armTranscribeWatchdog(): void {
+    this.clearTranscribeWatchdog();
+    const session = this.session;
+    this.transcribeTimer = setTimeout(() => {
+      this.transcribeTimer = null;
+      void this.recoverTranscription(session);
+    }, TRANSCRIBE_TIMEOUT_MS);
+  }
+
+  private async recoverTranscription(session: number): Promise<void> {
+    if (session !== this.session || this.awaitingFinals === 0) return;
+    this.awaitingFinals = 0;
+    const wav = this.streamer?.getWavBlob() ?? null;
+    if (!wav) {
+      this.setPhase("idle");
+      this.callbacks.onError("Transcription timed out");
+      return;
+    }
+    try {
+      const headers: Record<string, string> = { "Content-Type": "audio/wav" };
+      if (this.appContext) {
+        headers["x-app-context"] = encodeURIComponent(this.appContext);
+      }
+      const res = await apiFetch("/api/transcribe", {
+        method: "POST",
+        body: wav,
+        headers,
+      });
+      const data = (await res.json().catch(() => null)) as {
+        cleaned?: string;
+        raw?: string;
+        error?: string;
+        disposition?: string;
+      } | null;
+      if (session !== this.session) return;
+      this.setPhase("idle");
+      if (!res.ok) {
+        this.callbacks.onError(data?.error || "Transcription failed");
+        return;
+      }
+      if (data?.disposition && data.disposition !== "deliver") return;
+      this.enqueue(data?.cleaned || data?.raw || "");
+    } catch (err) {
+      if (session !== this.session) return;
+      this.setPhase("idle");
+      this.callbacks.onError(
+        err instanceof Error ? err.message : "Transcription failed",
+      );
+    }
   }
 
   private async mergeSegments(segments: string[]): Promise<string> {
@@ -227,6 +304,8 @@ export class DictationController {
   async start(): Promise<void> {
     if (this.active) return;
     this.active = true;
+    const session = ++this.session;
+    this.capturing = false;
     this.setPhase("recording");
     try {
       if (this.options.soundEnabled()) void playTone("start");
@@ -239,18 +318,29 @@ export class DictationController {
       const streamer = this.ensureStreamer();
       void this.captureAppContext();
       const stream = await this.recorder.acquireStream();
+      if (session !== this.session) return;
       if (!this.active) {
         this.recorder.releaseStream();
+        this.setPhase("idle");
         return;
       }
       this.attachMeter(stream);
       await streamer.startCapture(stream);
+      if (session !== this.session) return;
+      if (!this.active) {
+        streamer.cancel();
+        this.recorder.releaseStream();
+        this.setPhase("idle");
+        return;
+      }
+      this.capturing = true;
     } catch (err) {
+      if (session !== this.session || err instanceof RecorderSupersededError)
+        return;
       this.active = false;
       this.setPhase("idle");
       this.meter?.detach();
       void this.restoreAudio();
-      if (err instanceof RecorderSupersededError) return;
       this.callbacks.onError(
         err instanceof Error ? err.message : "Could not start recording",
       );
@@ -268,17 +358,28 @@ export class DictationController {
   stop(): void {
     if (!this.active) return;
     this.active = false;
-    this.setPhase("transcribing");
-    if (this.options.soundEnabled()) void playTone("stop");
-    this.streamer?.commit();
     this.meter?.detach();
     this.recorder.releaseStream();
     void this.restoreAudio();
+    if (!this.capturing) {
+      this.streamer?.cancel();
+      this.setPhase("idle");
+      return;
+    }
+    this.capturing = false;
+    this.setPhase("transcribing");
+    if (this.options.soundEnabled()) void playTone("stop");
+    this.awaitingFinals += 1;
+    this.streamer?.commit();
+    this.armTranscribeWatchdog();
     void this.drain();
   }
 
   cancel(): void {
     this.active = false;
+    this.capturing = false;
+    this.awaitingFinals = 0;
+    this.clearTranscribeWatchdog();
     this.setPhase("idle");
     this.pending = [];
     this.streamer?.cancel();

--- a/apps/electron/tests/app.test.ts
+++ b/apps/electron/tests/app.test.ts
@@ -131,6 +131,34 @@ test("embedded server answers health checks", async () => {
   expect(res.ok).toBe(true);
 });
 
+test("companion is served from the trusted app:// origin", async () => {
+  expect(companionPage.url()).toMatch(/^app:\/\/renderer\//);
+});
+
+test("companion can open the dictation WebSocket", async () => {
+  const outcome = await companionPage.evaluate(
+    (port) =>
+      new Promise<string>((resolve) => {
+        const ws = new WebSocket(`ws://127.0.0.1:${port}/stream`);
+        const timer = setTimeout(() => {
+          ws.close();
+          resolve("timeout");
+        }, 8_000);
+        ws.onmessage = (event) => {
+          clearTimeout(timer);
+          ws.close();
+          resolve(`message:${String(event.data).slice(0, 40)}`);
+        };
+        ws.onclose = (event) => {
+          clearTimeout(timer);
+          resolve(`closed:${event.code}`);
+        };
+      }),
+    serverPort,
+  );
+  expect(outcome).toMatch(/^message:\{"type":"(config|error)"/);
+});
+
 test("no dashboard window exists", async () => {
   const urls = (app?.windows() ?? []).map((w) => w.url());
   for (const url of urls) {

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -67,6 +67,7 @@ const stream = new Hono().get(
     let pendingAudioChunks: ArrayBuffer[] = [];
     let pendingChunksDropped = false;
     let pendingCommit = false;
+    let sessionStarting = false;
     let reconnectAttempts = 0;
     let readyToken = 0;
     let notifiedReadyToken = 0;
@@ -157,6 +158,7 @@ const stream = new Hono().get(
     ): void {
       if (token !== readyToken || notifiedReadyToken === token) return;
       notifiedReadyToken = token;
+      sessionStarting = false;
       flushPendingAudio();
       if (voiceDefaults?.provider === "soniox") {
         prewarmPostProcess();
@@ -677,6 +679,7 @@ const stream = new Hono().get(
           onError: (message, code) => {
             if (upstream !== session) return;
             sessionTransportUnavailable = true;
+            sessionStarting = false;
             ws.send(
               JSON.stringify({
                 type: "config",
@@ -811,6 +814,7 @@ const stream = new Hono().get(
             pendingAudioChunks = [];
             pendingChunksDropped = false;
             pendingCommit = false;
+            sessionStarting = true;
             reconnectAttempts = 0;
             // A prior upstream error disables session transport only for the
             // rest of that recording; each new recording gets a fresh attempt.
@@ -869,12 +873,15 @@ const stream = new Hono().get(
               (upstream.waitUntilReady || notifiedReadyToken === readyToken)
             ) {
               upstream.commit();
-            } else {
+            } else if (upstream || sessionStarting) {
               pendingCommit = true;
+            } else {
+              ws.send(JSON.stringify({ type: "final", text: "" }));
             }
             break;
           case "cancel":
             pendingCommit = false;
+            sessionStarting = false;
             pendingAudioChunks = [];
             if (
               upstream &&

--- a/apps/server/tests/trusted-origin.test.ts
+++ b/apps/server/tests/trusted-origin.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { isTrustedRendererOrigin } from "../src/lib/trusted-origin.js";
+
+describe("isTrustedRendererOrigin", () => {
+  it("accepts the packaged renderer, dev server, and origin-less clients", () => {
+    expect(isTrustedRendererOrigin("app://renderer")).toBe(true);
+    expect(isTrustedRendererOrigin("http://localhost:5173")).toBe(true);
+    expect(isTrustedRendererOrigin("http://127.0.0.1:4649")).toBe(true);
+    expect(isTrustedRendererOrigin(undefined)).toBe(true);
+  });
+
+  it("rejects file, null, and remote origins", () => {
+    expect(isTrustedRendererOrigin("file://")).toBe(false);
+    expect(isTrustedRendererOrigin("null")).toBe(false);
+    expect(isTrustedRendererOrigin("https://evil.example")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Phase 0 of the audit stack — hotfix: dictation works again in packaged builds

Stack: **#this** ← phase 1 ← phase 2 ← … (each later PR is based on the previous one).

### Root cause fixed
Packaged builds loaded `companion.html`/`panel.html`/`notification.html` with `loadFile()` (a `file://` origin). Chromium sends **no** Origin on fetch from `file://` pages but **does** send `Origin: file://` on WebSocket upgrades, and `isTrustedRendererOrigin` rejects it → the local server answered 403 to the companion's `/stream` upgrade → every dictation stayed on "transcribing" forever. Verified against the running 0.8.1 app (403 with `Origin: file://`, OPEN with `app://renderer`).

### Changes
- `main/renderer-url.ts`: `rendererUrl(file)` → dev server URL in dev, `app://renderer/<file>` in production; used for the panel, companion and notification windows (the `app` protocol handler was still registered).
- `DictationController`: 15 s transcribing watchdog → falls back to `POST /api/transcribe` with the recorded WAV; late streamed finals after a fallback are ignored; releasing the key before capture started returns to idle instead of sending a bare `commit`; superseded sessions no longer clobber the new one's state.
- `routes/stream.ts`: a `commit` with no session and no `start` in flight answers `final ""` instead of staying silent.
- Tests: `dictation.test.ts` (quick tap, watchdog + fallback, timeout, streamed final), `trusted-origin.test.ts` (origin policy).

### Verification
- Built renderer loaded via an identical `app://` handler in Electron: no failed assets, WebSocket to the live local server receives `config`.
- `pnpm typecheck` (electron), `vitest` electron 84/84, server 402/402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)