### PR TITLE
chore: remove the quiet-hours feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It keeps notes and todos for you, remembers what you tell it, and can draft the 
 
 ### Features
 
-- **Scheduled tasks** — "Every morning, look at my repo and tell me about open issues." "Tell me when a deal goes quiet for five days." Each one becomes a standing job that runs on a timer you set, and you get one desktop notification when something crosses the line, not a feed to scroll. Quiet hours keep it from pinging you at night.
+- **Scheduled tasks** — "Every morning, look at my repo and tell me about open issues." "Tell me when a deal goes quiet for five days." Each one becomes a standing job that runs on a timer you set, and you get one desktop notification when something crosses the line, not a feed to scroll.
 - **Connected apps** — Gmail, Google Calendar, Slack, GitHub, Notion, Google Drive and Sheets out of the box, plus around 1,200 more tools through MCP. Connect an app once and Freestyle can read from it to check the things you asked about, and write to it only through an action you approve.
 - **Todos and notes** — Freestyle tracks what you care about in a Todos list and plain-text notes. It reminds you when you are falling behind, verifies whether something actually got done, and checks items off for you when it sees they are finished.
 - **Brain** — a memory of the things you have told it, kept as plain text you can read, edit, and delete. Say something once and it is there for every future conversation.

--- a/apps/electron/src/renderer/src/components/notifications-history.tsx
+++ b/apps/electron/src/renderer/src/components/notifications-history.tsx
@@ -1,17 +1,10 @@
 import { DataSkeleton } from "@renderer/components/data-skeleton";
 import {
-  DEFAULT_QUIET_HOURS,
   NotificationHistoryError,
   type NotificationHistoryRow,
-  type QuietHours,
-  setQuietHours,
 } from "@renderer/lib/notifications";
