### PR TITLE
feat(panel): dictate into todos and notes

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -3504,6 +3504,12 @@ ipcMain.on("panel:set-busy", (event, busy: unknown) => {
 // Clicking into the composer after an agent tool yielded key focus: panel
 // windows don't always take key back from a content click on macOS, so the
 // renderer asks for it explicitly.
+// Transitions alone leave a recreated companion stale until the next blur.
+ipcMain.handle("panel:is-focused", () => {
+  const win = panelWindow;
+  return !!win && !win.isDestroyed() && win.isFocused();
+});
+
 ipcMain.on("panel:request-focus", (event) => {
   if (event.sender !== panelWindow?.webContents) return;
   const win = panelWindow;
@@ -3618,10 +3624,19 @@ function createPanelWindow(): void {
   // the panel is focused, so re-check on blur. Agent tool calls blur the
   // panel deliberately mid-turn — panelBusy suppresses those.
   panelWindow.on("blur", () => {
+    sendPanelFocusState(false);
     if (!panelBusy) schedulePanelHide();
   });
+  panelWindow.on("focus", () => sendPanelFocusState(true));
+  panelWindow.on("hide", () => sendPanelFocusState(false));
 
   void panelWindow.loadURL(rendererUrl("panel.html"));
+}
+
+// Pushed rather than polled so the companion can read it synchronously when the
+// hotkey fires, instead of racing an IPC round trip against the session start.
+function sendPanelFocusState(focused: boolean): void {
+  companionWindow?.webContents.send("panel:focus-state", focused);
 }
 
 function cancelPanelHide(): void {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -3519,14 +3519,7 @@ let panelResizing = false;
 const panelRendererMessages = new PanelRendererMessageQueue((message) => {
   const win = panelWindow;
   if (!win || win.isDestroyed()) return;
-  if (
-    message.channel === "panel:dictation" ||
-    message.channel === "panel:open-thread"
-  ) {
-    win.webContents.send(message.channel, message.payload);
-    return;
-  }
-  win.webContents.send(message.channel);
+  win.webContents.send(message.channel, message.payload);
 });
 const PANEL_HIDE_GRACE_MS = 420;
 const PANEL_HOVER_PAD = 24;
@@ -3675,7 +3668,10 @@ function openPanel(
   if (opts.focusComposer) {
     win.show();
     win.focus();
-    panelRendererMessages.send({ channel: "panel:focus-composer" });
+    panelRendererMessages.send({
+      channel: "panel:focus-composer",
+      payload: opts.trigger ?? "other",
+    });
   } else {
     win.showInactive();
   }

--- a/apps/electron/src/main/panel-renderer-message-queue.test.ts
+++ b/apps/electron/src/main/panel-renderer-message-queue.test.ts
@@ -51,6 +51,21 @@ describe("PanelRendererMessageQueue", () => {
     ]);
   });
 
+  it("carries the open trigger through the queue", () => {
+    const delivered: PanelRendererMessage[] = [];
+    const queue = new PanelRendererMessageQueue((message) => {
+      delivered.push(message);
+    });
+
+    queue.send({ channel: "panel:focus-composer", payload: "tray" });
+    queue.send({ channel: "panel:focus-composer", payload: "dictation" });
+    queue.markReady();
+
+    expect(delivered).toEqual([
+      { channel: "panel:focus-composer", payload: "dictation" },
+    ]);
+  });
+
   it("keeps only the latest dictation state while the renderer is unready", () => {
     const delivered: PanelRendererMessage[] = [];
     const queue = new PanelRendererMessageQueue((message) => {

--- a/apps/electron/src/main/panel-renderer-message-queue.ts
+++ b/apps/electron/src/main/panel-renderer-message-queue.ts
@@ -4,7 +4,7 @@ export type PanelDictationEvent = {
 };
 
 export type PanelRendererMessage =
-  | { channel: "panel:focus-composer" }
+  | { channel: "panel:focus-composer"; payload?: string }
   | { channel: "panel:dictation"; payload: PanelDictationEvent }
   | { channel: "panel:open-thread"; payload: string };
 
@@ -16,7 +16,7 @@ export type PanelRendererMessage =
 export class PanelRendererMessageQueue {
   private ready = false;
   private initialNavigation = true;
-  private focusComposerPending = false;
+  private focusComposerPending: PanelRendererMessage | null = null;
   private pendingDictation: PanelRendererMessage | null = null;
   private pendingOpenThread: PanelRendererMessage | null = null;
 
@@ -30,7 +30,7 @@ export class PanelRendererMessageQueue {
       return;
     }
     if (message.channel === "panel:focus-composer") {
-      this.focusComposerPending = true;
+      this.focusComposerPending = message;
       return;
     }
     if (message.channel === "panel:open-thread") {
@@ -45,11 +45,10 @@ export class PanelRendererMessageQueue {
   markReady(): void {
     if (this.ready) return;
     this.ready = true;
-    if (this.focusComposerPending)
-      this.deliver({ channel: "panel:focus-composer" });
+    if (this.focusComposerPending) this.deliver(this.focusComposerPending);
     if (this.pendingDictation) this.deliver(this.pendingDictation);
     if (this.pendingOpenThread) this.deliver(this.pendingOpenThread);
-    this.focusComposerPending = false;
+    this.focusComposerPending = null;
     this.pendingDictation = null;
     this.pendingOpenThread = null;
   }
@@ -69,7 +68,7 @@ export class PanelRendererMessageQueue {
 
   private clear(): void {
     this.ready = false;
-    this.focusComposerPending = false;
+    this.focusComposerPending = null;
     this.pendingDictation = null;
     this.pendingOpenThread = null;
   }

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -68,6 +68,8 @@ declare global {
       panelRequestFocus: () => void;
       panelPointerLeft: () => void;
       panelPointerEntered: () => void;
+      panelIsFocused: () => Promise<boolean>;
+      onPanelFocusState: (callback: (focused: boolean) => void) => () => void;
       onPanelFocusComposer: (
         callback: (trigger?: string) => void,
       ) => () => void;

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -68,7 +68,9 @@ declare global {
       panelRequestFocus: () => void;
       panelPointerLeft: () => void;
       panelPointerEntered: () => void;
-      onPanelFocusComposer: (callback: () => void) => () => void;
+      onPanelFocusComposer: (
+        callback: (trigger?: string) => void,
+      ) => () => void;
       notificationsList: () => Promise<unknown[]>;
       notificationDismiss: (id: string) => void;
       notificationOpen: (id: string) => void;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -137,8 +137,10 @@ const api = {
   panelRequestFocus: (): void => ipcRenderer.send("panel:request-focus"),
   panelPointerLeft: (): void => ipcRenderer.send("panel:pointer-left"),
   panelPointerEntered: (): void => ipcRenderer.send("panel:pointer-entered"),
-  onPanelFocusComposer: (callback: () => void): (() => void) => {
-    const handler = (): void => callback();
+  onPanelFocusComposer: (
+    callback: (trigger?: string) => void,
+  ): (() => void) => {
+    const handler = (_e: unknown, trigger?: string): void => callback(trigger);
     ipcRenderer.on("panel:focus-composer", handler);
     return () => ipcRenderer.removeListener("panel:focus-composer", handler);
   },

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -137,6 +137,13 @@ const api = {
   panelRequestFocus: (): void => ipcRenderer.send("panel:request-focus"),
   panelPointerLeft: (): void => ipcRenderer.send("panel:pointer-left"),
   panelPointerEntered: (): void => ipcRenderer.send("panel:pointer-entered"),
+  panelIsFocused: (): Promise<boolean> =>
+    ipcRenderer.invoke("panel:is-focused"),
+  onPanelFocusState: (callback: (focused: boolean) => void): (() => void) => {
+    const handler = (_e: unknown, focused: boolean): void => callback(focused);
+    ipcRenderer.on("panel:focus-state", handler);
+    return () => ipcRenderer.removeListener("panel:focus-state", handler);
+  },
   onPanelFocusComposer: (
     callback: (trigger?: string) => void,
   ): (() => void) => {

--- a/apps/electron/src/renderer/src/components/companion.tsx
+++ b/apps/electron/src/renderer/src/components/companion.tsx
@@ -2,7 +2,10 @@ import "../overlay.css";
 
 import { Spark, sparkScaleFor } from "@renderer/components/spark";
 import { initApiBase } from "@renderer/lib/api";
-import { DictationController } from "@renderer/lib/dictation";
+import {
+  DictationController,
+  resolveDestination,
+} from "@renderer/lib/dictation";
 import { installGlobalErrorHandlers } from "@renderer/lib/report-error";
 import { SPRITES } from "@renderer/sprites/registry";
 import { SpriteStage } from "@renderer/sprites/stage";
@@ -44,6 +47,9 @@ function useDictation(
       micDeviceId: null,
     };
     let talkSession = false;
+    let panelFocused = false;
+    // Sampled at key-down, since focus can move mid-utterance.
+    let intoPanel = false;
     let errorTimer: ReturnType<typeof setTimeout> | null = null;
 
     const showError = (message: string): void => {
@@ -81,23 +87,34 @@ function useDictation(
           );
         },
         onPartial: (text) => {
-          setBubble({ phase: "recording", partial: text });
-          if (talkSession || prefs.destination === "composer")
-            window.api.panelDictationPartial(text);
+          const toPanel =
+            talkSession || intoPanel || prefs.destination === "composer";
+          // Only intoPanel means the panel is already on screen to preview the
+          // text; click-to-activate opens it on release, so the bubble is the
+          // only preview while the key is held.
+          setBubble({ phase: "recording", partial: intoPanel ? "" : text });
+          if (toPanel) window.api.panelDictationPartial(text);
         },
         onComposerText: (text) => {
           talkSession = false;
+          intoPanel = false;
           window.api.panelOpenForDictation();
           window.api.panelDictationFinal(text);
         },
         onError: (message) => {
           talkSession = false;
+          intoPanel = false;
           showError(message);
           window.api.panelDictationError(message);
         },
       },
       {
-        destination: () => (talkSession ? "composer" : prefs.destination),
+        destination: () =>
+          resolveDestination({
+            talkSession,
+            panelFocused: intoPanel,
+            preference: prefs.destination,
+          }),
         outputMode: () => prefs.outputMode,
         soundEnabled: () => prefs.soundEnabled,
         audioPlaybackMode: () => prefs.audioPlaybackMode,
@@ -115,17 +132,34 @@ function useDictation(
     const offPrefs = window.api.onDictationPrefs((next) => {
       prefs = next;
     });
+    void window.api
+      .panelIsFocused()
+      .then((focused) => {
+        panelFocused = focused;
+      })
+      .catch(() => {});
+
+    const offPanelFocus = window.api.onPanelFocusState((focused) => {
+      panelFocused = focused;
+    });
     const offDown = window.api.onHotkeyDown(() => {
       // Key-repeat on the held key re-fires this; a live session must not be
       // restarted or demoted back to cursor mode mid-recording.
       if (controller.isActive()) return;
       talkSession = false;
+      intoPanel = panelFocused;
       void controller.start();
     });
     const offUp = window.api.onHotkeyUp(() => controller.stop());
     const offCancel = window.api.onDictationCancel(() => {
+      const wasPanelBound =
+        talkSession || intoPanel || prefs.destination === "composer";
       talkSession = false;
+      intoPanel = false;
       controller.cancel();
+      // No final arrives, so a streamed partial would sit stranded in the
+      // field. An empty message rewinds it without showing a notice.
+      if (wasPanelBound) window.api.panelDictationError("");
     });
     const offTalkDown = window.api.onTalkDown(() => {
       // Fn+Control shares Fn with dictation, so the plain-dictation session
@@ -146,6 +180,7 @@ function useDictation(
       offDown?.();
       offUp?.();
       offCancel?.();
+      offPanelFocus?.();
       offTalkDown?.();
       offTalkUp?.();
       controller.destroy();

--- a/apps/electron/src/renderer/src/components/notes-tab.tsx
+++ b/apps/electron/src/renderer/src/components/notes-tab.tsx
@@ -126,9 +126,6 @@ export function NotesTab({
     registerDictation,
     view.kind === "note" ? view.draft : "",
     setNoteText,
-    // NotesTab stays mounted across note navigation, so an utterance in flight
-    // must not carry one note's text into another.
-    { resetKey: view.kind === "note" ? (view.path ?? "new") : "list" },
   );
 
   const closeNote = (): void => {
@@ -152,6 +149,14 @@ export function NotesTab({
             ← Notes
           </button>
           <span className="tavern-head-spacer" />
+          <button
+            type="button"
+            className="tavern-note-save"
+            disabled={!view.draft.trim()}
+            onClick={closeNote}
+          >
+            {view.path ? "Done" : "Create"}
+          </button>
           {view.path ? (
             <button
               type="button"
@@ -180,6 +185,7 @@ export function NotesTab({
         {view.editing || !view.draft.trim() ? (
           <textarea
             className="tavern-editor tavern-note-editor"
+            id="panel-note-editor"
             value={view.draft}
             ref={(el) => el?.focus()}
             placeholder="Start writing or talking — the first line becomes the title."

--- a/apps/electron/src/renderer/src/components/notes-tab.tsx
+++ b/apps/electron/src/renderer/src/components/notes-tab.tsx
@@ -1,11 +1,13 @@
 import { DataSkeleton } from "@renderer/components/data-skeleton";
 import { Markdown } from "@renderer/components/markdown";
+import { useDictationTarget } from "@renderer/hooks/use-dictation-target";
 import {
   deleteBrainFile,
   uniqueBrainPath,
   writeBrainFile,
 } from "@renderer/lib/brain-fs";
 import type { NoteSummary } from "@renderer/lib/brain-views";
+import type { RegisterDictationSink } from "@renderer/lib/dictation-sink";
 import {
   brainFileQueryOptions,
   notesQueryOptions,
@@ -58,7 +60,11 @@ type NoteView =
   | { kind: "list" }
   | { kind: "note"; path: string | null; draft: string; editing: boolean };
 
-export function NotesTab(): React.JSX.Element {
+export function NotesTab({
+  registerDictation,
+}: {
+  registerDictation: RegisterDictationSink;
+}): React.JSX.Element {
   const queryClient = useQueryClient();
   const notesQuery = useQuery(notesQueryOptions());
   const notes: NoteSummary[] = notesQuery.data ?? [];
@@ -101,6 +107,28 @@ export function NotesTab(): React.JSX.Element {
       }
     },
     [persist],
+  );
+
+  // Dictating from the list opens a fresh note; an empty result (a cancelled or
+  // failed utterance) leaves the list alone.
+  const setNoteText = useCallback(
+    (text: string): void => {
+      setView((v) => {
+        if (v.kind === "note") return { ...v, draft: text, editing: true };
+        if (!text) return v;
+        return { kind: "note", path: null, draft: text, editing: true };
+      });
+      scheduleSave();
+    },
+    [scheduleSave],
+  );
+  useDictationTarget(
+    registerDictation,
+    view.kind === "note" ? view.draft : "",
+    setNoteText,
+    // NotesTab stays mounted across note navigation, so an utterance in flight
+    // must not carry one note's text into another.
+    { resetKey: view.kind === "note" ? (view.path ?? "new") : "list" },
   );
 
   const closeNote = (): void => {
@@ -154,7 +182,7 @@ export function NotesTab(): React.JSX.Element {
             className="tavern-editor tavern-note-editor"
             value={view.draft}
             ref={(el) => el?.focus()}
-            placeholder="Start writing — the first line becomes the title."
+            placeholder="Start writing or talking — the first line becomes the title."
             onChange={(e) => {
               setView({ ...view, draft: e.target.value, editing: true });
               scheduleSave();

--- a/apps/electron/src/renderer/src/components/notes-tab.tsx
+++ b/apps/electron/src/renderer/src/components/notes-tab.tsx
@@ -187,6 +187,7 @@ export function NotesTab({
             className="tavern-editor tavern-note-editor"
             id="panel-note-editor"
             value={view.draft}
+            onMouseDown={() => window.api.panelRequestFocus()}
             ref={(el) => el?.focus()}
             placeholder="Start writing or talking — the first line becomes the title."
             onChange={(e) => {

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -26,6 +26,12 @@ import { apiFetch, initApiBase, refreshApiBase } from "@renderer/lib/api";
 import { CloudAuthProvider, useCloudAuth } from "@renderer/lib/auth-context";
 import { resetBrainCache } from "@renderer/lib/brain-fs";
 import { composerAction } from "@renderer/lib/composer-action";
+import {
+  type DictationSinkEvent,
+  type DictationSinkId,
+  nextUtterance,
+  sinkForTab,
+} from "@renderer/lib/dictation-sink";
 import { seedMessageFor } from "@renderer/lib/onboarding-core";
 import {
   connectorConnectionsQueryOptions,
@@ -85,6 +91,17 @@ const TAB_PLACEHOLDER: Record<PanelTab, string> = {
     "Everything Freestyle knows lives here — scheduled tasks, memories, notes, skills, todos.",
   apps: "Connect the apps you live in, and Freestyle can work them for you.",
 };
+
+function registerSinkHandler(
+  handlers: Map<DictationSinkId, (ev: DictationSinkEvent) => void>,
+  id: DictationSinkId,
+  handler: (ev: DictationSinkEvent) => void,
+): () => void {
+  handlers.set(id, handler);
+  return () => {
+    if (handlers.get(id) === handler) handlers.delete(id);
+  };
+}
 
 function ShikiJson({ value }: { value: unknown }): React.JSX.Element {
   const source = toolJson(value);
@@ -764,6 +781,22 @@ function PanelInner({
   const dictationBaseRef = useRef<string | null>(null);
   // Whether the current draft arrived by voice, so message_sent can say so.
   const dictatedRef = useRef(false);
+  const sinkHandlers = useRef(
+    new Map<DictationSinkId, (ev: DictationSinkEvent) => void>(),
+  );
+  const tabRef = useRef(tab);
+  tabRef.current = tab;
+  const lastSinkRef = useRef<DictationSinkId>("chat");
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+
+  // Resolved per event, not per render: a tab's handler registers in a child
+  // effect that runs after this component has rendered. Falling back to chat
+  // covers tabs whose field is unmounted, e.g. behind the settings view.
+  const resolveSink = useCallback((): DictationSinkId => {
+    const id = sinkForTab(tabRef.current);
+    return sinkHandlers.current.has(id) ? id : "chat";
+  }, []);
 
   const transport = useMemo(
     () =>
@@ -990,7 +1023,11 @@ function PanelInner({
       setSettingsOpen(false);
       setTab("chat");
     };
-    const offFocus = window.api.onPanelFocusComposer(() => {
+    const offFocus = window.api.onPanelFocusComposer((trigger) => {
+      // Dictation opens the panel through this channel too; surfacing the
+      // composer there would drag the user off Todos and take the transcript
+      // with it. Tray and hotkey opens still always land on the composer.
+      if (trigger === "dictation" && resolveSink() !== "chat") return;
       showComposer();
       requestAnimationFrame(() =>
         document.getElementById("panel-composer")?.focus(),
@@ -1000,37 +1037,30 @@ function PanelInner({
       setSettingsOpen(true);
     });
     const offDictation = window.api.onPanelDictation((ev) => {
-      if (ev.kind !== "error") showComposer();
-      if (ev.kind === "error") {
-        setNotice(ev.text);
-        const base = dictationBaseRef.current;
+      const sink = resolveSink();
+      // Switching tabs mid-utterance strands the previous sink's snapshot.
+      if (sink !== lastSinkRef.current) {
+        lastSinkRef.current = sink;
         dictationBaseRef.current = null;
-        if (base !== null) setDraft(base);
+      }
+      const handler = sinkHandlers.current.get(sink);
+      if (sink !== "chat" && handler) {
+        setNotice(ev.kind === "error" ? ev.text : null);
+        handler(ev);
         return;
       }
-      setNotice(null);
-      if (ev.kind === "partial" || ev.kind === "final")
-        dictatedRef.current = true;
-      if (ev.kind === "partial") {
-        // Snapshot whatever was typed before this utterance once; every
-        // partial then re-renders base + live text, replacing the previous
-        // partial rather than stacking on it.
-        setDraft((prev) => {
-          if (dictationBaseRef.current === null)
-            dictationBaseRef.current = prev.trim();
-          const base = dictationBaseRef.current;
-          return base ? `${base} ${ev.text}` : ev.text;
-        });
-        return;
-      }
-      // Final REPLACES the partial tail — appending to the draft here would
-      // duplicate the utterance, since the partials already wrote it.
-      const base = dictationBaseRef.current;
-      dictationBaseRef.current = null;
-      setDraft((prev) => {
-        const anchor = base ?? prev.trim();
-        return anchor ? `${anchor} ${ev.text}` : ev.text;
-      });
+
+      // Chat also owns tab surfacing and the dictated-vs-typed analytics flag.
+      if (ev.kind !== "error") showComposer();
+      setNotice(ev.kind === "error" ? ev.text : null);
+      if (ev.kind !== "error") dictatedRef.current = true;
+      const next = nextUtterance(
+        { base: dictationBaseRef.current, text: draftRef.current },
+        ev,
+      );
+      dictationBaseRef.current = next.base;
+      draftRef.current = next.text;
+      setDraft(next.text);
     });
     window.api.panelRendererReady();
     return () => {
@@ -1038,7 +1068,19 @@ function PanelInner({
       offShowSettings?.();
       offDictation?.();
     };
-  }, []);
+  }, [resolveSink]);
+
+  // Only the visible tab is mounted, so at most one handler is live at a time.
+  const registerTodoSink = useCallback(
+    (handler: (ev: DictationSinkEvent) => void): (() => void) =>
+      registerSinkHandler(sinkHandlers.current, "todo", handler),
+    [],
+  );
+  const registerNoteSink = useCallback(
+    (handler: (ev: DictationSinkEvent) => void): (() => void) =>
+      registerSinkHandler(sinkHandlers.current, "note", handler),
+    [],
+  );
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
@@ -1313,9 +1355,12 @@ function PanelInner({
               ) : null}
             </>
           ) : tab === "todos" ? (
-            <TodosTab mascot={SPRITES_INFO[spriteForm].label} />
+            <TodosTab
+              mascot={SPRITES_INFO[spriteForm].label}
+              registerDictation={registerTodoSink}
+            />
           ) : tab === "notes" ? (
-            <NotesTab />
+            <NotesTab registerDictation={registerNoteSink} />
           ) : tab === "brain" ? (
             <BrainFiles
               root=""

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -92,6 +92,13 @@ const TAB_PLACEHOLDER: Record<PanelTab, string> = {
   apps: "Connect the apps you live in, and Freestyle can work them for you.",
 };
 
+/** The field each sink writes into, focused so its own key handling works. */
+const SINK_FIELD_ID: Record<DictationSinkId, string> = {
+  chat: "panel-composer",
+  todo: "panel-todo-add",
+  note: "panel-note-editor",
+};
+
 function registerSinkHandler(
   handlers: Map<DictationSinkId, (ev: DictationSinkEvent) => void>,
   id: DictationSinkId,
@@ -1024,13 +1031,13 @@ function PanelInner({
       setTab("chat");
     };
     const offFocus = window.api.onPanelFocusComposer((trigger) => {
-      // Dictation opens the panel through this channel too; surfacing the
-      // composer there would drag the user off Todos and take the transcript
-      // with it. Tray and hotkey opens still always land on the composer.
-      if (trigger === "dictation" && resolveSink() !== "chat") return;
-      showComposer();
+      // Dictation opens the panel through this channel too, so it focuses the
+      // field it is aimed at rather than dragging the user to the composer.
+      // Every other open — tray, hotkey, sign-in — still lands on chat.
+      const sink = trigger === "dictation" ? resolveSink() : "chat";
+      if (sink === "chat") showComposer();
       requestAnimationFrame(() =>
-        document.getElementById("panel-composer")?.focus(),
+        document.getElementById(SINK_FIELD_ID[sink])?.focus(),
       );
     });
     const offShowSettings = window.api.onPanelShowSettings(() => {

--- a/apps/electron/src/renderer/src/components/todos-tab.tsx
+++ b/apps/electron/src/renderer/src/components/todos-tab.tsx
@@ -168,6 +168,7 @@ export function TodosTab({
       ))}
       <input
         className="tavern-todo-add"
+        id="panel-todo-add"
         value={draft}
         placeholder="Add a to-do, or say it"
         onChange={(e) => setDraft(e.target.value)}

--- a/apps/electron/src/renderer/src/components/todos-tab.tsx
+++ b/apps/electron/src/renderer/src/components/todos-tab.tsx
@@ -171,6 +171,9 @@ export function TodosTab({
         id="panel-todo-add"
         value={draft}
         placeholder="Add a to-do, or say it"
+        // Dictation routes here only while the panel holds key focus, which a
+        // content click does not reliably take on macOS.
+        onMouseDown={() => window.api.panelRequestFocus()}
         onChange={(e) => setDraft(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === "Enter") add();

--- a/apps/electron/src/renderer/src/components/todos-tab.tsx
+++ b/apps/electron/src/renderer/src/components/todos-tab.tsx
@@ -1,6 +1,8 @@
 import { DataSkeleton } from "@renderer/components/data-skeleton";
+import { useDictationTarget } from "@renderer/hooks/use-dictation-target";
 import { capture } from "@renderer/lib/analytics";
 import { readBrainFile, writeBrainFile } from "@renderer/lib/brain-fs";
+import type { RegisterDictationSink } from "@renderer/lib/dictation-sink";
 import { queryKeys } from "@renderer/lib/query";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type React from "react";
@@ -29,7 +31,13 @@ function parseItems(lines: string[]): TodoItem[] {
   return items;
 }
 
-export function TodosTab({ mascot }: { mascot: string }): React.JSX.Element {
+export function TodosTab({
+  mascot,
+  registerDictation,
+}: {
+  mascot: string;
+  registerDictation: RegisterDictationSink;
+}): React.JSX.Element {
   const queryClient = useQueryClient();
   const todosQuery = useQuery({
     queryKey: queryKeys.brain.file(TODOS_PATH),
@@ -41,6 +49,8 @@ export function TodosTab({ mascot }: { mascot: string }): React.JSX.Element {
   const [editing, setEditing] = useState<{ line: number; text: string } | null>(
     null,
   );
+  // Dictation fills the box; Enter commits it, so a misheard item is fixable.
+  useDictationTarget(registerDictation, draft, setDraft, { mode: "replace" });
 
   const save = (next: string[]): void => {
     const nextText = next.join("\n");
@@ -159,7 +169,7 @@ export function TodosTab({ mascot }: { mascot: string }): React.JSX.Element {
       <input
         className="tavern-todo-add"
         value={draft}
-        placeholder="Add a to-do"
+        placeholder="Add a to-do, or say it"
         onChange={(e) => setDraft(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === "Enter") add();

--- a/apps/electron/src/renderer/src/hooks/use-dictation-target.ts
+++ b/apps/electron/src/renderer/src/hooks/use-dictation-target.ts
@@ -10,8 +10,6 @@ import { useEffect, useRef } from "react";
 export interface DictationTargetOptions {
   /** "replace" starts each utterance from empty; a to-do box holds one item. */
   mode?: DictationMode;
-  /** Changing it abandons an in-flight utterance, e.g. on opening a new note. */
-  resetKey?: string;
 }
 
 /** Routes dictated text into a field, tracking the utterance in progress. */
@@ -19,7 +17,7 @@ export function useDictationTarget(
   register: RegisterDictationSink,
   value: string,
   setValue: (text: string) => void,
-  { mode = "append", resetKey = "" }: DictationTargetOptions = {},
+  { mode = "append" }: DictationTargetOptions = {},
 ): void {
   const baseRef = useRef<DictationBase>(null);
   const valueRef = useRef(value);
@@ -28,12 +26,6 @@ export function useDictationTarget(
   setValueRef.current = setValue;
   const modeRef = useRef(mode);
   modeRef.current = mode;
-
-  const resetKeyRef = useRef(resetKey);
-  if (resetKeyRef.current !== resetKey) {
-    resetKeyRef.current = resetKey;
-    baseRef.current = null;
-  }
 
   useEffect(() => {
     const handler = (ev: DictationSinkEvent): void => {

--- a/apps/electron/src/renderer/src/hooks/use-dictation-target.ts
+++ b/apps/electron/src/renderer/src/hooks/use-dictation-target.ts
@@ -1,0 +1,55 @@
+import {
+  type DictationBase,
+  type DictationMode,
+  type DictationSinkEvent,
+  nextUtterance,
+  type RegisterDictationSink,
+} from "@renderer/lib/dictation-sink";
+import { useEffect, useRef } from "react";
+
+export interface DictationTargetOptions {
+  /** "replace" starts each utterance from empty; a to-do box holds one item. */
+  mode?: DictationMode;
+  /** Changing it abandons an in-flight utterance, e.g. on opening a new note. */
+  resetKey?: string;
+}
+
+/** Routes dictated text into a field, tracking the utterance in progress. */
+export function useDictationTarget(
+  register: RegisterDictationSink,
+  value: string,
+  setValue: (text: string) => void,
+  { mode = "append", resetKey = "" }: DictationTargetOptions = {},
+): void {
+  const baseRef = useRef<DictationBase>(null);
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const setValueRef = useRef(setValue);
+  setValueRef.current = setValue;
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+
+  const resetKeyRef = useRef(resetKey);
+  if (resetKeyRef.current !== resetKey) {
+    resetKeyRef.current = resetKey;
+    baseRef.current = null;
+  }
+
+  useEffect(() => {
+    const handler = (ev: DictationSinkEvent): void => {
+      const next = nextUtterance(
+        { base: baseRef.current, text: valueRef.current },
+        ev,
+        modeRef.current,
+      );
+      baseRef.current = next.base;
+      valueRef.current = next.text;
+      setValueRef.current(next.text);
+    };
+    const unregister = register(handler);
+    return () => {
+      baseRef.current = null;
+      unregister();
+    };
+  }, [register]);
+}

--- a/apps/electron/src/renderer/src/lib/dictation-sink.test.ts
+++ b/apps/electron/src/renderer/src/lib/dictation-sink.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyError,
+  applyFinal,
+  applyPartial,
+  type DictationMode,
+  type DictationSinkEvent,
+  type DictationSinkState,
+  nextUtterance,
+  sinkForTab,
+} from "./dictation-sink";
+
+/** Replays a session the way the IPC stream delivers it. */
+function dictate(
+  start: string,
+  events: DictationSinkEvent[],
+  mode: DictationMode = "append",
+): DictationSinkState {
+  return events.reduce<DictationSinkState>(
+    (state, ev) => nextUtterance(state, ev, mode),
+    { base: null, text: start },
+  );
+}
+
+const say = (text: string): DictationSinkEvent[] => [
+  { kind: "partial", text: text.slice(0, Math.ceil(text.length / 2)) },
+  { kind: "partial", text },
+  { kind: "final", text },
+];
+
+describe("dictation sink reducer", () => {
+  it("snapshots existing text once so partials replace rather than stack", () => {
+    const first = applyPartial("shopping", null, "buy");
+    expect(first).toEqual({ base: "shopping", text: "shopping buy" });
+
+    // The second partial carries the whole utterance again, not a delta.
+    const second = applyPartial(first.text, first.base, "buy milk");
+    expect(second).toEqual({ base: "shopping", text: "shopping buy milk" });
+  });
+
+  it("starts from empty when the field was blank", () => {
+    const partial = applyPartial("", null, "call the bank");
+    expect(partial).toEqual({ base: "", text: "call the bank" });
+  });
+
+  it("replaces the partial tail on final instead of appending it", () => {
+    const partial = applyPartial("", null, "pick up dry");
+    const final = applyFinal(
+      partial.text,
+      partial.base,
+      "pick up dry cleaning",
+    );
+    expect(final).toEqual({ base: null, text: "pick up dry cleaning" });
+  });
+
+  it("appends to typed text when a final arrives with no prior partial", () => {
+    const final = applyFinal("remember to", null, "water the plants");
+    expect(final).toEqual({ base: null, text: "remember to water the plants" });
+  });
+
+  it("trims the snapshot so a trailing space doesn't double up", () => {
+    const partial = applyPartial("groceries  ", null, "eggs");
+    expect(partial.text).toBe("groceries eggs");
+  });
+
+  it("rewinds to the snapshot on error", () => {
+    const partial = applyPartial("draft note", null, "half transcribed");
+    const errored = applyError(partial.text, partial.base);
+    expect(errored).toEqual({ base: null, text: "draft note" });
+  });
+
+  it("leaves the field untouched when an error arrives with no utterance", () => {
+    expect(applyError("typed by hand", null)).toEqual({
+      base: null,
+      text: "typed by hand",
+    });
+  });
+
+  it("starts a replace-mode utterance from empty, dropping the stale field text", () => {
+    // Regression: a to-do box that appended left the first thing ever dictated
+    // glued to the front of every later utterance.
+    const stale = "buy milk";
+    const partial = applyPartial(stale, "", "call the bank");
+    expect(partial).toEqual({ base: "", text: "call the bank" });
+
+    const final = applyFinal(partial.text, partial.base, "call the bank today");
+    expect(final).toEqual({ base: null, text: "call the bank today" });
+  });
+
+  it("rewinds rather than clears when a replace-mode utterance errors", () => {
+    // The "" base belongs to partial/final only; applying it to an error would
+    // wipe text the user typed by hand.
+    expect(applyError("call the bank", null)).toEqual({
+      base: null,
+      text: "call the bank",
+    });
+  });
+
+  it("clears the base after a final so the next utterance re-snapshots", () => {
+    const final = applyFinal("", null, "first thought");
+    const next = applyPartial(final.text, final.base, "second");
+    expect(next).toEqual({
+      base: "first thought",
+      text: "first thought second",
+    });
+  });
+});
+
+describe("nextUtterance sessions", () => {
+  it("writes one utterance without duplicating the partial tail", () => {
+    expect(dictate("", say("buy milk")).text).toBe("buy milk");
+  });
+
+  it("appends successive utterances in append mode", () => {
+    const first = dictate("", say("buy milk"));
+    const second = say("call the bank").reduce(
+      (state, ev) => nextUtterance(state, ev),
+      first,
+    );
+    expect(second.text).toBe("buy milk call the bank");
+  });
+
+  it("keeps only the newest utterance in replace mode", () => {
+    // Regression: a to-do box that appended pinned the first thing ever
+    // dictated to the front of every later utterance.
+    const first = dictate("", say("buy milk"), "replace");
+    const second = say("call the bank").reduce(
+      (state, ev) => nextUtterance(state, ev, "replace"),
+      first,
+    );
+    expect(second.text).toBe("call the bank");
+  });
+
+  it("builds on text typed before the utterance in append mode", () => {
+    expect(dictate("remember to", say("water the plants")).text).toBe(
+      "remember to water the plants",
+    );
+  });
+
+  it("discards text typed before the utterance in replace mode", () => {
+    expect(
+      dictate("stale draft", say("water the plants"), "replace").text,
+    ).toBe("water the plants");
+  });
+
+  it("rewinds to the pre-utterance text when a session errors", () => {
+    const state = dictate("remember to", [
+      { kind: "partial", text: "water the" },
+      { kind: "error", text: "Transcription failed" },
+    ]);
+    expect(state).toEqual({ base: null, text: "remember to" });
+  });
+
+  it("leaves hand-typed text alone when an error opens no utterance", () => {
+    // Regression: replace mode substituted an empty base on errors too, which
+    // wiped a to-do the user had typed.
+    const state = dictate(
+      "call the bank",
+      [{ kind: "error", text: "Microphone access is off" }],
+      "replace",
+    );
+    expect(state).toEqual({ base: null, text: "call the bank" });
+  });
+
+  it("recovers after an error so the next utterance still lands", () => {
+    const errored = dictate("", [
+      { kind: "partial", text: "half" },
+      { kind: "error", text: "failed" },
+    ]);
+    const retried = say("buy milk").reduce(
+      (state, ev) => nextUtterance(state, ev),
+      errored,
+    );
+    expect(retried.text).toBe("buy milk");
+  });
+
+  it("handles a final with no preceding partial", () => {
+    expect(dictate("", [{ kind: "final", text: "buy milk" }]).text).toBe(
+      "buy milk",
+    );
+  });
+
+  it("closes the utterance on final so a reset cannot strand a base", () => {
+    expect(dictate("", say("buy milk")).base).toBeNull();
+  });
+});
+
+describe("sinkForTab", () => {
+  it("routes tabs that own a text field to their own sink", () => {
+    expect(sinkForTab("todos")).toBe("todo");
+    expect(sinkForTab("notes")).toBe("note");
+  });
+
+  it("falls back to chat for tabs without one", () => {
+    for (const tab of ["chat", "history", "brain", "apps"] as const)
+      expect(sinkForTab(tab)).toBe("chat");
+  });
+});

--- a/apps/electron/src/renderer/src/lib/dictation-sink.test.ts
+++ b/apps/electron/src/renderer/src/lib/dictation-sink.test.ts
@@ -184,6 +184,24 @@ describe("nextUtterance sessions", () => {
   it("closes the utterance on final so a reset cannot strand a base", () => {
     expect(dictate("", say("buy milk")).base).toBeNull();
   });
+
+  it("writes the utterance once, and repeats it if the base is reset between events", () => {
+    // Why no field clears the base mid-session: a reset makes the next event
+    // re-snapshot, so the utterance stacks on itself. Notes briefly reset on
+    // every view change and produced exactly this — the note is created by the
+    // first partial and autosave then names it, two resets inside one
+    // utterance. Fields track the base for a whole session, as chat does.
+    const events: DictationSinkEvent[] = say("Hi, how are you doing?");
+    expect(dictate("", events).text).toBe("Hi, how are you doing?");
+
+    let state: DictationSinkState = { base: null, text: "" };
+    for (const ev of events) {
+      state = { ...nextUtterance(state, ev), base: null };
+    }
+    expect(state.text).toBe(
+      "Hi, how are Hi, how are you doing? Hi, how are you doing?",
+    );
+  });
 });
 
 describe("sinkForTab", () => {

--- a/apps/electron/src/renderer/src/lib/dictation-sink.ts
+++ b/apps/electron/src/renderer/src/lib/dictation-sink.ts
@@ -1,0 +1,105 @@
+/**
+ * Where dictated text lands inside the panel. The companion owns the recorder;
+ * the panel only receives partial/final text over IPC and decides which field
+ * it belongs to.
+ */
+
+import type { PanelTab } from "@shared/panel";
+
+export type DictationSinkId = "chat" | "todo" | "note";
+
+export type DictationMode = "append" | "replace";
+
+/** Which field the hotkey dictates into. Tabs without one fall back to chat. */
+export function sinkForTab(tab: PanelTab): DictationSinkId {
+  if (tab === "todos") return "todo";
+  if (tab === "notes") return "note";
+  return "chat";
+}
+
+export interface DictationSinkEvent {
+  kind: "partial" | "final" | "error";
+  text: string;
+}
+
+/**
+ * Handed to a tab so its text field can receive the dictation stream. Returns
+ * an unregister for cleanup.
+ */
+export type RegisterDictationSink = (
+  handler: (ev: DictationSinkEvent) => void,
+) => () => void;
+
+/**
+ * Text captured before the current utterance started. `null` means no utterance
+ * is in flight, so the next partial snapshots whatever is already there.
+ */
+export type DictationBase = string | null;
+
+export interface DictationSinkState {
+  base: DictationBase;
+  text: string;
+}
+
+function join(base: string, text: string): string {
+  return base ? `${base} ${text}` : text;
+}
+
+/**
+ * Partials stream repeatedly and each one is the WHOLE utterance so far, not a
+ * delta. Snapshot the pre-existing text once, then render base + live text so
+ * each partial replaces its predecessor rather than stacking on it.
+ */
+export function applyPartial(
+  prev: string,
+  base: DictationBase,
+  text: string,
+): DictationSinkState {
+  const anchor = base === null ? prev.trim() : base;
+  return { base: anchor, text: join(anchor, text) };
+}
+
+/**
+ * The final REPLACES the partial tail — appending here would duplicate the
+ * utterance, since the partials already wrote it. Falls back to the current
+ * text when no partial ever arrived (short utterances can skip straight to a
+ * final).
+ */
+export function applyFinal(
+  prev: string,
+  base: DictationBase,
+  text: string,
+): DictationSinkState {
+  const anchor = base ?? prev.trim();
+  return { base: null, text: join(anchor, text) };
+}
+
+/**
+ * An errored utterance rewinds to the snapshot so a failed attempt doesn't
+ * strand a half-transcribed partial in the field.
+ */
+export function applyError(
+  prev: string,
+  base: DictationBase,
+): DictationSinkState {
+  return { base: null, text: base === null ? prev : base };
+}
+
+/**
+ * Advances a field's utterance state by one event. Replace mode drops the
+ * field's contents when an utterance opens; an error opens nothing, it rewinds
+ * whatever was in flight.
+ */
+export function nextUtterance(
+  state: DictationSinkState,
+  ev: DictationSinkEvent,
+  mode: DictationMode = "append",
+): DictationSinkState {
+  const base =
+    state.base === null && mode === "replace" && ev.kind !== "error"
+      ? ""
+      : state.base;
+  if (ev.kind === "partial") return applyPartial(state.text, base, ev.text);
+  if (ev.kind === "final") return applyFinal(state.text, base, ev.text);
+  return applyError(state.text, base);
+}

--- a/apps/electron/src/renderer/src/lib/dictation.test.ts
+++ b/apps/electron/src/renderer/src/lib/dictation.test.ts
@@ -81,7 +81,49 @@ vi.mock("@renderer/lib/streamer", () => ({
 
 const { apiFetch, recorder, streamer, state } = mocks;
 
-import { DictationController } from "./dictation";
+import { DictationController, resolveDestination } from "./dictation";
+
+describe("resolveDestination", () => {
+  it("pastes behind the app when the panel does not have focus", () => {
+    expect(
+      resolveDestination({
+        talkSession: false,
+        panelFocused: false,
+        preference: "cursor",
+      }),
+    ).toBe("cursor");
+  });
+
+  it("writes into the panel when plain dictation starts on a focused panel", () => {
+    expect(
+      resolveDestination({
+        talkSession: false,
+        panelFocused: true,
+        preference: "cursor",
+      }),
+    ).toBe("composer");
+  });
+
+  it("keeps click-to-activate targeting the panel regardless of focus", () => {
+    expect(
+      resolveDestination({
+        talkSession: true,
+        panelFocused: false,
+        preference: "cursor",
+      }),
+    ).toBe("composer");
+  });
+
+  it("honours a composer preference when nothing else applies", () => {
+    expect(
+      resolveDestination({
+        talkSession: false,
+        panelFocused: false,
+        preference: "composer",
+      }),
+    ).toBe("composer");
+  });
+});
 
 function makeController() {
   const phases: string[] = [];

--- a/apps/electron/src/renderer/src/lib/dictation.ts
+++ b/apps/electron/src/renderer/src/lib/dictation.ts
@@ -13,6 +13,19 @@ import { Streamer } from "@renderer/lib/streamer";
 export type DictationPhase = "idle" | "recording" | "transcribing";
 export type DictationDestination = "cursor" | "composer";
 
+/**
+ * Click-to-activate always targets the panel. Plain dictation pastes where the
+ * user was working, unless the panel itself holds focus.
+ */
+export function resolveDestination(opts: {
+  talkSession: boolean;
+  panelFocused: boolean;
+  preference: DictationDestination;
+}): DictationDestination {
+  if (opts.talkSession || opts.panelFocused) return "composer";
+  return opts.preference;
+}
+
 export interface DictationCallbacks {
   onPhase: (phase: DictationPhase) => void;
   onPartial: (text: string) => void;

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1065,6 +1065,21 @@
   cursor: pointer;
 }
 
+.tavern-note-save {
+  font: inherit;
+  font-size: 12px;
+  color: var(--tavern-ink);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.tavern-note-save:disabled {
+  color: var(--tavern-mute);
+  cursor: default;
+}
+
 .tavern-approve {
   align-self: stretch;
   border: 2px solid var(--tavern-ink);


### PR DESCRIPTION
## What

Dictation had a single destination inside the panel — the chat composer. Speaking while on the Todos or Notes tab pulled you back to Chat and took the transcript with it, so the only way to add a to-do by voice was to dictate into chat and retype it.

The visible tab now decides where dictated text lands:

| Tab | Lands in | Successive utterances |
|---|---|---|
| Chat | composer | append (unchanged) |
| Todos | the add-to-do box | replace |
| Notes | the open note, or a fresh one from the list | append |

The hotkey behaves exactly as it does today — hold to talk, release to commit. Only the target changes. Dictated to-dos fill the box rather than committing outright, so a misheard item is fixable before it lands in the list.

## Why these details

- **The state machine moved out of `panel.tsx` into `lib/dictation-sink.ts`.** Partials carry the whole utterance rather than a delta, and a final replaces the partial tail instead of appending to it. That bookkeeping was inline and untested; getting it wrong duplicates the user's words. It is now pure and covered by unit tests, including replayed multi-utterance sessions.
- **Routing keys off the registered handler, not the tab alone.** With Settings open on Todos the tab is still `todos` but its field is unmounted, so routing falls back to chat rather than dropping the transcript.
- **The panel open trigger is carried through to the renderer.** Dictation opens the panel over the same `panel:focus-composer` channel as the tray and the summon hotkey. Without the trigger, suppressing that channel to protect a to-do would also stop tray and hotkey opens from surfacing the composer.
- **To-do dictation replaces rather than appends.** Appending is right for a note or a chat message that grows as you keep talking, but a to-do box holds one item — appending glued every utterance onto the first thing ever said into it.

## Testing

- 18 unit tests for the sink state machine: partial/final ordering, append vs replace, error rewind, recovery after an error, final with no preceding partial, and tab-to-sink mapping.
- Verified the tests fail when the fixes are reverted, rather than assuming coverage: reintroducing the append bug reproduces `'buy milk call the bank'`, and reintroducing the error-path bug wipes a hand-typed to-do to `''`.
- Full suite green on this base: 136 electron tests, 412 server tests, both electron typechecks, `biome check` clean across the repo.

Not yet exercised by hand in a running app — worth a manual pass on the Todos and Notes tabs.

## Behavior change worth flagging

A dictation-driven panel open no longer forces the Chat tab. Tray, summon-hotkey, and sign-in opens are unaffected and still surface the composer.