### PR TITLE
fix(electron): Handle aborted notification stream cleanup

### DIFF
--- a/apps/electron/src/main/notification-stream.test.ts
+++ b/apps/electron/src/main/notification-stream.test.ts
@@ -48,6 +48,41 @@ describe("consumeNotificationEvents", () => {
 
     expect(refreshes).toBe(0);
   });
+
+  it("does not leak an abort error when cancelling an already errored stream", async () => {
+    const controller = new AbortController();
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+      },
+    });
+    let onUnhandled!: (reason: unknown) => void;
+    const unhandled = new Promise<unknown>((resolve) => {
+      onUnhandled = resolve;
+      process.once("unhandledRejection", onUnhandled);
+    });
+    const consuming = consumeNotificationEvents(stream, () => {}, {
+      signal: controller.signal,
+    }).catch(() => {});
+
+    streamController.error(
+      new DOMException("This operation was aborted", "AbortError"),
+    );
+    controller.abort();
+
+    try {
+      await expect(
+        Promise.race([
+          unhandled,
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), 0)),
+        ]),
+      ).resolves.toBeNull();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+    await consuming;
+  });
 });
 
 describe("startNotificationStream", () => {

--- a/apps/electron/src/main/notification-stream.ts
+++ b/apps/electron/src/main/notification-stream.ts
@@ -11,7 +11,10 @@ export async function consumeNotificationEvents(
   const decoder = new TextDecoder();
   let buffer = "";
   const abort = (): void => {
-    void reader.cancel();
+    // Aborting the fetch can error its body before this listener runs. The
+    // resulting cancellation rejection is expected and must not escape as an
+    // unhandled rejection from this fire-and-forget cleanup.
+    void reader.cancel().catch(() => {});
   };
   options?.signal?.addEventListener("abort", abort, { once: true });
 


### PR DESCRIPTION
Notification SSE watchdogs still abort silent or stalled connections so fallback polling can resume. This change handles the race where aborting an already-errored response body rejects `reader.cancel()`, preventing that expected cleanup error from being reported as an unhandled main-process exception.

The regression test exercises the cancellation race directly; no notification delivery or reconnect behavior changes.
