### PR TITLE
chore(brand): retag Freestyle as "The intelligent reminders app"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://discord.gg/Fmgt5yZCDu"><img src="https://img.shields.io/badge/Discord-Join%20Server-5865F2.svg?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
-Freestyle is the AI assistant that lives on your desktop and makes sure you never forget an important thing again. Tell it what matters to you, connect the apps where that stuff lives, and it periodically checks on its own. When something needs you, it taps you on the shoulder: the invoice that is three weeks overdue, the pull request nobody has reviewed, the flight credit that expires Friday. Then it offers to do the next step, and waits for you to say yes.
+Freestyle is the intelligent reminders app. It lives on your desktop: tell it what matters to you, connect the apps where that stuff lives, and it periodically checks on its own. When something needs you, it taps you on the shoulder: the invoice that is three weeks overdue, the pull request nobody has reviewed, the flight credit that expires Friday. Then it offers to do the next step, and waits for you to say yes.
 
 It keeps notes and todos for you, remembers what you tell it, and can draft the reply, book the time, or start the task itself. Anything it wants to send, post, or buy is shown to you first and only happens when you press Allow.
 

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -3,7 +3,7 @@
   "productName": "Freestyle",
   "desktopName": "freestyle.desktop",
   "version": "0.8.5",
-  "description": "Voice-to-text that works everywhere",
+  "description": "The intelligent reminders app",
   "author": "freestyle-voice",
   "homepage": "https://github.com/freestyle-voice/freestyle",
   "main": "./out/main/index.js",

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -567,9 +567,7 @@ function SignInGate(): React.JSX.Element {
             freestyle<span className="tavern-gate-accent">.</span>
           </span>
         </div>
-        <h1 className="tavern-gate-heading">
-          Never forget important things again.
-        </h1>
+        <h1 className="tavern-gate-heading">The intelligent reminders app.</h1>
         <p className="tavern-gate-sub">Sign in to your Freestyle account</p>
         {auth.signingIn ? (
           <>


### PR DESCRIPTION
## Summary
- README opening line now leads with the new tagline: "Freestyle is the intelligent reminders app."
- `apps/electron/package.json` description was stale ("Voice-to-text that works everywhere") → "The intelligent reminders app".
- Panel sign-in gate heading: "Never forget important things again." → "The intelligent reminders app."
- Left Jeb's onboarding lines alone (character voice, not tagline).

Companion changes: cloud repo PR (marketing site SEO tagline/description/OG alt, hero sub, downloads/privacy/blog copy, agent system prompt) and the GitHub repo description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)