### PR TITLE
feat(scheduled): scheduled tasks live in the Brain tab, fully editable, with Run now

### DIFF
--- a/apps/electron/src/renderer/src/components/brain-files.tsx
+++ b/apps/electron/src/renderer/src/components/brain-files.tsx
@@ -1,5 +1,6 @@
 import { DataSkeleton } from "@renderer/components/data-skeleton";
 import { Markdown } from "@renderer/components/markdown";
+import { ScheduledTasks } from "@renderer/components/scheduled-tasks";
 import { capture } from "@renderer/lib/analytics";
 import {
   deleteBrainFile,
@@ -185,6 +186,8 @@ export function BrainFiles({
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [view, setView] = useState<FileView>({ kind: "list" });
   const [error, setError] = useState<string | null>(null);
+  const [scheduledOpen, setScheduledOpen] = useState(false);
+  const scheduled = root === "";
 
   if (filesQuery.isLoading) return <DataSkeleton label="Loading Brain files" />;
   if (filesQuery.isError)
@@ -318,8 +321,12 @@ export function BrainFiles({
     );
   }
 
+  if (scheduled && scheduledOpen)
+    return <ScheduledTasks onOpenChange={setScheduledOpen} />;
+
   return (
     <>
+      {scheduled ? <ScheduledTasks onOpenChange={setScheduledOpen} /> : null}
       {files.length === 0 ? (
         <div className="tavern-empty">{emptyText}</div>
       ) : (

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -285,7 +285,7 @@ function AutomationRow({
       <strong>{automation.name}</strong>
       <small>
         {state === "on"
-          ? "On. Manage it in Settings \u2192 Scheduled."
+          ? "On. Manage it in Brain \u2192 Scheduled."
           : state === "error"
             ? "Couldn't set that up. Ask in chat instead."
             : `Runs ${automation.schedule}. Only notifies when it matters.`}

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -85,7 +85,7 @@ const TAB_PLACEHOLDER: Record<PanelTab, string> = {
   todos: "Nothing to do yet.",
   notes: "No notes yet.",
   brain:
-    "Everything Freestyle knows lives here — memories, notes, skills, todos.",
+    "Everything Freestyle knows lives here — scheduled tasks, memories, notes, skills, todos.",
   apps: "Connect the apps you live in, and Freestyle can work them for you.",
 };
 
@@ -521,6 +521,15 @@ function touchesBrain(message: UIMessage): boolean {
   );
 }
 
+function touchesScheduled(message: UIMessage): boolean {
+  return message.parts.some(
+    (part) =>
+      part.type === "tool-scheduled_task_create" ||
+      part.type === "tool-scheduled_task_update" ||
+      part.type === "tool-scheduled_task_delete",
+  );
+}
+
 function PanelTail(): React.JSX.Element {
   // A manga balloon tail. The card fill reaches up through the panel's border
   // and hard shadow so the bubble opens into the tail; the ink stroke draws
@@ -838,6 +847,11 @@ function PanelInner({
         if (touchesBrain(last)) {
           resetBrainCache();
           void queryClient.invalidateQueries({ queryKey: queryKeys.brain.all });
+        }
+        if (touchesScheduled(last)) {
+          void queryClient.invalidateQueries({
+            queryKey: queryKeys.scheduled.tasks,
+          });
         }
         const text = messageText(last);
         if (!text) return;

--- a/apps/electron/src/renderer/src/components/scheduled-tasks.test.ts
+++ b/apps/electron/src/renderer/src/components/scheduled-tasks.test.ts
@@ -71,6 +71,8 @@ describe("ScheduledTasks", () => {
     expect(html).toContain("next in 1h");
     expect(html).toContain("never run");
     expect(html).toContain("New scheduled task");
+    expect(html).toContain('aria-label="Run Morning brief now"');
+    expect(html).toContain('role="switch"');
     expect(html).not.toContain("Check the");
   });
 

--- a/apps/electron/src/renderer/src/components/scheduled-tasks.test.ts
+++ b/apps/electron/src/renderer/src/components/scheduled-tasks.test.ts
@@ -1,0 +1,117 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+const { useQuery, useQueryClient } = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+  useQueryClient: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({ useQuery, useQueryClient }));
+vi.mock("@renderer/components/markdown", () => ({
+  Markdown: ({ text }: { text: string }) => createElement("pre", null, text),
+}));
+vi.mock("@renderer/lib/brain-fs", () => ({
+  deleteBrainFile: vi.fn(),
+  listBrainFiles: vi.fn(),
+  readBrainFile: vi.fn(),
+  writeBrainFile: vi.fn(),
+}));
+vi.mock("@renderer/lib/scheduled-tasks", () => ({
+  createScheduledTask: vi.fn(),
+  deleteScheduledTask: vi.fn(),
+  listScheduledTasks: vi.fn(),
+  runScheduledTaskNow: vi.fn(),
+  updateScheduledTask: vi.fn(),
+}));
+
+import { BrainFiles } from "./brain-files";
+import { ScheduledTasks } from "./scheduled-tasks";
+
+const task = {
+  id: "task-1",
+  name: "Morning brief",
+  instruction: "Check the **markets**.",
+  schedule: "every weekday at 8am",
+  cron: "0 8 * * 1-5",
+  kind: "cron" as const,
+  timezone: "America/Los_Angeles",
+  enabled: true,
+  nextDueAt: new Date(Date.now() + 3_600_000).toISOString(),
+  lastCompletedAt: null,
+  templateId: null,
+};
+
+function mockQueries({
+  tasks,
+  files,
+}: {
+  tasks: unknown[];
+  files: unknown[];
+}): void {
+  useQuery.mockImplementation((options: { queryKey: readonly string[] }) => ({
+    data: options.queryKey[0] === "scheduled" ? tasks : files,
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+  }));
+  useQueryClient.mockReturnValue({
+    invalidateQueries: vi.fn(),
+    getQueryData: vi.fn(),
+    setQueryData: vi.fn(),
+  });
+}
+
+describe("ScheduledTasks", () => {
+  it("lists tasks as cards with schedule and next run", () => {
+    mockQueries({ tasks: [task], files: [] });
+    const html = renderToStaticMarkup(createElement(ScheduledTasks));
+    expect(html).toContain("Morning brief");
+    expect(html).toContain("every weekday at 8am");
+    expect(html).toContain("next in 1h");
+    expect(html).toContain("never run");
+    expect(html).toContain("New scheduled task");
+    expect(html).not.toContain("Check the");
+  });
+
+  it("explains how to get a task when there are none", () => {
+    mockQueries({ tasks: [], files: [] });
+    const html = renderToStaticMarkup(
+      createElement(ScheduledTasks, { mascot: "Bramble" }),
+    );
+    expect(html).toContain("Ask Bramble to do something regularly");
+  });
+});
+
+describe("Brain tab", () => {
+  it("shows the Scheduled section above the file tree", () => {
+    mockQueries({
+      tasks: [task],
+      files: [{ path: "notes/a.md", size: 3, modified: 0 }],
+    });
+    const html = renderToStaticMarkup(
+      createElement(BrainFiles, {
+        root: "",
+        emptyText: "No files",
+        newLabel: "New file",
+      }),
+    );
+    expect(html.indexOf("Morning brief")).toBeGreaterThan(-1);
+    expect(html.indexOf("Morning brief")).toBeLessThan(html.indexOf("a.md"));
+  });
+
+  it("keeps folder views free of the Scheduled section", () => {
+    mockQueries({
+      tasks: [task],
+      files: [{ path: "notes/a.md", size: 3, modified: 0 }],
+    });
+    const html = renderToStaticMarkup(
+      createElement(BrainFiles, {
+        root: "notes",
+        emptyText: "No notes",
+        newLabel: "New note",
+      }),
+    );
+    expect(html).not.toContain("Morning brief");
+  });
+});

--- a/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
+++ b/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
@@ -422,23 +422,46 @@ export function ScheduledTasks({
         </div>
       ) : (
         tasks.map((task) => (
-          <button
+          <div
             key={task.id}
-            type="button"
             className={`tavern-sched is-card${task.enabled ? "" : " is-off"}`}
-            onClick={() => setView({ kind: "detail", id: task.id })}
           >
-            <div className="tavern-sched-head">
+            <button
+              type="button"
+              className="tavern-sched-open"
+              onClick={() => setView({ kind: "detail", id: task.id })}
+            >
               <span className="tavern-sched-name">{task.name}</span>
-              <span
+              <p className="tavern-sched-schedule">{task.schedule}</p>
+              <span className="tavern-sched-meta">{meta(task)}</span>
+            </button>
+            <div className="tavern-sched-side">
+              <button
+                type="button"
                 className={`tavern-sched-toggle${task.enabled ? " is-on" : ""}`}
+                role="switch"
+                aria-checked={task.enabled}
+                aria-label={`${task.name} enabled`}
+                disabled={busy === task.id}
+                onClick={() => toggle(task)}
               >
                 {task.enabled ? "On" : "Off"}
-              </span>
+              </button>
+              <button
+                type="button"
+                className="tavern-sched-action"
+                aria-label={`Run ${task.name} now`}
+                disabled={busy === task.id}
+                onClick={() => runNow(task)}
+              >
+                {busy === task.id
+                  ? "Running…"
+                  : ran === task.id
+                    ? "Ran ✓"
+                    : "Run now"}
+              </button>
             </div>
-            <p className="tavern-sched-schedule">{task.schedule}</p>
-            <span className="tavern-sched-meta">{meta(task)}</span>
-          </button>
+          </div>
         ))
       )}
       <button

--- a/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
+++ b/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
@@ -1,6 +1,8 @@
 import { DataSkeleton } from "@renderer/components/data-skeleton";
+import { capture } from "@renderer/lib/analytics";
 import { queryKeys, scheduledTasksQueryOptions } from "@renderer/lib/query";
 import {
+  runScheduledTaskNow,
   type ScheduledTaskView,
   updateScheduledTask,
 } from "@renderer/lib/scheduled-tasks";
@@ -28,6 +30,8 @@ export function ScheduledTasks({
   const tasksQuery = useQuery(scheduledTasksQueryOptions());
   const tasks = tasksQuery.data ?? [];
   const [busy, setBusy] = useState<string | null>(null);
+  const [running, setRunning] = useState<string | null>(null);
+  const [ran, setRan] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const toggle = (task: ScheduledTaskView): void => {
@@ -59,6 +63,28 @@ export function ScheduledTasks({
         setError("Couldn’t update that task. Try again.");
       })
       .finally(() => setBusy(null));
+  };
+
+  const runNow = (task: ScheduledTaskView): void => {
+    setRunning(task.id);
+    setRan(null);
+    setError(null);
+    capture("scheduled_task_run_now", { task: task.name });
+    void runScheduledTaskNow(task.id)
+      .then(() => {
+        setRan(task.id);
+        void queryClient.invalidateQueries({
+          queryKey: queryKeys.scheduled.tasks,
+        });
+      })
+      .catch((err: unknown) => {
+        setError(
+          err instanceof Error && err.message
+            ? err.message
+            : "That didn’t run. Try again in a moment.",
+        );
+      })
+      .finally(() => setRunning(null));
   };
 
   if (tasksQuery.isLoading)
@@ -118,6 +144,21 @@ export function ScheduledTasks({
           <span className="tavern-sched-meta">
             {whenLastRun(task.lastCompletedAt)} · {task.timezone}
           </span>
+          <div className="tavern-sched-actions">
+            <button
+              type="button"
+              className="tavern-sched-action"
+              disabled={running !== null}
+              aria-label={`Run ${task.name} now`}
+              onClick={() => runNow(task)}
+            >
+              {running === task.id
+                ? "Running…"
+                : ran === task.id
+                  ? "Ran ✓"
+                  : "Run now"}
+            </button>
+          </div>
         </div>
       ))}
     </>

--- a/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
+++ b/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
@@ -1,38 +1,190 @@
 import { DataSkeleton } from "@renderer/components/data-skeleton";
+import { Markdown } from "@renderer/components/markdown";
 import { capture } from "@renderer/lib/analytics";
 import { queryKeys, scheduledTasksQueryOptions } from "@renderer/lib/query";
 import {
+  createScheduledTask,
+  deleteScheduledTask,
   runScheduledTaskNow,
+  type ScheduledTaskInput,
   type ScheduledTaskView,
   updateScheduledTask,
 } from "@renderer/lib/scheduled-tasks";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-function whenLastRun(value: string | null): string {
-  if (!value) return "never run";
+type View =
+  | { kind: "list" }
+  | { kind: "detail"; id: string }
+  | { kind: "edit"; id: string; draft: ScheduledTaskInput }
+  | { kind: "create"; draft: ScheduledTaskInput };
+
+function relative(value: string | null, prefix: string): string | null {
+  if (!value) return null;
   const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "never run";
-  const diffMin = Math.round((Date.now() - date.getTime()) / 60_000);
-  if (diffMin < 1) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  if (diffMin < 60 * 24) return `${Math.round(diffMin / 60)}h ago`;
-  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  if (Number.isNaN(date.getTime())) return null;
+  const diffMin = Math.round((date.getTime() - Date.now()) / 60_000);
+  const abs = Math.abs(diffMin);
+  const when =
+    abs < 1
+      ? "now"
+      : abs < 60
+        ? `${abs}m`
+        : abs < 60 * 24
+          ? `${Math.round(abs / 60)}h`
+          : date.toLocaleDateString(undefined, {
+              month: "short",
+              day: "numeric",
+            });
+  if (abs >= 60 * 24) return `${prefix} ${when}`;
+  return diffMin < 0 ? `${prefix} ${when} ago` : `${prefix} in ${when}`;
+}
+
+function meta(task: ScheduledTaskView): string {
+  const parts = [
+    task.enabled ? relative(task.nextDueAt, "next") : "paused",
+    relative(task.lastCompletedAt, "last ran") ?? "never run",
+  ];
+  return parts.filter(Boolean).join(" · ");
+}
+
+function emptyDraft(): ScheduledTaskInput {
+  return {
+    name: "",
+    instruction: "",
+    schedule: "",
+    cron: null,
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  };
+}
+
+function draftOf(task: ScheduledTaskView): ScheduledTaskInput {
+  return {
+    name: task.name,
+    instruction: task.instruction,
+    schedule: task.schedule,
+    cron: task.cron,
+    timezone: task.timezone,
+  };
+}
+
+function TaskForm({
+  draft,
+  onDraft,
+  onSave,
+  onCancel,
+  busy,
+}: {
+  draft: ScheduledTaskInput;
+  onDraft: (draft: ScheduledTaskInput) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  busy: boolean;
+}): React.JSX.Element {
+  const field = (
+    label: string,
+    key: "name" | "schedule" | "cron" | "timezone",
+    placeholder: string,
+  ): React.JSX.Element => (
+    <label className="tavern-sched-field">
+      <span className="tavern-sched-label">{label}</span>
+      <input
+        className="tavern-editor-name"
+        value={draft[key] ?? ""}
+        placeholder={placeholder}
+        onChange={(e) =>
+          onDraft({
+            ...draft,
+            [key]: key === "cron" ? e.target.value || null : e.target.value,
+          })
+        }
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.stopPropagation();
+            onCancel();
+          }
+        }}
+      />
+    </label>
+  );
+  const valid =
+    draft.name.trim() && draft.schedule.trim() && draft.instruction.trim();
+  return (
+    <div className="tavern-sched-form">
+      {field("Name", "name", "Morning brief")}
+      {field("Schedule, in your words", "schedule", "every weekday at 8am")}
+      {field("Cron (optional, blank = fuzzy)", "cron", "0 8 * * 1-5")}
+      {field("Timezone", "timezone", "America/Los_Angeles")}
+      <label className="tavern-sched-field">
+        <span className="tavern-sched-label">What Freestyle does</span>
+        <textarea
+          className="tavern-editor"
+          value={draft.instruction}
+          placeholder="Check the markets and tell me anything worth knowing."
+          onChange={(e) => onDraft({ ...draft, instruction: e.target.value })}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.stopPropagation();
+              onCancel();
+            }
+          }}
+        />
+      </label>
+      <div className="tavern-approve-actions">
+        <button
+          type="button"
+          className="tavern-approve-btn tavern-approve-allow"
+          disabled={busy || !valid}
+          onClick={onSave}
+        >
+          {busy ? "Saving…" : "Save"}
+        </button>
+        <button type="button" className="tavern-approve-btn" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export function ScheduledTasks({
   mascot = "Freestyle",
+  onOpenChange,
 }: {
   mascot?: string;
+  onOpenChange?: (open: boolean) => void;
 }): React.JSX.Element {
   const queryClient = useQueryClient();
   const tasksQuery = useQuery(scheduledTasksQueryOptions());
   const tasks = tasksQuery.data ?? [];
+  const [view, setViewState] = useState<View>({ kind: "list" });
   const [busy, setBusy] = useState<string | null>(null);
-  const [running, setRunning] = useState<string | null>(null);
   const [ran, setRan] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const setView = (next: View): void => {
+    setError(null);
+    setConfirming(null);
+    setViewState(next);
+    onOpenChange?.(next.kind !== "list");
+  };
+
+  const openId =
+    view.kind === "detail" || view.kind === "edit" ? view.id : null;
+  const openTask = tasks.find((t) => t.id === openId);
+  useEffect(() => {
+    if (!openId || !tasksQuery.isSuccess || openTask) return;
+    setViewState({ kind: "list" });
+    onOpenChange?.(false);
+  }, [openId, openTask, tasksQuery.isSuccess, onOpenChange]);
+
+  const refresh = (): Promise<void> =>
+    queryClient.invalidateQueries({ queryKey: queryKeys.scheduled.tasks });
+
+  const fail = (fallback: string) => (err: unknown) =>
+    setError(err instanceof Error && err.message ? err.message : fallback);
 
   const toggle = (task: ScheduledTaskView): void => {
     const enabled = !task.enabled;
@@ -48,44 +200,65 @@ export function ScheduledTasks({
           entry.id === task.id ? { ...entry, enabled } : entry,
         ) ?? current,
     );
+    capture("scheduled_task_toggled", { task: task.name, enabled });
     void updateScheduledTask(task.id, { enabled })
-      .then((updated) => {
-        queryClient.setQueryData<ScheduledTaskView[]>(
-          queryKeys.scheduled.tasks,
-          (current) =>
-            current?.map((entry) =>
-              entry.id === updated.id ? updated : entry,
-            ) ?? current,
-        );
-      })
-      .catch(() => {
+      .then(() => refresh())
+      .catch((err: unknown) => {
         queryClient.setQueryData(queryKeys.scheduled.tasks, previous);
-        setError("Couldn’t update that task. Try again.");
+        fail("Couldn’t update that task. Try again.")(err);
       })
       .finally(() => setBusy(null));
   };
 
   const runNow = (task: ScheduledTaskView): void => {
-    setRunning(task.id);
+    setBusy(task.id);
     setRan(null);
     setError(null);
     capture("scheduled_task_run_now", { task: task.name });
     void runScheduledTaskNow(task.id)
       .then(() => {
         setRan(task.id);
-        void queryClient.invalidateQueries({
-          queryKey: queryKeys.scheduled.tasks,
-        });
+        void refresh();
       })
-      .catch((err: unknown) => {
-        setError(
-          err instanceof Error && err.message
-            ? err.message
-            : "That didn’t run. Try again in a moment.",
-        );
-      })
-      .finally(() => setRunning(null));
+      .catch(fail("That didn’t run. Try again in a moment."))
+      .finally(() => setBusy(null));
   };
+
+  const remove = (task: ScheduledTaskView): void => {
+    setBusy(task.id);
+    capture("scheduled_task_deleted", { task: task.name });
+    void deleteScheduledTask(task.id)
+      .then(() => {
+        setView({ kind: "list" });
+        void refresh();
+      })
+      .catch(fail("Couldn’t delete that task."))
+      .finally(() => setBusy(null));
+  };
+
+  const save = (id: string | null, draft: ScheduledTaskInput): void => {
+    setBusy(id ?? "new");
+    setError(null);
+    const request = id
+      ? updateScheduledTask(id, draft)
+      : createScheduledTask(draft);
+    void request
+      .then((task) => {
+        capture(id ? "scheduled_task_edited" : "scheduled_task_created", {
+          task: task.name,
+        });
+        void refresh();
+        setView({ kind: "detail", id: task.id });
+      })
+      .catch(fail("Couldn’t save that task."))
+      .finally(() => setBusy(null));
+  };
+
+  const notice = error ? (
+    <p className="tavern-notice" role="alert">
+      {error}
+    </p>
+  ) : null;
 
   if (tasksQuery.isLoading)
     return <DataSkeleton label="Loading scheduled tasks" />;
@@ -100,31 +273,66 @@ export function ScheduledTasks({
     );
   }
 
-  if (tasks.length === 0) {
+  if (view.kind === "create") {
     return (
-      <div className="tavern-empty">
-        Nothing scheduled. Ask {mascot} to do something regularly — "check the
-        stocks every weekday morning" — and it lands here.
-      </div>
+      <>
+        <button
+          type="button"
+          className="tavern-file-back"
+          onClick={() => setView({ kind: "list" })}
+        >
+          ← New scheduled task
+        </button>
+        {notice}
+        <TaskForm
+          draft={view.draft}
+          onDraft={(draft) => setViewState({ ...view, draft })}
+          onSave={() => save(null, view.draft)}
+          onCancel={() => setView({ kind: "list" })}
+          busy={busy === "new"}
+        />
+      </>
     );
   }
 
-  return (
-    <>
-      <p className="tavern-set-hint is-lead">
-        These run on their own, even with this app closed. They only notify you
-        when there&apos;s something worth knowing — every run is saved either
-        way.
-      </p>
-      {error ? (
-        <p className="tavern-notice" role="alert">
-          {error}
-        </p>
-      ) : null}
-      {tasks.map((task) => (
+  if (view.kind === "edit") {
+    const task = openTask;
+    return (
+      <>
+        <button
+          type="button"
+          className="tavern-file-back"
+          onClick={() => setView({ kind: "detail", id: view.id })}
+        >
+          ← {task?.name ?? "Scheduled task"}
+        </button>
+        {notice}
+        <TaskForm
+          draft={view.draft}
+          onDraft={(draft) => setViewState({ ...view, draft })}
+          onSave={() => save(view.id, view.draft)}
+          onCancel={() => setView({ kind: "detail", id: view.id })}
+          busy={busy === view.id}
+        />
+      </>
+    );
+  }
+
+  if (view.kind === "detail") {
+    const task = openTask;
+    if (!task) return <DataSkeleton label="Loading scheduled task" />;
+    return (
+      <>
+        <button
+          type="button"
+          className="tavern-file-back"
+          onClick={() => setView({ kind: "list" })}
+        >
+          ← Scheduled
+        </button>
+        {notice}
         <div
-          key={task.id}
-          className={`tavern-sched${task.enabled ? "" : " is-off"}`}
+          className={`tavern-sched is-detail${task.enabled ? "" : " is-off"}`}
         >
           <div className="tavern-sched-head">
             <span className="tavern-sched-name">{task.name}</span>
@@ -142,25 +350,104 @@ export function ScheduledTasks({
           </div>
           <p className="tavern-sched-schedule">{task.schedule}</p>
           <span className="tavern-sched-meta">
-            {whenLastRun(task.lastCompletedAt)} · {task.timezone}
+            {task.cron ? `cron ${task.cron} · ` : ""}
+            {task.timezone}
           </span>
-          <div className="tavern-sched-actions">
+          <span className="tavern-sched-meta">{meta(task)}</span>
+        </div>
+        <p className="tavern-sched-label">What {mascot} does</p>
+        <Markdown text={task.instruction} />
+        <div className="tavern-sched-actions">
+          <button
+            type="button"
+            className="tavern-sched-action"
+            onClick={() =>
+              setView({ kind: "edit", id: task.id, draft: draftOf(task) })
+            }
+          >
+            Edit
+          </button>
+          <button
+            type="button"
+            className="tavern-sched-action"
+            disabled={busy === task.id}
+            onClick={() => runNow(task)}
+          >
+            {busy === task.id
+              ? "Running…"
+              : ran === task.id
+                ? "Ran ✓"
+                : "Run now"}
+          </button>
+          {confirming === task.id ? (
+            <>
+              <button
+                type="button"
+                className="tavern-sched-action is-danger"
+                disabled={busy === task.id}
+                onClick={() => remove(task)}
+              >
+                Delete for good
+              </button>
+              <button
+                type="button"
+                className="tavern-sched-action"
+                onClick={() => setConfirming(null)}
+              >
+                Keep
+              </button>
+            </>
+          ) : (
             <button
               type="button"
-              className="tavern-sched-action"
-              disabled={running !== null}
-              aria-label={`Run ${task.name} now`}
-              onClick={() => runNow(task)}
+              className="tavern-sched-action is-danger"
+              onClick={() => setConfirming(task.id)}
             >
-              {running === task.id
-                ? "Running…"
-                : ran === task.id
-                  ? "Ran ✓"
-                  : "Run now"}
+              Delete
             </button>
-          </div>
+          )}
         </div>
-      ))}
-    </>
+      </>
+    );
+  }
+
+  return (
+    <section className="tavern-sched-section" aria-label="Scheduled tasks">
+      <p className="tavern-sched-label">Scheduled</p>
+      {notice}
+      {tasks.length === 0 ? (
+        <div className="tavern-empty">
+          Nothing scheduled. Ask {mascot} to do something regularly — "check the
+          stocks every weekday morning" — and it lands here.
+        </div>
+      ) : (
+        tasks.map((task) => (
+          <button
+            key={task.id}
+            type="button"
+            className={`tavern-sched is-card${task.enabled ? "" : " is-off"}`}
+            onClick={() => setView({ kind: "detail", id: task.id })}
+          >
+            <div className="tavern-sched-head">
+              <span className="tavern-sched-name">{task.name}</span>
+              <span
+                className={`tavern-sched-toggle${task.enabled ? " is-on" : ""}`}
+              >
+                {task.enabled ? "On" : "Off"}
+              </span>
+            </div>
+            <p className="tavern-sched-schedule">{task.schedule}</p>
+            <span className="tavern-sched-meta">{meta(task)}</span>
+          </button>
+        ))
+      )}
+      <button
+        type="button"
+        className="tavern-file-new"
+        onClick={() => setView({ kind: "create", draft: emptyDraft() })}
+      >
+        ＋ New scheduled task
+      </button>
+    </section>
   );
 }

--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -11,7 +11,6 @@ import {
   NotificationsHistory,
   QuietHoursSettings,
 } from "@renderer/components/notifications-history";
-import { ScheduledTasks } from "@renderer/components/scheduled-tasks";
 import {
   acceleratorsEqual,
   formatAcceleratorKeys,
@@ -55,7 +54,6 @@ type SettingsPage =
   | "profile"
   | "billing"
   | "notifications"
-  | "scheduled"
   | "dictation"
   | "talk"
   | "application"
@@ -66,7 +64,6 @@ const PAGE_TITLES: Record<Exclude<SettingsPage, "root">, string> = {
   profile: "Profile",
   billing: "Billing & Usage",
   notifications: "Notifications",
-  scheduled: "Scheduled",
   dictation: "Dictation",
   talk: "Talk & Summon",
   application: "Application",
@@ -1534,21 +1531,12 @@ export function SettingsView({
   const auth = useCloudAuth();
   const usage = useCloudUsage(!!auth.user);
   const [version, setVersion] = useState("");
-  const [spriteForm, setSpriteForm] = useState<CompanionForm>(
-    DEFAULT_COMPANION_FORM,
-  );
 
   useEffect(() => {
     void window.api
       .getAppVersion()
       .then(setVersion)
       .catch(() => {});
-    void window.api
-      .companionForm()
-      .then(setSpriteForm)
-      .catch(() => {});
-    const off = window.api.onCompanionForm(setSpriteForm);
-    return () => off?.();
   }, []);
 
   if (settings === null)
@@ -1571,8 +1559,6 @@ export function SettingsView({
           <ProfilePage />
         ) : page === "billing" ? (
           <BillingPage />
-        ) : page === "scheduled" ? (
-          <ScheduledTasks mascot={SPRITES_INFO[spriteForm].label} />
         ) : page === "notifications" ? (
           <>
             <QuietHoursSettings />
@@ -1626,7 +1612,6 @@ export function SettingsView({
         detail={auth.user ? (usage.isPro ? "Pro" : "Free") : undefined}
         onClick={() => setPage("billing")}
       />
-      <NavRow label="Scheduled" onClick={() => setPage("scheduled")} />
       <NavRow label="Notifications" onClick={() => setPage("notifications")} />
       <NavRow
         label="Dictation"

--- a/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
+++ b/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
@@ -3,10 +3,33 @@ import { apiFetch } from "@renderer/lib/api";
 export interface ScheduledTaskView {
   id: string;
   name: string;
+  instruction: string;
   schedule: string;
+  cron: string | null;
+  kind: "cron" | "fuzzy";
   timezone: string;
   enabled: boolean;
+  nextDueAt: string;
   lastCompletedAt: string | null;
+  templateId: string | null;
+}
+
+export interface ScheduledTaskInput {
+  name: string;
+  instruction: string;
+  schedule: string;
+  cron: string | null;
+  timezone: string;
+}
+
+export type ScheduledTaskPatch = Partial<ScheduledTaskInput> & {
+  enabled?: boolean;
+};
+
+export interface ScheduledTaskRunResult {
+  ok: true;
+  threadId: string | null;
+  notificationId: string | null;
 }
 
 async function responseJson<T>(response: Response): Promise<T> {
@@ -21,6 +44,11 @@ async function responseJson<T>(response: Response): Promise<T> {
   return payload as T;
 }
 
+const json = (body: unknown): RequestInit => ({
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+});
+
 export async function listScheduledTasks(): Promise<ScheduledTaskView[]> {
   const data = await responseJson<{ tasks: ScheduledTaskView[] }>(
     await apiFetch("/api/scheduled/tasks"),
@@ -28,24 +56,34 @@ export async function listScheduledTasks(): Promise<ScheduledTaskView[]> {
   return data.tasks.toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
+export async function createScheduledTask(
+  input: ScheduledTaskInput,
+): Promise<ScheduledTaskView> {
+  const data = await responseJson<{ task: ScheduledTaskView }>(
+    await apiFetch("/api/scheduled/tasks", { method: "POST", ...json(input) }),
+  );
+  return data.task;
+}
+
 export async function updateScheduledTask(
   id: string,
-  input: Pick<ScheduledTaskView, "enabled">,
+  patch: ScheduledTaskPatch,
 ): Promise<ScheduledTaskView> {
   const data = await responseJson<{ task: ScheduledTaskView }>(
     await apiFetch(`/api/scheduled/tasks/${encodeURIComponent(id)}`, {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(input),
+      ...json(patch),
     }),
   );
   return data.task;
 }
 
-export interface ScheduledTaskRunResult {
-  ok: true;
-  threadId: string | null;
-  notificationId: string | null;
+export async function deleteScheduledTask(id: string): Promise<void> {
+  const response = await apiFetch(
+    `/api/scheduled/tasks/${encodeURIComponent(id)}`,
+    { method: "DELETE" },
+  );
+  if (!response.ok) await responseJson(response);
 }
 
 export async function runScheduledTaskNow(

--- a/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
+++ b/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
@@ -41,3 +41,19 @@ export async function updateScheduledTask(
   );
   return data.task;
 }
+
+export interface ScheduledTaskRunResult {
+  ok: true;
+  threadId: string | null;
+  notificationId: string | null;
+}
+
+export async function runScheduledTaskNow(
+  id: string,
+): Promise<ScheduledTaskRunResult> {
+  return responseJson<ScheduledTaskRunResult>(
+    await apiFetch(`/api/scheduled/tasks/${encodeURIComponent(id)}/run`, {
+      method: "POST",
+    }),
+  );
+}

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -3539,21 +3539,40 @@
 }
 
 .tavern-sched.is-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.tavern-sched-open {
+  flex: 1;
+  min-width: 0;
   display: block;
-  width: 100%;
   font: inherit;
   text-align: left;
   color: inherit;
+  padding: 0;
+  border: 0;
+  background: none;
   cursor: pointer;
 }
 
-.tavern-sched.is-card:hover {
-  border-color: var(--tavern-ink);
+.tavern-sched-open:hover .tavern-sched-name {
+  text-decoration: underline;
 }
 
-.tavern-sched.is-card:focus-visible {
+.tavern-sched-open:focus-visible {
   outline: 2px solid var(--tavern-lantern);
-  outline-offset: 1px;
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.tavern-sched-side {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  flex-shrink: 0;
 }
 
 .tavern-sched.is-detail {

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -3524,6 +3524,62 @@
   color: var(--tavern-mute);
 }
 
+.tavern-sched-section {
+  margin-bottom: 14px;
+}
+
+.tavern-sched-label {
+  display: block;
+  margin: 0 0 6px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--tavern-mute);
+}
+
+.tavern-sched.is-card {
+  display: block;
+  width: 100%;
+  font: inherit;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+}
+
+.tavern-sched.is-card:hover {
+  border-color: var(--tavern-ink);
+}
+
+.tavern-sched.is-card:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: 1px;
+}
+
+.tavern-sched.is-detail {
+  margin-bottom: 12px;
+}
+
+.tavern-sched-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.tavern-sched-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tavern-sched-field .tavern-sched-label {
+  margin: 0;
+}
+
+.tavern-sched-field .tavern-editor {
+  min-height: 140px;
+}
+
 /* ── Apps page v2: logos, detail pane, in-chat connect cards ─────────── */
 
 .connector-card {


### PR DESCRIPTION
## Why

Follows `freestyle-ws/docs/scheduled-tasks-v2-spec.md`. Scheduled tasks were a toggle-only list hidden at Settings → Scheduled; #609 also dropped the Run-now/delete that #598 had added. With the cloud now the single source of truth (freestyle-voice/cloud#167), the tasks should sit where the user already looks and be fully editable.

## What

- **Brain tab** — a *Scheduled* section above the file tree. Card → detail view showing the whole task: name, schedule in the user's words, cron, timezone, On/Off, next/last run, and the full instruction rendered as markdown. **Edit** (all fields), **Run now**, **Delete** (with confirm), **＋ New scheduled task**. When a task is open it takes over the tab body the same way a file view does.
- `lib/scheduled-tasks.ts` — full task shape + `create / update / delete / runNow` against `/api/scheduled/tasks…` (proxied to `/v2/scheduled/…`).
- Settings → Scheduled page and nav row removed; connected-apps copy now says "Manage it in Brain → Scheduled".
- Agent `scheduled_task_*` tool calls invalidate the tasks query, so a task created in chat appears without a refresh.
- Reuses the existing `.tavern-sched*` / editor / file-back styles; ~50 lines of new CSS.

## Depends on

freestyle-voice/cloud#167 — deploy that first (`DELETE /tasks/:id` and `POST /tasks/:id/run` are new). Old desktop builds are unaffected by the cloud change.

## Tests

- `scheduled-tasks.test.ts` (new): cards render schedule + next run, empty state, section sits above the tree on the Brain tab and not in folder views.
- Full electron suite 112/112, typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)