### PR TITLE
feat(panel): drag the panel's right edge to resize it, width persists

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -108,6 +108,8 @@ import {
   COMPANION_CLEARANCE,
   PANEL_GAP,
   PANEL_HEIGHT,
+  PANEL_MAX_WIDTH,
+  PANEL_MIN_WIDTH,
   PANEL_WIDTH,
 } from "../shared/panel";
 import {
@@ -3435,6 +3437,33 @@ ipcMain.on("panel:close", (event) => {
 
 ipcMain.on("panel:pointer-left", (event) => {
   if (event.sender !== panelWindow?.webContents) return;
+  if (panelResizing) return;
+  schedulePanelHide();
+});
+
+// Live width while the renderer drags the resize handle. The pointer often
+// leaves the window mid-drag (the window resizes under it), so hides are
+// suppressed until the commit.
+ipcMain.on("panel:resize-width", (event, width: unknown) => {
+  if (event.sender !== panelWindow?.webContents) return;
+  const win = panelWindow;
+  if (!win || win.isDestroyed()) return;
+  if (typeof width !== "number" || !Number.isFinite(width)) return;
+  panelResizing = true;
+  cancelPanelHide();
+  const bounds = win.getBounds();
+  const display = screen.getDisplayMatching(bounds);
+  const next = clampPanelWidth(width, display);
+  if (next !== bounds.width) setPanelBounds(win, { ...bounds, width: next });
+});
+
+ipcMain.on("panel:commit-width", (event) => {
+  if (event.sender !== panelWindow?.webContents) return;
+  panelResizing = false;
+  const win = panelWindow;
+  if (win && !win.isDestroyed()) {
+    writeSettings({ panelWidth: win.getBounds().width });
+  }
   schedulePanelHide();
 });
 
@@ -3475,6 +3504,7 @@ ipcMain.on("panel:request-focus", (event) => {
 let panelWindow: BrowserWindow | null = null;
 let panelHideTimer: NodeJS.Timeout | null = null;
 let panelBusy = false;
+let panelResizing = false;
 const panelRendererMessages = new PanelRendererMessageQueue((message) => {
   const win = panelWindow;
   if (!win || win.isDestroyed()) return;
@@ -3487,33 +3517,60 @@ const panelRendererMessages = new PanelRendererMessageQueue((message) => {
 const PANEL_HIDE_GRACE_MS = 420;
 const PANEL_HOVER_PAD = 24;
 
+function clampPanelWidth(width: number, display: Display): number {
+  const max = Math.min(
+    PANEL_MAX_WIDTH,
+    Math.max(PANEL_MIN_WIDTH, display.workArea.width - 32),
+  );
+  return Math.min(max, Math.max(PANEL_MIN_WIDTH, Math.round(width)));
+}
+
+function storedPanelWidth(): number {
+  const raw = readSettings().panelWidth;
+  return typeof raw === "number" && Number.isFinite(raw)
+    ? Math.round(raw)
+    : PANEL_WIDTH;
+}
+
 function panelPosition(display: Display): {
   x: number;
   y: number;
+  width: number;
   height: number;
 } {
   const { x: waX, y: waY, width, height } = display.workArea;
-  const x = Math.min(waX + 16, waX + Math.max(0, width - PANEL_WIDTH - 16));
+  const panelWidth = clampPanelWidth(storedPanelWidth(), display);
+  const x = Math.min(waX + 16, waX + Math.max(0, width - panelWidth - 16));
   const available = height - COMPANION_CLEARANCE - PANEL_GAP;
   const panelHeight = Math.max(320, Math.min(PANEL_HEIGHT, available));
   const y = Math.max(waY, waY + height - COMPANION_CLEARANCE - panelHeight);
-  return { x, y, height: panelHeight };
+  return { x, y, width: panelWidth, height: panelHeight };
+}
+
+// The panel is created non-resizable, which on some platforms also pins its
+// size against setBounds. Lift the constraint just for the call.
+function setPanelBounds(
+  win: BrowserWindow,
+  bounds: { x: number; y: number; width: number; height: number },
+): void {
+  win.setResizable(true);
+  win.setBounds(bounds);
+  win.setResizable(false);
 }
 
 function positionPanelOnDisplay(display: Display): void {
   const win = panelWindow;
   if (!win || win.isDestroyed()) return;
-  const { x, y, height } = panelPosition(display);
-  win.setBounds({ x, y, width: PANEL_WIDTH, height });
+  setPanelBounds(win, panelPosition(display));
 }
 
 function createPanelWindow(): void {
   if (panelWindow && !panelWindow.isDestroyed()) return;
   const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
-  const { x, y, height } = panelPosition(display);
+  const { x, y, width, height } = panelPosition(display);
 
   panelWindow = new BrowserWindow({
-    width: PANEL_WIDTH,
+    width,
     height,
     x,
     y,
@@ -3540,6 +3597,7 @@ function createPanelWindow(): void {
   panelWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
   panelWindow.on("closed", () => {
     panelWindow = null;
+    panelResizing = false;
     panelRendererMessages.reset();
   });
   panelWindow.webContents.on(
@@ -3633,7 +3691,7 @@ function schedulePanelHide(): void {
     panelHideTimer = null;
     const win = panelWindow;
     if (!win || win.isDestroyed() || !win.isVisible()) return;
-    if (panelBusy) return;
+    if (panelBusy || panelResizing) return;
     if (win.isFocused()) return;
     // A pointer heading for the companion, or hovering the gap between the two,
     // is not a pointer leaving — only hide when it is clear of both.

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -62,6 +62,8 @@ declare global {
       ) => () => void;
       reloadDictationPrefs: () => void;
       panelClose: () => void;
+      panelResizeWidth: (width: number) => void;
+      panelCommitWidth: () => void;
       panelSetBusy: (busy: boolean) => void;
       panelRequestFocus: () => void;
       panelPointerLeft: () => void;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -129,6 +129,9 @@ const api = {
   },
   reloadDictationPrefs: (): void => ipcRenderer.send("dictation:reload-prefs"),
   panelClose: (): void => ipcRenderer.send("panel:close"),
+  panelResizeWidth: (width: number): void =>
+    ipcRenderer.send("panel:resize-width", width),
+  panelCommitWidth: (): void => ipcRenderer.send("panel:commit-width"),
   panelSetBusy: (busy: boolean): void =>
     ipcRenderer.send("panel:set-busy", busy),
   panelRequestFocus: (): void => ipcRenderer.send("panel:request-focus"),

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -46,7 +46,12 @@ import {
 } from "@renderer/lib/tool-presentation";
 import { SpriteBadge } from "@renderer/sprites/badge";
 import { type CompanionForm, DEFAULT_COMPANION_FORM } from "@shared/companion";
-import { PANEL_TABS, type PanelTab } from "@shared/panel";
+import {
+  PANEL_MAX_WIDTH,
+  PANEL_MIN_WIDTH,
+  PANEL_TABS,
+  type PanelTab,
+} from "@shared/panel";
 import { SPRITES_INFO } from "@shared/sprites";
 import {
   QueryClientProvider,
@@ -534,6 +539,57 @@ function PanelTail(): React.JSX.Element {
   );
 }
 
+function PanelResizeHandle(): React.JSX.Element {
+  const drag = useRef<{ startX: number; startWidth: number } | null>(null);
+  const frame = useRef<number | null>(null);
+  const pending = useRef<number | null>(null);
+
+  const widthFor = (e: React.PointerEvent<HTMLDivElement>): number => {
+    const d = drag.current;
+    if (!d) return window.innerWidth;
+    const next = d.startWidth + (e.screenX - d.startX);
+    return Math.min(PANEL_MAX_WIDTH, Math.max(PANEL_MIN_WIDTH, next));
+  };
+
+  const endDrag = (e: React.PointerEvent<HTMLDivElement>): void => {
+    if (!drag.current) return;
+    const width = widthFor(e);
+    drag.current = null;
+    pending.current = null;
+    if (frame.current !== null) {
+      cancelAnimationFrame(frame.current);
+      frame.current = null;
+    }
+    window.api.panelResizeWidth(width);
+    window.api.panelCommitWidth();
+  };
+
+  return (
+    <div
+      className="tavern-resize-handle"
+      onPointerDown={(e) => {
+        if (e.button !== 0) return;
+        e.preventDefault();
+        e.currentTarget.setPointerCapture(e.pointerId);
+        drag.current = { startX: e.screenX, startWidth: window.innerWidth };
+      }}
+      onPointerMove={(e) => {
+        if (!drag.current) return;
+        pending.current = widthFor(e);
+        if (frame.current !== null) return;
+        frame.current = requestAnimationFrame(() => {
+          frame.current = null;
+          if (pending.current === null) return;
+          window.api.panelResizeWidth(pending.current);
+          pending.current = null;
+        });
+      }}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+    />
+  );
+}
+
 function SignInGate(): React.JSX.Element {
   const auth = useCloudAuth();
   return (
@@ -994,6 +1050,7 @@ function PanelInner({
           {auth.loading ? null : <SignInGate />}
         </div>
         <PanelTail />
+        <PanelResizeHandle />
       </div>
     );
   }
@@ -1028,6 +1085,7 @@ function PanelInner({
           ) : null}
         </div>
         <PanelTail />
+        <PanelResizeHandle />
       </div>
     );
   }
@@ -1294,6 +1352,7 @@ function PanelInner({
         ) : null}
       </div>
       <PanelTail />
+      <PanelResizeHandle />
     </div>
   );
 }

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -79,6 +79,36 @@
   background-size: 7px 7px;
 }
 
+.tavern-resize-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 38px;
+  width: 12px;
+  cursor: ew-resize;
+  z-index: 10;
+  touch-action: none;
+}
+
+.tavern-resize-handle::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 44px;
+  border-radius: 2px;
+  background: var(--tavern-ink);
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.tavern-resize-handle:hover::after,
+.tavern-resize-handle:active::after {
+  opacity: 0.45;
+}
+
 /* The manga tail: an SVG swoosh growing out of the bubble's bottom border.
    Its top overlaps the 3px border only; the composer's content is never
    touched. */

--- a/apps/electron/src/shared/panel.ts
+++ b/apps/electron/src/shared/panel.ts
@@ -10,6 +10,8 @@ export type PanelTab = (typeof PANEL_TABS)[number];
 
 // 390px of bubble + 7px of hard shadow.
 export const PANEL_WIDTH = 397;
+export const PANEL_MIN_WIDTH = 340;
+export const PANEL_MAX_WIDTH = 760;
 export const PANEL_HEIGHT = 624;
 export const PANEL_GAP = 10;
 export const COMPANION_CLEARANCE = 84;


### PR DESCRIPTION
## What

The desktop panel is fixed at 397px wide. This adds a drag-to-resize affordance on the panel bubble's right edge: dragging it live-resizes the window, and the chosen width is persisted so it's restored on every open and across restarts.

## How

- **`shared/panel.ts`** — `PANEL_WIDTH` (397) stays as the default; new `PANEL_MIN_WIDTH` (340) and `PANEL_MAX_WIDTH` (760) bound the drag.
- **Renderer** — a new `PanelResizeHandle` strip sits along the bubble's right edge (in all three shell states: signed-out gate, onboarding, main panel). It uses pointer capture, computes the width from `screenX` deltas (stable while the window resizes underneath), rAF-throttles `panel:resize-width` sends, and sends `panel:commit-width` on release. A subtle grip bar appears on hover.
- **Main** — `panel:resize-width` clamps to min/max and the display work area and applies live via `setBounds`; `panel:commit-width` writes `panelWidth` to `settings.json`. `panelPosition` now reads the stored width (clamped per display), so reopening and display changes respect it.

## Gotchas handled

- The pointer routinely leaves the window mid-drag (the window resizes under it), which would fire the pointer-left → auto-hide path. A `panelResizing` flag suppresses hides during the drag and re-arms them on commit; it also resets if the window closes mid-drag.
- The panel window is created `resizable: false`, which on some platforms pins its size against `setBounds` — resizes lift the constraint around the call, same pattern as the pill window.

## Testing

- `npm run typecheck`, `biome check`, and `vitest run` (117 tests) all pass.
- Manual check: hover open the panel, drag the right edge — width follows the cursor and clamps at 340/760 and the screen edge; quit and relaunch — the panel reopens at the saved width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)