-import {
-  notificationHistoryQueryOptions,
-  queryKeys,
-  quietHoursQueryOptions,
-} from "@renderer/lib/query";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { notificationHistoryQueryOptions } from "@renderer/lib/query";
+import { useQuery } from "@tanstack/react-query";
 import type React from "react";
 
 function when(ts: number): string {
@@ -36,86 +29,6 @@ function statusOf(row: NotificationHistoryRow): {
   if (row.expiresAt !== null && row.expiresAt <= Date.now())
     return { label: "Expired", tone: "is-expired" };
   return { label: "Unread", tone: "is-unread" };
-}
-
-const HOUR_OPTIONS = Array.from({ length: 24 }, (_, hour) => ({
-  value: String(hour),
-  label: `${String(hour).padStart(2, "0")}:00`,
-}));
-
-export function QuietHoursSettings(): React.JSX.Element | null {
-  const queryClient = useQueryClient();
-  const quietQuery = useQuery(quietHoursQueryOptions());
-  const quiet = quietQuery.data;
-
-  if (quiet === undefined) return null;
-
-  const save = (next: QuietHours): void => {
-    queryClient.setQueryData(queryKeys.notifications.quietHours, next);
-    void setQuietHours(next).catch(() => {
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.notifications.quietHours,
-      });
-    });
-  };
-
-  return (
-    <>
-      <div className="tavern-set-row is-static">
-        <span className="tavern-set-label">Quiet hours</span>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={quiet !== null}
-          className={`tavern-set-switch${quiet !== null ? " is-on" : ""}`}
-          onClick={() => save(quiet === null ? DEFAULT_QUIET_HOURS : null)}
-        >
-          <span className="tavern-set-knob" />
-        </button>
-      </div>
-      {quiet !== null ? (
-        <>
-          <div className="tavern-set-row is-static">
-            <span className="tavern-set-label">From</span>
-            <select
-              className="tavern-set-select"
-              value={String(quiet.start)}
-              aria-label="Quiet hours start"
-              onChange={(e) =>
-                save({ ...quiet, start: Number(e.target.value) })
-              }
-            >
-              {HOUR_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="tavern-set-row is-static">
-            <span className="tavern-set-label">Until</span>
-            <select
-              className="tavern-set-select"
-              value={String(quiet.end)}
-              aria-label="Quiet hours end"
-              onChange={(e) => save({ ...quiet, end: Number(e.target.value) })}
-            >
-              {HOUR_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
-          </div>
-        </>
-      ) : null}
-      <p className="tavern-set-hint">
-        {quiet === null
-          ? "Freestyle can reach you at any hour."
-          : "Scheduled tasks still run and still write to your history — they just won't interrupt you in this window."}
-      </p>
-    </>
-  );
 }
 
 export function NotificationsHistory({

--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -7,10 +7,7 @@ import {
   normalizeLanguageList,
   resolveLanguageOptions,
 } from "@freestyle-voice/validations";
-import {
-  NotificationsHistory,
-  QuietHoursSettings,
-} from "@renderer/components/notifications-history";
+import { NotificationsHistory } from "@renderer/components/notifications-history";
 import {
   acceleratorsEqual,
   formatAcceleratorKeys,
@@ -1561,7 +1558,6 @@ export function SettingsView({
           <BillingPage />
         ) : page === "notifications" ? (
           <>
-            <QuietHoursSettings />
             <SectionLabel>History</SectionLabel>
             <NotificationsHistory {...(onOpenThread ? { onOpenThread } : {})} />
           </>

--- a/apps/electron/src/renderer/src/lib/notifications.ts
+++ b/apps/electron/src/renderer/src/lib/notifications.ts
@@ -38,29 +38,3 @@ export async function listNotificationHistory(): Promise<
     throw new NotificationHistoryError("unreachable");
   }
 }
-
-export type QuietHours = { start: number; end: number } | null;
-
-export const DEFAULT_QUIET_HOURS: QuietHours = { start: 21, end: 7 };
-
-export async function getQuietHours(): Promise<QuietHours> {
-  try {
-    const response = await apiFetch("/api/notifications/preferences");
-    if (!response.ok) return DEFAULT_QUIET_HOURS;
-    const data = (await response.json()) as { quietHours?: QuietHours };
-    return data.quietHours === undefined
-      ? DEFAULT_QUIET_HOURS
-      : data.quietHours;
-  } catch {
-    return DEFAULT_QUIET_HOURS;
-  }
-}
-
-export async function setQuietHours(quietHours: QuietHours): Promise<void> {
-  const res = await apiFetch("/api/notifications/preferences", {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ quietHours }),
-  });
-  if (!res.ok) throw new Error("Could not save quiet hours.");
-}

--- a/apps/electron/src/renderer/src/lib/query.ts
+++ b/apps/electron/src/renderer/src/lib/query.ts
@@ -9,7 +9,7 @@ import {
   listSuggestedConnectors,
 } from "./connectors";
 import type { AvailableModel } from "./models";
-import { getQuietHours, listNotificationHistory } from "./notifications";
+import { listNotificationHistory } from "./notifications";
 import { listScheduledTasks } from "./scheduled-tasks";
 import {
   getLatestThread,
@@ -99,7 +99,6 @@ export const queryKeys = {
   },
   notifications: {
     history: ["notifications", "history"] as const,
-    quietHours: ["notifications", "quiet-hours"] as const,
   },
   brain: {
     all: ["brain"] as const,
@@ -323,14 +322,6 @@ export function prependThreadToHistory(
       return { ...data, pages: [{ ...first, threads }, ...rest] };
     },
   );
-}
-
-export function quietHoursQueryOptions() {
-  return {
-    queryKey: queryKeys.notifications.quietHours,
-    queryFn: getQuietHours,
-    staleTime: ONE_HOUR,
-  };
 }
 
 export function notificationHistoryQueryOptions() {

--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -731,7 +731,6 @@ export async function unlinkCloudAccount(
  */
 export interface CloudUserProfile {
   timezone?: string;
-  quietHours?: { start: number; end: number } | null;
 }
 
 export async function putCloudUserProfile(
@@ -742,15 +741,6 @@ export async function putCloudUserProfile(
     method: "PUT",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(data),
-    signal: AbortSignal.timeout(PROFILE_REQUEST_TIMEOUT_MS),
-  });
-}
-
-export async function getCloudUserProfile(
-  token: string,
-): Promise<CloudUserProfile> {
-  return cloudJson<CloudUserProfile>("/profile", token, {
-    method: "GET",
     signal: AbortSignal.timeout(PROFILE_REQUEST_TIMEOUT_MS),
   });
 }

--- a/apps/server/src/routes/notifications.ts
+++ b/apps/server/src/routes/notifications.ts
@@ -2,11 +2,7 @@ import { createAppLogger } from "@freestyle-voice/utils";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
-import {
-  freestyleCloudUrl,
-  getCloudUserProfile,
-  putCloudUserProfile,
-} from "../lib/freestyle-cloud.js";
+import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
 import { notificationEvents } from "../lib/notifications/events.js";
 import { drainNotificationOutbox } from "../lib/notifications/outbox.js";
 import * as store from "../lib/notifications/store.js";
@@ -14,8 +10,6 @@ import { notificationTransport } from "../lib/notifications/transport.js";
 import { getSessionToken, invalidateSession } from "../lib/sessions.js";
 
 const log = createAppLogger("notifications");
-
-export const DEFAULT_QUIET_HOURS = { start: 21, end: 7 } as const;
 
 const createSchema = z.object({
   kind: z.enum(["thread", "info"]).default("thread"),
@@ -106,45 +100,9 @@ async function forwardHistory(): Promise<{ status: number; payload: unknown }> {
   }
 }
 
-const quietHoursSchema = z.object({
-  quietHours: z
-    .object({
-      start: z.number().int().min(0).max(23),
-      end: z.number().int().min(0).max(23),
-    })
-    .nullable(),
-});
-
 const notificationsRoute = new Hono()
   .get("/", (c) => c.json({ notifications: store.listActive() }))
   .get("/stream", (c) => notificationStream(c.req.raw))
-  .get("/preferences", async (c) => {
-    const token = getSessionToken();
-    if (!token) return c.json({ quietHours: DEFAULT_QUIET_HOURS });
-    try {
-      const profile = await getCloudUserProfile(token);
-      return c.json({
-        quietHours:
-          profile.quietHours === undefined
-            ? DEFAULT_QUIET_HOURS
-            : profile.quietHours,
-      });
-    } catch {
-      return c.json({ quietHours: DEFAULT_QUIET_HOURS });
-    }
-  })
-  .put("/preferences", zValidator("json", quietHoursSchema), async (c) => {
-    const token = getSessionToken();
-    if (!token)
-      return c.json({ ok: false, reason: "cloud_auth_required" }, 401);
-    try {
-      await putCloudUserProfile(token, c.req.valid("json"));
-      return c.json({ ok: true });
-    } catch (err) {
-      log.error(`Quiet hours update failed: ${err}`);
-      return c.json({ ok: false, reason: "cloud-unreachable" }, 502);
-    }
-  })
   .get("/history", async (c) => {
     const local = store
       .listActive()


### PR DESCRIPTION
Companion to freestyle-voice/cloud#180, which removes quiet hours from the server. This strips the desktop side:

- **Settings UI**: the `QuietHoursSettings` component (toggle + from/until selects) and its render in the Notifications settings page. The page now goes straight to History.
- **Renderer plumbing**: `getQuietHours` / `setQuietHours`, the `QuietHours` type and default, the react-query key and `quietHoursQueryOptions`.
- **Local server**: the `GET/PUT /notifications/preferences` proxy routes and `DEFAULT_QUIET_HOURS`; `getCloudUserProfile` is deleted too since the preferences GET was its only caller (`putCloudUserProfile` stays — timezone sync uses it).
- **README**: drops the "Quiet hours keep it from pinging you at night" sentence.

Order doesn't strictly matter — an old desktop against the new cloud degrades gracefully (the profile PUT just strips the field), and this desktop build never asks about quiet hours at all.

Typecheck clean; server suite 412 tests and electron suite 117 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)