### PR TITLE
fix(desktop): improve dictation and companion feedback

### DIFF
--- a/apps/electron/scripts/pack-sprites.js
+++ b/apps/electron/scripts/pack-sprites.js
@@ -41,7 +41,22 @@ const SPRITES = {
       throw: { fps: 14, loop: false, impactFrame: 5 },
       defend: { fps: 10, loop: false, holdLast: true },
       hurt: { fps: 10, loop: false },
-      death: { fps: 10, loop: false, holdLast: true },
+      death: {
+        fps: 10,
+        loop: false,
+        holdLast: true,
+        sheet: "death.png",
+        start: 0,
+        frames: 9,
+      },
+      "death-fall": {
+        fps: 10,
+        loop: false,
+        holdLast: true,
+        sheet: "death.png",
+        start: 4,
+        frames: 5,
+      },
       healing: { fps: 10, loop: true },
       "healing-no-effect": { fps: 10, loop: true },
       // typing.png hosts two states: the sit-down transition and the loop.

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -127,6 +127,7 @@ import * as linuxAutostart from "./linux-autostart";
 import { checkLinuxSetup } from "./linux-setup";
 import { MicListener } from "./mic-listener";
 import { getNativeBinaryPath } from "./native-binary";
+import { startNotificationStream } from "./notification-stream";
 import {
   hideNotifications,
   initNotificationWindow,
@@ -447,6 +448,7 @@ function broadcastServerChanged(): void {
   panelWindow?.webContents.send("server:changed");
   companionWindow?.webContents.send("server:changed");
   invalidatePluginViews();
+  if (stopNotificationStream) restartNotificationStream();
 }
 
 function broadcastUpdateStatus(): void {
@@ -469,6 +471,7 @@ let keyListener: NativeKeyListener | null = null;
 // but is never used to override the current macOS Accessibility trust result.
 let accessibilityConfirmed = false;
 let hotkeyPressed = false;
+let dictationInProgress = false;
 let currentHotkeyAccel: string | null = null;
 let hotkeyActivationMode: "hold" | "toggle" = "hold";
 let micListener: MicListener | null = null;
@@ -618,7 +621,6 @@ function setPillExpanded(
   win.setResizable(true);
   win.setBounds(target);
   win.setResizable(false);
-  updatePillEscape();
 }
 
 // Returns the pill alignment token for a custom position, using the actual
@@ -655,24 +657,6 @@ function openPanelSettings(): void {
  * Resolves once a freshly-created pill window has finished loading and is
  * visible.  `null` when no deferred show is in progress.
  */
-
-function updatePillEscape(): void {
-  const chatLike = pillExpansion === "remix-chat";
-  const isExpanded = pillExpandOffset.dx !== 0 || pillExpandOffset.dy !== 0;
-  if (mainWindow?.isVisible() && !(chatLike && isExpanded)) {
-    if (!globalShortcut.isRegistered("Escape")) {
-      globalShortcut.register("Escape", () => {
-        if (mainWindow?.isVisible()) {
-          mainWindow.webContents.send("pill:cancel");
-        }
-      });
-    }
-  } else {
-    try {
-      globalShortcut.unregister("Escape");
-    } catch {}
-  }
-}
 
 // -- Async helper: run a command without blocking the main thread --
 function execAsync(
@@ -1722,6 +1706,13 @@ app.whenReady().then(async () => {
     });
   });
 
+  ipcMain.on("dictation:state", (event, phase: unknown) => {
+    if (event.sender !== companionWindow?.webContents) return;
+    if (phase === "recording" || phase === "transcribing" || phase === "idle") {
+      setDictationPhase(phase);
+    }
+  });
+
   // IPC: expose the server port to the renderer
   ipcMain.handle("server:port", () => serverPort);
 
@@ -1874,6 +1865,7 @@ app.whenReady().then(async () => {
   if (process.env.FREESTYLE_E2E === "1") {
     ipcMain.on("e2e:trigger-hotkey-down", handleNativeHotkeyDown);
     ipcMain.on("e2e:trigger-hotkey-up", handleNativeHotkeyUp);
+    ipcMain.on("e2e:trigger-escape", cancelActiveDictation);
   }
 
   // IPC: Linux system setup (input-group access for the hotkey listener and
@@ -1988,7 +1980,7 @@ app.whenReady().then(async () => {
         return { x: b.x, y: b.y, width: b.width };
       },
     });
-    startNotificationPoll();
+    startNotificationEvents();
   }
 
   // A signed-out launch surfaces the panel unprompted: the sign-in gate is
@@ -3187,12 +3179,13 @@ ipcMain.on("sprite:event", (event, ev: unknown) => {
   }
 });
 
-const NOTIFICATION_POLL_MS = 20_000;
+const NOTIFICATION_FALLBACK_POLL_MS = 120_000;
 /** How long an unread bubble sits open before it collapses to the
  *  companion's suggestion glow. It stays unread either way. */
 const NOTIFICATION_COLLAPSE_MS = 30_000;
-let notificationPollTimer: NodeJS.Timeout | null = null;
+let notificationFallbackPollTimer: NodeJS.Timeout | null = null;
 let notificationCollapseTimer: NodeJS.Timeout | null = null;
+let stopNotificationStream: (() => void) | null = null;
 let notificationHovered = false;
 const notifiedIds = new Set<string>();
 const collapsedIds = new Set<string>();
@@ -3335,14 +3328,42 @@ async function openNotification(id: string): Promise<void> {
   if (result?.url) void shell.openExternal(result.url);
 }
 
-function startNotificationPoll(): void {
-  if (notificationPollTimer) return;
-  void refreshNotifications();
-  notificationPollTimer = setInterval(
+function startNotificationFallbackPoll(): void {
+  if (notificationFallbackPollTimer) return;
+  notificationFallbackPollTimer = setInterval(
     () => void refreshNotifications(),
-    NOTIFICATION_POLL_MS,
+    NOTIFICATION_FALLBACK_POLL_MS,
   );
-  notificationPollTimer.unref();
+  notificationFallbackPollTimer.unref();
+}
+
+function stopNotificationFallbackPoll(): void {
+  if (!notificationFallbackPollTimer) return;
+  clearInterval(notificationFallbackPollTimer);
+  notificationFallbackPollTimer = null;
+}
+
+function startNotificationEvents(): void {
+  if (stopNotificationStream) return;
+  void refreshNotifications();
+  stopNotificationStream = startNotificationStream({
+    url: getServerBaseUrl,
+    headers: getServerAuthHeaders,
+    onChange: () => void refreshNotifications(),
+    onConnected: stopNotificationFallbackPoll,
+    onDisconnected: startNotificationFallbackPoll,
+  });
+}
+
+function stopNotificationEvents(): void {
+  stopNotificationStream?.();
+  stopNotificationStream = null;
+  stopNotificationFallbackPoll();
+}
+
+function restartNotificationStream(): void {
+  stopNotificationEvents();
+  startNotificationEvents();
 }
 
 ipcMain.handle("notifications:list", async () => await fetchNotifications());
@@ -3715,6 +3736,8 @@ function createCompanionWindow(): void {
 
   companionWindow.on("closed", () => {
     stopCompanionHotPoll();
+    dictationInProgress = false;
+    updateDictationEscape();
     companionWindow = null;
   });
 
@@ -3830,6 +3853,38 @@ function dictationTargets(): BrowserWindow[] {
   if (companionWindow && !companionWindow.isDestroyed())
     targets.push(companionWindow);
   return targets;
+}
+
+function updateDictationEscape(): void {
+  if (!dictationInProgress) {
+    try {
+      globalShortcut.unregister("Escape");
+    } catch {}
+    return;
+  }
+
+  if (globalShortcut.isRegistered("Escape")) return;
+  try {
+    if (!globalShortcut.register("Escape", cancelActiveDictation)) {
+      hotkeyLog.warn("Could not register Escape to cancel dictation.");
+    }
+  } catch (err) {
+    hotkeyLog.warn(
+      `Could not register Escape to cancel dictation: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function setDictationPhase(phase: "idle" | "recording" | "transcribing"): void {
+  dictationInProgress = phase !== "idle";
+  updateDictationEscape();
+}
+
+function cancelActiveDictation(): void {
+  if (!dictationInProgress) return;
+  hotkeyPressed = false;
+  clearHotkeyStuckWatchdog();
+  companionWindow?.webContents.send("dictation:cancel");
 }
 
 function sendHotkeyDown(): void {
@@ -4141,6 +4196,7 @@ async function registerHotkey(hotkey?: string): Promise<void> {
     hotkeyPressed = false;
     clearHotkeyStuckWatchdog();
     globalShortcut.unregisterAll();
+    updateDictationEscape();
     // unregisterAll() drops every accelerator this app holds, including the
     // panel summon claimed at boot — re-claim it or it dies on the first
     // hotkey registration and never comes back within the session.
@@ -4253,6 +4309,7 @@ async function registerHotkey(hotkey?: string): Promise<void> {
 app.on("will-quit", () => {
   audioPlaybackController.restoreSync();
   stopLinuxPasteHelper();
+  stopNotificationEvents();
   destroyCompanionWindow();
   destroyPanelWindow();
   if (keyListener) {
@@ -4297,6 +4354,7 @@ function cleanupBeforeQuit(): void {
   void disposeServerPlugins().catch(() => {});
   audioPlaybackController.restoreSync();
   stopLinuxPasteHelper();
+  stopNotificationEvents();
   if (keyListener) {
     keyListener.stop();
     keyListener = null;

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1018,11 +1018,13 @@ function hidePill(): void {
   // The next session starts as a bare capsule, so give the extra room back
   // now — the renderer's own collapse only runs when it animates a card away.
   setPillExpanded(false);
-  // Session ended (cancel, error, or paste complete). Clear latched hotkey
-  // state so the next press starts fresh — e.g. after ESC while still
-  // holding the dictation key.
-  hotkeyPressed = false;
-  clearHotkeyStuckWatchdog();
+  // Remix can hide its pill while a hold-to-dictation session remains active.
+  // Preserve that session's physical key state so its eventual key-up still
+  // stops recording; completed/cancelled sessions can be reset here.
+  if (!dictationInProgress) {
+    hotkeyPressed = false;
+    clearHotkeyStuckWatchdog();
+  }
   clearRemixStuckWatchdog();
   setRemixRouteKeys(false);
   // Chat may have set focusable; clear it when hiding.

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -127,7 +127,10 @@ import * as linuxAutostart from "./linux-autostart";
 import { checkLinuxSetup } from "./linux-setup";
 import { MicListener } from "./mic-listener";
 import { getNativeBinaryPath } from "./native-binary";
-import { startNotificationStream } from "./notification-stream";
+import {
+  notificationStreamUrl,
+  startNotificationStream,
+} from "./notification-stream";
 import {
   hideNotifications,
   initNotificationWindow,
@@ -1026,10 +1029,7 @@ function hidePill(): void {
   try {
   } catch {}
   updateRemixBar();
-  // Unregister Escape shortcut when pill is hidden
-  try {
-    globalShortcut.unregister("Escape");
-  } catch {}
+  updateDictationEscape();
 }
 
 function wait(ms: number): Promise<void> {
@@ -3347,7 +3347,7 @@ function startNotificationEvents(): void {
   if (stopNotificationStream) return;
   void refreshNotifications();
   stopNotificationStream = startNotificationStream({
-    url: getServerBaseUrl,
+    url: () => notificationStreamUrl(getServerBaseUrl()),
     headers: getServerAuthHeaders,
     onChange: () => void refreshNotifications(),
     onConnected: stopNotificationFallbackPoll,

--- a/apps/electron/src/main/notification-stream.test.ts
+++ b/apps/electron/src/main/notification-stream.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  consumeNotificationEvents,
+  startNotificationStream,
+} from "./notification-stream";
+
+describe("consumeNotificationEvents", () => {
+  it("refreshes once for a changed SSE event split across chunks", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("event: changed\nda"));
+        controller.enqueue(encoder.encode("ta: 1\n\n"));
+        controller.close();
+      },
+    });
+    let refreshes = 0;
+
+    await consumeNotificationEvents(stream, () => {
+      refreshes += 1;
+    });
+
+    expect(refreshes).toBe(1);
+  });
+
+  it("does not refresh for heartbeat events", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("event: ping\ndata: 1\n\n"));
+        controller.close();
+      },
+    });
+    let refreshes = 0;
+
+    await consumeNotificationEvents(stream, () => {
+      refreshes += 1;
+    });
+
+    expect(refreshes).toBe(0);
+  });
+});
+
+describe("startNotificationStream", () => {
+  it("uses the existing auth headers and refreshes when the server changes notifications", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("event: changed\ndata: 1\n\n"));
+        controller.close();
+      },
+    });
+    const fetchStream = vi.fn(async () => new Response(stream));
+    const onChange = vi.fn();
+    const onConnected = vi.fn();
+
+    const stop = startNotificationStream({
+      url: "http://127.0.0.1:4649/api/notifications/stream",
+      headers: { Authorization: "Bearer token" },
+      fetchStream,
+      onChange,
+      onConnected,
+    });
+
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+    expect(onConnected).toHaveBeenCalledTimes(1);
+    expect(fetchStream).toHaveBeenCalledWith(
+      "http://127.0.0.1:4649/api/notifications/stream",
+      expect.objectContaining({ headers: { Authorization: "Bearer token" } }),
+    );
+    stop();
+  });
+});

--- a/apps/electron/src/main/notification-stream.test.ts
+++ b/apps/electron/src/main/notification-stream.test.ts
@@ -101,4 +101,23 @@ describe("startNotificationStream", () => {
     expect(onConnected).not.toHaveBeenCalled();
     stop();
   });
+
+  it("drops a silent stream so fallback polling can resume", async () => {
+    const stream = new ReadableStream<Uint8Array>({});
+    const onDisconnected = vi.fn();
+    const stop = startNotificationStream({
+      url: "http://127.0.0.1:4649/api/notifications/stream",
+      headers: {},
+      fetchStream: async () =>
+        new Response(stream, {
+          headers: { "content-type": "text/event-stream" },
+        }),
+      onChange: () => {},
+      onDisconnected,
+      inactivityTimeoutMs: 10,
+    });
+
+    await vi.waitFor(() => expect(onDisconnected).toHaveBeenCalledTimes(1));
+    stop();
+  });
 });

--- a/apps/electron/src/main/notification-stream.test.ts
+++ b/apps/electron/src/main/notification-stream.test.ts
@@ -102,6 +102,31 @@ describe("startNotificationStream", () => {
     stop();
   });
 
+  it("drops a connection that never returns response headers", async () => {
+    const onDisconnected = vi.fn();
+    const fetchStream = vi.fn(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    const stop = startNotificationStream({
+      url: "http://127.0.0.1:4649/api/notifications/stream",
+      headers: {},
+      fetchStream,
+      onChange: () => {},
+      onDisconnected,
+      inactivityTimeoutMs: 10,
+    });
+
+    await vi.waitFor(() => expect(onDisconnected).toHaveBeenCalledTimes(1));
+    stop();
+  });
+
   it("drops a silent stream so fallback polling can resume", async () => {
     const stream = new ReadableStream<Uint8Array>({});
     const onDisconnected = vi.fn();

--- a/apps/electron/src/main/notification-stream.test.ts
+++ b/apps/electron/src/main/notification-stream.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   consumeNotificationEvents,
+  notificationStreamUrl,
   startNotificationStream,
 } from "./notification-stream";
+
+describe("notificationStreamUrl", () => {
+  it("adds the notifications stream path without a duplicate slash", () => {
+    expect(notificationStreamUrl("http://127.0.0.1:4649/")).toBe(
+      "http://127.0.0.1:4649/api/notifications/stream",
+    );
+  });
+});
 
 describe("consumeNotificationEvents", () => {
   it("refreshes once for a changed SSE event split across chunks", async () => {
@@ -50,7 +59,12 @@ describe("startNotificationStream", () => {
         controller.close();
       },
     });
-    const fetchStream = vi.fn(async () => new Response(stream));
+    const fetchStream = vi.fn(
+      async () =>
+        new Response(stream, {
+          headers: { "content-type": "text/event-stream" },
+        }),
+    );
     const onChange = vi.fn();
     const onConnected = vi.fn();
 
@@ -68,6 +82,23 @@ describe("startNotificationStream", () => {
       "http://127.0.0.1:4649/api/notifications/stream",
       expect.objectContaining({ headers: { Authorization: "Bearer token" } }),
     );
+    stop();
+  });
+
+  it("keeps fallback polling available for a non-SSE response", async () => {
+    const stream = new ReadableStream<Uint8Array>({});
+    const onConnected = vi.fn();
+    const stop = startNotificationStream({
+      url: "http://127.0.0.1:4649/api/notifications/stream",
+      headers: {},
+      fetchStream: async () => new Response(stream),
+      onChange: () => {},
+      onConnected,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onConnected).not.toHaveBeenCalled();
     stop();
   });
 });

--- a/apps/electron/src/main/notification-stream.ts
+++ b/apps/electron/src/main/notification-stream.ts
@@ -86,6 +86,9 @@ export function startNotificationStream(options: {
       inactivityTimer.unref();
     };
     try {
+      // Cover stalled connections as well as quiet established streams. Without
+      // this, a proxy that never sends response headers could suppress polling.
+      onActivity();
       const url =
         typeof options.url === "function" ? options.url() : options.url;
       const headers =

--- a/apps/electron/src/main/notification-stream.ts
+++ b/apps/electron/src/main/notification-stream.ts
@@ -1,3 +1,7 @@
+export function notificationStreamUrl(baseUrl: string): string {
+  return `${baseUrl.replace(/\/$/, "")}/api/notifications/stream`;
+}
+
 export async function consumeNotificationEvents(
   stream: ReadableStream<Uint8Array>,
   onChange: () => void,
@@ -73,7 +77,16 @@ export function startNotificationStream(options: {
         headers,
         signal: requestController.signal,
       });
-      if (!response.ok || !response.body) throw new Error("SSE unavailable");
+      if (
+        !response.ok ||
+        !response.body ||
+        !response.headers
+          .get("content-type")
+          ?.toLowerCase()
+          .startsWith("text/event-stream")
+      ) {
+        throw new Error("SSE unavailable");
+      }
       reconnects = 0;
       options.onConnected?.();
       await consumeNotificationEvents(response.body, options.onChange);

--- a/apps/electron/src/main/notification-stream.ts
+++ b/apps/electron/src/main/notification-stream.ts
@@ -1,0 +1,95 @@
+export async function consumeNotificationEvents(
+  stream: ReadableStream<Uint8Array>,
+  onChange: () => void,
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let boundary = buffer.search(/\r?\n\r?\n/);
+      while (boundary >= 0) {
+        const frame = buffer.slice(0, boundary);
+        buffer = buffer.slice(
+          buffer[boundary] === "\r" ? boundary + 4 : boundary + 2,
+        );
+        if (frame.split(/\r?\n/).some((line) => line === "event: changed")) {
+          onChange();
+        }
+        boundary = buffer.search(/\r?\n\r?\n/);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+type NotificationStreamFetch = (
+  input: string,
+  init: RequestInit,
+) => Promise<Response>;
+
+export function startNotificationStream(options: {
+  url: string | (() => string);
+  headers: HeadersInit | (() => HeadersInit);
+  onChange: () => void;
+  fetchStream?: NotificationStreamFetch;
+  onConnected?: () => void;
+  onDisconnected?: () => void;
+}): () => void {
+  const fetchStream = options.fetchStream ?? fetch;
+  let stopped = false;
+  let controller: AbortController | null = null;
+  let reconnects = 0;
+  let retryTimer: NodeJS.Timeout | null = null;
+
+  const reconnect = (): void => {
+    if (stopped) return;
+    const delay = Math.min(1_000 * 2 ** Math.min(reconnects, 5), 30_000);
+    reconnects += 1;
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      void connect();
+    }, delay);
+    retryTimer.unref();
+  };
+
+  const connect = async (): Promise<void> => {
+    const requestController = new AbortController();
+    controller = requestController;
+    try {
+      const url =
+        typeof options.url === "function" ? options.url() : options.url;
+      const headers =
+        typeof options.headers === "function"
+          ? options.headers()
+          : options.headers;
+      const response = await fetchStream(url, {
+        headers,
+        signal: requestController.signal,
+      });
+      if (!response.ok || !response.body) throw new Error("SSE unavailable");
+      reconnects = 0;
+      options.onConnected?.();
+      await consumeNotificationEvents(response.body, options.onChange);
+    } catch {
+      // The reconnect below handles server restarts and temporary network loss.
+    } finally {
+      if (controller === requestController) controller = null;
+      if (!stopped) options.onDisconnected?.();
+      reconnect();
+    }
+  };
+
+  void connect();
+  return (): void => {
+    stopped = true;
+    controller?.abort();
+    if (retryTimer) clearTimeout(retryTimer);
+  };
+}

--- a/apps/electron/src/main/notification-stream.ts
+++ b/apps/electron/src/main/notification-stream.ts
@@ -5,10 +5,15 @@ export function notificationStreamUrl(baseUrl: string): string {
 export async function consumeNotificationEvents(
   stream: ReadableStream<Uint8Array>,
   onChange: () => void,
+  options?: { onActivity?: () => void; signal?: AbortSignal },
 ): Promise<void> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  const abort = (): void => {
+    void reader.cancel();
+  };
+  options?.signal?.addEventListener("abort", abort, { once: true });
 
   try {
     while (true) {
@@ -22,6 +27,7 @@ export async function consumeNotificationEvents(
         buffer = buffer.slice(
           buffer[boundary] === "\r" ? boundary + 4 : boundary + 2,
         );
+        options?.onActivity?.();
         if (frame.split(/\r?\n/).some((line) => line === "event: changed")) {
           onChange();
         }
@@ -29,6 +35,7 @@ export async function consumeNotificationEvents(
       }
     }
   } finally {
+    options?.signal?.removeEventListener("abort", abort);
     reader.releaseLock();
   }
 }
@@ -38,6 +45,8 @@ type NotificationStreamFetch = (
   init: RequestInit,
 ) => Promise<Response>;
 
+const DEFAULT_INACTIVITY_TIMEOUT_MS = 60_000;
+
 export function startNotificationStream(options: {
   url: string | (() => string);
   headers: HeadersInit | (() => HeadersInit);
@@ -45,6 +54,7 @@ export function startNotificationStream(options: {
   fetchStream?: NotificationStreamFetch;
   onConnected?: () => void;
   onDisconnected?: () => void;
+  inactivityTimeoutMs?: number;
 }): () => void {
   const fetchStream = options.fetchStream ?? fetch;
   let stopped = false;
@@ -66,6 +76,15 @@ export function startNotificationStream(options: {
   const connect = async (): Promise<void> => {
     const requestController = new AbortController();
     controller = requestController;
+    let inactivityTimer: NodeJS.Timeout | null = null;
+    const onActivity = (): void => {
+      if (inactivityTimer) clearTimeout(inactivityTimer);
+      inactivityTimer = setTimeout(
+        () => requestController.abort(),
+        options.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS,
+      );
+      inactivityTimer.unref();
+    };
     try {
       const url =
         typeof options.url === "function" ? options.url() : options.url;
@@ -88,11 +107,16 @@ export function startNotificationStream(options: {
         throw new Error("SSE unavailable");
       }
       reconnects = 0;
+      onActivity();
       options.onConnected?.();
-      await consumeNotificationEvents(response.body, options.onChange);
+      await consumeNotificationEvents(response.body, options.onChange, {
+        onActivity,
+        signal: requestController.signal,
+      });
     } catch {
       // The reconnect below handles server restarts and temporary network loss.
     } finally {
+      if (inactivityTimer) clearTimeout(inactivityTimer);
       if (controller === requestController) controller = null;
       if (!stopped) options.onDisconnected?.();
       reconnect();

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -27,6 +27,8 @@ declare global {
       onTalkUp: (cb: () => void) => () => void;
       onHotkeyDown: (callback: () => void) => () => void;
       onHotkeyUp: (callback: () => void) => () => void;
+      onDictationCancel: (callback: () => void) => () => void;
+      setDictationPhase: (phase: "idle" | "recording" | "transcribing") => void;
       reloadRemixHotkey: () => void;
       remixGetContext: () => Promise<RemixContextResult>;
       remixReadDocument: () => Promise<RemixReadDocumentResult>;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -51,6 +51,13 @@ const api = {
     ipcRenderer.on("hotkey:up", handler);
     return () => ipcRenderer.removeListener("hotkey:up", handler);
   },
+  onDictationCancel: (callback: () => void): (() => void) => {
+    const handler = (): void => callback();
+    ipcRenderer.on("dictation:cancel", handler);
+    return () => ipcRenderer.removeListener("dictation:cancel", handler);
+  },
+  setDictationPhase: (phase: "idle" | "recording" | "transcribing"): void =>
+    ipcRenderer.send("dictation:state", phase),
   // --- Remix ---
   reloadRemixHotkey: (): void => ipcRenderer.send("remix-hotkey:reload"),
   // --- Remix primitives (the agent's tools; workflow lives in its prompt) ---

--- a/apps/electron/src/renderer/src/assets/jeb/manifest.ts
+++ b/apps/electron/src/renderer/src/assets/jeb/manifest.ts
@@ -5,6 +5,22 @@ export const JEB_MANIFEST: SpriteManifest = {
   frameSize: 96,
   scale: 2,
   states: {
+    death: {
+      fps: 10,
+      loop: false,
+      holdLast: true,
+      sheet: "death.png",
+      start: 0,
+      frames: 9,
+    },
+    "death-fall": {
+      fps: 10,
+      loop: false,
+      holdLast: true,
+      sheet: "death.png",
+      start: 4,
+      frames: 5,
+    },
     "typing-start": {
       fps: 12,
       loop: false,
@@ -58,13 +74,6 @@ export const JEB_MANIFEST: SpriteManifest = {
       frames: 8,
       fps: 16,
       loop: true,
-    },
-    death: {
-      sheet: "death.png",
-      frames: 9,
-      fps: 10,
-      loop: false,
-      holdLast: true,
     },
     defend: {
       sheet: "defend.png",

--- a/apps/electron/src/renderer/src/components/companion.tsx
+++ b/apps/electron/src/renderer/src/components/companion.tsx
@@ -43,6 +43,7 @@ function useDictation(
     const controller = new DictationController(
       {
         onPhase: (phase) => {
+          window.api.setDictationPhase(phase);
           setState(phase === "idle" ? "idle" : "working");
           setListening(phase === "recording");
           if (phase === "idle") {
@@ -108,6 +109,10 @@ function useDictation(
       void controller.start();
     });
     const offUp = window.api.onHotkeyUp(() => controller.stop());
+    const offCancel = window.api.onDictationCancel(() => {
+      talkSession = false;
+      controller.cancel();
+    });
     const offTalkDown = window.api.onTalkDown(() => {
       // Fn+Control shares Fn with dictation, so the plain-dictation session
       // often starts first. PROMOTE it to a talk session rather than
@@ -121,6 +126,7 @@ function useDictation(
       offPrefs?.();
       offDown?.();
       offUp?.();
+      offCancel?.();
       offTalkDown?.();
       offTalkUp?.();
       controller.destroy();

--- a/apps/electron/src/renderer/src/components/settings-view.test.ts
+++ b/apps/electron/src/renderer/src/components/settings-view.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+import { profileAvatarInitial } from "./settings-view";
+
+describe("profileAvatarInitial", () => {
+  test("uses the display name when a profile image cannot load", () => {
+    expect(profileAvatarInitial("Aditya Mathur", "aditya@example.com")).toBe(
+      "A",
+    );
+  });
+
+  test("falls back to the email when the display name is absent", () => {
+    expect(profileAvatarInitial("", "aditya@example.com")).toBe("A");
+  });
+});

--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -74,6 +74,44 @@ const PAGE_TITLES: Record<Exclude<SettingsPage, "root">, string> = {
   data: "Data",
 };
 
+export function profileAvatarInitial(
+  name: string | null | undefined,
+  email: string | null | undefined,
+): string {
+  return (name?.trim() || email?.trim() || "?").slice(0, 1).toUpperCase();
+}
+
+function ProfileAvatar({
+  image,
+  name,
+  email,
+}: {
+  image: string | null | undefined;
+  name: string | null | undefined;
+  email: string | null | undefined;
+}): React.JSX.Element {
+  const [failedImage, setFailedImage] = useState<string | null>(null);
+  const src = image && image !== failedImage ? image : null;
+
+  if (src) {
+    return (
+      <img
+        className="tavern-set-avatar"
+        src={src}
+        alt=""
+        referrerPolicy="no-referrer"
+        onError={() => setFailedImage(src)}
+      />
+    );
+  }
+
+  return (
+    <span className="tavern-set-avatar is-empty" aria-hidden="true">
+      {profileAvatarInitial(name, email)}
+    </span>
+  );
+}
+
 function useServerSettings(): {
   settings: Record<string, string> | null;
   setSetting: (key: string, value: string) => void;
@@ -341,18 +379,11 @@ function AccountCard({
         onClick={onOpenProfile}
       >
         <div className="tavern-set-profile">
-          {auth.user.image ? (
-            <img
-              className="tavern-set-avatar"
-              src={auth.user.image}
-              alt=""
-              referrerPolicy="no-referrer"
-            />
-          ) : (
-            <span className="tavern-set-avatar is-empty">
-              {(auth.user.name || auth.user.email)[0]?.toUpperCase()}
-            </span>
-          )}
+          <ProfileAvatar
+            image={auth.user.image}
+            name={auth.user.name}
+            email={auth.user.email}
+          />
           <div className="tavern-set-profile-text">
             <div className="tavern-set-card-title">
               {auth.user.name || "Signed in"}
@@ -672,18 +703,11 @@ function ProfilePage(): React.JSX.Element {
   return (
     <>
       <div className="tavern-set-profile">
-        {auth.user.image ? (
-          <img
-            className="tavern-set-avatar"
-            src={auth.user.image}
-            alt=""
-            referrerPolicy="no-referrer"
-          />
-        ) : (
-          <span className="tavern-set-avatar is-empty">
-            {(auth.user.name || auth.user.email)[0]?.toUpperCase()}
-          </span>
-        )}
+        <ProfileAvatar
+          image={auth.user.image}
+          name={auth.user.name}
+          email={auth.user.email}
+        />
         <div className="tavern-set-profile-text">
           <div className="tavern-set-card-title">
             {auth.user.name || "Signed in"}

--- a/apps/electron/src/renderer/src/sprites/jeb/index.ts
+++ b/apps/electron/src/renderer/src/sprites/jeb/index.ts
@@ -70,7 +70,7 @@ export const JEB: SheetSpriteDefinition = {
     ambients: { thinking: "typing", listening: "idle" },
     thinkingEnter: [{ state: "typing-start" }],
     thinkingExit: [{ state: "typing-start", reverse: true, fpsScale: 1.6 }],
-    sleep: { enter: [{ state: "death" }], ambient: "death" },
+    sleep: { enter: [{ state: "death-fall" }], ambient: "death" },
     // Getting up: the fall, backwards, fast — then a hop to attention.
     wake: [
       { state: "death", reverse: true, fpsScale: 2 },

--- a/apps/electron/src/renderer/src/sprites/performer.test.ts
+++ b/apps/electron/src/renderer/src/sprites/performer.test.ts
@@ -1,0 +1,59 @@
+import { expect, test, vi } from "vitest";
+import { JEB_MANIFEST } from "../assets/jeb/manifest";
+import type { SheetEngine } from "./engine";
+import { Performer } from "./performer";
+import type { SheetSpriteDefinition } from "./types";
+
+const def = {
+  id: "test",
+  label: "Test",
+  kind: "sheet",
+  windowSize: 96,
+  anchor: null,
+  hotRect: { x: 0, y: 0, width: 1, height: 1 },
+  bubble: { x: 0, y: 0, maxChars: 1 },
+  manifest: {
+    frameSize: 1,
+    scale: 1,
+    states: {
+      idle: { sheet: "idle.png", frames: 1, fps: 1, loop: true },
+      typing: { sheet: "typing.png", frames: 1, fps: 1, loop: true },
+    },
+  },
+  sheets: {},
+  timings: { sleepAfterMs: 10_000, microMinMs: 60_000, microMaxMs: 60_000 },
+  choreography: {
+    tool: { byName: {}, byClass: {} },
+    emote: {},
+    ambients: { thinking: "typing" },
+  },
+} as SheetSpriteDefinition;
+
+test("does not log sprite events", () => {
+  const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+  const engine = {
+    ambient: "idle",
+    busy: false,
+    setAmbient: vi.fn(),
+    playSequence: vi.fn(),
+  } as unknown as SheetEngine;
+  const performer = new Performer(engine, def, false);
+
+  performer.handle({ kind: "thinking", on: true });
+
+  expect(debug).not.toHaveBeenCalled();
+
+  performer.destroy();
+  debug.mockRestore();
+});
+
+test("Jeb's manifest provides the fall-only portion of the death sheet", () => {
+  expect(JEB_MANIFEST.states["death-fall"]).toMatchObject({
+    sheet: "death.png",
+    start: 4,
+    frames: 5,
+    fps: 10,
+    loop: false,
+    holdLast: true,
+  });
+});

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1744,7 +1744,7 @@
 .tavern-set-avatar {
   width: 38px;
   height: 38px;
-  border-radius: 0;
+  border-radius: 6px;
   object-fit: cover;
   border: 2px solid var(--tavern-ink);
   flex-shrink: 0;
@@ -1755,7 +1755,10 @@
   place-items: center;
   background: var(--tavern-wash);
   color: var(--tavern-ink);
+  font-family: "Pixelify Sans", monospace;
   font-weight: 700;
+  font-size: 17px;
+  line-height: 1;
 }
 
 .tavern-set-profile-text {
@@ -3957,4 +3960,3 @@
 .tavern-opener {
   padding: 7px 10px;
 }
-

--- a/apps/electron/tests/fixtures/permission-main.cjs
+++ b/apps/electron/tests/fixtures/permission-main.cjs
@@ -56,6 +56,10 @@ electron.ipcMain.on("e2e:mic-requested", () => {
   record({ type: "mic-requested" });
 });
 
+electron.ipcMain.on("dictation:state", (_event, phase) => {
+  record({ type: "dictation-state", body: { phase } });
+});
+
 const originalFetch = global.fetch;
 global.fetch = async (input, init) => {
   const url =

--- a/apps/electron/tests/permission-flow.test.ts
+++ b/apps/electron/tests/permission-flow.test.ts
@@ -146,6 +146,12 @@ async function triggerHotkeyDown(page: Page): Promise<void> {
   });
 }
 
+async function triggerEscape(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.electron.ipcRenderer.send("e2e:trigger-escape");
+  });
+}
+
 async function instrumentMicrophoneRequest(
   app: ElectronApplication,
 ): Promise<void> {
@@ -469,7 +475,9 @@ test("granted permissions allow the existing dictation flow", async () => {
     await expect
       .poll(() =>
         readEvents(launched.eventsPath).some(
-          (event) => event.type === "mic-requested",
+          (event) =>
+            event.type === "dictation-state" &&
+            event.body?.phase === "recording",
         ),
       )
       .toBe(true);
@@ -481,6 +489,41 @@ test("granted permissions allow the existing dictation flow", async () => {
               window.webContents.getURL().includes("companion"),
             )
             .some((window) => window.isVisible()),
+        ),
+      )
+      .toBe(true);
+  } finally {
+    await closePermissionApp(launched.app);
+  }
+});
+
+test("Escape cancels an active dictation session", async () => {
+  const launched = await launchPermissionApp({
+    accessibility: "granted",
+    microphone: "granted",
+    onboardingComplete: true,
+  });
+  try {
+    await waitForStartupPermissionChecks(launched.eventsPath);
+    await instrumentMicrophoneRequest(launched.app);
+    await triggerHotkeyDown(launched.companion);
+    await expect
+      .poll(() =>
+        readEvents(launched.eventsPath).some(
+          (event) =>
+            event.type === "dictation-state" &&
+            event.body?.phase === "recording",
+        ),
+      )
+      .toBe(true);
+
+    await triggerEscape(launched.companion);
+
+    await expect
+      .poll(() =>
+        readEvents(launched.eventsPath).some(
+          (event) =>
+            event.type === "dictation-state" && event.body?.phase === "idle",
         ),
       )
       .toBe(true);

--- a/apps/electron/vitest.config.ts
+++ b/apps/electron/vitest.config.ts
@@ -5,11 +5,12 @@ export default defineConfig({
   resolve: {
     alias: {
       "@renderer": resolve(__dirname, "src/renderer/src"),
+      "@shared": resolve(__dirname, "src/shared"),
     },
   },
   test: {
     globals: true,
-    include: ["src/renderer/**/*.test.ts"],
+    include: ["src/renderer/**/*.test.ts", "src/main/**/*.test.ts"],
     environment: "node",
   },
 });

--- a/apps/server/src/lib/notifications/events.ts
+++ b/apps/server/src/lib/notifications/events.ts
@@ -1,0 +1,16 @@
+type NotificationChangeListener = () => void;
+
+class NotificationEvents {
+  private readonly listeners = new Set<NotificationChangeListener>();
+
+  subscribe(listener: NotificationChangeListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  emitChange(): void {
+    for (const listener of this.listeners) listener();
+  }
+}
+
+export const notificationEvents = new NotificationEvents();

--- a/apps/server/src/lib/notifications/transport.ts
+++ b/apps/server/src/lib/notifications/transport.ts
@@ -4,6 +4,7 @@ import {
   isTransientCloudError,
 } from "../freestyle-cloud.js";
 import { getSession, getSessionToken } from "../sessions.js";
+import { notificationEvents } from "./events.js";
 import { purgeExpired, upsertFromCloud } from "./store.js";
 
 const log = createAppLogger("notification-transport");
@@ -99,6 +100,7 @@ export class PollingTransport implements NotificationTransport {
         getSession()?.user.id ?? null,
       );
       purgeExpired();
+      notificationEvents.emitChange();
       for (const listener of this.listeners) {
         try {
           listener();

--- a/apps/server/src/routes/notifications.ts
+++ b/apps/server/src/routes/notifications.ts
@@ -7,6 +7,7 @@ import {
   getCloudUserProfile,
   putCloudUserProfile,
 } from "../lib/freestyle-cloud.js";
+import { notificationEvents } from "../lib/notifications/events.js";
 import { drainNotificationOutbox } from "../lib/notifications/outbox.js";
 import * as store from "../lib/notifications/store.js";
 import { notificationTransport } from "../lib/notifications/transport.js";
@@ -25,6 +26,59 @@ const createSchema = z.object({
 });
 
 const seenSchema = z.object({ ids: z.array(z.string().min(1)).max(100) });
+
+const NOTIFICATION_STREAM_HEARTBEAT_MS = 25_000;
+
+function notificationStream(request: Request): Response {
+  const encoder = new TextEncoder();
+  let cleanup = (): void => {};
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let closed = false;
+      const close = (): void => {
+        if (closed) return;
+        closed = true;
+        cleanup();
+        try {
+          controller.close();
+        } catch {}
+      };
+      const send = (event: "ready" | "changed" | "ping"): void => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(`event: ${event}\ndata: 1\n\n`));
+        } catch {
+          close();
+        }
+      };
+      const unsubscribe = notificationEvents.subscribe(() => send("changed"));
+      const heartbeat = setInterval(
+        () => send("ping"),
+        NOTIFICATION_STREAM_HEARTBEAT_MS,
+      );
+      heartbeat.unref();
+      const onAbort = (): void => close();
+      request.signal.addEventListener("abort", onAbort, { once: true });
+      cleanup = (): void => {
+        clearInterval(heartbeat);
+        unsubscribe();
+        request.signal.removeEventListener("abort", onAbort);
+      };
+      send("ready");
+    },
+    cancel() {
+      cleanup();
+    },
+  });
+  return new Response(stream, {
+    headers: {
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "Content-Type": "text/event-stream",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
 
 async function forwardHistory(): Promise<{ status: number; payload: unknown }> {
   const token = getSessionToken();
@@ -63,6 +117,7 @@ const quietHoursSchema = z.object({
 
 const notificationsRoute = new Hono()
   .get("/", (c) => c.json({ notifications: store.listActive() }))
+  .get("/stream", (c) => notificationStream(c.req.raw))
   .get("/preferences", async (c) => {
     const token = getSessionToken();
     if (!token) return c.json({ quietHours: DEFAULT_QUIET_HOURS });
@@ -133,6 +188,7 @@ const notificationsRoute = new Hono()
       threadId: input.threadId ?? null,
       payload: input.url ? { url: input.url } : null,
     });
+    notificationEvents.emitChange();
     return c.json({ ok: true, notification: record });
   })
   .post("/refresh", (c) => {
@@ -142,15 +198,18 @@ const notificationsRoute = new Hono()
   })
   .post("/seen", zValidator("json", seenSchema), (c) => {
     store.markSeen(c.req.valid("json").ids);
+    notificationEvents.emitChange();
     return c.json({ ok: true });
   })
   .post("/:id/dismiss", (c) => {
     const ok = store.dismiss(c.req.param("id"));
+    if (ok) notificationEvents.emitChange();
     void drainNotificationOutbox();
     return c.json({ ok });
   })
   .post("/:id/open", (c) => {
     const result = store.open(c.req.param("id"));
+    if (result.ok) notificationEvents.emitChange();
     void drainNotificationOutbox();
     return c.json(result);
   });

--- a/apps/server/tests/notification-events.test.ts
+++ b/apps/server/tests/notification-events.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import createApp from "../src/index.js";
+import { notificationEvents } from "../src/lib/notifications/events.js";
+
+describe("notification events", () => {
+  it("notifies active subscribers when the notification store changes", () => {
+    let changes = 0;
+    const unsubscribe = notificationEvents.subscribe(() => {
+      changes += 1;
+    });
+
+    notificationEvents.emitChange();
+    unsubscribe();
+    notificationEvents.emitChange();
+
+    expect(changes).toBe(1);
+  });
+});
+
+describe("notification event stream", () => {
+  it("sends a changed event to a connected client", async () => {
+    const app = createApp();
+    const response = await app.request("/api/notifications/stream");
+
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+    const reader = response.body?.getReader();
+    expect(reader).toBeDefined();
+    await reader?.read();
+
+    await app.request("/api/notifications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        kind: "thread",
+        title: "Jeb finished",
+        body: "Your task is ready.",
+      }),
+    });
+    const event = await reader?.read();
+
+    expect(new TextDecoder().decode(event?.value)).toContain("event: changed");
+    await reader?.cancel();
+  });
+});


### PR DESCRIPTION
Improves desktop interaction reliability: Escape now cancels active dictation, Jeb uses fall-only sleep frames, and Settings avatars fall back cleanly when provider images fail.\n\nThe companion now receives notification changes over an authenticated SSE stream rather than fixed polling, with heartbeats, reconnects, connection/activity deadlines, and a polling fallback when streaming is unavailable.\n\nReview focus: main-process handoff between Remix and dictation, and the notification stream fallback/reconnect lifecycle.