### PR TITLE
fix(tray): Enlarge Freestyle menu-bar icon

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1507,7 +1507,11 @@ function buildTrayContextMenu(): Menu {
 }
 
 function createTray(): void {
-  const trayImage = nativeImage.createFromPath(trayIconPath);
+  // Give the Freestyle mark enough presence in system trays while staying
+  // within the standard macOS menu-bar icon height.
+  const trayImage = nativeImage
+    .createFromPath(trayIconPath)
+    .resize({ width: 20, height: 20, quality: "best" });
   // Mark as template so macOS adapts to menu bar light/dark
   trayImage.setTemplateImage(true);
 


### PR DESCRIPTION
## Summary\n- render the Freestyle tray template at 20×20 instead of 16×16\n- preserve template rendering for light and dark system menu bars\n\n## Validation\n- Checked 1 file in 77ms. No fixes applied.\n- 
> @freestyle-voice/electron@0.8.1 typecheck /Users/am/dev/freestyle-voice/freestyle/apps/electron
> npm run typecheck:node && npm run typecheck:web


> @freestyle-voice/electron@0.8.1 typecheck:node
> tsc --noEmit -p tsconfig.node.json --composite false


> @freestyle-voice/electron@0.8.1 typecheck:web
> tsc --noEmit -p tsconfig.web.json --composite false