### PR TITLE
fix(panel): running tool calls render as the same collapsible chip

### DIFF
--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -165,6 +165,7 @@ function ToolChip({
 }): React.JSX.Element {
   const [open, setOpen] = useState(false);
   const presentation = toolPresentation(partType, phase);
+  const running = phase === "running";
   const hasInput =
     input !== undefined &&
     input !== null &&
@@ -174,34 +175,13 @@ function ToolChip({
     output !== null &&
     (typeof output !== "object" ||
       Object.keys(output).some((key) => key !== "ok"));
-  const canExpand = (hasInput || hasOutput) && phase !== "running";
-  const activity = (
-    <>
-      <ToolMark partType={partType} />
-      <span className="tavern-tool-label">
-        {presentation.title}
-        {presentation.detail ? ` · ${presentation.detail}` : ""}
-      </span>
-      {canExpand ? (
-        <span className="tavern-tool-caret" aria-hidden="true">
-          {open ? "▾" : "▸"}
-        </span>
-      ) : null}
-    </>
-  );
+  const canExpand = hasInput || hasOutput || running;
 
-  const tone =
-    phase === "running"
-      ? " is-running"
-      : phase === "declined" || phase === "failed"
-        ? " is-inert"
-        : "";
-
-  if (!canExpand) {
-    return (
-      <div className={`tavern-tool tavern-tool-static${tone}`}>{activity}</div>
-    );
-  }
+  const tone = running
+    ? " is-running"
+    : phase === "declined" || phase === "failed"
+      ? " is-inert"
+      : "";
 
   return (
     <div className={`tavern-tool${tone}`}>
@@ -210,8 +190,25 @@ function ToolChip({
         className="tavern-tool-toggle"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
+        disabled={!canExpand}
       >
-        {activity}
+        <ToolMark partType={partType} />
+        <span className="tavern-tool-label">
+          {presentation.title}
+          {presentation.detail ? ` · ${presentation.detail}` : ""}
+        </span>
+        {running ? (
+          <span
+            className="tavern-tool-spinner"
+            role="status"
+            aria-label="Working"
+          />
+        ) : null}
+        {canExpand ? (
+          <span className="tavern-tool-caret" aria-hidden="true">
+            {open ? "▾" : "▸"}
+          </span>
+        ) : null}
       </button>
       {open ? (
         <div className="tavern-tool-detail">
@@ -225,6 +222,11 @@ function ToolChip({
             <>
               <span className="tavern-tool-heading">Result</span>
               <ShikiJson value={output} />
+            </>
+          ) : running ? (
+            <>
+              <span className="tavern-tool-heading">Result</span>
+              <span className="tavern-tool-waiting">Working…</span>
             </>
           ) : null}
         </div>
@@ -425,7 +427,7 @@ function ChatMessage({
                 <ToolChip
                   key={`${message.id}-${i}`}
                   partType={part.type}
-                  input={undefined}
+                  input={tool.input}
                   output={undefined}
                   phase="running"
                 />

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1476,12 +1476,12 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .tavern-tool.is-running .tavern-tool-mark {
+  .tavern-tool.is-running .tavern-tool-mark,
+  .tavern-tool-spinner {
     animation: none;
   }
 }
 
-.tavern-tool-static,
 .tavern-tool-toggle {
   font: inherit;
   display: inline-flex;
@@ -1501,8 +1501,33 @@
   cursor: pointer;
 }
 
-.tavern-tool-toggle:hover {
+.tavern-tool-toggle:disabled {
+  cursor: default;
+}
+
+.tavern-tool-toggle:hover:not(:disabled) {
   color: var(--tavern-ink);
+}
+
+.tavern-tool-spinner {
+  width: 9px;
+  height: 9px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 1.5px solid var(--tavern-rule);
+  border-top-color: var(--tavern-lantern);
+  animation: tavern-tool-spin 0.8s linear infinite;
+}
+
+@keyframes tavern-tool-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.tavern-tool-waiting {
+  font-size: 11px;
+  color: var(--tavern-mute);
 }
 
 .tavern-tool-toggle:focus-visible {


### PR DESCRIPTION
## Summary
- `ToolChip` rendered a static `.tavern-tool-static` row (no caret, no input, not clickable) while a call was `input-streaming`/`input-available`, then switched to the collapsible toggle once resolved — a visible layout jump.
- Now every phase renders the same collapsible: the running phase passes the request-so-far as input, shows a small spinner at the end of the row, and, when expanded, a "Working…" placeholder under Result until output arrives. Toggle is disabled only when there is truly nothing to show.
- Removed the `.tavern-tool-static` style; spinner honors `prefers-reduced-motion`.

## Test plan
- [x] typecheck, biome, vitest (107), `electron-vite build`
- [ ] Manual: send a prompt that triggers a tool → chip appears as a collapsible immediately with a spinner; expanding shows the request; on completion the same chip fills in the result with no reflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)