### PR TITLE
fix(scheduled): give Run now polling headroom for server-queued runs

### DIFF
--- a/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
+++ b/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
@@ -49,7 +49,9 @@ export interface ScheduledTaskRunView {
 }
 
 const RUN_POLL_INTERVAL_MS = 2_000;
-const RUN_POLL_TIMEOUT_MS = 12 * 60_000;
+// Run now queues the run for the next server tick (up to 5 minutes) before
+// the run itself starts, so the budget covers queue wait plus a long run.
+const RUN_POLL_TIMEOUT_MS = 20 * 60_000;
 
 async function responseJson<T>(response: Response): Promise<T> {
   const payload = (await response.json().catch(() => null)) as


### PR DESCRIPTION
Companion to freestyle-voice/cloud#179, which makes "Run now" queue the run onto the server's next scheduler tick (≤5 minutes) instead of executing inside the HTTP invocation (where Cloudflare killed anything longer than ~30 seconds).

With queueing, the client's poll budget must cover queue wait plus the run itself. The 12-minute timeout was already marginal for a ~8-minute task; this bumps it to 20 minutes. No wire changes — the client already tolerates the `claimed` status while a run waits for pickup.

Safe to merge independently of the server PR (it only widens a timeout), but only useful once #179 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)