### PR TITLE
fix(electron): notification bubble lands far from Jeb / Spark

### DIFF
--- a/apps/electron/src/main/notification-window.ts
+++ b/apps/electron/src/main/notification-window.ts
@@ -38,20 +38,19 @@ function anchorBounds(): {
   const height = Math.min(Math.max(contentHeight, 60), MAX_HEIGHT);
   const info = SPRITES_INFO[host.spriteForm()];
   const bounds = host.companionBounds();
-  const display = screen.getDisplayNearestPoint(
-    bounds ? { x: bounds.x, y: bounds.y } : screen.getCursorScreenPoint(),
-  );
-  const { x: waX, y: waY, width: waW, height: waH } = display.workArea;
-
-  const windowX = bounds ? bounds.x : waX;
-  const windowY = bounds ? bounds.y : waY + waH - info.windowSize;
-
-  const bodyTop = windowY + (info.anchor?.bodyTop ?? 0);
-  const bodyCenterX =
-    windowX +
-    (info.anchor
-      ? info.anchor.bodyLeft + info.anchor.bodyWidth / 2
-      : info.windowSize / 2);
+  const cursor = screen.getCursorScreenPoint();
+  const homeDisplay = screen.getDisplayNearestPoint(cursor);
+  const windowX = bounds ? bounds.x : homeDisplay.workArea.x;
+  const windowY = bounds
+    ? bounds.y
+    : homeDisplay.workArea.y + homeDisplay.workArea.height - info.windowSize;
+  const bodyTop = windowY + info.body.y;
+  const bodyCenterX = windowX + info.body.x + info.body.width / 2;
+  const display = screen.getDisplayNearestPoint({
+    x: Math.round(bodyCenterX),
+    y: Math.round(bodyTop + info.body.height / 2),
+  });
+  const { x: waX, y: waY, width: waW } = display.workArea;
 
   const x = Math.min(
     Math.max(Math.round(bodyCenterX - TAIL_OFFSET), waX + 4),

--- a/apps/electron/src/renderer/src/components/companion.tsx
+++ b/apps/electron/src/renderer/src/components/companion.tsx
@@ -13,11 +13,12 @@ import {
   DEFAULT_COMPANION_FORM,
 } from "@shared/companion";
 import type { DictationPrefs } from "@shared/dictation-prefs";
+import { SPRITES_INFO } from "@shared/sprites";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 
-const SPARK_HOT_RECT = { x: 18, y: 190, width: 52, height: 52 };
+const SPARK_HOT_RECT = SPRITES_INFO.spark.body;
 
 export interface BubbleState {
   phase: "recording" | "transcribing" | "error";

--- a/apps/electron/src/renderer/src/sprites/jeb/index.ts
+++ b/apps/electron/src/renderer/src/sprites/jeb/index.ts
@@ -24,8 +24,7 @@ export const JEB: SheetSpriteDefinition = {
   kind: "sheet",
   manifest: JEB_MANIFEST,
   sheets,
-  // Body measured from the frames' alpha at 2x: x 100–144, y 150–218.
-  hotRect: { x: 100, y: 150, width: 44, height: 68 },
+  hotRect: SPRITES_INFO.jeb.body,
   bubble: { x: 106, y: 116, maxChars: 80 },
   fx: {
     shuriken: {

--- a/apps/electron/src/renderer/src/sprites/performer.test.ts
+++ b/apps/electron/src/renderer/src/sprites/performer.test.ts
@@ -10,6 +10,7 @@ const def = {
   kind: "sheet",
   windowSize: 96,
   anchor: null,
+  body: { x: 0, y: 0, width: 1, height: 1 },
   hotRect: { x: 0, y: 0, width: 1, height: 1 },
   bubble: { x: 0, y: 0, maxChars: 1 },
   manifest: {

--- a/apps/electron/src/renderer/src/sprites/registry.ts
+++ b/apps/electron/src/renderer/src/sprites/registry.ts
@@ -13,7 +13,7 @@ export const SPRITES: Record<SpriteId, SpriteDefinition> = {
   spark: {
     ...SPRITES_INFO.spark,
     kind: "custom",
-    hotRect: { x: 18, y: 190, width: 52, height: 52 },
+    hotRect: SPRITES_INFO.spark.body,
     bubble: { x: 12, y: 68, maxChars: 220 },
   },
   jeb: JEB,

--- a/apps/electron/src/shared/sprites.ts
+++ b/apps/electron/src/shared/sprites.ts
@@ -11,10 +11,13 @@ export interface SpriteAnchor {
   bodyBottom: number;
   /** Breathing room between the body and the screen corner, px. */
   margin: number;
-  /** Where the drawn body's top edge sits inside the window, px. */
-  bodyTop: number;
-  /** Drawn body width, px. */
-  bodyWidth: number;
+}
+
+export interface SpriteBody {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
 
 export interface SpriteInfo {
@@ -29,6 +32,8 @@ export interface SpriteInfo {
    * corner. null = the sprite fills its own corner (Spark).
    */
   anchor: SpriteAnchor | null;
+  /** The drawn body's box inside the window, px; where bubbles hang from. */
+  body: SpriteBody;
   /** May physically fly across the screen to perform deliver-class tools. */
   travel?: boolean;
 }
@@ -40,6 +45,7 @@ export const SPRITES_INFO = {
     kind: "custom",
     windowSize: 256,
     anchor: null,
+    body: { x: 18, y: 190, width: 52, height: 52 },
     travel: false,
   },
   jeb: {
@@ -51,9 +57,8 @@ export const SPRITES_INFO = {
       bodyLeft: 100,
       bodyBottom: 38,
       margin: 4,
-      bodyTop: 150,
-      bodyWidth: 44,
     },
+    body: { x: 100, y: 150, width: 44, height: 68 },
     travel: true,
   },
 } as const satisfies Record<string, SpriteInfo>;


### PR DESCRIPTION
## Summary
- The notification bubble anchored to `SpriteAnchor.bodyTop/bodyLeft`, and for sprites with no anchor (Spark) fell back to "the sprite fills the 256px window". Spark is a 52px orb at the bottom-left of that window, so its bubble landed ~190px above and ~55px right of it.
- For Jeb, the target display was resolved from the companion window's top-left, which hangs 96px past the display edge; with a monitor to the left, the bubble got clamped onto that monitor.
- Fix: every sprite now declares a shared `body` rect in `shared/sprites.ts` (also used as the renderer's `hotRect`, so main and renderer can't drift). `notification-window.ts` hangs the bubble off `body` for all sprites and resolves the display from the body's center.

## Test plan
- [x] `npm run typecheck`, biome, `vitest run` (107 tests) pass
- [ ] Manual: with Spark selected, trigger a notification → bubble tail sits just above the orb
- [ ] Manual: with Jeb selected, same → bubble sits just above his head
- [ ] Manual (multi-display): companion on a display that has another monitor to its left → bubble stays on the companion's display

🤖 Generated with [Claude Code](https://claude.com/claude-code)