### PR TITLE
feat(agent): run every tool without approval; connector tools execute server-side

### DIFF
--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -156,7 +156,7 @@ function ToolChip({
   phase?: ToolPhase;
 }): React.JSX.Element {
   const [open, setOpen] = useState(false);
-  const presentation = toolPresentation(partType, phase);
+  const presentation = toolPresentation(partType, phase, input);
   const running = phase === "running";
   const hasInput =
     input !== undefined &&
@@ -760,7 +760,7 @@ function PanelInner({
         }
         const output =
           tier === "free"
-            ? await executeAgentTool(call, thread.id)
+            ? await executeAgentTool(call)
             : { ok: false, reason: `unknown tool: ${call.toolName}` };
         addToolOutput({
           tool: toolCall.toolName,
@@ -884,9 +884,7 @@ function PanelInner({
       prev.filter((a) => a.toolCallId !== call.toolCallId),
     );
     void (async () => {
-      const output = allowed
-        ? await executeAgentTool(call, thread.id)
-        : DECLINED_OUTPUT;
+      const output = allowed ? await executeAgentTool(call) : DECLINED_OUTPUT;
       addToolOutput({
         tool: call.toolName,
         toolCallId: call.toolCallId,

--- a/apps/electron/src/renderer/src/lib/agent-tools.test.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.test.ts
@@ -4,7 +4,7 @@ vi.mock("@shared/sprite-events", () => ({
   parseSpriteEmotion: vi.fn(),
 }));
 
-import { agentToolTier, bashIsReadOnly } from "./agent-tools";
+import { agentToolTier } from "./agent-tools";
 
 describe("agent tool approval tiers", () => {
   const call = (toolName: string) => ({
@@ -19,23 +19,17 @@ describe("agent tool approval tiers", () => {
     await expect(agentToolTier(call("Grep"))).resolves.toBe("free");
   });
 
-  it("runs only explicitly read-only connected-app tools without asking", async () => {
+  it("runs mutating local tools without asking too", async () => {
+    await expect(agentToolTier(call("Write"))).resolves.toBe("free");
+    await expect(agentToolTier(call("Edit"))).resolves.toBe("free");
     await expect(
-      agentToolTier(
-        call("connector__gmail__ro_474d41494c5f46455443485f454d41494c53"),
-      ),
+      agentToolTier({ ...call("Bash"), input: { command: "rm -rf ./x" } }),
     ).resolves.toBe("free");
-    await expect(
-      agentToolTier(call("connector__gmail__474d41494c5f53454")),
-    ).resolves.toBe("confirmed");
   });
 
-  it("keeps mutating find invocations out of the free tier", () => {
-    expect(bashIsReadOnly("find . -name '*.log'")).toBe(true);
-    expect(bashIsReadOnly("find . -name '*.log' -delete")).toBe(false);
-    expect(bashIsReadOnly("find . -fprint /Users/me/.zshrc")).toBe(false);
-    expect(bashIsReadOnly("find . -exec rm {} +")).toBe(false);
-    expect(bashIsReadOnly("ls -la")).toBe(true);
-    expect(bashIsReadOnly("rm -rf ./x")).toBe(false);
+  it("does not claim connected-app tools, which run on the server", async () => {
+    await expect(
+      agentToolTier(call("connector__gmail__474d41494c5f53454")),
+    ).resolves.toBeNull();
   });
 });

--- a/apps/electron/src/renderer/src/lib/agent-tools.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.ts
@@ -1,10 +1,7 @@
 import { apiFetch } from "@renderer/lib/api";
 import {
-  approveConnectorAction,
   connectorToolActionName,
-  executeConnectorAction,
   isConnectorToolName,
-  isReadOnlyConnectorToolName,
 } from "@renderer/lib/connectors";
 import { parseSpriteEmotion } from "@shared/sprite-events";
 
@@ -16,66 +13,22 @@ export interface AgentToolCall {
   input: unknown;
 }
 
-const BASH_ALLOWLIST = new Set([
-  "ls",
-  "cat",
-  "grep",
-  "find",
-  "head",
-  "tail",
-  "wc",
-  "pwd",
-  "date",
-  "echo",
-  "which",
-  "file",
-  "du",
-]);
-
-const BASH_SAFE_SHAPE = /^[a-zA-Z0-9_./\s"'*=:,+-]+$/;
-
-const BASH_MUTATING_FLAGS: Record<string, RegExp> = {
-  find: /(^|\s)-(delete|exec|execdir|ok|okdir|fprint0?|fprintf|fls)(\s|$)/,
-};
-
-export function bashIsReadOnly(command: string): boolean {
-  if (!BASH_SAFE_SHAPE.test(command)) return false;
-  const first = command.trim().split(/\s+/)[0] ?? "";
-  if (!BASH_ALLOWLIST.has(first)) return false;
-  return !BASH_MUTATING_FLAGS[first]?.test(command);
-}
-
 const str = (input: Record<string, unknown>, key: string): string =>
   typeof input[key] === "string" ? (input[key] as string) : "";
 
 export async function agentToolTier(
   call: AgentToolCall,
 ): Promise<AgentToolTier | null> {
-  const input = (call.input ?? {}) as Record<string, unknown>;
-  void input;
-  if (isConnectorToolName(call.toolName))
-    return isReadOnlyConnectorToolName(call.toolName) ? "free" : "confirmed";
   switch (call.toolName) {
     case "current_time":
     case "emote":
-      return "free";
-    // Cursor/screen/clipboard tools disabled for now — see AGENT_CLIENT_TOOLS.
-    // case "get_context":
-    // case "read_document":
-    // case "get_clipboard":
-    //   return "free";
-    // case "set_clipboard":
-    // case "paste":
-    //   return "confirmed";
     case "Bash":
-      return bashIsReadOnly(str(input, "command")) ? "free" : "confirmed";
     case "Read":
     case "Glob":
     case "Grep":
-      return "free";
     case "Write":
     case "Edit":
-      return "confirmed";
+      return "free";
     default:
       return null;
   }
@@ -85,19 +38,12 @@ export function describeAgentAction(call: AgentToolCall): string {
   const input = (call.input ?? {}) as Record<string, unknown>;
   if (isConnectorToolName(call.toolName)) {
     const action =
-      connectorToolActionName(call.toolName).replace(/_/g, " ").toLowerCase() ||
-      "connected-app action";
+      connectorToolActionName(call.toolName, input)
+        .replace(/_/g, " ")
+        .toLowerCase() || "connected-app action";
     return `Use a connected app to ${action}.`;
   }
   switch (call.toolName) {
-    // Cursor/clipboard tools disabled for now.
-    // case "set_clipboard": {
-    //   const text = str(input, "text");
-    //   const preview = text.length > 120 ? `${text.slice(0, 120)}…` : text;
-    //   return `Put this on your clipboard (${text.length} characters):\n“${preview}”`;
-    // }
-    // case "paste":
-    //   return "Paste the clipboard into the app you're using, at your cursor.";
     case "Bash": {
       const command = str(input, "command");
       const preview =
@@ -136,7 +82,6 @@ async function runOsTool(
 
 export async function executeAgentTool(
   call: AgentToolCall,
-  threadId?: string,
 ): Promise<Record<string, unknown>> {
   const input = (call.input ?? {}) as Record<string, unknown>;
   const badArgs = (expected: string): Record<string, unknown> => ({
@@ -147,20 +92,6 @@ export async function executeAgentTool(
   });
 
   try {
-    if (isConnectorToolName(call.toolName)) {
-      if (!threadId) return { ok: false, reason: "missing-thread" };
-      const approval = await approveConnectorAction({
-        threadId,
-        toolName: call.toolName,
-        input,
-      });
-      return await executeConnectorAction({
-        approvalToken: approval.approvalToken,
-        threadId,
-        toolName: call.toolName,
-        input,
-      });
-    }
     switch (call.toolName) {
       case "current_time": {
         const now = new Date();
@@ -177,27 +108,6 @@ export async function executeAgentTool(
         });
         return { ok: true };
       }
-      // Cursor/screen/clipboard tools disabled for now — restore together
-      // with their AGENT_CLIENT_TOOLS entries and the agent-prompt guidance.
-      // case "get_context":
-      //   return { ...(await window.api.remixGetContext()) };
-      // case "read_document":
-      //   return { ...(await window.api.remixReadDocument()) };
-      // case "get_clipboard":
-      //   return { ...(await window.api.remixGetClipboard()) };
-      // case "set_clipboard":
-      //   if (!str(input, "text")) return badArgs("{ text: string }");
-      //   return {
-      //     ...(await window.api.remixSetClipboard(str(input, "text"))),
-      //   };
-      // case "paste":
-      //   // The theater contract: the sprite travels to the caret and swings;
-      //   // this resolves at the impact frame (or a hard ceiling), so the
-      //   // paste lands on the hit. A missing sprite resolves immediately.
-      //   await window.api
-      //     .spritePerformSync({ name: "paste", toolClass: "deliver" })
-      //     .catch(() => {});
-      //   return { ...(await window.api.remixPasteClipboard()) };
       case "Bash":
         if (!str(input, "command")) return badArgs("{ command: string }");
         return runOsTool("bash", { command: str(input, "command") });

--- a/apps/electron/src/renderer/src/lib/connectors.test.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.test.ts
@@ -7,7 +7,6 @@ vi.mock("@renderer/lib/api", () => ({ apiFetch }));
 import {
   connectorToolActionName,
   isConnectorToolName,
-  isReadOnlyConnectorToolName,
   listConnectorCatalog,
 } from "./connectors";
 import { connectorSearchInfiniteQueryOptions } from "./query";
@@ -15,7 +14,7 @@ import { connectorSearchInfiniteQueryOptions } from "./query";
 describe("connected-app tool approvals", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("requires confirmation before a connector action can execute", async () => {
+  it("recognizes server-named connector tools", async () => {
     expect(
       isConnectorToolName("connector__connection_1__GMAIL_SEND_EMAIL"),
     ).toBe(true);
@@ -23,17 +22,6 @@ describe("connected-app tool approvals", () => {
 
   it("does not mistake malformed tool names for connector actions", async () => {
     expect(isConnectorToolName("connector__broken")).toBe(false);
-  });
-
-  it("identifies only server-marked read-only connector tools", () => {
-    expect(
-      isReadOnlyConnectorToolName(
-        "connector__gmail__ro_474d41494c5f46455443485f454d41494c53",
-      ),
-    ).toBe(true);
-    expect(
-      isReadOnlyConnectorToolName("connector__gmail__474d41494c5f53454"),
-    ).toBe(false);
   });
 
   it("keeps the approval copy readable for collision-safe tool names", () => {
@@ -45,6 +33,20 @@ describe("connected-app tool approvals", () => {
         "connector__gmail__ro_474d41494c5f46455443485f454d41494c53",
       ),
     ).toBe("GMAIL_FETCH_EMAILS");
+  });
+
+  it("prefers the executed tool slug from the input over the executor name", () => {
+    expect(
+      connectorToolActionName("connector__github__ro_524541445f544f4f4c", {
+        tool_slug: "GITHUB_LIST_PULL_REQUESTS",
+        arguments: {},
+      }),
+    ).toBe("GITHUB_LIST_PULL_REQUESTS");
+    expect(
+      connectorToolActionName("connector__github__ro_524541445f544f4f4c", {
+        tool_slug: "not a slug",
+      }),
+    ).toBe("READ_TOOL");
   });
 
   it("requests a bounded connector catalog page using the opaque cursor", async () => {

--- a/apps/electron/src/renderer/src/lib/connectors.ts
+++ b/apps/electron/src/renderer/src/lib/connectors.ts
@@ -79,26 +79,26 @@ export function isConnectorToolName(name: string): boolean {
   return /^connector__[a-zA-Z0-9_-]+__(?:ro_)?[a-zA-Z0-9_]+$/.test(name);
 }
 
-/** A read-only marker is added server-side from Composio's tool metadata. */
-export function isReadOnlyConnectorToolName(name: string): boolean {
-  return /^connector__[a-zA-Z0-9_-]+__ro_[a-zA-Z0-9_]+$/.test(name);
-}
-
-/** Decode the collision-safe Cloud tool suffix for human approval copy. */
-export function connectorToolActionName(toolName: string): string {
+export function connectorToolActionName(
+  toolName: string,
+  input?: unknown,
+): string {
+  const slug =
+    input && typeof input === "object"
+      ? (input as { tool_slug?: unknown }).tool_slug
+      : undefined;
+  if (typeof slug === "string" && /^[A-Z0-9_]+$/.test(slug)) return slug;
   const encoded = (toolName.split("__").at(-1) ?? "").replace(/^ro_/, "");
-  if (/^(?:[0-9a-f]{2})+$/i.test(encoded)) {
-    try {
-      return new TextDecoder().decode(
-        Uint8Array.from(encoded.match(/.{2}/g) ?? [], (byte) =>
-          parseInt(byte, 16),
-        ),
-      );
-    } catch {
-      // Fall through to the opaque name below. The server still validates it.
-    }
+  if (!/^(?:[0-9a-f]{2})+$/i.test(encoded)) return encoded;
+  try {
+    return new TextDecoder().decode(
+      Uint8Array.from(encoded.match(/.{2}/g) ?? [], (byte) =>
+        parseInt(byte, 16),
+      ),
+    );
+  } catch {
+    return encoded;
   }
-  return encoded;
 }
 
 async function responseJson<T>(response: Response): Promise<T> {
@@ -147,7 +147,6 @@ export async function listConnectorConnections(): Promise<
 
 export type SuggestedConnectors = {
   connectors: ConnectorCatalogItem[];
-  /** Section title, e.g. "Recommended for engineers"; role-aware server-side. */
   heading: string;
 };
 
@@ -181,8 +180,6 @@ export async function connectToolkit(toolkit: string): Promise<void> {
     throw new Error("Could not open your browser to connect this app.");
 }
 
-/** API-key apps skip the browser: the key goes straight to the cloud, which
- * verifies it with Composio and returns the now-active connection. */
 export async function connectToolkitWithCredentials(
   toolkit: string,
   credentials: Record<string, string>,
@@ -214,37 +211,4 @@ export async function disconnectToolkit(toolkit: string): Promise<void> {
     ),
   );
   capture("connector_disconnected", { toolkit });
-}
-
-export async function approveConnectorAction(input: {
-  threadId: string;
-  toolName: string;
-  input: Record<string, unknown>;
-}): Promise<{ approvalToken: string }> {
-  return responseJson(
-    await apiFetch("/api/connectors/approve", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(input),
-    }),
-  );
-}
-
-export async function executeConnectorAction(input: {
-  approvalToken: string;
-  threadId: string;
-  toolName: string;
-  input: Record<string, unknown>;
-}): Promise<Record<string, unknown>> {
-  const data = await responseJson<{
-    ok: true;
-    output: Record<string, unknown>;
-  }>(
-    await apiFetch("/api/connectors/execute", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(input),
-    }),
-  );
-  return data.output;
 }

--- a/apps/electron/src/renderer/src/lib/tool-presentation.ts
+++ b/apps/electron/src/renderer/src/lib/tool-presentation.ts
@@ -25,9 +25,12 @@ const TOOL_LABELS: Record<string, string> = {
   "tool-brain_search": "Searched memories",
   "tool-brain_delete": "Forgot a memory",
   "tool-emote": "Changed expression",
+  "tool-connector_search_tools": "Looked up connected-app actions",
+  "tool-suggest_connections": "Suggested apps to connect",
 };
 
 const RUNNING_LABELS: Record<string, string> = {
+  "tool-connector_search_tools": "Looking up connected-app actions",
   "tool-current_time": "Checking the time",
   "tool-web_search": "Searching the web",
   "tool-image_search": "Searching for images",
@@ -93,7 +96,6 @@ function appName(slug: string): string {
   );
 }
 
-/** Toolkit slug for a connected-app tool part, or null for built-in tools. */
 export function connectorToolkitSlug(partType: string): string | null {
   const name = partType.replace(/^tool-/, "");
   if (!isConnectorToolName(name)) return null;
@@ -102,10 +104,10 @@ export function connectorToolkitSlug(partType: string): string | null {
 
 export type ToolPhase = "running" | "done" | "declined" | "failed";
 
-/** The short, user-facing label for an AI SDK tool part. */
 export function toolPresentation(
   partType: string,
   phase: ToolPhase = "done",
+  input?: unknown,
 ): {
   title: string;
   detail: string | undefined;
@@ -113,7 +115,7 @@ export function toolPresentation(
   const name = partType.replace(/^tool-/, "");
   if (isConnectorToolName(name)) {
     const [, toolkitSlug = "connected app"] = name.split("__");
-    const action = words(connectorToolActionName(name)).replace(
+    const action = words(connectorToolActionName(name, input)).replace(
       new RegExp(
         `^${toolkitSlug.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&").replace(/[-_]/g, " ")}\\s*`,
         "i",

--- a/apps/server/src/lib/notifications/store.ts
+++ b/apps/server/src/lib/notifications/store.ts
@@ -118,7 +118,10 @@ export function upsertFromCloud(
        title = excluded.title,
        body = excluded.body,
        payload = excluded.payload,
-       expires_at = excluded.expires_at`,
+       expires_at = excluded.expires_at,
+       seen_at = CASE WHEN excluded.created_at > notifications.created_at THEN NULL ELSE notifications.seen_at END,
+       dismissed_at = CASE WHEN excluded.created_at > notifications.created_at THEN NULL ELSE notifications.dismissed_at END,
+       created_at = MAX(excluded.created_at, notifications.created_at)`,
   );
 
   db.exec("BEGIN");

--- a/apps/server/tests/notification-store.test.ts
+++ b/apps/server/tests/notification-store.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { getDb } from "../src/lib/db.js";
+import {
+  getNotification,
+  listActive,
+  markSeen,
+  upsertFromCloud,
+} from "../src/lib/notifications/store.js";
+
+const cloud = (id: string, createdAt: number, body: string) => ({
+  id,
+  kind: "thread" as const,
+  title: "Open PRs",
+  body,
+  payload: { threadId: `thread-${createdAt}` },
+  createdAt,
+  expiresAt: createdAt + 60_000,
+});
+
+describe("upsertFromCloud", () => {
+  it("re-pops a notification the cloud re-posted after it was seen and dismissed here", () => {
+    const id = `cloud-${Date.now()}`;
+    const first = Date.now();
+    upsertFromCloud([cloud(id, first, "v1")], "user-1");
+    markSeen([id]);
+    getDb()
+      .prepare("UPDATE notifications SET dismissed_at = ? WHERE id = ?")
+      .run(first + 1, id);
+    expect(listActive().some((n) => n.id === id)).toBe(false);
+
+    upsertFromCloud([cloud(id, first + 5_000, "v2")], "user-1");
+
+    const record = getNotification(id);
+    expect(record).toMatchObject({
+      body: "v2",
+      seenAt: null,
+      createdAt: first + 5_000,
+    });
+    expect(listActive().some((n) => n.id === id)).toBe(true);
+  });
+
+  it("keeps the seen marker when the cloud row is unchanged", () => {
+    const id = `cloud-same-${Date.now()}`;
+    const createdAt = Date.now();
+    upsertFromCloud([cloud(id, createdAt, "v1")], "user-1");
+    markSeen([id]);
+    upsertFromCloud([cloud(id, createdAt, "v1")], "user-1");
+    expect(getNotification(id)?.seenAt).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What
- `agentToolTier` returns `"free"` for every known tool (Bash/Write/Edit included) — no confirmation prompts. The approvals UI in `panel.tsx` is untouched but never populated.
- Connected-app tools now execute on the server (see freestyle-voice/cloud#171), so the client's `approveConnectorAction`/`executeConnectorAction`, the connector branch of `executeAgentTool`, the Bash read-only allowlist, and `isReadOnlyConnectorToolName` are removed.
- `connectorToolActionName(name, input)` prefers `input.tool_slug`, so chips and action copy read "Using GitHub · list pull requests" rather than the generic executor name; labels added for `connector_search_tools`.
- **Notification mirror:** `upsertFromCloud` now clears `seen_at` / `dismissed_at` (and bumps `created_at`) when the cloud row's `created_at` is newer than the local one, so a deduped notification the cloud re-posts pops again natively. Pairs with freestyle-voice/cloud#172, which makes the cloud resurface such rows. Test: `tests/notification-store.test.ts`.
- Comments removed from the touched files.

Pairs with freestyle-voice/cloud#171 — deploy that first; until then connector tools on the old cloud would fall through to `agentToolTier === null` and be reported as unknown tools.

## Verification
- Electron: `tsc -p tsconfig.web.json`, `biome check`, `vitest run src/renderer/src/lib` (17 files / 87 tests) green.
- Local server: `vitest run` (57 files / 412 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
