### PR TITLE
fix(panel): Keep agent hotkey panel with spirit

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -139,6 +139,7 @@ import {
   setTravelling,
   showNotifications,
 } from "./notification-window";
+import { PanelRendererMessageQueue } from "./panel-renderer-message-queue";
 import {
   copySelectionFromFocusedApp,
   isWaylandSession,
@@ -3443,24 +3444,16 @@ ipcMain.on("companion:hover", (event) => {
   openPanel({ trigger: "hover" });
 });
 
-let pendingDictation: { kind: string; text: string } | null = null;
-
 function forwardDictation(
   kind: "partial" | "final" | "error",
   text: string,
 ): void {
   const win = panelWindow;
   if (!win || win.isDestroyed()) return;
-  if (win.webContents.isLoading()) {
-    pendingDictation = { kind, text };
-    win.webContents.once("did-finish-load", () => {
-      if (!pendingDictation) return;
-      win.webContents.send("panel:dictation", pendingDictation);
-      pendingDictation = null;
-    });
-    return;
-  }
-  win.webContents.send("panel:dictation", { kind, text });
+  panelRendererMessages.send({
+    channel: "panel:dictation",
+    payload: { kind, text },
+  });
 }
 
 ipcMain.on("panel:open-for-dictation", (event) => {
@@ -3481,6 +3474,11 @@ ipcMain.on("panel:dictation-final", (event, text: string) => {
 ipcMain.on("panel:dictation-error", (event, message: string) => {
   if (event.sender !== companionWindow?.webContents) return;
   forwardDictation("error", message);
+});
+
+ipcMain.on("panel:renderer-ready", (event) => {
+  if (event.sender !== panelWindow?.webContents) return;
+  panelRendererMessages.markReady();
 });
 
 ipcMain.on("panel:close", (event) => {
@@ -3530,6 +3528,15 @@ ipcMain.on("panel:request-focus", (event) => {
 let panelWindow: BrowserWindow | null = null;
 let panelHideTimer: NodeJS.Timeout | null = null;
 let panelBusy = false;
+const panelRendererMessages = new PanelRendererMessageQueue((message) => {
+  const win = panelWindow;
+  if (!win || win.isDestroyed()) return;
+  if (message.channel === "panel:dictation") {
+    win.webContents.send(message.channel, message.payload);
+    return;
+  }
+  win.webContents.send(message.channel);
+});
 const PANEL_HIDE_GRACE_MS = 420;
 const PANEL_HOVER_PAD = 24;
 
@@ -3573,11 +3580,13 @@ function createPanelWindow(): void {
       backgroundThrottling: false,
     },
   });
+  panelRendererMessages.reset();
 
   panelWindow.setAlwaysOnTop(true, "screen-saver");
   panelWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
   panelWindow.on("closed", () => {
     panelWindow = null;
+    panelRendererMessages.reset();
   });
   // Losing focus is the only signal that "hover off then hide" can rely on
   // once the composer has been clicked: pointer-leave alone is ignored while
@@ -3634,7 +3643,7 @@ function openPanel(
   if (opts.focusComposer) {
     win.show();
     win.focus();
-    win.webContents.send("panel:focus-composer");
+    panelRendererMessages.send({ channel: "panel:focus-composer" });
   } else {
     win.showInactive();
   }

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -94,6 +94,7 @@ import {
   createDictationDisplayRequestTracker,
   invalidateDictationDisplayRequest,
   resolveCompanionDisplay,
+  resolveDictationWindowDisplays,
   resolvePanelCompanionDisplays,
 } from "../shared/companion-position";
 import {
@@ -3051,15 +3052,26 @@ function anchorCompanionForDictation(): void {
   const cursorDisplay = screen.getDisplayNearestPoint(
     screen.getCursorScreenPoint(),
   );
-  positionCompanionOnDisplay(resolveCompanionDisplay(null, cursorDisplay));
+  positionDictationWindows(resolveCompanionDisplay(null, cursorDisplay));
 
   void getFocusedExternalDisplay().then((focusedDisplay) => {
     if (!dictationDisplayRequests.isCurrent(request)) return;
     if (!companionWindow || companionWindow.isDestroyed()) return;
-    positionCompanionOnDisplay(
+    positionDictationWindows(
       resolveCompanionDisplay(focusedDisplay, cursorDisplay),
     );
   });
+}
+
+function positionDictationWindows(display: Display): void {
+  const panelVisible =
+    !!panelWindow && !panelWindow.isDestroyed() && panelWindow.isVisible();
+  const { panelDisplay, companionDisplay } = resolveDictationWindowDisplays(
+    display,
+    panelVisible,
+  );
+  if (panelDisplay) positionPanelOnDisplay(panelDisplay);
+  positionCompanionOnDisplay(companionDisplay);
 }
 
 function positionCompanionOnDisplay(display: Display): void {
@@ -3553,6 +3565,13 @@ function panelPosition(display: Display): {
   return { x, y, height: panelHeight };
 }
 
+function positionPanelOnDisplay(display: Display): void {
+  const win = panelWindow;
+  if (!win || win.isDestroyed()) return;
+  const { x, y, height } = panelPosition(display);
+  win.setBounds({ x, y, width: PANEL_WIDTH, height });
+}
+
 function createPanelWindow(): void {
   if (panelWindow && !panelWindow.isDestroyed()) return;
   const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
@@ -3637,8 +3656,7 @@ function openPanel(
   );
   const { panelDisplay, companionDisplay } =
     resolvePanelCompanionDisplays(cursorDisplay);
-  const { x, y, height } = panelPosition(panelDisplay);
-  win.setBounds({ x, y, width: PANEL_WIDTH, height });
+  positionPanelOnDisplay(panelDisplay);
   positionCompanionOnDisplay(companionDisplay);
   if (opts.focusComposer) {
     win.show();

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -94,6 +94,7 @@ import {
   createDictationDisplayRequestTracker,
   invalidateDictationDisplayRequest,
   resolveCompanionDisplay,
+  resolveDictationPanelDisplay,
   resolveDictationWindowDisplays,
   resolvePanelCompanionDisplays,
 } from "../shared/companion-position";
@@ -3038,6 +3039,7 @@ async function getFocusedExternalDisplay(): Promise<Display | null> {
 }
 
 const dictationDisplayRequests = createDictationDisplayRequestTracker();
+let activeDictationDisplay: Display | null = null;
 
 /**
  * Associate the visible companion with the target captured for this dictation
@@ -3064,6 +3066,7 @@ function anchorCompanionForDictation(): void {
 }
 
 function positionDictationWindows(display: Display): void {
+  activeDictationDisplay = display;
   const panelVisible =
     !!panelWindow && !panelWindow.isDestroyed() && panelWindow.isVisible();
   const { panelDisplay, companionDisplay } = resolveDictationWindowDisplays(
@@ -3650,12 +3653,17 @@ function openPanel(
   if (!wasVisible) {
     captureMain("panel_opened", { trigger: opts.trigger ?? "other" });
   }
-  invalidateDictationDisplayRequest(dictationDisplayRequests);
   const cursorDisplay = screen.getDisplayNearestPoint(
     screen.getCursorScreenPoint(),
   );
+  const dictationTriggered = opts.trigger === "dictation";
+  if (!dictationTriggered)
+    invalidateDictationDisplayRequest(dictationDisplayRequests);
+  const targetDisplay = dictationTriggered
+    ? resolveDictationPanelDisplay(activeDictationDisplay, cursorDisplay)
+    : cursorDisplay;
   const { panelDisplay, companionDisplay } =
-    resolvePanelCompanionDisplays(cursorDisplay);
+    resolvePanelCompanionDisplays(targetDisplay);
   positionPanelOnDisplay(panelDisplay);
   positionCompanionOnDisplay(companionDisplay);
   if (opts.focusComposer) {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -3610,6 +3610,12 @@ function createPanelWindow(): void {
     panelWindow = null;
     panelRendererMessages.reset();
   });
+  panelWindow.webContents.on(
+    "did-start-navigation",
+    (_event, _url, _isInPlace, isMainFrame) => {
+      if (isMainFrame) panelRendererMessages.handleNavigationStart();
+    },
+  );
   // Losing focus is the only signal that "hover off then hide" can rely on
   // once the composer has been clicked: pointer-leave alone is ignored while
   // the panel is focused, so re-check on blur. Agent tool calls blur the

--- a/apps/electron/src/main/panel-renderer-message-queue.test.ts
+++ b/apps/electron/src/main/panel-renderer-message-queue.test.ts
@@ -79,4 +79,38 @@ describe("PanelRendererMessageQueue", () => {
       },
     ]);
   });
+
+  it("waits for readiness again after a renderer navigation", () => {
+    const delivered: PanelRendererMessage[] = [];
+    const queue = new PanelRendererMessageQueue((message) => {
+      delivered.push(message);
+    });
+
+    queue.handleNavigationStart();
+    queue.markReady();
+    queue.send({
+      channel: "panel:dictation",
+      payload: { kind: "final", text: "First transcript" },
+    });
+
+    queue.handleNavigationStart();
+    queue.send({
+      channel: "panel:dictation",
+      payload: { kind: "final", text: "Transcript after reload" },
+    });
+
+    expect(delivered).toEqual([
+      {
+        channel: "panel:dictation",
+        payload: { kind: "final", text: "First transcript" },
+      },
+    ]);
+
+    queue.markReady();
+
+    expect(delivered.at(-1)).toEqual({
+      channel: "panel:dictation",
+      payload: { kind: "final", text: "Transcript after reload" },
+    });
+  });
 });

--- a/apps/electron/src/main/panel-renderer-message-queue.test.ts
+++ b/apps/electron/src/main/panel-renderer-message-queue.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  type PanelRendererMessage,
+  PanelRendererMessageQueue,
+} from "./panel-renderer-message-queue";
+
+describe("PanelRendererMessageQueue", () => {
+  it("delivers a final dictation received before the renderer registers its listeners", () => {
+    const delivered: PanelRendererMessage[] = [];
+    const queue = new PanelRendererMessageQueue((message) => {
+      delivered.push(message);
+    });
+
+    queue.send({
+      channel: "panel:dictation",
+      payload: { kind: "final", text: "Schedule my daily briefing" },
+    });
+
+    expect(delivered).toEqual([]);
+
+    queue.markReady();
+
+    expect(delivered).toEqual([
+      {
+        channel: "panel:dictation",
+        payload: { kind: "final", text: "Schedule my daily briefing" },
+      },
+    ]);
+  });
+
+  it("preserves composer focus before the final dictation while the renderer loads", () => {
+    const delivered: PanelRendererMessage[] = [];
+    const queue = new PanelRendererMessageQueue((message) => {
+      delivered.push(message);
+    });
+
+    queue.send({ channel: "panel:focus-composer" });
+    queue.send({
+      channel: "panel:dictation",
+      payload: { kind: "final", text: "Write a follow-up" },
+    });
+
+    queue.markReady();
+
+    expect(delivered).toEqual([
+      { channel: "panel:focus-composer" },
+      {
+        channel: "panel:dictation",
+        payload: { kind: "final", text: "Write a follow-up" },
+      },
+    ]);
+  });
+
+  it("keeps only the latest dictation state while the renderer is unready", () => {
+    const delivered: PanelRendererMessage[] = [];
+    const queue = new PanelRendererMessageQueue((message) => {
+      delivered.push(message);
+    });
+
+    queue.send({
+      channel: "panel:dictation",
+      payload: { kind: "partial", text: "Write a" },
+    });
+    queue.send({
+      channel: "panel:dictation",
+      payload: { kind: "partial", text: "Write a follow-up" },
+    });
+    queue.send({
+      channel: "panel:dictation",
+      payload: { kind: "final", text: "Write a follow-up email" },
+    });
+
+    queue.markReady();
+
+    expect(delivered).toEqual([
+      {
+        channel: "panel:dictation",
+        payload: { kind: "final", text: "Write a follow-up email" },
+      },
+    ]);
+  });
+});

--- a/apps/electron/src/main/panel-renderer-message-queue.ts
+++ b/apps/electron/src/main/panel-renderer-message-queue.ts
@@ -14,6 +14,7 @@ export type PanelRendererMessage =
  */
 export class PanelRendererMessageQueue {
   private ready = false;
+  private initialNavigation = true;
   private focusComposerPending = false;
   private pendingDictation: PanelRendererMessage | null = null;
 
@@ -45,7 +46,20 @@ export class PanelRendererMessageQueue {
     this.pendingDictation = null;
   }
 
+  handleNavigationStart(): void {
+    if (this.initialNavigation) {
+      this.initialNavigation = false;
+      return;
+    }
+    this.clear();
+  }
+
   reset(): void {
+    this.initialNavigation = true;
+    this.clear();
+  }
+
+  private clear(): void {
     this.ready = false;
     this.focusComposerPending = false;
     this.pendingDictation = null;

--- a/apps/electron/src/main/panel-renderer-message-queue.ts
+++ b/apps/electron/src/main/panel-renderer-message-queue.ts
@@ -1,0 +1,53 @@
+export type PanelDictationEvent = {
+  kind: "partial" | "final" | "error";
+  text: string;
+};
+
+export type PanelRendererMessage =
+  | { channel: "panel:focus-composer" }
+  | { channel: "panel:dictation"; payload: PanelDictationEvent };
+
+/**
+ * Holds panel messages until React has registered its IPC listeners. Electron's
+ * `did-finish-load` fires before those effects run, so it is not a renderer
+ * readiness signal.
+ */
+export class PanelRendererMessageQueue {
+  private ready = false;
+  private focusComposerPending = false;
+  private pendingDictation: PanelRendererMessage | null = null;
+
+  constructor(
+    private readonly deliver: (message: PanelRendererMessage) => void,
+  ) {}
+
+  send(message: PanelRendererMessage): void {
+    if (this.ready) {
+      this.deliver(message);
+      return;
+    }
+    if (message.channel === "panel:focus-composer") {
+      this.focusComposerPending = true;
+      return;
+    }
+    // The final transcript supersedes every prior partial. Retaining only the
+    // newest event avoids unbounded buffering if a renderer fails to mount.
+    this.pendingDictation = message;
+  }
+
+  markReady(): void {
+    if (this.ready) return;
+    this.ready = true;
+    if (this.focusComposerPending)
+      this.deliver({ channel: "panel:focus-composer" });
+    if (this.pendingDictation) this.deliver(this.pendingDictation);
+    this.focusComposerPending = false;
+    this.pendingDictation = null;
+  }
+
+  reset(): void {
+    this.ready = false;
+    this.focusComposerPending = false;
+    this.pendingDictation = null;
+  }
+}

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -45,6 +45,7 @@ declare global {
       panelDictationPartial: (text: string) => void;
       panelDictationFinal: (text: string) => void;
       panelDictationError: (message: string) => void;
+      panelRendererReady: () => void;
       onPanelDictation: (
         callback: (ev: {
           kind: "partial" | "final" | "error";

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -87,6 +87,7 @@ const api = {
     ipcRenderer.send("panel:dictation-final", text),
   panelDictationError: (message: string): void =>
     ipcRenderer.send("panel:dictation-error", message),
+  panelRendererReady: (): void => ipcRenderer.send("panel:renderer-ready"),
   onPanelDictation: (
     callback: (ev: {
       kind: "partial" | "final" | "error";

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -1011,6 +1011,7 @@ function PanelInner({
         return anchor ? `${anchor} ${ev.text}` : ev.text;
       });
     });
+    window.api.panelRendererReady();
     return () => {
       offFocus?.();
       offShowSettings?.();

--- a/apps/electron/src/renderer/src/lib/companion-position.test.ts
+++ b/apps/electron/src/renderer/src/lib/companion-position.test.ts
@@ -3,6 +3,7 @@ import {
   createDictationDisplayRequestTracker,
   invalidateDictationDisplayRequest,
   resolveCompanionDisplay,
+  resolveDictationWindowDisplays,
   resolvePanelCompanionDisplays,
 } from "../../../shared/companion-position";
 
@@ -31,6 +32,13 @@ test("keeps the companion on the display selected when opening the panel", () =>
   expect(resolvePanelCompanionDisplays(cursorDisplay)).toEqual({
     panelDisplay: cursorDisplay,
     companionDisplay: cursorDisplay,
+  });
+});
+
+test("keeps a visible panel beside the companion during dictation", () => {
+  expect(resolveDictationWindowDisplays(focusedDisplay, true)).toEqual({
+    panelDisplay: focusedDisplay,
+    companionDisplay: focusedDisplay,
   });
 });
 

--- a/apps/electron/src/renderer/src/lib/companion-position.test.ts
+++ b/apps/electron/src/renderer/src/lib/companion-position.test.ts
@@ -3,6 +3,7 @@ import {
   createDictationDisplayRequestTracker,
   invalidateDictationDisplayRequest,
   resolveCompanionDisplay,
+  resolveDictationPanelDisplay,
   resolveDictationWindowDisplays,
   resolvePanelCompanionDisplays,
 } from "../../../shared/companion-position";
@@ -40,6 +41,12 @@ test("keeps a visible panel beside the companion during dictation", () => {
     panelDisplay: focusedDisplay,
     companionDisplay: focusedDisplay,
   });
+});
+
+test("opens the dictation panel on the active dictation display", () => {
+  expect(resolveDictationPanelDisplay(focusedDisplay, cursorDisplay)).toBe(
+    focusedDisplay,
+  );
 });
 
 test("ignores a focused-display result from an earlier dictation session", () => {

--- a/apps/electron/src/shared/companion-position.ts
+++ b/apps/electron/src/shared/companion-position.ts
@@ -30,6 +30,14 @@ export function resolveDictationWindowDisplays<T extends CompanionDisplay>(
   };
 }
 
+/** The current dictation target wins over a parked cursor when opening a panel. */
+export function resolveDictationPanelDisplay<T extends CompanionDisplay>(
+  dictationDisplay: T | null,
+  cursorDisplay: T,
+): T {
+  return dictationDisplay ?? cursorDisplay;
+}
+
 /**
  * Opening the panel establishes the shared display for the panel and its
  * companion, even if the companion was previously anchored for dictation.

--- a/apps/electron/src/shared/companion-position.ts
+++ b/apps/electron/src/shared/companion-position.ts
@@ -17,6 +17,20 @@ export function resolveCompanionDisplay<T extends CompanionDisplay>(
 }
 
 /**
+ * Dictation keeps the visible panel alongside the companion on the target
+ * display, while leaving a hidden panel alone.
+ */
+export function resolveDictationWindowDisplays<T extends CompanionDisplay>(
+  dictationDisplay: T,
+  panelVisible: boolean,
+): { panelDisplay: T | null; companionDisplay: T } {
+  return {
+    panelDisplay: panelVisible ? dictationDisplay : null,
+    companionDisplay: dictationDisplay,
+  };
+}
+
+/**
  * Opening the panel establishes the shared display for the panel and its
  * companion, even if the companion was previously anchored for dictation.
  */


### PR DESCRIPTION
Agent-hotkey dictation now keeps an already visible panel beside the spirit on the focused display, even when the cursor remains on another monitor. A newly created panel also queues the transcript and composer-focus request until its React IPC listeners are installed, leaving the draft ready for review and Enter-to-send.

The dictation queue retains only the newest pending event and resets with the panel window lifecycle; hidden panels are not surfaced or moved.
