### PR TITLE
fix(desktop): stop asking for permissions at launch

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -150,8 +150,6 @@ import {
   type DictationPermission,
   missingDictationPermission,
   resolveAccessibilityPermission,
-  type StartupPermissionWarning,
-  startupPermissionWarning,
 } from "./permission-checks";
 import {
   FreestyleEventType,
@@ -1301,47 +1299,33 @@ function openMicrophoneSettings(): void {
 let permissionDialogPromise: Promise<void> | null = null;
 
 function showRequiredPermissionDialog(
-  permission: StartupPermissionWarning,
+  permission: DictationPermission,
 ): Promise<void> {
   if (permissionDialogPromise) return permissionDialogPromise;
 
   const accessibility = permission === "accessibility";
-  const both = permission === "accessibility-and-microphone";
   permissionDialogPromise = dialog
     .showMessageBox({
-      type: "error",
-      title: both
-        ? "Permissions Required"
-        : accessibility
-          ? "Accessibility Permission Required"
-          : "Microphone Permission Required",
-      message: both
-        ? "Accessibility and Microphone permissions are required before dictation can work."
-        : accessibility
-          ? "Accessibility permission is required for dictation and text insertion."
-          : "Microphone access is required to record dictation.",
-      detail: both
-        ? "Enable Freestyle in System Settings > Privacy & Security under Accessibility and Microphone."
-        : accessibility
-          ? "Enable Freestyle in System Settings > Privacy & Security > Accessibility."
-          : process.platform === "darwin"
-            ? "Enable Freestyle in System Settings > Privacy & Security > Microphone."
-            : "Enable microphone access for Freestyle in Windows Settings.",
-      buttons: both
-        ? ["Open Accessibility Settings", "Open Microphone Settings", "Not Now"]
-        : ["Open System Settings", "Cancel"],
+      type: "info",
+      title: accessibility
+        ? "Accessibility Permission Required"
+        : "Microphone Permission Required",
+      message: accessibility
+        ? "Accessibility permission is required for dictation and text insertion."
+        : "Microphone access is required to record dictation.",
+      detail: accessibility
+        ? "Enable Freestyle in System Settings > Privacy & Security > Accessibility."
+        : process.platform === "darwin"
+          ? "Enable Freestyle in System Settings > Privacy & Security > Microphone."
+          : "Enable microphone access for Freestyle in Windows Settings.",
+      buttons: ["Open System Settings", "Cancel"],
       defaultId: 0,
-      cancelId: both ? 2 : 1,
+      cancelId: 1,
     })
     .then(({ response }) => {
-      if (both) {
-        if (response === 0) openAccessibilitySettings();
-        if (response === 1) openMicrophoneSettings();
-      } else if (response === 0 && accessibility) {
-        openAccessibilitySettings();
-      } else if (response === 0) {
-        openMicrophoneSettings();
-      }
+      if (response !== 0) return;
+      if (accessibility) openAccessibilitySettings();
+      else openMicrophoneSettings();
     })
     .finally(() => {
       permissionDialogPromise = null;
@@ -2023,20 +2007,6 @@ app.whenReady().then(async () => {
   // (recorder + paste), which double-delivered alongside the companion's.
   // The companion owns dictation; the pill exists only via the showPill()
   // boot-race fallback when no companion window could be created.
-
-  // Onboarding already has dedicated permission cards. Existing users instead
-  // get one actionable warning once a user-facing window can be shown.
-  {
-    const warning = startupPermissionWarning(
-      process.platform,
-      false,
-      hasCurrentAccessibilityPermission(),
-      getCurrentMicrophonePermission(),
-    );
-    if (warning) {
-      void showRequiredPermissionDialog(warning);
-    }
-  }
 
   // -- Auto-update helpers --
   const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes

--- a/apps/electron/src/main/permission-checks.ts
+++ b/apps/electron/src/main/permission-checks.ts
@@ -1,7 +1,4 @@
 export type DictationPermission = "accessibility" | "microphone";
-export type StartupPermissionWarning =
-  | DictationPermission
-  | "accessibility-and-microphone";
 
 export interface AccessibilityPermissionState {
   granted: boolean;
@@ -41,27 +38,5 @@ export function missingDictationPermission(
   ) {
     return "microphone";
   }
-  return null;
-}
-
-export function startupPermissionWarning(
-  platform: NodeJS.Platform,
-  onboardingActive: boolean,
-  accessibilityGranted: boolean,
-  microphoneStatus: string,
-): StartupPermissionWarning | null {
-  if (onboardingActive || (platform !== "darwin" && platform !== "win32")) {
-    return null;
-  }
-
-  const accessibilityMissing = platform === "darwin" && !accessibilityGranted;
-  const microphoneMissing =
-    microphoneStatus === "denied" || microphoneStatus === "restricted";
-
-  if (accessibilityMissing && microphoneMissing) {
-    return "accessibility-and-microphone";
-  }
-  if (accessibilityMissing) return "accessibility";
-  if (microphoneMissing) return "microphone";
   return null;
 }

--- a/apps/electron/tests/permission-checks.test.ts
+++ b/apps/electron/tests/permission-checks.test.ts
@@ -2,60 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   missingDictationPermission,
   resolveAccessibilityPermission,
-  startupPermissionWarning,
 } from "../src/main/permission-checks";
-
-test("missing accessibility permission triggers a startup warning", () => {
-  expect(startupPermissionWarning("darwin", false, false, "granted")).toBe(
-    "accessibility",
-  );
-});
-
-test("granted accessibility permission does not trigger a startup warning", () => {
-  expect(startupPermissionWarning("darwin", false, true, "granted")).toBeNull();
-});
-
-test("onboarding suppresses the duplicate startup warning", () => {
-  expect(startupPermissionWarning("darwin", true, false, "denied")).toBeNull();
-});
-
-test("denied and restricted microphone states trigger a startup warning", () => {
-  expect(startupPermissionWarning("darwin", false, true, "denied")).toBe(
-    "microphone",
-  );
-  expect(startupPermissionWarning("darwin", false, true, "restricted")).toBe(
-    "microphone",
-  );
-});
-
-test("granted and not-determined microphone states do not trigger a startup warning", () => {
-  expect(startupPermissionWarning("darwin", false, true, "granted")).toBeNull();
-  expect(
-    startupPermissionWarning("darwin", false, true, "not-determined"),
-  ).toBeNull();
-});
-
-test("missing accessibility and microphone permissions use one combined warning", () => {
-  expect(startupPermissionWarning("darwin", false, false, "denied")).toBe(
-    "accessibility-and-microphone",
-  );
-});
-
-test("Windows explicit microphone denial triggers its supported warning path", () => {
-  expect(startupPermissionWarning("win32", false, true, "denied")).toBe(
-    "microphone",
-  );
-});
-
-test("Linux does not receive an OS-specific startup permission warning", () => {
-  expect(startupPermissionWarning("linux", false, true, "denied")).toBeNull();
-});
-
-test("unsupported platforms do not receive an OS-specific startup permission warning", () => {
-  expect(
-    startupPermissionWarning("freebsd", false, false, "denied"),
-  ).toBeNull();
-});
 
 test("missing accessibility permission blocks dictation", () => {
   expect(missingDictationPermission("darwin", false, "granted")).toBe(

--- a/apps/electron/tests/permission-flow.test.ts
+++ b/apps/electron/tests/permission-flow.test.ts
@@ -22,6 +22,7 @@ test.skip(
 
 interface RecordedEvent {
   type: string;
+  prompt?: boolean;
   options?: {
     title?: string;
     message?: string;
@@ -122,18 +123,19 @@ async function launchPermissionApp(
   return { app, companion: await waitForCompanion(app), eventsPath };
 }
 
-async function waitForStartupPermissionChecks(
-  eventsPath: string,
-): Promise<void> {
+async function waitForBoot(app: ElectronApplication): Promise<void> {
   await expect
-    .poll(() => {
-      const events = readEvents(eventsPath);
-      return (
-        events.some((event) => event.type === "accessibility-check") &&
-        events.some((event) => event.type === "media-check")
-      );
+    .poll(async () => {
+      try {
+        return await app.evaluate(({ BrowserWindow }) =>
+          BrowserWindow.getAllWindows().some((win) => win.isVisible()),
+        );
+      } catch {
+        return false;
+      }
     })
     .toBe(true);
+  await new Promise((resolve) => setTimeout(resolve, 1_500));
 }
 
 function permissionDialogs(eventsPath: string): RecordedEvent[] {
@@ -173,170 +175,20 @@ async function instrumentMicrophoneRequest(
   });
 }
 
-test("startup warns once and opens Accessibility settings when requested", async () => {
-  const launched = await launchPermissionApp({
-    accessibility: "denied",
-    onboardingComplete: true,
-    dialogResponse: 0,
-  });
-  try {
-    await waitForStartupPermissionChecks(launched.eventsPath);
-    await expect
-      .poll(
-        () =>
-          readEvents(launched.eventsPath).filter(
-            (event) =>
-              event.type === "dialog" &&
-              event.options?.title === "Accessibility Permission Required",
-          ).length,
-      )
-      .toBe(1);
-
-    const events = readEvents(launched.eventsPath);
-    const warning = events.find((event) => event.type === "dialog")?.options;
-    expect(warning?.message).toContain(
-      "required for dictation and text insertion",
-    );
-    expect(warning?.buttons).toContain("Open System Settings");
-    expect(
-      events.some(
-        (event) =>
-          event.type === "open-external" &&
-          event.url?.includes("Privacy_Accessibility"),
-      ),
-    ).toBe(true);
-  } finally {
-    await closePermissionApp(launched.app);
-  }
-});
-
-test("startup does not warn when Accessibility permission is granted", async () => {
-  const launched = await launchPermissionApp({
-    accessibility: "granted",
-    onboardingComplete: true,
-  });
-  try {
-    await waitForStartupPermissionChecks(launched.eventsPath);
-    expect(permissionDialogs(launched.eventsPath)).toHaveLength(0);
-  } finally {
-    await closePermissionApp(launched.app);
-  }
-});
-
-test("first run warns exactly once, same as any other run", async () => {
+test("launch never shows a permission dialog, even with everything denied", async () => {
   const launched = await launchPermissionApp({
     accessibility: "denied",
     microphone: "denied",
     onboardingComplete: false,
   });
   try {
-    await waitForStartupPermissionChecks(launched.eventsPath);
-    expect(permissionDialogs(launched.eventsPath)).toHaveLength(1);
-  } finally {
-    await closePermissionApp(launched.app);
-  }
-});
-
-test("startup warns for denied Microphone and opens its privacy settings", async () => {
-  const launched = await launchPermissionApp({
-    accessibility: "granted",
-    microphone: "denied",
-    onboardingComplete: true,
-    dialogResponse: 0,
-  });
-  try {
-    await waitForStartupPermissionChecks(launched.eventsPath);
-    await expect
-      .poll(() => permissionDialogs(launched.eventsPath).length)
-      .toBe(1);
-
-    const events = readEvents(launched.eventsPath);
-    const warning = permissionDialogs(launched.eventsPath)[0]?.options;
-    expect(warning?.title).toBe("Microphone Permission Required");
-    expect(warning?.message).toContain(
-      "Microphone access is required to record dictation",
-    );
-    expect(warning?.buttons).toContain("Open System Settings");
+    await waitForBoot(launched.app);
+    expect(permissionDialogs(launched.eventsPath)).toHaveLength(0);
     expect(
-      events.some(
-        (event) =>
-          event.type === "open-external" &&
-          event.url?.includes("Privacy_Microphone"),
+      readEvents(launched.eventsPath).some(
+        (event) => event.type === "accessibility-check" && event.prompt,
       ),
-    ).toBe(true);
-    expect(events.some((event) => event.type === "pipeline-event")).toBe(false);
-    expect(events.some((event) => event.type === "mic-requested")).toBe(false);
-  } finally {
-    await closePermissionApp(launched.app);
-  }
-});
-
-test("startup warns when Microphone permission is restricted", async () => {
-  const launched = await launchPermissionApp({
-    accessibility: "granted",
-    microphone: "restricted",
-    onboardingComplete: true,
-  });
-  try {
-    await waitForStartupPermissionChecks(launched.eventsPath);
-    await expect
-      .poll(() => permissionDialogs(launched.eventsPath).length)
-      .toBe(1);
-    expect(permissionDialogs(launched.eventsPath)[0]?.options?.title).toBe(
-      "Microphone Permission Required",
-    );
-  } finally {
-    await closePermissionApp(launched.app);
-  }
-});
-
-for (const microphone of ["granted", "not-determined"] as const) {
-  test(`startup does not warn when Microphone permission is ${microphone}`, async () => {
-    const launched = await launchPermissionApp({
-      accessibility: "granted",
-      microphone,
-      onboardingComplete: true,
-    });
-    try {
-      await waitForStartupPermissionChecks(launched.eventsPath);
-      expect(permissionDialogs(launched.eventsPath)).toHaveLength(0);
-    } finally {
-      await closePermissionApp(launched.app);
-    }
-  });
-}
-
-test("startup combines missing Accessibility and Microphone into one warning", async () => {
-  const launched = await launchPermissionApp({
-    accessibility: "denied",
-    microphone: "denied",
-    onboardingComplete: true,
-    dialogResponse: 1,
-  });
-  try {
-    await waitForStartupPermissionChecks(launched.eventsPath);
-    await expect
-      .poll(() => permissionDialogs(launched.eventsPath).length)
-      .toBe(1);
-
-    const events = readEvents(launched.eventsPath);
-    const warning = permissionDialogs(launched.eventsPath)[0]?.options;
-    expect(warning?.title).toBe("Permissions Required");
-    expect(warning?.message).toContain(
-      "Accessibility and Microphone permissions are required",
-    );
-    expect(warning?.buttons).toEqual([
-      "Open Accessibility Settings",
-      "Open Microphone Settings",
-      "Not Now",
-    ]);
-    expect(events.filter((event) => event.type === "open-external")).toEqual([
-      expect.objectContaining({
-        url: expect.stringContaining("Privacy_Microphone"),
-      }),
-    ]);
-    expect(events.some((event) => event.type === "pipeline-event")).toBe(false);
-    expect(events.some((event) => event.type === "mic-requested")).toBe(false);
+    ).toBe(false);
   } finally {
     await closePermissionApp(launched.app);
   }
@@ -348,7 +200,7 @@ test("denied Accessibility blocks dictation before RecordingStarted", async () =
     onboardingComplete: true,
   });
   try {
-    await waitForStartupPermissionChecks(launched.eventsPath);
+    await waitForBoot(launched.app);
     await instrumentMicrophoneRequest(launched.app);
 
     // A signed-out launch auto-opens the panel (sign-in gate). Wait for the
@@ -428,7 +280,7 @@ test("denied Microphone blocks dictation before RecordingStarted", async () => {
     onboardingComplete: true,
   });
   try {
-    await waitForStartupPermissionChecks(launched.eventsPath);
+    await waitForBoot(launched.app);
     await instrumentMicrophoneRequest(launched.app);
     const dialogsBefore = permissionDialogs(launched.eventsPath).length;
     await triggerHotkeyDown(launched.companion);
@@ -460,7 +312,7 @@ test("granted permissions allow the existing dictation flow", async () => {
     onboardingComplete: true,
   });
   try {
-    await waitForStartupPermissionChecks(launched.eventsPath);
+    await waitForBoot(launched.app);
     await instrumentMicrophoneRequest(launched.app);
     await triggerHotkeyDown(launched.companion);
     await expect
@@ -504,7 +356,7 @@ test("Escape cancels an active dictation session", async () => {
     onboardingComplete: true,
   });
   try {
-    await waitForStartupPermissionChecks(launched.eventsPath);
+    await waitForBoot(launched.app);
     await instrumentMicrophoneRequest(launched.app);
     await triggerHotkeyDown(launched.companion);
     await expect


### PR DESCRIPTION
On every launch where Accessibility or Microphone wasn't granted, the app showed a modal `type: "error"` system dialog on top of whatever the user was doing — including on top of onboarding for a brand-new user. Since dictation is no longer the core of the product, that's the wrong first impression.

### Changes
- Removed the startup permission warning (`startupPermissionWarning` + the boot-time `showRequiredPermissionDialog` call). Nothing at launch calls `isTrustedAccessibilityClient` or `getMediaAccessStatus` any more; the app never adds itself to the Accessibility list unless the user asks.
- Kept the on-demand check when the **dictation hotkey** is pressed (`sendHotkeyDown` → `getMissingDictationPermission`), and Settings › Permissions still lets users grant/open both. The on-demand dialog is now `type: "info"` and only ever names one permission (the combined "both" variant only existed for boot).
- Tests: dropped the startup-warning unit cases and the six "startup warns…" e2e cases; added "launch never shows a permission dialog, even with everything denied" (also asserts no `isTrustedAccessibilityClient(true)` prompt at boot); the dictation-gate e2e cases wait for boot instead of for startup permission checks.

Independent of the audit stack (based on `main`); phase 5 (#620) no longer touches this block, so no conflict either way.

### Verification
- Playwright `permission-flow` + `permission-checks`: 9/9 ✓; electron typecheck ✓, vitest ✓, biome/knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)