### PR TITLE
fix(companion): Anchor Jeb dialogue tail to face

### DIFF
--- a/apps/electron/src/renderer/src/sprites/jeb/index.ts
+++ b/apps/electron/src/renderer/src/sprites/jeb/index.ts
@@ -26,7 +26,10 @@ export const JEB: SheetSpriteDefinition = {
   sheets,
   // Body measured from the frames' alpha at 2x: x 100–144, y 150–218.
   hotRect: { x: 100, y: 150, width: 44, height: 68 },
-  bubble: { x: 106, y: 116, maxChars: 80 },
+  // Mouth position in the listening/idle pose. The bubble tail, not its box,
+  // is anchored here so it remains connected to Jeb.
+  speechAnchor: { x: 122, y: 154 },
+  bubble: { maxChars: 80 },
   fx: {
     shuriken: {
       sheet: "shuriken.png",

--- a/apps/electron/src/renderer/src/sprites/performer.test.ts
+++ b/apps/electron/src/renderer/src/sprites/performer.test.ts
@@ -11,7 +11,8 @@ const def = {
   windowSize: 96,
   anchor: null,
   hotRect: { x: 0, y: 0, width: 1, height: 1 },
-  bubble: { x: 0, y: 0, maxChars: 1 },
+  speechAnchor: { x: 0, y: 0 },
+  bubble: { maxChars: 1 },
   manifest: {
     frameSize: 1,
     scale: 1,

--- a/apps/electron/src/renderer/src/sprites/registry.ts
+++ b/apps/electron/src/renderer/src/sprites/registry.ts
@@ -14,7 +14,7 @@ export const SPRITES: Record<SpriteId, SpriteDefinition> = {
     ...SPRITES_INFO.spark,
     kind: "custom",
     hotRect: { x: 18, y: 190, width: 52, height: 52 },
-    bubble: { x: 12, y: 68, maxChars: 220 },
+    bubble: { maxChars: 220 },
   },
   jeb: JEB,
 };

--- a/apps/electron/src/renderer/src/sprites/speech-bubble-layout.test.ts
+++ b/apps/electron/src/renderer/src/sprites/speech-bubble-layout.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { speechBubbleLayout } from "./speech-bubble-layout";
+
+describe("speechBubbleLayout", () => {
+  it("keeps Jeb's bubble close to his face with a short tail", () => {
+    const layout = speechBubbleLayout({
+      windowSize: 256,
+      anchor: { x: 122, y: 154 },
+    });
+
+    expect(layout).toEqual({
+      bubble: { left: 98, bottom: 116 },
+      tail: { left: 15, bottom: -14 },
+    });
+  });
+});

--- a/apps/electron/src/renderer/src/sprites/speech-bubble-layout.ts
+++ b/apps/electron/src/renderer/src/sprites/speech-bubble-layout.ts
@@ -1,0 +1,38 @@
+export interface SpeechAnchor {
+  x: number;
+  y: number;
+}
+
+const BUBBLE_TAIL_HEIGHT = 14;
+const BUBBLE_TAIL_TIP_X = 9;
+const BUBBLE_TAIL_OFFSET_X = 24;
+
+/**
+ * Positions a speech bubble from the point its tail must reach, rather than
+ * from a separate, hand-tuned bubble coordinate.
+ */
+export function speechBubbleLayout({
+  windowSize,
+  anchor,
+}: {
+  windowSize: number;
+  anchor: SpeechAnchor;
+}): {
+  bubble: { left: number; bottom: number };
+  tail: {
+    left: number;
+    bottom: number;
+  };
+} {
+  const bubbleLeft = anchor.x - BUBBLE_TAIL_OFFSET_X;
+  return {
+    bubble: {
+      left: bubbleLeft,
+      bottom: windowSize - anchor.y + BUBBLE_TAIL_HEIGHT,
+    },
+    tail: {
+      left: BUBBLE_TAIL_OFFSET_X - BUBBLE_TAIL_TIP_X,
+      bottom: -BUBBLE_TAIL_HEIGHT,
+    },
+  };
+}

--- a/apps/electron/src/renderer/src/sprites/stage.tsx
+++ b/apps/electron/src/renderer/src/sprites/stage.tsx
@@ -4,6 +4,7 @@ import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { SheetEngine } from "./engine";
 import { Performer } from "./performer";
+import { speechBubbleLayout } from "./speech-bubble-layout";
 import type { SheetSpriteDefinition } from "./types";
 
 function bubbleText(
@@ -38,6 +39,10 @@ export function SpriteStage({
   const [say, setSay] = useState<string | null>(null);
   const [shout, setShout] = useState<string | null>(null);
   const shoutTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const bubbleLayout = speechBubbleLayout({
+    windowSize: def.windowSize,
+    anchor: def.speechAnchor,
+  });
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -101,9 +106,9 @@ export function SpriteStage({
         /* Manga speech balloon (listening): tail pinned to the mouth. */
         .sprite-bubble {
           position: absolute;
-          left: ${def.bubble.x}px;
-          bottom: ${def.bubble.y}px;
-          max-width: ${def.windowSize - def.bubble.x - 14}px;
+          left: ${bubbleLayout.bubble.left}px;
+          bottom: ${bubbleLayout.bubble.bottom}px;
+          max-width: ${def.windowSize - bubbleLayout.bubble.left - 14}px;
           padding: 8px 12px;
           background: #fbf5e4;
           border: 3px solid #2a2114;
@@ -114,32 +119,22 @@ export function SpriteStage({
           pointer-events: none;
           white-space: pre-wrap;
           box-shadow: 4px 4px 0 rgba(42, 33, 20, 0.8);
+          isolation: isolate;
         }
-        .sprite-bubble::before {
-          content: "";
+        .sprite-bubble-tail {
           position: absolute;
-          left: 12px;
-          bottom: -17px;
-          border-style: solid;
-          border-width: 18px 16px 0 5px;
-          border-color: #2a2114 transparent transparent transparent;
-          transform: rotate(14deg);
-        }
-        .sprite-bubble::after {
-          content: "";
-          position: absolute;
-          left: 16px;
-          bottom: -11px;
-          border-style: solid;
-          border-width: 13px 12px 0 3px;
-          border-color: #fbf5e4 transparent transparent transparent;
-          transform: rotate(14deg);
+          left: ${bubbleLayout.tail.left}px;
+          bottom: ${bubbleLayout.tail.bottom}px;
+          width: 18px;
+          height: 14px;
+          overflow: visible;
+          z-index: -1;
         }
         /* Shout burst (paste lands): jagged flash. */
         .sprite-shout {
           position: absolute;
-          left: ${def.bubble.x}px;
-          bottom: ${def.bubble.y + 16}px;
+          left: ${bubbleLayout.bubble.left}px;
+          bottom: ${bubbleLayout.bubble.bottom + 16}px;
           background: #fbf5e4;
           border: 3px solid #2a2114;
           padding: 10px 18px;
@@ -169,7 +164,21 @@ export function SpriteStage({
       {shout ? (
         <div className="sprite-shout">{shout}</div>
       ) : say ? (
-        <div className="sprite-bubble">{say}</div>
+        <div className="sprite-bubble">
+          <svg
+            aria-hidden="true"
+            className="sprite-bubble-tail"
+            viewBox="0 0 18 14"
+          >
+            <path
+              d="M 1 0 C 4 3, 7 8, 9 14 C 12 8, 15 3, 17 0 Z"
+              fill="#fbf5e4"
+              stroke="#2a2114"
+              strokeWidth="3"
+            />
+          </svg>
+          {say}
+        </div>
       ) : null}
     </div>
   );

--- a/apps/electron/src/renderer/src/sprites/types.ts
+++ b/apps/electron/src/renderer/src/sprites/types.ts
@@ -74,11 +74,13 @@ export interface ChoreographyTable {
 interface SpriteDefinitionBase extends SpriteInfo {
   /** Cursor hitbox = exactly the drawn body, in window coordinates. */
   hotRect: { x: number; y: number; width: number; height: number };
-  bubble: { x: number; y: number; maxChars: number };
+  bubble: { maxChars: number };
 }
 
 export interface SheetSpriteDefinition extends SpriteDefinitionBase {
   kind: "sheet";
+  /** The point the dialogue-tail should reach on the sprite's face. */
+  speechAnchor: { x: number; y: number };
   manifest: SpriteManifest;
   /** Sheet filename → bundled URL (built with import.meta.glob). */
   sheets: Record<string, string>;


### PR DESCRIPTION
## Summary\n- replace Jeb's independent bubble and CSS-tail offsets with an explicit face anchor\n- render a connected SVG tail whose tip reaches that anchor\n- remove stale bubble coordinates and add a regression test for the tail geometry\n\n## Validation\n- 
> @freestyle-voice/electron@0.8.1 test /Users/am/dev/freestyle-voice/freestyle/apps/electron
> vitest run


 RUN  v4.1.7 /Users/am/dev/freestyle-voice/freestyle/apps/electron


 Test Files  24 passed (24)
      Tests  97 passed (97)
   Start at  14:46:46
   Duration  482ms (transform 599ms, setup 0ms, import 1.10s, tests 362ms, environment 1ms) (97 tests)\n- 
> @freestyle-voice/electron@0.8.1 typecheck /Users/am/dev/freestyle-voice/freestyle/apps/electron
> npm run typecheck:node && npm run typecheck:web


> @freestyle-voice/electron@0.8.1 typecheck:node
> tsc --noEmit -p tsconfig.node.json --composite false


> @freestyle-voice/electron@0.8.1 typecheck:web
> tsc --noEmit -p tsconfig.web.json --composite false\n- 
> @freestyle-voice/electron@0.8.1 build /Users/am/dev/freestyle-voice/freestyle/apps/electron
> npm run typecheck && electron-vite build


> @freestyle-voice/electron@0.8.1 typecheck
> npm run typecheck:node && npm run typecheck:web


> @freestyle-voice/electron@0.8.1 typecheck:node
> tsc --noEmit -p tsconfig.node.json --composite false


> @freestyle-voice/electron@0.8.1 typecheck:web
> tsc --noEmit -p tsconfig.web.json --composite false

vite v7.3.3 building ssr environment for production...
transforming...
✓ 1144 modules transformed.
rendering chunks...
out/main/token-util-B3GZGUSo.js      0.90 kB
out/main/token-BgU5rqPg.js           3.47 kB
out/main/index-BJMEBIgJ.js         246.24 kB
out/main/index.js                3,592.16 kB
✓ built in 1.90s
vite v7.3.3 building ssr environment for production...
transforming...
✓ 1 modules transformed.
rendering chunks...
out/preload/index.js  10.88 kB
✓ built in 7ms
vite v7.3.3 building client environment for production...
transforming...
✓ 661 modules transformed.
rendering chunks...
../../out/renderer/companion.html                                      0.76 kB
../../out/renderer/notification.html                                   0.77 kB
../../out/renderer/panel.html                                          0.96 kB
../../out/renderer/assets/healing-C3y6w3t3.png                         4.38 kB
../../out/renderer/assets/typing-CogrMedA.png                          4.40 kB
../../out/renderer/assets/run-CDTg6mps.png                             6.15 kB
../../out/renderer/assets/special-attack-Bt2echy-.png                  6.86 kB
../../out/renderer/assets/ibm-plex-mono-DpGnXj3s.woff2                10.12 kB
../../out/renderer/assets/pixelify-sans-D1rQrCZP.woff2                12.01 kB
../../out/renderer/assets/schibsted-grotesk-DxefFeRw.woff2            46.86 kB
../../out/renderer/assets/schibsted-grotesk-italic-DOpoR6u6.woff2     50.16 kB
../../out/renderer/assets/client-DF0thCL6.css                          0.23 kB
../../out/renderer/assets/panel-CZk1_Zea.css                           2.02 kB
../../out/renderer/assets/tavern-C40dW3cw.css                         72.09 kB
../../out/renderer/assets/json-TjWBGEk1.js                             2.86 kB
../../out/renderer/assets/notification-BG3yIcfx.js                     4.24 kB
../../out/renderer/assets/vitesse-light-476zM4e6.js                   13.65 kB
../../out/renderer/assets/companion-BpnORn-w.js                       56.41 kB
../../out/renderer/assets/companion-Bk4-nh_9.js                       83.10 kB
../../out/renderer/assets/engine-javascript-B1xPiBBe.js              112.65 kB
../../out/renderer/assets/core-C48B2O1H.js                           199.04 kB
../../out/renderer/assets/client-5MzZ5AFv.js                         569.49 kB
../../out/renderer/assets/panel-BrJnG7fo.js                        1,240.80 kB
✓ built in 960ms\n- 
> @freestyle-voice/electron@0.8.1 test:e2e /Users/am/dev/freestyle-voice/freestyle/apps/electron
> playwright test


Running 52 tests using 1 worker

  ✓   1 tests/app.test.ts:102:5 › app launches and creates windows (2ms)
  ✓   2 tests/app.test.ts:107:5 › main process is responsive (3ms)
  ✓   3 tests/app.test.ts:112:5 › app name is Freestyle (1ms)
  ✓   4 tests/app.test.ts:117:5 › app version is defined (1ms)
  ✓   5 tests/app.test.ts:123:5 › companion window boots (15ms)
  ✓   6 tests/app.test.ts:129:5 › embedded server answers health checks (7ms)
  ✓   7 tests/app.test.ts:134:5 › no dashboard window exists (0ms)
  ✓   8 tests/key-listener.test.ts:46:5 › solo Fn hotkey activates after the chord grace window (77ms)
  ✓   9 tests/key-listener.test.ts:59:5 › modifier-first Fn chord does not activate a solo Fn hotkey (77ms)
  ✓  10 tests/key-listener.test.ts:69:5 › Fn-first chord within the grace window does not activate solo Fn (78ms)
  ✓  11 tests/key-listener.test.ts:80:5 › rapid solo Fn release inside the grace window does not activate (78ms)
  ✓  12 tests/key-listener.test.ts:90:5 › adding a modifier after solo Fn activation keeps hold-to-talk active (80ms)
  ✓  13 tests/key-listener.test.ts:101:5 › hotkey recorder preserves modifiers emitted with Fn chord lines (1ms)
  ✓  14 tests/key-listener.test.ts:114:5 › hotkey recorder preserves the side-specific token for a right modifier press (0ms)
  ✓  15 tests/key-listener.test.ts:127:5 › NativeKeyListener with hotkey RightCommand ignores the generic FLAGS event (2ms)
  ✓  16 tests/key-listener.test.ts:149:5 › NativeKeyListener with hotkey Command still fires on the generic FLAGS event (regression) (0ms)
  ✓  17 tests/key-listener.test.ts:161:5 › comboToAccelerator serializes a bare side-specific modifier combo (0ms)
  ✓  18 tests/key-listener.test.ts:167:5 › isValidHotkeyCombo accepts a bare side-specific modifier combo (0ms)
  ✓  19 tests/key-listener.test.ts:171:5 › nextRightModifierLatch latches a lone right modifier on an empty draft (0ms)
  ✓  20 tests/key-listener.test.ts:184:5 › nextRightModifierLatch clears when a second modifier joins the chord (0ms)
  ✓  21 tests/key-listener.test.ts:197:5 › nextRightModifierLatch clears on a generic (non-right) modifier update (0ms)
  ✓  22 tests/key-listener.test.ts:206:5 › nextRightModifierLatch survives a duplicate delivery of the same right modifier (0ms)
  ✓  23 tests/key-listener.test.ts:221:5 › nextRightModifierLatch does not latch a right modifier when the draft is not empty (0ms)
  ✓  24 tests/key-listener.test.ts:234:5 › nextRightModifierLatch survives the native RIGHT_MOD_DOWN followed by its trailing generic FLAGS emission (0ms)
  ✓  25 tests/key-listener.test.ts:258:5 › nextRightModifierLatch clears when the DOM event explicitly identifies a left-side key (0ms)
  ✓  26 tests/key-listener.test.ts:272:5 › nextRightModifierLatch clears when a chord forms even if it maps back through the latched generic key (0ms)
  ✓  27 tests/key-listener.test.ts:285:5 › nextRightModifierLatch does not latch when a right token arrives after a left modifier is already in the draft (0ms)
  ✓  28 tests/permission-checks.test.ts:8:5 › missing accessibility permission triggers a startup warning (0ms)
  ✓  29 tests/permission-checks.test.ts:14:5 › granted accessibility permission does not trigger a startup warning (0ms)
  ✓  30 tests/permission-checks.test.ts:18:5 › onboarding suppresses the duplicate startup warning (0ms)
  ✓  31 tests/permission-checks.test.ts:22:5 › denied and restricted microphone states trigger a startup warning (0ms)
  ✓  32 tests/permission-checks.test.ts:31:5 › granted and not-determined microphone states do not trigger a startup warning (0ms)
  ✓  33 tests/permission-checks.test.ts:38:5 › missing accessibility and microphone permissions use one combined warning (0ms)
  ✓  34 tests/permission-checks.test.ts:44:5 › Windows explicit microphone denial triggers its supported warning path (0ms)
  ✓  35 tests/permission-checks.test.ts:50:5 › Linux does not receive an OS-specific startup permission warning (0ms)
  ✓  36 tests/permission-checks.test.ts:54:5 › unsupported platforms do not receive an OS-specific startup permission warning (0ms)
  ✓  37 tests/permission-checks.test.ts:60:5 › missing accessibility permission blocks dictation (0ms)
  ✓  38 tests/permission-checks.test.ts:66:5 › denied microphone permission blocks dictation (0ms)
  ✓  39 tests/permission-checks.test.ts:72:5 › granted permissions allow dictation (0ms)
  ✓  40 tests/permission-checks.test.ts:76:5 › a stale accessibility latch cannot override current macOS trust (0ms)
  ✓  41 tests/permission-flow.test.ts:176:5 › startup warns once and opens Accessibility settings when requested (517ms)
  ✓  42 tests/permission-flow.test.ts:213:5 › startup does not warn when Accessibility permission is granted (489ms)
  ✓  43 tests/permission-flow.test.ts:226:5 › first run warns exactly once, same as any other run (488ms)
  ✓  44 tests/permission-flow.test.ts:240:5 › startup warns for denied Microphone and opens its privacy settings (495ms)
  ✓  45 tests/permission-flow.test.ts:274:5 › startup warns when Microphone permission is restricted (492ms)
  ✓  46 tests/permission-flow.test.ts:294:7 › startup does not warn when Microphone permission is granted (486ms)
  ✓  47 tests/permission-flow.test.ts:294:7 › startup does not warn when Microphone permission is not-determined (476ms)
  ✓  48 tests/permission-flow.test.ts:309:5 › startup combines missing Accessibility and Microphone into one warning (486ms)
  ✓  49 tests/permission-flow.test.ts:345:5 › denied Accessibility blocks dictation before RecordingStarted (526ms)
  ✓  50 tests/permission-flow.test.ts:424:5 › denied Microphone blocks dictation before RecordingStarted (513ms)
  ✓  51 tests/permission-flow.test.ts:456:5 › granted permissions allow the existing dictation flow (529ms)
  ✓  52 tests/permission-flow.test.ts:500:5 › Escape cancels an active dictation session (644ms)

  52 passed (7.7s) (52 tests)