### PR TITLE
fix(agent): keep threads and brain files truthful

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -98,6 +98,7 @@ import {
   resolveDictationWindowDisplays,
   resolvePanelCompanionDisplays,
 } from "../shared/companion-position";
+import type { DictationPrefs } from "../shared/dictation-prefs";
 import {
   findFocusedSwayNode,
   getSwayFocusedWindowBounds,
@@ -1090,6 +1091,7 @@ async function deliverOutput(
 
 // Per-request timeout for main-process API calls to the server.
 const SERVER_SETTING_TIMEOUT_MS = 5000;
+const EXTERNAL_SERVER_POLL_MS = 30_000;
 // How long boot waits for the server to answer before registering the hotkey
 // with whatever it can read (falling back to the default accelerator).
 const SERVER_READY_TIMEOUT_MS = 5000;
@@ -1944,8 +1946,10 @@ app.whenReady().then(async () => {
     startFreestyleServer({ port, host: "127.0.0.1" })
       .then(({ server, port: boundPort }) => {
         httpServer = server;
+        const changed = serverPort !== boundPort;
         serverPort = boundPort;
         log.info(`Server running on http://localhost:${boundPort}`);
+        if (changed) broadcastServerChanged();
       })
       .catch((err: NodeJS.ErrnoException) => {
         if (err.code === "EADDRINUSE" && port === DEFAULT_PORT) {
@@ -1968,30 +1972,40 @@ app.whenReady().then(async () => {
 
   if (existingServer) {
     serverPort = DEFAULT_PORT;
-    log.info(
+    log.warn(
       `Reusing existing Freestyle server on http://localhost:${DEFAULT_PORT}`,
     );
+    const watchdog = setInterval(async () => {
+      if (httpServer || getServerUrl()) {
+        clearInterval(watchdog);
+        return;
+      }
+      if (await probeServerHealth(`http://127.0.0.1:${DEFAULT_PORT}`, 1500))
+        return;
+      clearInterval(watchdog);
+      log.warn("Reused Freestyle server went away; starting our own.");
+      startServer(DEFAULT_PORT);
+    }, EXTERNAL_SERVER_POLL_MS);
+    watchdog.unref();
   } else {
     startServer(DEFAULT_PORT);
   }
 
-  if (readSettings().companionEnabled !== false) {
-    createCompanionWindow();
-    registerSummonShortcut();
-    capturePerson({
-      companion_form: companionFormSetting(),
-      launch_at_login: app.getLoginItemSettings().openAtLogin,
-    });
-    initNotificationWindow({
-      spriteForm: () => companionFormSetting(),
-      companionBounds: () => {
-        if (!companionWindow || companionWindow.isDestroyed()) return null;
-        const b = companionWindow.getBounds();
-        return { x: b.x, y: b.y, width: b.width };
-      },
-    });
-    startNotificationEvents();
-  }
+  createCompanionWindow();
+  registerSummonShortcut();
+  capturePerson({
+    companion_form: companionFormSetting(),
+    launch_at_login: app.getLoginItemSettings().openAtLogin,
+  });
+  initNotificationWindow({
+    spriteForm: () => companionFormSetting(),
+    companionBounds: () => {
+      if (!companionWindow || companionWindow.isDestroyed()) return null;
+      const b = companionWindow.getBounds();
+      return { x: b.x, y: b.y, width: b.width };
+    },
+  });
+  startNotificationEvents();
 
   // A signed-out launch surfaces the panel unprompted: the sign-in gate is
   // the whole product until there's a session, and a first-time user doesn't
@@ -3137,17 +3151,14 @@ function companionFormSetting(): CompanionForm {
   return parseCompanionForm(readSettings().companionForm as string | undefined);
 }
 
-function dictationPrefs(): {
-  destination: "cursor" | "composer";
-  outputMode: "paste" | "clipboard";
-  soundEnabled: boolean;
-  audioPlaybackMode: AudioPlaybackMode;
-} {
+function dictationPrefs(): DictationPrefs {
   let destination: "cursor" | "composer" = "cursor";
   let outputMode: "paste" | "clipboard" = "paste";
   let soundEnabled = true;
   let audioPlaybackMode: AudioPlaybackMode = "off";
+  let micDeviceId: string | null = null;
   try {
+    micDeviceId = readServerSetting(SETTINGS_KEYS.micDeviceId) || null;
     destination = parseDictationDestination(
       readServerSetting(SETTINGS_KEYS.dictationDestination),
     );
@@ -3161,7 +3172,13 @@ function dictationPrefs(): {
       audioPlaybackMode = mode;
     }
   } catch {}
-  return { destination, outputMode, soundEnabled, audioPlaybackMode };
+  return {
+    destination,
+    outputMode,
+    soundEnabled,
+    audioPlaybackMode,
+    micDeviceId,
+  };
 }
 
 export function broadcastDictationPrefs(): void {
@@ -3785,6 +3802,12 @@ function createCompanionWindow(): void {
     companionWindow = null;
   });
 
+  companionWindow.webContents.on("render-process-gone", (_event, details) => {
+    log.error(`Companion renderer gone (${details.reason}); recreating.`);
+    destroyCompanionWindow();
+    createCompanionWindow();
+  });
+
   companionWindow.once("ready-to-show", () => {
     companionWindow?.showInactive();
   });
@@ -4126,6 +4149,20 @@ function handleNativeHotkeyUp(): void {
   }
 }
 
+let lastHotkeyError: string | null = null;
+function reportHotkeyError(message: string): void {
+  hotkeyLog.error(message);
+  panelWindow?.webContents.send("hotkey:error", { message });
+  if (message === lastHotkeyError) return;
+  lastHotkeyError = message;
+  if (Notification.isSupported()) {
+    new Notification({
+      title: "Freestyle hotkey problem",
+      body: message,
+    }).show();
+  }
+}
+
 // Notify once per session when hold-to-talk degrades to toggle mode, so the
 // user isn't left wondering why holding the hotkey stopped working.
 let hotkeyDegradedNotified = false;
@@ -4236,7 +4273,7 @@ async function registerHotkey(hotkey?: string): Promise<void> {
     // unregisterAll() drops every accelerator this app holds, including the
     // panel summon claimed at boot — re-claim it or it dies on the first
     // hotkey registration and never comes back within the session.
-    if (readSettings().companionEnabled !== false) registerSummonShortcut();
+    registerSummonShortcut();
 
     if (!hotkey) {
       // Unreachable server yields no map; registration falls back to the
@@ -4280,10 +4317,9 @@ async function registerHotkey(hotkey?: string): Promise<void> {
         if (registeredAccel) {
           notifyHotkeyDegraded(accel, nativeError);
         } else {
-          const errorPayload = {
-            message: `The hotkey listener stopped working and "${accel}" could not be re-registered. Restart Freestyle or pick a different combination in Settings.`,
-          };
-          panelWindow?.webContents.send("hotkey:error", errorPayload);
+          reportHotkeyError(
+            `The hotkey listener stopped working and "${accel}" could not be re-registered. Restart Freestyle or pick a different combination in Settings.`,
+          );
         }
       },
     });
@@ -4330,8 +4366,7 @@ async function registerHotkey(hotkey?: string): Promise<void> {
         ) {
           message = `Hotkey "${accel}" requires access to input devices. Run: sudo usermod -aG input $USER — then log out and back in.`;
         }
-        const errorPayload = { message };
-        panelWindow?.webContents.send("hotkey:error", errorPayload);
+        reportHotkeyError(message);
       }
     }
   } catch (err) {

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -360,12 +360,13 @@ export class NativeKeyListener {
     }
 
     if (line.startsWith("KEY_DOWN:")) {
+      if (this.macFnDown) this.cancelMacSoloFnDown();
       this.handleMacKeyEvent(line.slice(9), true);
       return;
     }
 
     if (line.startsWith("KEY_UP:")) {
-      this.handleMacKeyEvent(line.slice(9), false);
+      this.handleMacKeyEvent(line.slice(7), false);
       return;
     }
   }

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -1,6 +1,7 @@
 import { ElectronAPI } from "@electron-toolkit/preload";
 import type { ActiveAudioPlaybackMode } from "../shared/audio-playback";
 import type { CompanionForm, CompanionState } from "../shared/companion";
+import type { DictationPrefs } from "../shared/dictation-prefs";
 import type {
   RemixContextResult,
   RemixCopyResult,
@@ -21,6 +22,7 @@ declare global {
       getServerPort: () => Promise<number>;
       getServerUrl: () => Promise<string>;
       getServerToken: () => Promise<string>;
+      onServerChanged: (callback: () => void) => () => void;
       openLogsFolder: () => Promise<boolean>;
       openExternal: (url: string) => Promise<boolean>;
       onTalkDown: (cb: () => void) => () => void;
@@ -29,6 +31,8 @@ declare global {
       onHotkeyUp: (callback: () => void) => () => void;
       onDictationCancel: (callback: () => void) => () => void;
       setDictationPhase: (phase: "idle" | "recording" | "transcribing") => void;
+      onHotkeyError: (callback: (message: string) => void) => () => void;
+      setHotkeyMode: (mode: "hold" | "toggle") => void;
       reloadRemixHotkey: () => void;
       remixGetContext: () => Promise<RemixContextResult>;
       remixReadDocument: () => Promise<RemixReadDocumentResult>;
@@ -52,19 +56,9 @@ declare global {
           text: string;
         }) => void,
       ) => () => void;
-      dictationPrefs: () => Promise<{
-        destination: "cursor" | "composer";
-        outputMode: "paste" | "clipboard";
-        soundEnabled: boolean;
-        audioPlaybackMode: "off" | "duck" | "pause";
-      }>;
+      dictationPrefs: () => Promise<DictationPrefs>;
       onDictationPrefs: (
-        callback: (prefs: {
-          destination: "cursor" | "composer";
-          outputMode: "paste" | "clipboard";
-          soundEnabled: boolean;
-          audioPlaybackMode: "off" | "duck" | "pause";
-        }) => void,
+        callback: (prefs: DictationPrefs) => void,
       ) => () => void;
       reloadDictationPrefs: () => void;
       panelClose: () => void;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -2,6 +2,7 @@ import { electronAPI } from "@electron-toolkit/preload";
 import { contextBridge, ipcRenderer } from "electron";
 import type { ActiveAudioPlaybackMode } from "../shared/audio-playback";
 import type { CompanionForm, CompanionState } from "../shared/companion";
+import type { DictationPrefs } from "../shared/dictation-prefs";
 import type {
   RemixContextResult,
   RemixCopyResult,
@@ -26,6 +27,11 @@ const api = {
   // Configured external server URL/token ("" = built-in local server / no auth).
   getServerUrl: (): Promise<string> => ipcRenderer.invoke("server:url"),
   getServerToken: (): Promise<string> => ipcRenderer.invoke("server:token"),
+  onServerChanged: (callback: () => void): (() => void) => {
+    const handler = (): void => callback();
+    ipcRenderer.on("server:changed", handler);
+    return () => ipcRenderer.removeListener("server:changed", handler);
+  },
   // Reveal the diagnostic logs folder (freestyle.log) in the OS file manager.
   openLogsFolder: (): Promise<boolean> =>
     ipcRenderer.invoke("logs:open-folder"),
@@ -58,6 +64,16 @@ const api = {
   },
   setDictationPhase: (phase: "idle" | "recording" | "transcribing"): void =>
     ipcRenderer.send("dictation:state", phase),
+  onHotkeyError: (callback: (message: string) => void): (() => void) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      payload: { message: string },
+    ): void => callback(payload.message);
+    ipcRenderer.on("hotkey:error", handler);
+    return () => ipcRenderer.removeListener("hotkey:error", handler);
+  },
+  setHotkeyMode: (mode: "hold" | "toggle"): void =>
+    ipcRenderer.send("hotkey:set-mode", mode),
   // --- Remix ---
   reloadRemixHotkey: (): void => ipcRenderer.send("remix-hotkey:reload"),
   // --- Remix primitives (the agent's tools; workflow lives in its prompt) ---
@@ -101,27 +117,13 @@ const api = {
     ipcRenderer.on("panel:dictation", handler);
     return () => ipcRenderer.removeListener("panel:dictation", handler);
   },
-  dictationPrefs: (): Promise<{
-    destination: "cursor" | "composer";
-    outputMode: "paste" | "clipboard";
-    soundEnabled: boolean;
-    audioPlaybackMode: "off" | "duck" | "pause";
-  }> => ipcRenderer.invoke("dictation:prefs"),
+  dictationPrefs: (): Promise<DictationPrefs> =>
+    ipcRenderer.invoke("dictation:prefs"),
   onDictationPrefs: (
-    callback: (prefs: {
-      destination: "cursor" | "composer";
-      outputMode: "paste" | "clipboard";
-    }) => void,
+    callback: (prefs: DictationPrefs) => void,
   ): (() => void) => {
-    const handler = (
-      _e: unknown,
-      prefs: {
-        destination: "cursor" | "composer";
-        outputMode: "paste" | "clipboard";
-        soundEnabled: boolean;
-        audioPlaybackMode: "off" | "duck" | "pause";
-      },
-    ): void => callback(prefs);
+    const handler = (_e: unknown, prefs: DictationPrefs): void =>
+      callback(prefs);
     ipcRenderer.on("dictation:prefs", handler);
     return () => ipcRenderer.removeListener("dictation:prefs", handler);
   },

--- a/apps/electron/src/renderer/src/components/brain-files.tsx
+++ b/apps/electron/src/renderer/src/components/brain-files.tsx
@@ -196,9 +196,11 @@ export function BrainFiles({
     );
 
   const openFile = (path: string): void => {
-    void readBrainFile(path).then((text) => {
-      if (text !== null) setView({ kind: "view", path, text });
-    });
+    void readBrainFile(path)
+      .then((text) => {
+        if (text !== null) setView({ kind: "view", path, text });
+      })
+      .catch(() => {});
   };
 
   const saveFile = (path: string, text: string): void => {

--- a/apps/electron/src/renderer/src/components/companion.tsx
+++ b/apps/electron/src/renderer/src/components/companion.tsx
@@ -2,10 +2,7 @@ import "../overlay.css";
 
 import { Spark, sparkScaleFor } from "@renderer/components/spark";
 import { initApiBase } from "@renderer/lib/api";
-import {
-  DictationController,
-  type DictationDestination,
-} from "@renderer/lib/dictation";
+import { DictationController } from "@renderer/lib/dictation";
 import { installGlobalErrorHandlers } from "@renderer/lib/report-error";
 import { SPRITES } from "@renderer/sprites/registry";
 import { SpriteStage } from "@renderer/sprites/stage";
@@ -15,6 +12,7 @@ import {
   type CompanionState,
   DEFAULT_COMPANION_FORM,
 } from "@shared/companion";
+import type { DictationPrefs } from "@shared/dictation-prefs";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -22,9 +20,11 @@ import { createRoot } from "react-dom/client";
 const SPARK_HOT_RECT = { x: 18, y: 190, width: 52, height: 52 };
 
 export interface BubbleState {
-  phase: "recording" | "transcribing";
+  phase: "recording" | "transcribing" | "error";
   partial: string;
 }
+
+const ERROR_BUBBLE_MS = 4000;
 
 function useDictation(
   setState: (s: CompanionState) => void,
@@ -32,24 +32,41 @@ function useDictation(
   levelRef: React.RefObject<HTMLSpanElement | null>,
   setBubble: (b: BubbleState | null) => void,
   bubbleLevelRef: React.RefObject<HTMLDivElement | null>,
+  busyRef: React.RefObject<boolean>,
 ): void {
   useEffect(() => {
-    let destination: DictationDestination = "cursor";
-    let outputMode: "paste" | "clipboard" = "paste";
-    let soundEnabled = true;
-    let audioPlaybackMode: "off" | "duck" | "pause" = "off";
+    let prefs: DictationPrefs = {
+      destination: "cursor",
+      outputMode: "paste",
+      soundEnabled: true,
+      audioPlaybackMode: "off",
+      micDeviceId: null,
+    };
     let talkSession = false;
+    let errorTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const showError = (message: string): void => {
+      if (errorTimer) clearTimeout(errorTimer);
+      setBubble({ phase: "error", partial: message });
+      errorTimer = setTimeout(() => {
+        errorTimer = null;
+        setBubble(null);
+      }, ERROR_BUBBLE_MS);
+    };
 
     const controller = new DictationController(
       {
         onPhase: (phase) => {
           window.api.setDictationPhase(phase);
+          busyRef.current = phase !== "idle";
           setState(phase === "idle" ? "idle" : "working");
           setListening(phase === "recording");
-          if (phase === "idle") {
-            setBubble(null);
-          } else {
+          if (phase !== "idle") {
+            if (errorTimer) clearTimeout(errorTimer);
+            errorTimer = null;
             setBubble({ phase, partial: "" });
+          } else if (!errorTimer) {
+            setBubble(null);
           }
         },
         onLevel: (level) => {
@@ -64,7 +81,7 @@ function useDictation(
         },
         onPartial: (text) => {
           setBubble({ phase: "recording", partial: text });
-          if (talkSession || destination === "composer")
+          if (talkSession || prefs.destination === "composer")
             window.api.panelDictationPartial(text);
         },
         onComposerText: (text) => {
@@ -74,32 +91,28 @@ function useDictation(
         },
         onError: (message) => {
           talkSession = false;
+          showError(message);
           window.api.panelDictationError(message);
         },
       },
       {
-        destination: () => (talkSession ? "composer" : destination),
-        outputMode: () => outputMode,
-        soundEnabled: () => soundEnabled,
-        audioPlaybackMode: () => audioPlaybackMode,
+        destination: () => (talkSession ? "composer" : prefs.destination),
+        outputMode: () => prefs.outputMode,
+        soundEnabled: () => prefs.soundEnabled,
+        audioPlaybackMode: () => prefs.audioPlaybackMode,
+        micDeviceId: () => prefs.micDeviceId,
       },
     );
 
     void window.api
       .dictationPrefs()
-      .then((prefs) => {
-        destination = prefs.destination;
-        outputMode = prefs.outputMode;
-        soundEnabled = prefs.soundEnabled;
-        audioPlaybackMode = prefs.audioPlaybackMode;
+      .then((next) => {
+        prefs = next;
       })
       .catch(() => {});
 
-    const offPrefs = window.api.onDictationPrefs((prefs) => {
-      destination = prefs.destination;
-      outputMode = prefs.outputMode;
-      soundEnabled = prefs.soundEnabled;
-      audioPlaybackMode = prefs.audioPlaybackMode;
+    const offPrefs = window.api.onDictationPrefs((next) => {
+      prefs = next;
     });
     const offDown = window.api.onHotkeyDown(() => {
       // Key-repeat on the held key re-fires this; a live session must not be
@@ -122,7 +135,12 @@ function useDictation(
       if (!controller.isActive()) void controller.start();
     });
     const offTalkUp = window.api.onTalkUp(() => controller.stop());
+    const offServer = window.api.onServerChanged(() => {
+      void controller.reconnectServer();
+    });
     return () => {
+      offServer?.();
+      if (errorTimer) clearTimeout(errorTimer);
       offPrefs?.();
       offDown?.();
       offUp?.();
@@ -131,7 +149,7 @@ function useDictation(
       offTalkUp?.();
       controller.destroy();
     };
-  }, [setState, setListening, levelRef, setBubble, bubbleLevelRef]);
+  }, [setState, setListening, levelRef, setBubble, bubbleLevelRef, busyRef]);
 }
 
 const BUBBLE_BARS = [0.6, 1, 0.7];
@@ -153,7 +171,9 @@ function SparkBubble({
       : "…";
   return (
     <div className="bubble" ref={levelHostRef}>
-      <div className="bubble-chip">
+      <div
+        className={`bubble-chip${bubble.phase === "error" ? " is-error" : ""}`}
+      >
         <div className="bubble-bars">
           {BUBBLE_BARS.map((weight, i) => (
             <span
@@ -265,6 +285,16 @@ function SparkStage({
         .bubble-bar.is-paused {
           background: #8e7f5f;
         }
+        .bubble-chip.is-error {
+          background: rgba(251, 233, 231, 0.95);
+          border-color: rgba(214, 120, 108, 0.8);
+        }
+        .bubble-chip.is-error .bubble-bar {
+          background: #b42318;
+        }
+        .bubble-chip.is-error .bubble-text {
+          color: #7a2016;
+        }
         .bubble-text {
           font-size: 11px;
           line-height: 1.35;
@@ -314,8 +344,16 @@ function CompanionRoot(): React.JSX.Element | null {
   const [bubble, setBubble] = useState<BubbleState | null>(null);
   const levelRef = useRef<HTMLSpanElement>(null);
   const bubbleLevelRef = useRef<HTMLDivElement>(null);
+  const busyRef = useRef(false);
 
-  useDictation(setState, setListening, levelRef, setBubble, bubbleLevelRef);
+  useDictation(
+    setState,
+    setListening,
+    levelRef,
+    setBubble,
+    bubbleLevelRef,
+    busyRef,
+  );
   (window as unknown as Record<string, unknown>).__companionTest = {
     setBubble,
   };
@@ -326,7 +364,10 @@ function CompanionRoot(): React.JSX.Element | null {
       .then(setForm)
       .catch(() => setForm(DEFAULT_COMPANION_FORM));
     const offForm = window.api.onCompanionForm((next) => setForm(next));
-    const offState = window.api.onCompanionState((next) => setState(next));
+    const offState = window.api.onCompanionState((next) => {
+      if (next === "idle" && busyRef.current) return;
+      setState(next);
+    });
     const offHot = window.api.onCompanionHotEnter(() => {
       window.api.companionHover();
     });

--- a/apps/electron/src/renderer/src/components/notes-tab.tsx
+++ b/apps/electron/src/renderer/src/components/notes-tab.tsx
@@ -220,7 +220,8 @@ export function NotesTab(): React.JSX.Element {
                   draft: text ?? "",
                   editing: false,
                 });
-              });
+              })
+              .catch(() => {});
           }}
         >
           <span className="tavern-note-title">{n.title}</span>

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -21,7 +21,7 @@ import {
   executeAgentTool,
 } from "@renderer/lib/agent-tools";
 import { capture } from "@renderer/lib/analytics";
-import { apiFetch, initApiBase } from "@renderer/lib/api";
+import { apiFetch, initApiBase, refreshApiBase } from "@renderer/lib/api";
 import { CloudAuthProvider, useCloudAuth } from "@renderer/lib/auth-context";
 import { composerAction } from "@renderer/lib/composer-action";
 import { seedMessageFor } from "@renderer/lib/onboarding-core";
@@ -1353,6 +1353,9 @@ initApiBase();
 installGlobalErrorHandlers();
 
 const queryClient = createQueryClient();
+window.api.onServerChanged(() => {
+  void refreshApiBase().then(() => queryClient.invalidateQueries());
+});
 
 const container = document.getElementById("root");
 if (container)

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -23,12 +23,15 @@ import {
 import { capture } from "@renderer/lib/analytics";
 import { apiFetch, initApiBase, refreshApiBase } from "@renderer/lib/api";
 import { CloudAuthProvider, useCloudAuth } from "@renderer/lib/auth-context";
+import { resetBrainCache } from "@renderer/lib/brain-fs";
 import { composerAction } from "@renderer/lib/composer-action";
 import { seedMessageFor } from "@renderer/lib/onboarding-core";
 import {
   connectorConnectionsQueryOptions,
   createQueryClient,
+  invalidateThreads,
   latestThreadQueryOptions,
+  prependThreadToHistory,
   queryKeys,
   threadHistoryInfiniteQueryOptions,
   threadQueryOptions,
@@ -507,6 +510,15 @@ function newThread(): ThreadState {
   return { id: crypto.randomUUID(), messages: [] };
 }
 
+function touchesBrain(message: UIMessage): boolean {
+  return message.parts.some(
+    (part) =>
+      part.type === "tool-brain_write" ||
+      part.type === "tool-brain_edit" ||
+      part.type === "tool-brain_delete",
+  );
+}
+
 function PanelTail(): React.JSX.Element {
   // A manga balloon tail. The card fill reaches up through the panel's border
   // and hard shadow so the bubble opens into the tail; the ink stroke draws
@@ -622,6 +634,7 @@ function PanelRoot(): React.JSX.Element {
 
   useEffect(() => {
     const off = window.api.onPanelOpenThread((threadId) => {
+      void invalidateThreads(queryClient);
       void getThread(threadId)
         .catch(() => null)
         .then((picked) => {
@@ -630,7 +643,15 @@ function PanelRoot(): React.JSX.Element {
           setThread(picked);
         });
     });
-    return () => off?.();
+    const offNotifications = window.api.onNotificationsChanged(() => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.threads.list("scheduled"),
+      });
+    });
+    return () => {
+      off?.();
+      offNotifications?.();
+    };
   }, [queryClient]);
 
   useEffect(() => {
@@ -740,6 +761,7 @@ function PanelInner({
   onSwitchThread: (thread: ThreadState) => void;
 }): React.JSX.Element {
   const [tab, setTab] = useState<PanelTab>("chat");
+  const queryClient = useQueryClient();
   const auth = useCloudAuth();
   const onboarding = useOnboarding(!!auth.user);
   const [spriteForm, setSpriteForm] = useState<CompanionForm>(
@@ -803,9 +825,18 @@ function PanelInner({
       transport,
       sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
       onFinish: ({ messages: finished }) => {
+        queryClient.setQueryData(queryKeys.threads.detail(thread.id), {
+          id: thread.id,
+          messages: finished,
+        });
+        void invalidateThreads(queryClient);
         if (finished.length === 0) return;
         const last = finished[finished.length - 1];
         if (last?.role !== "assistant") return;
+        if (touchesBrain(last)) {
+          resetBrainCache();
+          void queryClient.invalidateQueries({ queryKey: queryKeys.brain.all });
+        }
         const text = messageText(last);
         if (!text) return;
         window.api.agentTurnFinished({
@@ -839,12 +870,26 @@ function PanelInner({
         setNotice(
           message.includes("cloud_auth_required") || message.includes("401")
             ? "Sign in to Freestyle Cloud to chat."
-            : message && message !== "[object Object]"
-              ? message
-              : "That didn't go through. Try again.",
+            : message.includes("thread_too_long")
+              ? "This conversation is too long to continue. Start a new one from the menu."
+              : message && message !== "[object Object]"
+                ? message
+                : "That didn't go through. Try again.",
         );
       },
     });
+
+  const startedRef = useRef(thread.messages.length > 0);
+  useEffect(() => {
+    if (startedRef.current || messages.length === 0) return;
+    startedRef.current = true;
+    prependThreadToHistory(queryClient, {
+      id: thread.id,
+      title: "New conversation",
+      updatedAt: Date.now(),
+      origin: "user",
+    });
+  }, [messages.length, queryClient, thread.id]);
 
   const busy = status === "submitted" || status === "streaming";
   const action = composerAction(status);
@@ -1207,7 +1252,10 @@ function PanelInner({
                   if (picked) onSwitchThread(picked);
                 });
               }}
-              onThreadsCleared={() => onSwitchThread(newThread())}
+              onThreadsCleared={() => {
+                void invalidateThreads(queryClient);
+                onSwitchThread(newThread());
+              }}
               onReplayIntro={() => {
                 setSettingsOpen(false);
                 onboarding.replay();

--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -1079,6 +1079,8 @@ function DictationPage({
     value(SETTINGS_KEYS.language),
   );
   const translateOn = value(SETTINGS_KEYS.translateMode) === "true";
+  const [hotkeyError, setHotkeyError] = useState<string | null>(null);
+  useEffect(() => window.api.onHotkeyError(setHotkeyError), []);
 
   const setLanguages = (next: string[]): void => {
     const normalized = normalizeLanguageList(next);
@@ -1103,8 +1105,12 @@ function DictationPage({
             value(SETTINGS_KEYS.remixHotkey) || getDefaultRemixHotkey(),
           )
         }
-        onSaved={(accel) => setSetting(SETTINGS_KEYS.hotkey, accel)}
+        onSaved={(accel) => {
+          setHotkeyError(null);
+          setSetting(SETTINGS_KEYS.hotkey, accel);
+        }}
       />
+      {hotkeyError ? <p className="tavern-notice">{hotkeyError}</p> : null}
       <ChoiceRow
         label="Press style"
         value={value(SETTINGS_KEYS.hotkeyMode, "hold")}
@@ -1112,7 +1118,10 @@ function DictationPage({
           { id: "hold", label: "Hold" },
           { id: "toggle", label: "Toggle" },
         ]}
-        onChange={(id) => setSetting(SETTINGS_KEYS.hotkeyMode, id)}
+        onChange={(id) => {
+          setSetting(SETTINGS_KEYS.hotkeyMode, id);
+          window.api.setHotkeyMode(id === "toggle" ? "toggle" : "hold");
+        }}
       />
       <MicrophoneRow
         value={value(SETTINGS_KEYS.micDeviceId)}

--- a/apps/electron/src/renderer/src/components/todos-tab.tsx
+++ b/apps/electron/src/renderer/src/components/todos-tab.tsx
@@ -53,6 +53,15 @@ export function TodosTab({ mascot }: { mascot: string }): React.JSX.Element {
     });
   };
 
+  if (todosQuery.isError)
+    return (
+      <div className="tavern-empty">
+        <p>Couldn&apos;t load todos.</p>
+        <button type="button" onClick={() => void todosQuery.refetch()}>
+          Try again
+        </button>
+      </div>
+    );
   if (lines === null) return <DataSkeleton label="Loading todos" />;
 
   const items = parseItems(lines);

--- a/apps/electron/src/renderer/src/lib/agent-tools.test.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.test.ts
@@ -4,7 +4,7 @@ vi.mock("@shared/sprite-events", () => ({
   parseSpriteEmotion: vi.fn(),
 }));
 
-import { agentToolTier } from "./agent-tools";
+import { agentToolTier, bashIsReadOnly } from "./agent-tools";
 
 describe("agent tool approval tiers", () => {
   const call = (toolName: string) => ({
@@ -28,5 +28,14 @@ describe("agent tool approval tiers", () => {
     await expect(
       agentToolTier(call("connector__gmail__474d41494c5f53454")),
     ).resolves.toBe("confirmed");
+  });
+
+  it("keeps mutating find invocations out of the free tier", () => {
+    expect(bashIsReadOnly("find . -name '*.log'")).toBe(true);
+    expect(bashIsReadOnly("find . -name '*.log' -delete")).toBe(false);
+    expect(bashIsReadOnly("find . -fprint /Users/me/.zshrc")).toBe(false);
+    expect(bashIsReadOnly("find . -exec rm {} +")).toBe(false);
+    expect(bashIsReadOnly("ls -la")).toBe(true);
+    expect(bashIsReadOnly("rm -rf ./x")).toBe(false);
   });
 });

--- a/apps/electron/src/renderer/src/lib/agent-tools.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.ts
@@ -34,10 +34,15 @@ const BASH_ALLOWLIST = new Set([
 
 const BASH_SAFE_SHAPE = /^[a-zA-Z0-9_./\s"'*=:,+-]+$/;
 
-function bashIsReadOnly(command: string): boolean {
+const BASH_MUTATING_FLAGS: Record<string, RegExp> = {
+  find: /(^|\s)-(delete|exec|execdir|ok|okdir|fprint0?|fprintf|fls)(\s|$)/,
+};
+
+export function bashIsReadOnly(command: string): boolean {
   if (!BASH_SAFE_SHAPE.test(command)) return false;
   const first = command.trim().split(/\s+/)[0] ?? "";
-  return BASH_ALLOWLIST.has(first);
+  if (!BASH_ALLOWLIST.has(first)) return false;
+  return !BASH_MUTATING_FLAGS[first]?.test(command);
 }
 
 const str = (input: Record<string, unknown>, key: string): string =>

--- a/apps/electron/src/renderer/src/lib/api.ts
+++ b/apps/electron/src/renderer/src/lib/api.ts
@@ -65,8 +65,8 @@ export async function initApiBase(): Promise<void> {
   // doesn't fire the server-URL/token/health probe twice in the same tick.
   if (!initPromise) {
     initPromise = refreshApiBase()
-      .then(() => {
-        initialized = true;
+      .then((healthy) => {
+        initialized = healthy;
       })
       .finally(() => {
         initPromise = null;

--- a/apps/electron/src/renderer/src/lib/brain-fs.test.ts
+++ b/apps/electron/src/renderer/src/lib/brain-fs.test.ts
@@ -92,7 +92,53 @@ describe("brain file cache", () => {
     const { listBrainFiles } = await import("./brain-fs");
 
     await expect(listBrainFiles("notes")).rejects.toThrow(
-      "Could not load Brain files.",
+      "Could not reach your Brain.",
     );
+  });
+});
+
+describe("brain read failures", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    vi.resetModules();
+  });
+
+  it("throws instead of reporting a missing file when the request fails", async () => {
+    apiFetch.mockResolvedValueOnce(new Response("nope", { status: 502 }));
+    const { readBrainFile, BrainRequestError } = await import("./brain-fs");
+    await expect(readBrainFile("todos.md")).rejects.toBeInstanceOf(
+      BrainRequestError,
+    );
+  });
+
+  it("throws when the proxy reports the cloud is unreachable", async () => {
+    apiFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: false, reason: "cloud-unreachable" }),
+    );
+    const { readBrainFile } = await import("./brain-fs");
+    await expect(readBrainFile("todos.md")).rejects.toThrow();
+  });
+
+  it("returns null for a file that does not exist", async () => {
+    apiFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: false, reason: "not-found" }),
+    );
+    const { readBrainFile } = await import("./brain-fs");
+    await expect(readBrainFile("todos.md")).resolves.toBeNull();
+  });
+
+  it("sends the last seen version with a write", async () => {
+    apiFetch
+      .mockResolvedValueOnce(jsonResponse({ ok: true, text: "a", version: 7 }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true, version: 8 }));
+    const { readBrainFile, writeBrainFile } = await import("./brain-fs");
+    await readBrainFile("todos.md");
+    await writeBrainFile("todos.md", "b");
+    const init = apiFetch.mock.calls[1][1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({
+      path: "todos.md",
+      text: "b",
+      ifMatch: 7,
+    });
   });
 });

--- a/apps/electron/src/renderer/src/lib/brain-fs.ts
+++ b/apps/electron/src/renderer/src/lib/brain-fs.ts
@@ -16,7 +16,15 @@ const MAX_READ_CACHE_ENTRIES = 100;
 type CacheEntry<T> = { value: T; at: number };
 
 const readCache = new Map<string, CacheEntry<string>>();
+const versions = new Map<string, number>();
 let listCache: CacheEntry<BrainFile[]> | null = null;
+
+export class BrainRequestError extends Error {
+  constructor(readonly reason: string) {
+    super("Could not reach your Brain.");
+    this.name = "BrainRequestError";
+  }
+}
 
 function isFresh(at: number): boolean {
   return Date.now() - at < CACHE_TTL_MS;
@@ -45,6 +53,13 @@ function invalidateList(): void {
 
 function dropRead(path: string): void {
   readCache.delete(path);
+  versions.delete(path);
+}
+
+export function resetBrainCache(): void {
+  readCache.clear();
+  versions.clear();
+  listCache = null;
 }
 
 /** Sync cache peek — `undefined` means miss (not yet fetched / expired). */
@@ -81,13 +96,23 @@ export async function fsCall(
             body: JSON.stringify(body),
           }),
     });
-    if (!res.ok) return null;
+    if (!res.ok) throw new BrainRequestError(`http-${res.status}`);
     const payload = (await res.json()) as Record<string, unknown>;
+    if (
+      payload.ok === false &&
+      typeof payload.reason === "string" &&
+      TRANSPORT_FAILURES.has(payload.reason)
+    ) {
+      throw new BrainRequestError(payload.reason);
+    }
     if (payload.ok === true && route === "write") {
       const path = body.path;
       const text = body.text;
       if (typeof path === "string" && typeof text === "string") {
         putRead(path, text);
+        if (typeof payload.version === "number")
+          versions.set(path, payload.version);
+        else versions.delete(path);
         invalidateList();
       }
     }
@@ -99,10 +124,17 @@ export async function fsCall(
       }
     }
     return payload;
-  } catch {
-    return null;
+  } catch (err) {
+    if (err instanceof BrainRequestError) throw err;
+    throw new BrainRequestError("network");
   }
 }
+
+const TRANSPORT_FAILURES = new Set([
+  "cloud_auth_required",
+  "cloud-unreachable",
+  "brain-failed",
+]);
 
 export async function readBrainFile(path: string): Promise<string | null> {
   const cached = peekBrainFile(path);
@@ -112,6 +144,7 @@ export async function readBrainFile(path: string): Promise<string | null> {
   if (!res?.ok) return null;
   const text = (res.text as string) ?? "";
   putRead(path, text);
+  if (typeof res.version === "number") versions.set(path, res.version);
   return text;
 }
 
@@ -126,14 +159,20 @@ export async function writeBrainFile(
   path: string,
   text: string,
 ): Promise<boolean> {
-  const res = await fsCall("write", { path, text });
+  const version = versions.get(path);
+  const res = await fsCall("write", {
+    path,
+    text,
+    ...(version !== undefined ? { ifMatch: version } : {}),
+  }).catch(() => null);
   const ok = res?.ok === true;
   if (ok) capture("brain_file_edited", { folder: brainFolder(path) });
+  else dropRead(path);
   return ok;
 }
 
 export async function deleteBrainFile(path: string): Promise<boolean> {
-  const res = await fsCall("delete", { path });
+  const res = await fsCall("delete", { path }).catch(() => null);
   const ok = res?.ok === true;
   if (ok) capture("brain_file_deleted", { folder: brainFolder(path) });
   return ok;

--- a/apps/electron/src/renderer/src/lib/dictation.ts
+++ b/apps/electron/src/renderer/src/lib/dictation.ts
@@ -4,6 +4,7 @@ import {
   getClient,
   getServerToken,
   initApiBase,
+  refreshApiBase,
 } from "@renderer/lib/api";
 import { LevelMeter } from "@renderer/lib/level-meter";
 import { Recorder, RecorderSupersededError } from "@renderer/lib/recorder";
@@ -16,7 +17,7 @@ export interface DictationCallbacks {
   onPhase: (phase: DictationPhase) => void;
   onPartial: (text: string) => void;
   onComposerText: (text: string) => void;
-  onError: (message: string) => void;
+  onError: (message: string, code?: string) => void;
   onLevel?: (level: number) => void;
 }
 
@@ -25,11 +26,31 @@ export interface DictationOptions {
   outputMode: () => "paste" | "clipboard";
   soundEnabled: () => boolean;
   audioPlaybackMode: () => "off" | "duck" | "pause";
+  micDeviceId?: () => string | null;
 }
 
 type TonePreset = "start" | "stop";
 
 const TRANSCRIBE_TIMEOUT_MS = 15_000;
+
+const ERROR_COPY: Record<string, string> = {
+  cloud_auth_required: "Sign in to Freestyle to dictate",
+  usage_exceeded: "You've reached your Freestyle usage limit",
+  provider_unavailable: "Transcription is temporarily unavailable",
+};
+
+function describeError(message: string, code?: string): string {
+  return (code && ERROR_COPY[code]) || message;
+}
+
+function startErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    if (err.name === "NotAllowedError") return "Microphone access is off";
+    if (err.name === "NotFoundError") return "No microphone found";
+    return err.message;
+  }
+  return "Could not start recording";
+}
 
 const TONE_PRESETS: Record<TonePreset, { freq: number; ms: number }> = {
   start: { freq: 347, ms: 125 },
@@ -118,17 +139,13 @@ export class DictationController {
       onPartial: (text) => this.callbacks.onPartial(text),
       onFinal: (text) => {
         if (!this.settleFinal()) return;
-        this.setPhase("idle");
+        if (!this.active) this.setPhase("idle");
         this.enqueue(text);
       },
-      onError: (message) => {
-        // A streaming transport can report an error after the watchdog has
-        // already recovered the recording through the REST path. Treat that
-        // as stale just like a late final: the user has their transcript and
-        // should not see a spurious failure card.
-        if (!this.settleFinal()) return;
-        this.setPhase("idle");
-        this.callbacks.onError(message);
+      onError: (message, code) => {
+        if (!this.active && this.awaitingFinals === 0) return;
+        this.abort();
+        this.callbacks.onError(describeError(message, code), code);
       },
       onReady: () => {},
       onConfig: () => {},
@@ -305,6 +322,16 @@ export class DictationController {
     return this.active;
   }
 
+  async reconnectServer(): Promise<void> {
+    await refreshApiBase();
+    if (this.streamer && this.streamer.baseUrl === getApiBase()) return;
+    this.cancel();
+    this.streamer?.destroy();
+    this.streamer = null;
+    this.ensureStreamer();
+    void refreshBeforeOutputHookPresence();
+  }
+
   async start(): Promise<void> {
     if (this.active) return;
     this.active = true;
@@ -321,7 +348,9 @@ export class DictationController {
       await initApiBase();
       const streamer = this.ensureStreamer();
       void this.captureAppContext();
-      const stream = await this.recorder.acquireStream();
+      const stream = await this.recorder.acquireStream(
+        this.options.micDeviceId?.() ?? null,
+      );
       if (session !== this.session) return;
       if (!this.active) {
         this.recorder.releaseStream();
@@ -345,9 +374,7 @@ export class DictationController {
       this.setPhase("idle");
       this.meter?.detach();
       void this.restoreAudio();
-      this.callbacks.onError(
-        err instanceof Error ? err.message : "Could not start recording",
-      );
+      this.callbacks.onError(startErrorMessage(err));
     }
   }
 
@@ -379,17 +406,21 @@ export class DictationController {
     void this.drain();
   }
 
-  cancel(): void {
+  private abort(): void {
     this.active = false;
     this.capturing = false;
     this.awaitingFinals = 0;
     this.clearTranscribeWatchdog();
     this.setPhase("idle");
-    this.pending = [];
     this.streamer?.cancel();
     this.meter?.detach();
     this.recorder.releaseStream();
     void this.restoreAudio();
+  }
+
+  cancel(): void {
+    this.abort();
+    this.pending = [];
   }
 
   destroy(): void {

--- a/apps/electron/src/renderer/src/lib/query.ts
+++ b/apps/electron/src/renderer/src/lib/query.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from "@tanstack/react-query";
+import { type InfiniteData, QueryClient } from "@tanstack/react-query";
 import { getClient } from "./api";
 import { listNoteSummaries } from "./brain-views";
 import {
@@ -17,6 +17,7 @@ import {
   listThreads,
   type ThreadOrigin,
   type ThreadPage,
+  type ThreadSummary,
 } from "./threads";
 
 /** Common staleTime for cached queries (1 hour). */
@@ -297,7 +298,31 @@ export function threadHistoryInfiniteQueryOptions(
     queryFn: ({ pageParam }: { pageParam: number | null }) =>
       listThreads({ cursor: pageParam ?? undefined, origin }),
     getNextPageParam: (page: ThreadPage) => page.nextCursor ?? undefined,
+    staleTime: 0,
   };
+}
+
+export function invalidateThreads(queryClient: QueryClient): Promise<void> {
+  return queryClient.invalidateQueries({ queryKey: queryKeys.threads.all });
+}
+
+export function prependThreadToHistory(
+  queryClient: QueryClient,
+  summary: ThreadSummary,
+): void {
+  const key = queryKeys.threads.list(summary.origin ?? "user");
+  queryClient.setQueryData<InfiniteData<ThreadPage, number | null>>(
+    key,
+    (data) => {
+      if (!data || data.pages.length === 0) return data;
+      const [first, ...rest] = data.pages;
+      const threads = [
+        summary,
+        ...first.threads.filter((t) => t.id !== summary.id),
+      ];
+      return { ...data, pages: [{ ...first, threads }, ...rest] };
+    },
+  );
 }
 
 export function quietHoursQueryOptions() {

--- a/apps/electron/src/renderer/src/lib/streamer.test.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.test.ts
@@ -166,4 +166,49 @@ describe("Streamer reconnects an active capture", () => {
     );
     expect(streamer.isConnected()).toBe(true);
   });
+
+  it("replays the recording and commits after a drop between capture and commit", async () => {
+    streamer = new Streamer("http://localhost:3000", "", {
+      onConfig: vi.fn(),
+      onReady: vi.fn(),
+      onFinal: vi.fn(),
+      onError: vi.fn(),
+    });
+    const config = {
+      type: "config",
+      streaming: true,
+      sessionTransport: true,
+      providerCategory: "freestyle_cloud",
+    };
+
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.open();
+    await streamer.startCapture({} as MediaStream);
+    firstSocket.message(config);
+    firstSocket.message({ type: "session.ready" });
+    const pcm = new Int16Array([1, 2, 3]).buffer;
+    FakeAudioWorkletNode.instances[0].port.onmessage?.({ data: pcm });
+
+    firstSocket.disconnect();
+    streamer.commit();
+
+    await vi.advanceTimersByTimeAsync(400);
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.open();
+    secondSocket.message(config);
+    expect(secondSocket.sent).toContainEqual(
+      JSON.stringify({ type: "start", context: null }),
+    );
+    expect(
+      secondSocket.sent.some(
+        (m) => typeof m === "string" && m.includes('"commit"'),
+      ),
+    ).toBe(false);
+
+    secondSocket.message({ type: "session.ready" });
+    const kinds = secondSocket.sent.map((m) =>
+      m instanceof ArrayBuffer ? "audio" : JSON.parse(m as string).type,
+    );
+    expect(kinds).toEqual(["start", "audio", "commit"]);
+  });
 });

--- a/apps/electron/src/renderer/src/lib/streamer.ts
+++ b/apps/electron/src/renderer/src/lib/streamer.ts
@@ -48,6 +48,7 @@ export class Streamer {
   private configReceived = false;
   private readonly callbacks: StreamerCallbacks;
   private readonly wsUrl: string;
+  readonly baseUrl: string;
   private currentContext: string | null = null;
   private connectionState: StreamerConnectionState = "disconnected";
   private reconnectAttempts = 0;
@@ -58,6 +59,7 @@ export class Streamer {
    * first recording after a disconnect cannot silently stream into no session.
    */
   private sessionStartPending = false;
+  private commitMessage: Record<string, unknown> | null = null;
 
   // Capture pipeline — reused across sessions when possible
   private ctx: AudioContext | null = null;
@@ -75,6 +77,7 @@ export class Streamer {
     // configured server's bearer token travels as a `?token=` query param
     // (the server authenticates WS upgrades from it). Empty for the local
     // server / no-auth case.
+    this.baseUrl = baseUrl;
     const wsBase = `${baseUrl.replace(/^http/, "ws")}/stream`;
     this.wsUrl = token
       ? `${wsBase}?token=${encodeURIComponent(token)}`
@@ -150,18 +153,18 @@ export class Streamer {
       (this.pcmSampleCount / TARGET_RATE) * 1000,
     );
     this.stopCapture();
-    this.sessionStartPending = false;
-    this.flushPendingChunks();
-    this.sendJSON({
+    this.commitMessage = {
       type: "commit",
       audioDurationMs,
       context: this.currentContext,
-    });
+    };
+    this.tryCommit();
   }
 
   cancel(): void {
     this.stopCapture();
     this.sessionStartPending = false;
+    this.commitMessage = null;
     this.sendJSON({ type: "cancel" });
   }
 
@@ -176,6 +179,7 @@ export class Streamer {
   destroy(): void {
     this.destroyed = true;
     this.sessionStartPending = false;
+    this.commitMessage = null;
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -251,7 +255,7 @@ export class Streamer {
   private startPendingSession(): void {
     if (
       !this.sessionStartPending ||
-      !this.capturing ||
+      !(this.capturing || this.commitMessage) ||
       !this.configReceived ||
       this.ws?.readyState !== WebSocket.OPEN
     ) {
@@ -261,6 +265,18 @@ export class Streamer {
       JSON.stringify({ type: "start", context: this.currentContext }),
     );
     this.sessionStartPending = false;
+  }
+
+  private tryCommit(): void {
+    if (!this.commitMessage) return;
+    if (this.ws?.readyState !== WebSocket.OPEN || !this.configReceived) {
+      this.ensureConnected();
+      return;
+    }
+    if (this.sessionStartPending) return;
+    this.flushPendingChunks();
+    this.ws.send(JSON.stringify(this.commitMessage));
+    this.commitMessage = null;
   }
 
   /**
@@ -356,11 +372,13 @@ export class Streamer {
             model: msg.model ?? "",
             providerCategory: msg.providerCategory,
           });
-          this.startPendingSession();
+          if (this.sessionStartPending) this.startPendingSession();
+          else this.tryCommit();
           break;
         case "session.ready":
           this.flushPendingChunks();
           this.callbacks.onReady();
+          this.tryCommit();
           break;
         case "partial":
           this.callbacks.onPartial?.(msg.text ?? "");
@@ -380,7 +398,7 @@ export class Streamer {
       if (this.ws !== ws) return;
       this.ws = null;
       this.configReceived = false;
-      if (this.capturing) {
+      if (this.capturing || this.commitMessage) {
         this.sessionStartPending = true;
         this.stageCapturedAudioForReplay();
       }

--- a/apps/electron/src/renderer/src/lib/use-cloud-usage.ts
+++ b/apps/electron/src/renderer/src/lib/use-cloud-usage.ts
@@ -177,7 +177,11 @@ export function useCloudUsage(signedIn: boolean): UseCloudUsageResult {
     if (checkoutStatus !== "pending") return;
     const timer = setTimeout(() => {
       if (checkoutStore.status === "pending") {
-        updateCheckout({ status: "idle" });
+        updateCheckout({
+          status: "error",
+          error:
+            "We haven't seen your payment yet. If you completed checkout, wait a moment and refresh — otherwise contact support.",
+        });
       }
     }, CHECKOUT_POLL_WINDOW_MS);
     return () => clearTimeout(timer);

--- a/apps/electron/src/renderer/src/sprites/stage.tsx
+++ b/apps/electron/src/renderer/src/sprites/stage.tsx
@@ -15,6 +15,7 @@ function bubbleText(
   if (partial) {
     return partial.length > maxChars ? `…${partial.slice(-maxChars)}` : partial;
   }
+  if (bubble.phase === "error") return "Something went wrong";
   return bubble.phase === "recording" ? "I'm listening…" : "…";
 }
 
@@ -88,7 +89,10 @@ export function SpriteStage({
   }, [state]);
 
   useEffect(() => {
-    performerRef.current?.handle({ kind: "listening", on: bubble !== null });
+    performerRef.current?.handle({
+      kind: "listening",
+      on: bubble !== null && bubble.phase !== "error",
+    });
     setSay(bubbleText(bubble, def.bubble.maxChars));
   }, [bubble, def]);
 

--- a/apps/electron/src/shared/dictation-prefs.ts
+++ b/apps/electron/src/shared/dictation-prefs.ts
@@ -1,0 +1,7 @@
+export interface DictationPrefs {
+  destination: "cursor" | "composer";
+  outputMode: "paste" | "clipboard";
+  soundEnabled: boolean;
+  audioPlaybackMode: "off" | "duck" | "pause";
+  micDeviceId: string | null;
+}

--- a/apps/electron/tests/key-listener.test.ts
+++ b/apps/electron/tests/key-listener.test.ts
@@ -294,3 +294,29 @@ test("nextRightModifierLatch does not latch when a right token arrives after a l
   );
   expect(latch).toBeNull();
 });
+
+test("Fn held with a regular key is a chord, not a solo Fn press", async () => {
+  const { listener, events } = createFnListener();
+
+  listener.handleLine("FN_DOWN");
+  listener.handleLine("KEY_DOWN:Delete");
+  await wait(75);
+  listener.handleLine("FN_UP");
+  expect(events).toEqual([]);
+});
+
+test("compound hotkey releases when its key goes up while the modifier is held", () => {
+  const events: string[] = [];
+  const listener = new NativeKeyListener({
+    hotkey: "Alt+Space",
+    onKeyDown: () => events.push("down"),
+    onKeyUp: () => events.push("up"),
+  }) as unknown as LineHandler;
+
+  listener.handleLine("FLAGS:option");
+  listener.handleLine("KEY_DOWN:Space");
+  expect(events).toEqual(["down"]);
+
+  listener.handleLine("KEY_UP:Space");
+  expect(events).toEqual(["down", "up"]);
+});

--- a/apps/server/src/lib/agent-os.ts
+++ b/apps/server/src/lib/agent-os.ts
@@ -58,7 +58,10 @@ export function editAgentFile(
   const first = raw.indexOf(oldText);
   if (first === -1) return "not-found";
   if (raw.indexOf(oldText, first + 1) !== -1) return "ambiguous";
-  writeFileSync(full, raw.replace(oldText, newText));
+  writeFileSync(
+    full,
+    raw.slice(0, first) + newText + raw.slice(first + oldText.length),
+  );
   return "ok";
 }
 

--- a/apps/server/src/lib/freestyle-cloud-defaults.ts
+++ b/apps/server/src/lib/freestyle-cloud-defaults.ts
@@ -53,26 +53,4 @@ export function revertFreestyleCloudDefaults(): void {
        ON CONFLICT(key) DO UPDATE SET value = 'false', updated_at = datetime('now')`,
     ).run();
   }
-
-  const current = db
-    .prepare(
-      "SELECT provider FROM model_configs WHERE type = 'voice' AND is_default = 1 LIMIT 1",
-    )
-    .get() as { provider: string } | undefined;
-  if (!current || current.provider !== FREESTYLE_CLOUD_PROVIDER_ID) return;
-
-  db.prepare(
-    "UPDATE model_configs SET is_default = 0 WHERE type = 'voice'",
-  ).run();
-
-  const fallback = db
-    .prepare(
-      "SELECT id FROM model_configs WHERE type = 'voice' AND provider != ? ORDER BY created_at DESC LIMIT 1",
-    )
-    .get(FREESTYLE_CLOUD_PROVIDER_ID) as { id: number } | undefined;
-  if (!fallback) return;
-
-  db.prepare("UPDATE model_configs SET is_default = 1 WHERE id = ?").run(
-    fallback.id,
-  );
 }

--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -303,9 +303,10 @@ export async function fetchCloudUser(token: string): Promise<CloudUser> {
     },
   });
   if (authClientErrorStatus(error) === 401) throw new FreestyleCloudAuthError();
-  if (error || !data?.user) {
+  if (error) {
     throw new Error(authClientErrorMessage(error, "Failed to load profile"));
   }
+  if (!data?.user) throw new FreestyleCloudAuthError();
   const { id, email, name, image } = data.user;
   return { id, email, name, image };
 }
@@ -555,10 +556,26 @@ function assertBillingUrl(url: unknown): asserts url is string {
  * Create a Stripe hosted Checkout session for the Pro plan. Returns the URL
  * the user must open in their browser to pay.
  */
+export class FreestyleCloudOrgError extends Error {
+  constructor() {
+    super("No active organization for this account");
+    this.name = "FreestyleCloudOrgError";
+  }
+}
+
+async function billingReference(
+  token: string,
+): Promise<{ customerType: "organization"; referenceId: string }> {
+  const referenceId = await resolveActiveOrgId(token);
+  if (!referenceId) throw new FreestyleCloudOrgError();
+  return { customerType: "organization", referenceId };
+}
+
 export async function createCheckoutSession(
   token: string,
   opts: { annual: boolean },
 ): Promise<{ url: string }> {
+  const reference = await billingReference(token);
   const { url } = await cloudJson<{ url?: string; redirect?: boolean }>(
     "/auth/subscription/upgrade",
     token,
@@ -570,6 +587,7 @@ export async function createCheckoutSession(
         annual: opts.annual,
         successUrl: CHECKOUT_SUCCESS_URL,
         cancelUrl: CHECKOUT_CANCEL_URL,
+        ...reference,
       }),
       signal: AbortSignal.timeout(BILLING_REQUEST_TIMEOUT_MS),
     },
@@ -589,13 +607,17 @@ export async function createCheckoutSession(
 export async function createBillingPortalSession(
   token: string,
 ): Promise<{ url: string }> {
+  const reference = await billingReference(token);
   const { url } = await cloudJson<{ url?: string; redirect?: boolean }>(
     "/auth/subscription/billing-portal",
     token,
     {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ returnUrl: BILLING_PORTAL_RETURN_URL }),
+      body: JSON.stringify({
+        returnUrl: BILLING_PORTAL_RETURN_URL,
+        ...reference,
+      }),
       signal: AbortSignal.timeout(BILLING_REQUEST_TIMEOUT_MS),
     },
   );
@@ -920,11 +942,27 @@ export async function setCloudActiveOrganization(
  * active org's slug once per session and reuse it. Cleared on sign-out and
  * whenever the active org changes.
  */
-let cachedOrgSlug: { token: string; slug: string } | null = null;
+let cachedOrg: { token: string; id: string; slug: string } | null = null;
 
-/** Drop the cached org slug (call on sign-out or after switching orgs). */
+/** Drop the cached org (call on sign-out or after switching orgs). */
 export function clearCachedOrgSlug(): void {
-  cachedOrgSlug = null;
+  cachedOrg = null;
+}
+
+async function resolveActiveOrg(
+  token: string,
+): Promise<{ id: string; slug: string } | null> {
+  if (cachedOrg && cachedOrg.token === token) return cachedOrg;
+  const org = await getCloudActiveOrganization(token);
+  if (!org?.slug || !org.id) return null;
+  cachedOrg = { token, id: org.id, slug: org.slug };
+  return cachedOrg;
+}
+
+export async function resolveActiveOrgId(
+  token: string,
+): Promise<string | null> {
+  return (await resolveActiveOrg(token))?.id ?? null;
 }
 
 /**
@@ -937,11 +975,7 @@ export function clearCachedOrgSlug(): void {
 export async function resolveActiveOrgSlug(
   token: string,
 ): Promise<string | null> {
-  if (cachedOrgSlug && cachedOrgSlug.token === token) return cachedOrgSlug.slug;
-  const org = await getCloudActiveOrganization(token);
-  const slug = org?.slug ?? null;
-  if (slug) cachedOrgSlug = { token, slug };
-  return slug;
+  return (await resolveActiveOrg(token))?.slug ?? null;
 }
 
 /** Upper bound for the best-effort connection prewarm. */

--- a/apps/server/src/lib/streaming/providers/freestyle-cloud.ts
+++ b/apps/server/src/lib/streaming/providers/freestyle-cloud.ts
@@ -157,12 +157,33 @@ export class FreestyleCloudTranscriptionProvider
       }
     });
 
-    ws.on("error", (err) => {
-      if (!closed) {
+    let rejected = false;
+    ws.on("unexpected-response", (_req, res) => {
+      rejected = true;
+      const status = res.statusCode ?? 0;
+      if (status === 401 || status === 403) {
         callbacks.onError(
-          err instanceof Error ? err.message : "Cloud WebSocket error",
+          "Sign in to Freestyle Transcribe",
+          "cloud_auth_required",
+        );
+      } else if (status === 429) {
+        callbacks.onError(
+          "Freestyle Cloud usage limit reached",
+          "usage_exceeded",
+        );
+      } else {
+        callbacks.onError(
+          `Freestyle Cloud rejected the connection (${status})`,
         );
       }
+      ws.terminate();
+    });
+
+    ws.on("error", (err) => {
+      if (closed || rejected) return;
+      callbacks.onError(
+        err instanceof Error ? err.message : "Cloud WebSocket error",
+      );
     });
 
     ws.on("close", () => {

--- a/apps/server/src/routes/agent-threads.ts
+++ b/apps/server/src/routes/agent-threads.ts
@@ -45,9 +45,15 @@ const agentThreadsRoute = new Hono()
     return c.json(payload as object, status as 200);
   })
   .get("/list", async (c) => {
+    const params = new URLSearchParams();
     const origin = c.req.query("origin");
-    const query =
-      origin === "user" || origin === "scheduled" ? `?origin=${origin}` : "";
+    if (origin === "user" || origin === "scheduled")
+      params.set("origin", origin);
+    for (const key of ["limit", "cursor"] as const) {
+      const value = Number(c.req.query(key));
+      if (Number.isInteger(value) && value > 0) params.set(key, String(value));
+    }
+    const query = params.size > 0 ? `?${params.toString()}` : "";
     const { status, payload } = await forward(query);
     return c.json(payload as object, status as 200);
   })

--- a/apps/server/src/routes/agent.ts
+++ b/apps/server/src/routes/agent.ts
@@ -74,6 +74,16 @@ const agentRoute = new Hono().post(
       log.error(
         `Agent cloud returned ${upstream.status}: ${detail.slice(0, 200)}`,
       );
+      if (upstream.status === 400 && detail.includes("messages")) {
+        return c.json(
+          {
+            error: "thread_too_long",
+            detail:
+              "This conversation is too long to continue. Start a new conversation.",
+          },
+          413,
+        );
+      }
       return c.json({ error: "failed", detail: "Agent failed upstream." }, 502);
     }
 

--- a/apps/server/src/routes/brain.ts
+++ b/apps/server/src/routes/brain.ts
@@ -4,6 +4,7 @@ import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
 import { getSessionToken, invalidateSession } from "../lib/sessions.js";
 
 const log = createAppLogger("brain-proxy");
+const BRAIN_REQUEST_TIMEOUT_MS = 15_000;
 
 async function forward(
   segment: string,
@@ -24,6 +25,7 @@ async function forward(
         ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
       },
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      signal: AbortSignal.timeout(BRAIN_REQUEST_TIMEOUT_MS),
     });
     if (upstream.status === 401) {
       invalidateSession();

--- a/apps/server/src/routes/stream.ts
+++ b/apps/server/src/routes/stream.ts
@@ -59,6 +59,7 @@ const stream = new Hono().get(
     let voiceDefaults: { provider: string; model_id: string } | null = null;
     /** Fingerprint of the settings the current upstream session was built with. */
     let upstreamConfigKey: string | null = null;
+    let announcedKey: string | null = null;
     let appContext: string | null = null;
     const effectiveAppContext = (): string | null =>
       resolveAppContextForCleanup(appContext);
@@ -194,6 +195,38 @@ const stream = new Hono().get(
         });
     }
 
+    function failSession(
+      ws: { send: (data: string) => void },
+      message: string,
+      code?: string,
+    ): void {
+      sessionStarting = false;
+      const hadCommit = pendingCommit;
+      pendingCommit = false;
+      pendingAudioChunks = [];
+      if (closed) return;
+      ws.send(
+        JSON.stringify({ type: "error", ...(code ? { code } : {}), message }),
+      );
+      if (hadCommit) ws.send(JSON.stringify({ type: "final", text: "" }));
+    }
+
+    function startUpstream(
+      ws: {
+        send: (data: string) => void;
+        close: () => void;
+      },
+      announced?: AnnouncedStreamConfig,
+    ): void {
+      connectUpstream(ws, announced).catch((err: unknown) => {
+        captureException(err);
+        failSession(
+          ws,
+          err instanceof Error ? err.message : "Could not start transcription",
+        );
+      });
+    }
+
     function announceConfig(ws: {
       send: (data: string) => void;
       close: () => void;
@@ -220,15 +253,19 @@ const stream = new Hono().get(
 
       const modelShort = stripProviderPrefix(voice.model_id);
 
-      ws.send(
-        JSON.stringify({
-          type: "config",
-          model: modelShort,
-          streaming: canStream,
-          sessionTransport: canUseSessionTransport,
-          providerCategory: voiceProviderCategory(voice.provider),
-        }),
-      );
+      const announceKey = `${config.key}:${canStream}:${canUseSessionTransport}`;
+      if (announceKey !== announcedKey) {
+        announcedKey = announceKey;
+        ws.send(
+          JSON.stringify({
+            type: "config",
+            model: modelShort,
+            streaming: canStream,
+            sessionTransport: canUseSessionTransport,
+            providerCategory: voiceProviderCategory(voice.provider),
+          }),
+        );
+      }
 
       return {
         config,
@@ -679,7 +716,7 @@ const stream = new Hono().get(
           onError: (message, code) => {
             if (upstream !== session) return;
             sessionTransportUnavailable = true;
-            sessionStarting = false;
+            announcedKey = null;
             ws.send(
               JSON.stringify({
                 type: "config",
@@ -688,32 +725,24 @@ const stream = new Hono().get(
                 model: modelShort,
               }),
             );
-            ws.send(
-              JSON.stringify({
-                type: "error",
-                ...(code ? { code } : {}),
-                message,
-              }),
-            );
             upstream = null;
             try {
               session.close();
             } catch {}
+            if (code === "cloud_auth_required") invalidateSession();
+            failSession(ws, message, code);
           },
           onClose: () => {
             // Ignore close from a superseded socket (replaced on a later "start").
             if (upstream !== session) return;
             upstream = null;
-            if (
-              !closed &&
-              !sessionTransportUnavailable &&
-              reconnectAttempts < MAX_RECONNECT_ATTEMPTS
-            ) {
+            if (closed || sessionTransportUnavailable) return;
+            if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
               reconnectAttempts++;
-              try {
-                connectUpstream(ws);
-              } catch {}
+              startUpstream(ws);
+              return;
             }
+            failSession(ws, "Could not reach Freestyle Transcribe");
           },
         },
       });
@@ -744,7 +773,7 @@ const stream = new Hono().get(
           ) {
             return;
           }
-          connectUpstream(ws, announced);
+          startUpstream(ws, announced);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           ws.send(JSON.stringify({ type: "error", message }));
@@ -853,9 +882,7 @@ const stream = new Hono().get(
             if (upstream) {
               closeUpstreamSession(upstream);
             }
-            try {
-              connectUpstream(ws);
-            } catch {}
+            startUpstream(ws);
             break;
           }
           case "commit":

--- a/apps/server/tests/agent-os.test.ts
+++ b/apps/server/tests/agent-os.test.ts
@@ -40,6 +40,8 @@ describe("file ops", () => {
     expect(editAgentFile(target, "hello", "goodbye")).toBe("ok");
     expect(readFileSync(target, "utf8")).toContain("goodbye world");
     expect(editAgentFile(target, "absent", "x")).toBe("not-found");
+    expect(editAgentFile(target, "goodbye", "$$ $& costs $'5")).toBe("ok");
+    expect(readFileSync(target, "utf8")).toContain("$$ $& costs $'5 world");
   });
 
   it("glob and grep under an absolute root", () => {

--- a/apps/server/tests/agent-threads-proxy.test.ts
+++ b/apps/server/tests/agent-threads-proxy.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/lib/sessions.js", () => ({
+  getSessionToken: () => "token",
+  invalidateSession: vi.fn(),
+}));
+
+vi.mock("../src/lib/freestyle-cloud.js", () => ({
+  freestyleCloudUrl: () => "https://cloud.test",
+}));
+
+import agentThreadsRoute from "../src/routes/agent-threads.js";
+
+describe("agent thread list proxy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards origin, limit and cursor to the cloud", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ threads: [], nextCursor: null }), {
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await agentThreadsRoute.request(
+      "/list?limit=24&cursor=1700000000000&origin=user&junk=1",
+    );
+    expect(res.status).toBe(200);
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.pathname).toBe("/v2/threads");
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      origin: "user",
+      limit: "24",
+      cursor: "1700000000000",
+    });
+  });
+});

--- a/apps/server/tests/cloud-auth.test.ts
+++ b/apps/server/tests/cloud-auth.test.ts
@@ -217,23 +217,21 @@ describe("Freestyle Transcribe default on sign-in", () => {
     expect(getDefaultModels().voice?.provider).toBe("openai");
   });
 
-  it("reverts to a non-cloud model and disables cleanup on sign-out", async () => {
-    insertNonCloudVoiceDefault();
+  it("keeps the Freestyle voice default and disables cleanup on sign-out", async () => {
     await signIn();
     expect(getDefaultModels().voice?.provider).toBe("freestyle-cloud");
 
     const res = await app.request("/api/auth/sign-out", { method: "POST" });
     expect(res.status).toBe(200);
 
-    expect(getDefaultModels().voice?.provider).toBe("openai");
+    expect(getDefaultModels().voice?.provider).toBe("freestyle-cloud");
     expect(readSetting("llm_cleanup")).toBe("false");
   });
 
   it("re-applies the Freestyle bundle when signing in again", async () => {
-    insertNonCloudVoiceDefault();
     await signIn();
     await app.request("/api/auth/sign-out", { method: "POST" });
-    expect(getDefaultModels().voice?.provider).toBe("openai");
+    expect(readSetting("llm_cleanup")).toBe("false");
 
     await signIn();
 
@@ -241,16 +239,5 @@ describe("Freestyle Transcribe default on sign-in", () => {
     expect(defaults.voice?.provider).toBe("freestyle-cloud");
     expect(defaults.llm?.provider).toBe("freestyle-cloud");
     expect(readSetting("llm_cleanup")).toBe("true");
-  });
-
-  it("clears the voice default on sign-out when nothing else is configured", async () => {
-    await signIn();
-    expect(getDefaultModels().voice?.provider).toBe("freestyle-cloud");
-
-    const res = await app.request("/api/auth/sign-out", { method: "POST" });
-    expect(res.status).toBe(200);
-
-    expect(getDefaultModels().voice).toBeNull();
-    expect(readSetting("llm_cleanup")).toBe("false");
   });
 });

--- a/apps/server/tests/fetch-cloud-user.test.ts
+++ b/apps/server/tests/fetch-cloud-user.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  FreestyleCloudAuthError,
+  fetchCloudUser,
+} from "../src/lib/freestyle-cloud.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("fetchCloudUser", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the profile for a live session", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          session: { token: "t" },
+          user: { id: "u1", email: "a@b.c", name: "A", image: null },
+        }),
+      ),
+    );
+    await expect(fetchCloudUser("token")).resolves.toMatchObject({
+      id: "u1",
+      email: "a@b.c",
+    });
+  });
+
+  it("treats a null session body as an authentication failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(null)),
+    );
+    await expect(fetchCloudUser("dead")).rejects.toBeInstanceOf(
+      FreestyleCloudAuthError,
+    );
+  });
+
+  it("treats a 401 as an authentication failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ message: "Unauthorized" }, 401)),
+    );
+    await expect(fetchCloudUser("dead")).rejects.toBeInstanceOf(
+      FreestyleCloudAuthError,
+    );
+  });
+});

--- a/packages/utils/src/cloud-client.ts
+++ b/packages/utils/src/cloud-client.ts
@@ -191,15 +191,16 @@ export function createCloudClient(config: CloudClientConfig): CloudClient {
     const res = await request(path, init);
     if (res.status === 401) throw new CloudAuthError();
     if (res.status === 429) {
-      const resetsAt = await res
-        .json()
-        .then((b) =>
-          b && typeof (b as { resetsAt?: unknown }).resetsAt === "string"
-            ? (b as { resetsAt: string }).resetsAt
-            : null,
-        )
-        .catch(() => null);
-      throw new CloudUsageError(resetsAt);
+      const body = (await res.json().catch(() => null)) as {
+        code?: unknown;
+        resetsAt?: unknown;
+      } | null;
+      if (body?.code === "rate_limited") {
+        throw new CloudRequestError(429, "Too many requests");
+      }
+      throw new CloudUsageError(
+        typeof body?.resetsAt === "string" ? body.resetsAt : null,
+      );
     }
     if (!res.ok) {
       const detail = await res.text().catch(() => "");


### PR DESCRIPTION
## Phase 3 of the audit stack (desktop) — agent, brain, threads

Stack: #616 ← #617 ← #618 ← **this** ← phase 5. Pairs with the Worker PR freestyle-voice/cloud#153 (brain write `ifMatch`, persistence, scheduler); safe to merge in either order — the desktop only sends `ifMatch` when the Worker returned a `version`.

### Changes
- **A3b — new conversations missing from History**: `useChat.onFinish` writes the thread detail and invalidates `queryKeys.threads.all`; the list query has `staleTime: 0`; a brand-new thread is optimistically prepended on its first message; clear/open/brief-notification also invalidate.
- **A3**: local proxy forwards `limit`/`cursor` (test added).
- **A2**: `readBrainFile` throws `BrainRequestError` on HTTP/network/proxy failure and returns `null` only for a genuinely missing file — Todos shows an error+retry instead of an empty list it would later overwrite; Notes/Brain file opens catch failures; writes send `ifMatch` (last seen `version`) and drop the cached copy on failure; `resetBrainCache()` + brain query invalidation after any turn with `brain_write`/`brain_edit`/`brain_delete` parts. Brain proxy gets a 15 s timeout.
- **A1**: `find` with `-delete/-exec/-execdir/-ok/-fprint*/-fls` is no longer "free" (`bashIsReadOnly` exported + tested).
- **A7**: desktop `Edit` splices instead of `String.replace` (`$&`, `$$` literal; test added).
- **A9**: Worker 400 on the 400-message cap maps to `thread_too_long` (413) with actionable copy.

### Verification
- electron typecheck ✓, vitest 90/90 ✓; server vitest 405/405 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)