### PR TITLE
fix(scheduled): reliability fixes for run-now, notifications, and thread opening

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -3173,7 +3173,8 @@ const NOTIFICATION_FALLBACK_POLL_MS = 120_000;
 let notificationFallbackPollTimer: NodeJS.Timeout | null = null;
 let stopNotificationStream: (() => void) | null = null;
 let notificationsShowing = false;
-const notifiedIds = new Set<string>();
+const notifiedIds = new Map<string, number>();
+const activeNotifications = new Map<string, Notification>();
 
 interface DesktopNotification {
   id: string;
@@ -3238,15 +3239,29 @@ async function refreshNotifications(): Promise<void> {
   showNotifications();
   setCompanionState("suggestion");
 
+  const live = new Set(items.map((n) => n.id));
+  for (const id of notifiedIds.keys()) {
+    if (!live.has(id)) notifiedIds.delete(id);
+  }
   const fresh = items.filter(
-    (n) => n.seenAt === null && !notifiedIds.has(n.id),
+    (n) => n.seenAt === null && notifiedIds.get(n.id) !== n.createdAt,
   );
   if (fresh.length === 0) return;
+  if (!Notification.isSupported()) return;
   for (const item of fresh) {
-    notifiedIds.add(item.id);
-    if (!Notification.isSupported()) continue;
+    notifiedIds.set(item.id, item.createdAt);
+    activeNotifications.get(item.id)?.close();
     const note = new Notification({ title: item.title, body: item.body });
-    note.on("click", () => void openNotification(item.id));
+    activeNotifications.set(item.id, note);
+    note.on("click", () => {
+      activeNotifications.delete(item.id);
+      void openNotification(item.id);
+    });
+    note.on("close", () => {
+      if (activeNotifications.get(item.id) === note) {
+        activeNotifications.delete(item.id);
+      }
+    });
     note.show();
   }
   // The companion reacts to work that finished while the panel was closed;
@@ -3266,22 +3281,18 @@ async function openNotification(id: string): Promise<void> {
     threadId?: string;
     url?: string;
   } | null;
-  await refreshNotifications();
-  if (result?.threadId) {
-    openPanel({ focusComposer: false, trigger: "notification" });
-    const win = panelWindow;
-    if (!win || win.isDestroyed()) return;
-    const threadId = result.threadId;
-    const send = (): void =>
-      win.webContents.send("panel:open-thread", threadId);
-    if (win.webContents.isLoading()) {
-      win.webContents.once("did-finish-load", send);
-    } else {
-      send();
-    }
+  void refreshNotifications();
+  if (result?.url) {
+    void shell.openExternal(result.url);
     return;
   }
-  if (result?.url) void shell.openExternal(result.url);
+  openPanel({ focusComposer: false, trigger: "notification" });
+  if (result?.threadId) {
+    panelRendererMessages.send({
+      channel: "panel:open-thread",
+      payload: result.threadId,
+    });
+  }
 }
 
 function startNotificationFallbackPoll(): void {
@@ -3508,7 +3519,10 @@ let panelResizing = false;
 const panelRendererMessages = new PanelRendererMessageQueue((message) => {
   const win = panelWindow;
   if (!win || win.isDestroyed()) return;
-  if (message.channel === "panel:dictation") {
+  if (
+    message.channel === "panel:dictation" ||
+    message.channel === "panel:open-thread"
+  ) {
     win.webContents.send(message.channel, message.payload);
     return;
   }

--- a/apps/electron/src/main/panel-renderer-message-queue.ts
+++ b/apps/electron/src/main/panel-renderer-message-queue.ts
@@ -5,7 +5,8 @@ export type PanelDictationEvent = {
 
 export type PanelRendererMessage =
   | { channel: "panel:focus-composer" }
-  | { channel: "panel:dictation"; payload: PanelDictationEvent };
+  | { channel: "panel:dictation"; payload: PanelDictationEvent }
+  | { channel: "panel:open-thread"; payload: string };
 
 /**
  * Holds panel messages until React has registered its IPC listeners. Electron's
@@ -17,6 +18,7 @@ export class PanelRendererMessageQueue {
   private initialNavigation = true;
   private focusComposerPending = false;
   private pendingDictation: PanelRendererMessage | null = null;
+  private pendingOpenThread: PanelRendererMessage | null = null;
 
   constructor(
     private readonly deliver: (message: PanelRendererMessage) => void,
@@ -31,6 +33,10 @@ export class PanelRendererMessageQueue {
       this.focusComposerPending = true;
       return;
     }
+    if (message.channel === "panel:open-thread") {
+      this.pendingOpenThread = message;
+      return;
+    }
     // The final transcript supersedes every prior partial. Retaining only the
     // newest event avoids unbounded buffering if a renderer fails to mount.
     this.pendingDictation = message;
@@ -42,8 +48,10 @@ export class PanelRendererMessageQueue {
     if (this.focusComposerPending)
       this.deliver({ channel: "panel:focus-composer" });
     if (this.pendingDictation) this.deliver(this.pendingDictation);
+    if (this.pendingOpenThread) this.deliver(this.pendingOpenThread);
     this.focusComposerPending = false;
     this.pendingDictation = null;
+    this.pendingOpenThread = null;
   }
 
   handleNavigationStart(): void {
@@ -63,5 +71,6 @@ export class PanelRendererMessageQueue {
     this.ready = false;
     this.focusComposerPending = false;
     this.pendingDictation = null;
+    this.pendingOpenThread = null;
   }
 }

--- a/apps/electron/src/renderer/src/components/brain-files.tsx
+++ b/apps/electron/src/renderer/src/components/brain-files.tsx
@@ -172,10 +172,12 @@ export function BrainFiles({
   root,
   emptyText,
   newLabel,
+  onOpenThread,
 }: {
   root: string;
   emptyText: string;
   newLabel: string;
+  onOpenThread?: (threadId: string) => void;
 }): React.JSX.Element {
   const queryClient = useQueryClient();
   const filesQuery = useQuery({
@@ -188,17 +190,6 @@ export function BrainFiles({
   const [error, setError] = useState<string | null>(null);
   const [scheduledOpen, setScheduledOpen] = useState(false);
   const scheduled = root === "";
-
-  if (filesQuery.isLoading) return <DataSkeleton label="Loading Brain files" />;
-  if (filesQuery.isError)
-    return (
-      <div className="tavern-empty">
-        <p>Couldn&apos;t load Brain files.</p>
-        <button type="button" onClick={() => void filesQuery.refetch()}>
-          Try again
-        </button>
-      </div>
-    );
 
   const openFile = (path: string): void => {
     void readBrainFile(path)
@@ -322,12 +313,31 @@ export function BrainFiles({
   }
 
   if (scheduled && scheduledOpen)
-    return <ScheduledTasks onOpenChange={setScheduledOpen} />;
+    return (
+      <ScheduledTasks
+        onOpenChange={setScheduledOpen}
+        {...(onOpenThread ? { onOpenThread } : {})}
+      />
+    );
 
   return (
     <>
-      {scheduled ? <ScheduledTasks onOpenChange={setScheduledOpen} /> : null}
-      {files.length === 0 ? (
+      {scheduled ? (
+        <ScheduledTasks
+          onOpenChange={setScheduledOpen}
+          {...(onOpenThread ? { onOpenThread } : {})}
+        />
+      ) : null}
+      {filesQuery.isLoading ? (
+        <DataSkeleton label="Loading Brain files" />
+      ) : filesQuery.isError ? (
+        <div className="tavern-empty">
+          <p>Couldn&apos;t load Brain files.</p>
+          <button type="button" onClick={() => void filesQuery.refetch()}>
+            Try again
+          </button>
+        </div>
+      ) : files.length === 0 ? (
         <div className="tavern-empty">{emptyText}</div>
       ) : (
         <div className="tavern-tree">

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -64,7 +64,7 @@ import {
   type UIMessage,
 } from "ai";
 import type React from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 const TAB_LABELS: Record<PanelTab, string> = {
@@ -673,14 +673,21 @@ function PanelRoot(): React.JSX.Element {
   const [thread, setThread] = useState<ThreadState | null>(null);
   const queryClient = useQueryClient();
   const latestQuery = useQuery(latestThreadQueryOptions());
+  const selectionRef = useRef(0);
+
+  const switchThread = useCallback((next: ThreadState) => {
+    selectionRef.current += 1;
+    setThread(next);
+  }, []);
 
   useEffect(() => {
     const off = window.api.onPanelOpenThread((threadId) => {
+      const selection = ++selectionRef.current;
       void invalidateThreads(queryClient);
       void getThread(threadId)
         .catch(() => null)
         .then((picked) => {
-          if (!picked) return;
+          if (!picked || selectionRef.current !== selection) return;
           queryClient.setQueryData(queryKeys.threads.detail(threadId), picked);
           setThread(picked);
         });
@@ -698,12 +705,12 @@ function PanelRoot(): React.JSX.Element {
 
   useEffect(() => {
     if (latestQuery.isPending) return;
-    setThread(latestQuery.data ?? newThread());
+    setThread((current) => current ?? latestQuery.data ?? newThread());
   }, [latestQuery.data, latestQuery.isPending]);
 
   if (!thread) return <div className="tavern tavern-panel" />;
   return (
-    <PanelInner key={thread.id} thread={thread} onSwitchThread={setThread} />
+    <PanelInner key={thread.id} thread={thread} onSwitchThread={switchThread} />
   );
 }
 
@@ -1302,6 +1309,12 @@ function PanelInner({
               root=""
               emptyText={TAB_PLACEHOLDER.brain}
               newLabel="New file"
+              onOpenThread={(threadId) => {
+                setTab("chat");
+                void openThreadById(threadId).then((picked) => {
+                  if (picked) onSwitchThread(picked);
+                });
+              }}
             />
           ) : chatActive ? (
             <OpenerCards

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -779,71 +779,83 @@ function PanelInner({
     [thread.id],
   );
 
-  const { messages, sendMessage, regenerate, stop, status, addToolOutput } =
-    useChat({
-      id: thread.id,
-      messages: thread.messages,
-      transport,
-      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-      onFinish: ({ messages: finished }) => {
-        queryClient.setQueryData(queryKeys.threads.detail(thread.id), {
-          id: thread.id,
-          messages: finished,
+  const {
+    messages,
+    sendMessage,
+    regenerate,
+    stop,
+    status,
+    addToolOutput,
+    setMessages,
+  } = useChat({
+    id: thread.id,
+    messages: thread.messages,
+    transport,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    onFinish: ({ messages: finished }) => {
+      queryClient.setQueryData(queryKeys.threads.detail(thread.id), {
+        id: thread.id,
+        messages: finished,
+      });
+      void invalidateThreads(queryClient);
+      if (finished.length === 0) return;
+      const last = finished[finished.length - 1];
+      if (last?.role !== "assistant") return;
+      if (touchesBrain(last)) {
+        resetBrainCache();
+        void queryClient.invalidateQueries({ queryKey: queryKeys.brain.all });
+      }
+      if (touchesScheduled(last)) {
+        void queryClient.invalidateQueries({
+          queryKey: queryKeys.scheduled.tasks,
         });
-        void invalidateThreads(queryClient);
-        if (finished.length === 0) return;
-        const last = finished[finished.length - 1];
-        if (last?.role !== "assistant") return;
-        if (touchesBrain(last)) {
-          resetBrainCache();
-          void queryClient.invalidateQueries({ queryKey: queryKeys.brain.all });
-        }
-        if (touchesScheduled(last)) {
-          void queryClient.invalidateQueries({
-            queryKey: queryKeys.scheduled.tasks,
-          });
-        }
-        const text = messageText(last);
-        if (!text) return;
-        window.api.agentTurnFinished({
-          threadId: thread.id,
-          excerpt: text.slice(0, 140),
-        });
-      },
-      onToolCall: async ({ toolCall }) => {
-        const call: AgentToolCall = {
-          toolName: toolCall.toolName,
-          toolCallId: toolCall.toolCallId,
-          input: toolCall.input,
-        };
-        const tier = await agentToolTier(call);
-        if (tier === "confirmed") {
-          setApprovals((prev) => [...prev, call]);
-          return;
-        }
-        const output =
-          tier === "free"
-            ? await executeAgentTool(call)
-            : { ok: false, reason: `unknown tool: ${call.toolName}` };
-        addToolOutput({
-          tool: toolCall.toolName,
-          toolCallId: toolCall.toolCallId,
-          output,
-        });
-      },
-      onError: (err) => {
-        const message = typeof err.message === "string" ? err.message : "";
-        setNotice(
-          message.includes("cloud_auth_required") || message.includes("401")
-            ? "Sign in to Freestyle Cloud to chat."
-            : message.includes("thread_too_long")
-              ? "This conversation is too long to continue. Start a new one from the menu."
-              : message && message !== "[object Object]"
-                ? message
-                : "That didn't go through. Try again.",
-        );
-      },
-    });
+      }
+      const text = messageText(last);
+      if (!text) return;
+      window.api.agentTurnFinished({
+        threadId: thread.id,
+        excerpt: text.slice(0, 140),
+      });
+    },
+    onToolCall: async ({ toolCall }) => {
+      const call: AgentToolCall = {
+        toolName: toolCall.toolName,
+        toolCallId: toolCall.toolCallId,
+        input: toolCall.input,
+      };
+      const tier = await agentToolTier(call);
+      if (tier === "confirmed") {
+        setApprovals((prev) => [...prev, call]);
+        return;
+      }
+      const output =
+        tier === "free"
+          ? await executeAgentTool(call)
+          : { ok: false, reason: `unknown tool: ${call.toolName}` };
+      addToolOutput({
+        tool: toolCall.toolName,
+        toolCallId: toolCall.toolCallId,
+        output,
+      });
+    },
+    onError: (err) => {
+      const message = typeof err.message === "string" ? err.message : "";
+      setNotice(
+        message.includes("cloud_auth_required") || message.includes("401")
+          ? "Sign in to Freestyle Cloud to chat."
+          : message.includes("thread_too_long")
+            ? "This conversation is too long to continue. Start a new one from the menu."
+            : message && message !== "[object Object]"
+              ? message
+              : "That didn't go through. Try again.",
+      );
+    },
+  });
+
+  useEffect(() => {
+    if (status === "submitted" || status === "streaming") return;
+    if (thread.messages.length > messages.length) setMessages(thread.messages);
+  }, [thread.messages, messages.length, setMessages, status]);
 
   const startedRef = useRef(thread.messages.length > 0);
   useEffect(() => {

--- a/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
+++ b/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
@@ -3,16 +3,21 @@ import { Markdown } from "@renderer/components/markdown";
 import { capture } from "@renderer/lib/analytics";
 import { queryKeys, scheduledTasksQueryOptions } from "@renderer/lib/query";
 import {
+  clearRunNow,
+  runNowSnapshot,
+  startRunNow,
+  subscribeRunNow,
+} from "@renderer/lib/run-now-store";
+import {
   createScheduledTask,
   deleteScheduledTask,
-  runScheduledTaskNow,
   type ScheduledTaskInput,
   type ScheduledTaskView,
   updateScheduledTask,
 } from "@renderer/lib/scheduled-tasks";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 
 type View =
   | { kind: "list" }
@@ -151,16 +156,22 @@ function TaskForm({
 export function ScheduledTasks({
   mascot = "Freestyle",
   onOpenChange,
+  onOpenThread,
 }: {
   mascot?: string;
   onOpenChange?: (open: boolean) => void;
+  onOpenThread?: (threadId: string) => void;
 }): React.JSX.Element {
   const queryClient = useQueryClient();
   const tasksQuery = useQuery(scheduledTasksQueryOptions());
   const tasks = tasksQuery.data ?? [];
+  const runStates = useSyncExternalStore(
+    subscribeRunNow,
+    runNowSnapshot,
+    runNowSnapshot,
+  );
   const [view, setViewState] = useState<View>({ kind: "list" });
   const [busy, setBusy] = useState<string | null>(null);
-  const [ran, setRan] = useState<string | null>(null);
   const [confirming, setConfirming] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -211,18 +222,57 @@ export function ScheduledTasks({
   };
 
   const runNow = (task: ScheduledTaskView): void => {
-    setBusy(task.id);
-    setRan(null);
     setError(null);
-    capture("scheduled_task_run_now", { task: task.name });
-    void runScheduledTaskNow(task.id)
-      .then(() => {
-        setRan(task.id);
-        void refresh();
-      })
-      .catch(fail("That didn’t run. Try again in a moment."))
-      .finally(() => setBusy(null));
+    startRunNow(queryClient, task);
   };
+
+  const runControls = (task: ScheduledTaskView): React.JSX.Element => {
+    const runState = runStates.get(task.id);
+    const running = runState?.status === "running";
+    return (
+      <>
+        <button
+          type="button"
+          className="tavern-sched-action"
+          aria-label={`Run ${task.name} now`}
+          disabled={running}
+          onClick={() => runNow(task)}
+        >
+          {running
+            ? "Running…"
+            : runState?.status === "ran"
+              ? "Ran ✓"
+              : "Run now"}
+        </button>
+        {runState?.status === "ran" && runState.threadId && onOpenThread ? (
+          <button
+            type="button"
+            className="tavern-sched-action"
+            onClick={() => {
+              const threadId = runState.threadId;
+              clearRunNow(task.id);
+              if (threadId) onOpenThread(threadId);
+            }}
+          >
+            View brief
+          </button>
+        ) : null}
+      </>
+    );
+  };
+
+  const runNotices = (ids: string[]): React.JSX.Element[] =>
+    ids.flatMap((id) => {
+      const runState = runStates.get(id);
+      if (runState?.status !== "error") return [];
+      const task = tasks.find((entry) => entry.id === id);
+      return [
+        <p key={`run-${id}`} className="tavern-notice" role="alert">
+          {task ? `${task.name}: ` : ""}
+          {runState.message}
+        </p>,
+      ];
+    });
 
   const remove = (task: ScheduledTaskView): void => {
     setBusy(task.id);
@@ -260,9 +310,16 @@ export function ScheduledTasks({
     </p>
   ) : null;
 
+  const refreshFailed =
+    tasksQuery.isError && tasksQuery.data ? (
+      <p className="tavern-notice" role="alert">
+        Couldn&apos;t refresh scheduled tasks — showing the last loaded list.
+      </p>
+    ) : null;
+
   if (tasksQuery.isLoading)
     return <DataSkeleton label="Loading scheduled tasks" />;
-  if (tasksQuery.isError) {
+  if (tasksQuery.isError && !tasksQuery.data) {
     return (
       <div className="tavern-empty">
         <p>Couldn&apos;t load scheduled tasks.</p>
@@ -331,6 +388,8 @@ export function ScheduledTasks({
           ← Scheduled
         </button>
         {notice}
+        {refreshFailed}
+        {runNotices([task.id])}
         <div
           className={`tavern-sched is-detail${task.enabled ? "" : " is-off"}`}
         >
@@ -342,7 +401,9 @@ export function ScheduledTasks({
               role="switch"
               aria-checked={task.enabled}
               aria-label={`${task.name} enabled`}
-              disabled={busy === task.id}
+              disabled={
+                busy === task.id || runStates.get(task.id)?.status === "running"
+              }
               onClick={() => toggle(task)}
             >
               {task.enabled ? "On" : "Off"}
@@ -367,18 +428,7 @@ export function ScheduledTasks({
           >
             Edit
           </button>
-          <button
-            type="button"
-            className="tavern-sched-action"
-            disabled={busy === task.id}
-            onClick={() => runNow(task)}
-          >
-            {busy === task.id
-              ? "Running…"
-              : ran === task.id
-                ? "Ran ✓"
-                : "Run now"}
-          </button>
+          {runControls(task)}
           {confirming === task.id ? (
             <>
               <button
@@ -415,6 +465,8 @@ export function ScheduledTasks({
     <section className="tavern-sched-section" aria-label="Scheduled tasks">
       <p className="tavern-sched-label">Scheduled</p>
       {notice}
+      {refreshFailed}
+      {runNotices(tasks.map((t) => t.id))}
       {tasks.length === 0 ? (
         <div className="tavern-empty">
           Nothing scheduled. Ask {mascot} to do something regularly — "check the
@@ -442,24 +494,15 @@ export function ScheduledTasks({
                 role="switch"
                 aria-checked={task.enabled}
                 aria-label={`${task.name} enabled`}
-                disabled={busy === task.id}
+                disabled={
+                  busy === task.id ||
+                  runStates.get(task.id)?.status === "running"
+                }
                 onClick={() => toggle(task)}
               >
                 {task.enabled ? "On" : "Off"}
               </button>
-              <button
-                type="button"
-                className="tavern-sched-action"
-                aria-label={`Run ${task.name} now`}
-                disabled={busy === task.id}
-                onClick={() => runNow(task)}
-              >
-                {busy === task.id
-                  ? "Running…"
-                  : ran === task.id
-                    ? "Ran ✓"
-                    : "Run now"}
-              </button>
+              {runControls(task)}
             </div>
           </div>
         ))

--- a/apps/electron/src/renderer/src/lib/run-now-store.ts
+++ b/apps/electron/src/renderer/src/lib/run-now-store.ts
@@ -1,0 +1,71 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { capture } from "./analytics";
+import { queryKeys } from "./query";
+import { runScheduledTaskNow } from "./scheduled-tasks";
+
+export type RunNowState =
+  | { status: "running"; startedAt: number }
+  | { status: "ran"; threadId: string | null; completedAt: number }
+  | { status: "error"; message: string };
+
+type Listener = () => void;
+
+const states = new Map<string, RunNowState>();
+const listeners = new Set<Listener>();
+let snapshot: ReadonlyMap<string, RunNowState> = new Map();
+
+function emit(): void {
+  snapshot = new Map(states);
+  for (const listener of listeners) listener();
+}
+
+export function subscribeRunNow(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function runNowSnapshot(): ReadonlyMap<string, RunNowState> {
+  return snapshot;
+}
+
+export function clearRunNow(taskId: string): void {
+  if (states.delete(taskId)) emit();
+}
+
+export function startRunNow(
+  queryClient: QueryClient,
+  task: { id: string; name: string },
+): void {
+  if (states.get(task.id)?.status === "running") return;
+  states.set(task.id, { status: "running", startedAt: Date.now() });
+  emit();
+  capture("scheduled_task_run_now", { task: task.name });
+  void runScheduledTaskNow(task.id)
+    .then((result) => {
+      states.set(task.id, {
+        status: "ran",
+        threadId: result.threadId,
+        completedAt: Date.now(),
+      });
+    })
+    .catch((err: unknown) => {
+      states.set(task.id, {
+        status: "error",
+        message:
+          err instanceof Error && err.message
+            ? err.message
+            : "That didn’t run. Try again in a moment.",
+      });
+    })
+    .finally(() => {
+      emit();
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.scheduled.tasks,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.threads.list("scheduled"),
+      });
+    });
+}

--- a/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
+++ b/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
@@ -49,7 +49,9 @@ export interface ScheduledTaskRunView {
 }
 
 const RUN_POLL_INTERVAL_MS = 2_000;
-const RUN_POLL_TIMEOUT_MS = 12 * 60_000;
+// Run now queues the run for the next server tick (up to 5 minutes) before
+// the run itself starts, so the budget covers queue wait plus a long run.
+const RUN_POLL_TIMEOUT_MS = 20 * 60_000;
 
 async function responseJson<T>(response: Response): Promise<T> {
   const payload = (await response.json().catch(() => null)) as

--- a/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
+++ b/apps/electron/src/renderer/src/lib/scheduled-tasks.ts
@@ -49,6 +49,8 @@ export interface ScheduledTaskRunView {
 }
 
 const RUN_POLL_INTERVAL_MS = 2_000;
+const REQUEST_TIMEOUT_MS = 15_000;
+const MAX_CONSECUTIVE_POLL_FAILURES = 5;
 // Run now queues the run for the next server tick (up to 5 minutes) before
 // the run itself starts, so the budget covers queue wait plus a long run.
 const RUN_POLL_TIMEOUT_MS = 20 * 60_000;
@@ -60,19 +62,28 @@ async function responseJson<T>(response: Response): Promise<T> {
     | null;
   if (!response.ok) {
     const error = (payload as { error?: string } | null)?.error;
-    throw new Error(error ?? "Scheduled tasks are unavailable.");
+    if (error) throw new Error(error);
+    if (response.status === 409)
+      throw new Error("That task is already running. Try again in a moment.");
+    throw new Error("Scheduled tasks are unavailable.");
   }
   return payload as T;
 }
 
-const json = (body: unknown): RequestInit => ({
-  headers: { "Content-Type": "application/json" },
-  body: JSON.stringify(body),
+const withTimeout = (init: RequestInit = {}): RequestInit => ({
+  signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  ...init,
 });
+
+const json = (body: unknown): RequestInit =>
+  withTimeout({
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
 
 export async function listScheduledTasks(): Promise<ScheduledTaskView[]> {
   const data = await responseJson<{ tasks: ScheduledTaskView[] }>(
-    await apiFetch("/api/scheduled/tasks"),
+    await apiFetch("/api/scheduled/tasks", withTimeout()),
   );
   return data.tasks.toSorted((a, b) => a.name.localeCompare(b.name));
 }
@@ -102,7 +113,7 @@ export async function updateScheduledTask(
 export async function deleteScheduledTask(id: string): Promise<void> {
   const response = await apiFetch(
     `/api/scheduled/tasks/${encodeURIComponent(id)}`,
-    { method: "DELETE" },
+    withTimeout({ method: "DELETE" }),
   );
   if (!response.ok) await responseJson(response);
 }
@@ -114,6 +125,7 @@ export async function getScheduledTaskRun(
   const data = await responseJson<{ run: ScheduledTaskRunView }>(
     await apiFetch(
       `/api/scheduled/tasks/${encodeURIComponent(taskId)}/runs/${encodeURIComponent(runId)}`,
+      withTimeout(),
     ),
   );
   return data.run;
@@ -133,9 +145,10 @@ export async function runScheduledTaskNow(
     threadId?: string | null;
     notificationId?: string | null;
   }>(
-    await apiFetch(`/api/scheduled/tasks/${encodeURIComponent(id)}/run`, {
-      method: "POST",
-    }),
+    await apiFetch(
+      `/api/scheduled/tasks/${encodeURIComponent(id)}/run`,
+      withTimeout({ method: "POST" }),
+    ),
   );
   if (!started.runId) {
     return {
@@ -146,19 +159,27 @@ export async function runScheduledTaskNow(
   }
   const interval = options.pollIntervalMs ?? RUN_POLL_INTERVAL_MS;
   const deadline = Date.now() + (options.timeoutMs ?? RUN_POLL_TIMEOUT_MS);
+  let failures = 0;
   while (Date.now() < deadline) {
-    await sleep(interval);
-    const run = await getScheduledTaskRun(id, started.runId);
-    if (run.status === "succeeded") {
+    let run: ScheduledTaskRunView | null = null;
+    try {
+      run = await getScheduledTaskRun(id, started.runId);
+      failures = 0;
+    } catch (err) {
+      failures += 1;
+      if (failures >= MAX_CONSECUTIVE_POLL_FAILURES) throw err;
+    }
+    if (run?.status === "succeeded") {
       return {
         ok: true,
         threadId: run.threadId,
         notificationId: run.notificationId,
       };
     }
-    if (run.status === "failed") {
+    if (run?.status === "failed") {
       throw new Error(run.error ?? "Scheduled task failed.");
     }
+    await sleep(interval);
   }
   throw new Error("That run is taking longer than expected. Check back soon.");
 }

--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -464,7 +464,7 @@ export interface CloudNotificationDto {
   kind: "thread" | "info";
   title: string;
   body: string;
-  payload: { messages?: unknown[]; url?: string } | null;
+  payload: { threadId?: string; messages?: unknown[]; url?: string } | null;
   createdAt: number;
   expiresAt: number | null;
 }

--- a/apps/server/src/lib/notifications/store.ts
+++ b/apps/server/src/lib/notifications/store.ts
@@ -195,7 +195,7 @@ function enqueue(id: string, action: NotificationAction): void {
         `INSERT INTO notification_outbox (notification_id, action, next_attempt_at, attempts, last_error)
          VALUES (?, ?, datetime('now'), 0, NULL)
          ON CONFLICT(notification_id) DO UPDATE SET
-           action = excluded.action,
+           action = CASE WHEN notification_outbox.action = 'open' THEN 'open' ELSE excluded.action END,
            next_attempt_at = datetime('now'),
            attempts = 0,
            last_error = NULL`,
@@ -230,8 +230,8 @@ export function open(id: string): OpenResult {
   const record = getNotification(id);
   if (!record) return { ok: false };
 
-  const threadId = record.threadId ?? record.payload?.threadId ?? null;
-  if (threadId && !record.threadId) {
+  const threadId = record.payload?.threadId ?? record.threadId ?? null;
+  if (threadId && record.threadId !== threadId) {
     getDb()
       .prepare("UPDATE notifications SET thread_id = ? WHERE id = ?")
       .run(threadId, id);


### PR DESCRIPTION
Implements the desktop-side fixes from the scheduled-tasks/notifications reliability audit. **Branched on top of #652** (poll-timeout bump), so merging this covers both. Companion to freestyle-voice/cloud#182.

## Wrong-thread fixes
- **Latest-thread effect no longer clobbers explicit navigation** (`panel.tsx`): it now only seeds the initial selection (`setThread((current) => current ?? …)`), and open-thread requests are sequenced with a selection counter so a slow `getThread` can't override a newer click. This was the most likely everyday cause of reminders opening the wrong thread.
- **`panel:open-thread` rides the `PanelRendererMessageQueue`** instead of `did-finish-load`, which the queue's own docs say is not a renderer readiness signal — cold-start clicks no longer get dropped (and no longer fall back to the latest thread).
- **Local store prefers the payload's threadId over the pinned `thread_id`** and re-pins on divergence, so a cloud-side re-point (see the cloud PR) is honored instead of serving the first-ever thread forever.
- **Banner bookkeeping keyed by id + createdAt** instead of a grow-only id set: re-posted notifications banner again; `Notification` objects are retained until click/close (no GC'd click handlers); a click that resolves no threadId still opens the panel instead of silently doing nothing; nothing is marked seen when banners aren't supported.
- **Outbox never downgrades a queued `open` to a `dismiss`**; the cloud DTO type now declares `payload.threadId`.

## Run-now fixes
- **Run state lives in a module store** (`lib/run-now-store.ts`, consumed via `useSyncExternalStore`) instead of component `useState` — tab switches, hotkey summons, and thread switches (which remount the whole tab tree) no longer erase an in-flight run. Completion invalidates the task list *and* the Briefs list; per-task state means two runs can't stomp each other's status.
- **The result is finally surfaced**: a successful run shows a **View brief** button that opens the run's thread (wired `panel → BrainFiles → ScheduledTasks` via `onOpenThread`). Errors render as per-task notices.
- **A failed background refetch no longer blanks the task list** — cached data keeps rendering with a "couldn't refresh" notice; the full error card only appears when there's nothing cached. Brain-*file* load errors no longer hide the Scheduled section.
- **Hardened plumbing**: 15 s timeouts on scheduled API calls (a hung request used to pin "Running…" forever), the poll loop polls before sleeping and tolerates up to five consecutive transient failures, and a bare 409 reads "already running" instead of "unavailable".

## Testing
Component tests updated for the new gating; full electron suite (117) and server suite (412) green; typecheck and biome clean.

**Not merged, not deployed** — for review. Pairs with cloud PR #182 but degrades gracefully in either merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)