### PR TITLE
fix(scheduled): Run now polls the cloud run instead of holding the request open

### DIFF
--- a/apps/electron/src/renderer/src/lib/scheduled-tasks.test.ts
+++ b/apps/electron/src/renderer/src/lib/scheduled-tasks.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiFetch = vi.fn();
+vi.mock("@renderer/lib/api", () => ({
+  apiFetch: (...args: unknown[]) => apiFetch(...args),
+}));
+
+const { runScheduledTaskNow } = await import("./scheduled-tasks");
+
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeEach(() => {
+  apiFetch.mockReset();
+});
+
+describe("runScheduledTaskNow", () => {
+  it("starts the run, polls until it succeeds, and returns the thread", async () => {
+    apiFetch
+      .mockResolvedValueOnce(
+        json({ ok: true, runId: "run-1", status: "running" }, 202),
+      )
+      .mockResolvedValueOnce(
+        json({
+          run: {
+            id: "run-1",
+            status: "running",
+            threadId: null,
+            notificationId: null,
+            error: null,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        json({
+          run: {
+            id: "run-1",
+            status: "succeeded",
+            threadId: "thread-1",
+            notificationId: "n-1",
+            error: null,
+          },
+        }),
+      );
+    await expect(
+      runScheduledTaskNow("task-1", { pollIntervalMs: 1 }),
+    ).resolves.toEqual({
+      ok: true,
+      threadId: "thread-1",
+      notificationId: "n-1",
+    });
+    expect(apiFetch).toHaveBeenCalledTimes(3);
+    expect(apiFetch.mock.calls[0][0]).toBe("/api/scheduled/tasks/task-1/run");
+    expect(apiFetch.mock.calls[1][0]).toBe(
+      "/api/scheduled/tasks/task-1/runs/run-1",
+    );
+  });
+
+  it("surfaces the run's error when it fails", async () => {
+    apiFetch
+      .mockResolvedValueOnce(
+        json({ ok: true, runId: "run-1", status: "running" }, 202),
+      )
+      .mockResolvedValueOnce(
+        json({
+          run: {
+            id: "run-1",
+            status: "failed",
+            threadId: null,
+            notificationId: null,
+            error: "boom",
+          },
+        }),
+      );
+    await expect(
+      runScheduledTaskNow("task-1", { pollIntervalMs: 1 }),
+    ).rejects.toThrow("boom");
+  });
+
+  it("still accepts a synchronous response from older servers", async () => {
+    apiFetch.mockResolvedValueOnce(
+      json({ ok: true, threadId: "thread-9", notificationId: null }),
+    );
+    await expect(runScheduledTaskNow("task-1")).resolves.toEqual({
+      ok: true,
+      threadId: "thread-9",
+      notificationId: null,
+    });
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after the timeout instead of polling forever", async () => {
+    apiFetch
+      .mockResolvedValueOnce(
+        json({ ok: true, runId: "run-1", status: "running" }, 202),
+      )
+      .mockImplementation(async () =>
+        json({
+          run: {
+            id: "run-1",
+            status: "running",
+            threadId: null,
+            notificationId: null,
+            error: null,
+          },
+        }),
+      );
+    await expect(
+      runScheduledTaskNow("task-1", { pollIntervalMs: 1, timeoutMs: 10 }),
+    ).rejects.toThrow(/longer than expected/);
+  });
+});

--- a/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
+++ b/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
@@ -32,6 +32,25 @@ export interface ScheduledTaskRunResult {
   notificationId: string | null;
 }
 
+export type ScheduledTaskRunStatus =
+  | "claimed"
+  | "running"
+  | "succeeded"
+  | "failed";
+
+export interface ScheduledTaskRunView {
+  id: string;
+  status: ScheduledTaskRunStatus;
+  threadId: string | null;
+  notificationId: string | null;
+  error: string | null;
+  startedAt: number | null;
+  completedAt: number | null;
+}
+
+const RUN_POLL_INTERVAL_MS = 2_000;
+const RUN_POLL_TIMEOUT_MS = 12 * 60_000;
+
 async function responseJson<T>(response: Response): Promise<T> {
   const payload = (await response.json().catch(() => null)) as
     | T
@@ -86,12 +105,58 @@ export async function deleteScheduledTask(id: string): Promise<void> {
   if (!response.ok) await responseJson(response);
 }
 
+export async function getScheduledTaskRun(
+  taskId: string,
+  runId: string,
+): Promise<ScheduledTaskRunView> {
+  const data = await responseJson<{ run: ScheduledTaskRunView }>(
+    await apiFetch(
+      `/api/scheduled/tasks/${encodeURIComponent(taskId)}/runs/${encodeURIComponent(runId)}`,
+    ),
+  );
+  return data.run;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 export async function runScheduledTaskNow(
   id: string,
+  options: { pollIntervalMs?: number; timeoutMs?: number } = {},
 ): Promise<ScheduledTaskRunResult> {
-  return responseJson<ScheduledTaskRunResult>(
+  const started = await responseJson<{
+    ok: true;
+    runId?: string;
+    status?: string;
+    threadId?: string | null;
+    notificationId?: string | null;
+  }>(
     await apiFetch(`/api/scheduled/tasks/${encodeURIComponent(id)}/run`, {
       method: "POST",
     }),
   );
+  if (!started.runId) {
+    return {
+      ok: true,
+      threadId: started.threadId ?? null,
+      notificationId: started.notificationId ?? null,
+    };
+  }
+  const interval = options.pollIntervalMs ?? RUN_POLL_INTERVAL_MS;
+  const deadline = Date.now() + (options.timeoutMs ?? RUN_POLL_TIMEOUT_MS);
+  while (Date.now() < deadline) {
+    await sleep(interval);
+    const run = await getScheduledTaskRun(id, started.runId);
+    if (run.status === "succeeded") {
+      return {
+        ok: true,
+        threadId: run.threadId,
+        notificationId: run.notificationId,
+      };
+    }
+    if (run.status === "failed") {
+      throw new Error(run.error ?? "Scheduled task failed.");
+    }
+  }
+  throw new Error("That run is taking longer than expected. Check back soon.");
 }


### PR DESCRIPTION
## Why
Companion to freestyle-voice/cloud#178. The cloud's `POST /v2/scheduled/tasks/:id/run` now returns `202 { runId, status: "running" }` immediately and executes under `ctx.waitUntil`. Previously the desktop held that request open for the entire agent run through the local proxy (`signal: c.req.raw.signal`) and Node fetch's default 5-minute `headersTimeout` — any abort cancelled the Worker invocation, leaving runs stuck `running` and an empty "Duke basketball morning brief" thread behind.

## Change
- `runScheduledTaskNow` POSTs, then polls `GET /api/scheduled/tasks/:id/runs/:runId` (new, proxied by the existing `/api/scheduled/*` passthrough) every 2s, up to 12 min. Same contract as before for `scheduled-tasks.tsx`: resolves with `{ ok, threadId, notificationId }` on success, rejects with the run's error on failure.
- Accepts a synchronous `{ ok, threadId }` response from older servers unchanged.
- New `getScheduledTaskRun` helper + types.

## Tests
`scheduled-tasks.test.ts`: success after polling, failure surfaces error, legacy sync response, poll timeout. `tsc` web + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)