### PR TITLE
fix(notifications): bubbles stay until opened or dismissed

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -3168,15 +3168,10 @@ ipcMain.on("sprite:event", (event, ev: unknown) => {
 });
 
 const NOTIFICATION_FALLBACK_POLL_MS = 120_000;
-/** How long an unread bubble sits open before it collapses to the
- *  companion's suggestion glow. It stays unread either way. */
-const NOTIFICATION_COLLAPSE_MS = 30_000;
 let notificationFallbackPollTimer: NodeJS.Timeout | null = null;
-let notificationCollapseTimer: NodeJS.Timeout | null = null;
 let stopNotificationStream: (() => void) | null = null;
-let notificationHovered = false;
+let notificationsShowing = false;
 const notifiedIds = new Set<string>();
-const collapsedIds = new Set<string>();
 
 interface DesktopNotification {
   id: string;
@@ -3222,33 +3217,10 @@ async function postNotification(
   }
 }
 
-function clearCollapseTimer(): void {
-  if (!notificationCollapseTimer) return;
-  clearTimeout(notificationCollapseTimer);
-  notificationCollapseTimer = null;
-}
-
-function scheduleCollapse(ids: string[]): void {
-  clearCollapseTimer();
-  if (ids.length === 0) return;
-  notificationCollapseTimer = setTimeout(() => {
-    notificationCollapseTimer = null;
-    if (notificationHovered) {
-      scheduleCollapse(ids);
-      return;
-    }
-    for (const id of ids) collapsedIds.add(id);
-    hideNotifications();
-    setCompanionState("suggestion");
-  }, NOTIFICATION_COLLAPSE_MS);
-  notificationCollapseTimer.unref();
-}
-
 async function refreshNotifications(): Promise<void> {
   const items = await fetchNotifications();
   if (items.length === 0) {
-    clearCollapseTimer();
-    collapsedIds.clear();
+    notificationsShowing = false;
     hideNotifications();
     notifyRendererChanged();
     if (!panelBusy) setCompanionState("idle");
@@ -3257,18 +3229,12 @@ async function refreshNotifications(): Promise<void> {
 
   notifyRendererChanged();
 
-  // A bubble the user neither opened nor dismissed used to float over their
-  // desktop until the 14-day server TTL. It now folds into the companion's
-  // glow, which keeps the item unread without holding the screen.
-  const live = items.filter((n) => !collapsedIds.has(n.id));
-  if (live.length === 0) {
-    hideNotifications();
-    setCompanionState("suggestion");
-  } else {
-    showNotifications();
-    setCompanionState("suggestion");
-    scheduleCollapse(live.map((n) => n.id));
-  }
+  // A bubble stays on screen until the user opens or dismisses it. There is
+  // deliberately no auto-collapse: a reminder that quietly folds itself away
+  // while the user is at lunch is a reminder that never happened.
+  notificationsShowing = true;
+  showNotifications();
+  setCompanionState("suggestion");
 
   const fresh = items.filter(
     (n) => n.seenAt === null && !notifiedIds.has(n.id),
@@ -3371,10 +3337,6 @@ ipcMain.on("notifications:open", (_event, id: unknown) => {
 ipcMain.on("notifications:set-height", (_event, height: unknown) => {
   if (typeof height !== "number") return;
   setNotificationHeight(height);
-});
-
-ipcMain.on("notifications:hover", (_event, hovering: unknown) => {
-  notificationHovered = hovering === true;
 });
 
 ipcMain.on("agent:turn-finished", (_event, payload: unknown) => {
@@ -3492,7 +3454,7 @@ ipcMain.on("panel:set-busy", (event, busy: unknown) => {
   // Falling out of a run must not clear a pending suggestion glow.
   if (next !== panelBusy) {
     setCompanionState(
-      next ? "working" : collapsedIds.size > 0 ? "suggestion" : "idle",
+      next ? "working" : notificationsShowing ? "suggestion" : "idle",
     );
   }
   panelBusy = next;

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -71,7 +71,6 @@ declare global {
       notificationDismiss: (id: string) => void;
       notificationOpen: (id: string) => void;
       notificationSetHeight: (height: number) => void;
-      notificationSetHovered: (hovering: boolean) => void;
       onNotificationsChanged: (callback: () => void) => () => void;
       agentTurnFinished: (payload: {
         threadId: string;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -147,8 +147,6 @@ const api = {
     ipcRenderer.send("notifications:open", id),
   notificationSetHeight: (height: number): void =>
     ipcRenderer.send("notifications:set-height", height),
-  notificationSetHovered: (hovering: boolean): void =>
-    ipcRenderer.send("notifications:hover", hovering),
   onNotificationsChanged: (callback: () => void): (() => void) => {
     const handler = (): void => callback();
     ipcRenderer.on("notifications:changed", handler);

--- a/apps/electron/src/renderer/src/components/notification.tsx
+++ b/apps/electron/src/renderer/src/components/notification.tsx
@@ -127,10 +127,6 @@ function NotificationStack(): React.JSX.Element | null {
       className="tavern tavern-bub-stack"
       ref={rootRef}
       aria-label="Notifications"
-      onMouseEnter={() => window.api.notificationSetHovered(true)}
-      onMouseLeave={() => window.api.notificationSetHovered(false)}
-      onFocus={() => window.api.notificationSetHovered(true)}
-      onBlur={() => window.api.notificationSetHovered(false)}
     >
       {shown.map((item, index) => (
         <NotificationCard


### PR DESCRIPTION
## Summary
- Removes the 30-second notification auto-collapse (`NOTIFICATION_COLLAPSE_MS`, introduced in #597/#598). Bubbles now stay on screen until the user clicks them or hits ×.
- Removes `collapsedIds`, the collapse timer, and the `notifications:hover` IPC + `notificationSetHovered` preload/renderer wiring — all of it only existed to pause the timer.
- `panel:set-busy` falling out of a run now restores `suggestion` vs `idle` based on whether a bubble is showing.

## Why
Scheduled-task notifications were showing up as Unread in the Notifications tab without the user ever seeing the bubble. The timer ran regardless of whether the user was at the machine, and for character sprites the "suggestion" state is a one-shot `proud` emote — no persistent indicator survives the collapse. So anything that landed while away was effectively lost.

## Testing
- `pnpm run typecheck` (node + web), biome clean
- `vitest` notification-stream + notifications tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)