### PR TITLE
fix(agent): harden Windows local tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,6 +418,9 @@ jobs:
       - name: Build server
         run: pnpm turbo build --filter=@freestyle-voice/server
 
+      - name: Run focused agent OS tests
+        run: pnpm --filter @freestyle-voice/server exec vitest run tests/agent-os.test.ts
+
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
 

--- a/apps/electron/src/main/agent-files.test.ts
+++ b/apps/electron/src/main/agent-files.test.ts
@@ -24,7 +24,10 @@ describe("agent Downloads saves", () => {
         { filename: "plan.md", content: "\u00a1Hola, Freestyle!" },
         { downloadsDir },
       ),
-    ).resolves.toEqual({ ok: true, filename: "plan.md" });
+    ).resolves.toEqual({
+      ok: true,
+      path: path.join(downloadsDir, "plan.md"),
+    });
 
     expect(readFileSync(path.join(downloadsDir, "plan.md"), "utf8")).toBe(
       "\u00a1Hola, Freestyle!",
@@ -51,7 +54,10 @@ describe("agent Downloads saves", () => {
         { filename: "plan.md", content: "new plan" },
         { downloadsDir },
       ),
-    ).resolves.toEqual({ ok: true, filename: "plan (1).md" });
+    ).resolves.toEqual({
+      ok: true,
+      path: path.join(downloadsDir, "plan (1).md"),
+    });
 
     expect(readFileSync(path.join(downloadsDir, "plan.md"), "utf8")).toBe(
       "existing",
@@ -171,7 +177,10 @@ describe("agent Downloads saves", () => {
         { sender: panel },
         { ...input, grant: granted.grant },
       ),
-    ).resolves.toEqual({ ok: true, filename: "report.txt" });
+    ).resolves.toEqual({
+      ok: true,
+      path: "/safe/downloads/report.txt",
+    });
     await expect(
       handlers.get("agent:save-file")!(
         { sender: panel },

--- a/apps/electron/src/main/agent-files.test.ts
+++ b/apps/electron/src/main/agent-files.test.ts
@@ -1,8 +1,12 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { registerAgentFileIpc, saveAgentDownload } from "./agent-files";
+import {
+  AgentFileSaveGrants,
+  registerAgentFileIpc,
+  saveAgentDownload,
+} from "./agent-files";
 
 let downloadsDir: string | undefined;
 
@@ -38,26 +42,193 @@ describe("agent Downloads saves", () => {
     ).resolves.toEqual({ ok: false, reason: "invalid-filename" });
   });
 
-  it("registers the IPC handler with Electron's Downloads directory", async () => {
-    const handle = vi.fn();
+  it("preserves an existing download by saving the next collision-safe name", async () => {
+    downloadsDir = mkdtempSync(path.join(tmpdir(), "agent-downloads-"));
+    writeFileSync(path.join(downloadsDir, "plan.md"), "existing", "utf8");
+
+    await expect(
+      saveAgentDownload(
+        { filename: "plan.md", content: "new plan" },
+        { downloadsDir },
+      ),
+    ).resolves.toEqual({ ok: true, filename: "plan (1).md" });
+
+    expect(readFileSync(path.join(downloadsDir, "plan.md"), "utf8")).toBe(
+      "existing",
+    );
+    expect(readFileSync(path.join(downloadsDir, "plan (1).md"), "utf8")).toBe(
+      "new plan",
+    );
+  });
+
+  it("requires a main-process grant before saving through IPC", async () => {
+    const handlers = new Map<
+      string,
+      (event: unknown, input: unknown) => Promise<unknown>
+    >();
+    const handle = vi.fn(
+      (
+        channel: string,
+        handler: (event: unknown, input: unknown) => Promise<unknown>,
+      ) => {
+        handlers.set(channel, handler);
+      },
+    );
     const getDownloadsPath = vi.fn(() => "/safe/downloads");
     const writeFile = vi.fn().mockResolvedValue(undefined);
+    const panel = { id: 1 };
 
-    registerAgentFileIpc({ handle }, getDownloadsPath, { writeFile });
+    registerAgentFileIpc({ handle }, getDownloadsPath, {
+      writeFile,
+      isPanelSender: (sender) => sender === panel,
+      confirmSave: vi.fn().mockResolvedValue(true),
+    });
 
-    const handler = handle.mock.calls[0]?.[1] as (
-      event: unknown,
-      input: unknown,
-    ) => Promise<unknown>;
+    const handler = handlers.get("agent:save-file")!;
     await expect(
-      handler({}, { filename: "report.txt", content: "safe" }),
-    ).resolves.toEqual({ ok: true, filename: "report.txt" });
+      handler(
+        { sender: panel },
+        { toolCallId: "call-1", filename: "report.txt", content: "safe" },
+      ),
+    ).resolves.toEqual({ ok: false, reason: "approval-required" });
 
-    expect(getDownloadsPath).toHaveBeenCalledOnce();
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("denies a save request from a renderer other than the approved panel", async () => {
+    const handlers = new Map<
+      string,
+      (event: unknown, input: unknown) => Promise<unknown>
+    >();
+    const handle = vi.fn(
+      (
+        channel: string,
+        handler: (event: unknown, input: unknown) => Promise<unknown>,
+      ) => {
+        handlers.set(channel, handler);
+      },
+    );
+    const writeFile = vi.fn().mockResolvedValue(undefined);
+    const panel = { id: 1 };
+
+    registerAgentFileIpc({ handle }, () => "/safe/downloads", {
+      writeFile,
+      isPanelSender: (sender) => sender === panel,
+      confirmSave: vi.fn().mockResolvedValue(true),
+    });
+
+    await expect(
+      handlers.get("agent:save-file")!(
+        { sender: { id: 2 } },
+        {
+          toolCallId: "call-1",
+          filename: "report.txt",
+          content: "safe",
+          grant: "forged",
+        },
+      ),
+    ).resolves.toEqual({ ok: false, reason: "approval-denied" });
+
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("consumes each approved grant exactly once", async () => {
+    const handlers = new Map<
+      string,
+      (event: unknown, input: unknown) => Promise<unknown>
+    >();
+    const handle = vi.fn(
+      (
+        channel: string,
+        handler: (event: unknown, input: unknown) => Promise<unknown>,
+      ) => {
+        handlers.set(channel, handler);
+      },
+    );
+    const writeFile = vi.fn().mockResolvedValue(undefined);
+    const panel = { id: 1 };
+
+    registerAgentFileIpc({ handle }, () => "/safe/downloads", {
+      writeFile,
+      isPanelSender: (sender) => sender === panel,
+      confirmSave: vi.fn().mockResolvedValue(true),
+    });
+
+    const input = {
+      toolCallId: "call-1",
+      filename: "report.txt",
+      content: "safe",
+    };
+    const grant = await handlers.get("agent:grant-file-save")!(
+      { sender: panel },
+      input,
+    );
+
+    expect(grant).toMatchObject({ ok: true });
+    const granted = grant as { grant: string };
+    await expect(
+      handlers.get("agent:save-file")!(
+        { sender: panel },
+        { ...input, grant: granted.grant },
+      ),
+    ).resolves.toEqual({ ok: true, filename: "report.txt" });
+    await expect(
+      handlers.get("agent:save-file")!(
+        { sender: panel },
+        { ...input, grant: granted.grant },
+      ),
+    ).resolves.toEqual({ ok: false, reason: "approval-used" });
+
     expect(writeFile).toHaveBeenCalledWith(
       "/safe/downloads/report.txt",
       "safe",
-      "utf8",
+      { encoding: "utf8", flag: "wx" },
     );
+  });
+
+  it("rejects a grant after its short main-process lifetime", async () => {
+    const handlers = new Map<
+      string,
+      (event: unknown, input: unknown) => Promise<unknown>
+    >();
+    const handle = vi.fn(
+      (
+        channel: string,
+        handler: (event: unknown, input: unknown) => Promise<unknown>,
+      ) => {
+        handlers.set(channel, handler);
+      },
+    );
+    const panel = { id: 1 };
+    let now = 1_000;
+    const grants = new AgentFileSaveGrants({
+      now: () => now,
+      issueToken: () => "grant-1",
+      ttlMs: 10,
+    });
+
+    registerAgentFileIpc({ handle }, () => "/safe/downloads", {
+      isPanelSender: (sender) => sender === panel,
+      confirmSave: vi.fn().mockResolvedValue(true),
+      grants,
+    });
+
+    const input = {
+      toolCallId: "call-1",
+      filename: "report.txt",
+      content: "safe",
+    };
+    const granted = (await handlers.get("agent:grant-file-save")!(
+      { sender: panel },
+      input,
+    )) as { grant: string };
+    now += 11;
+
+    await expect(
+      handlers.get("agent:save-file")!(
+        { sender: panel },
+        { ...input, grant: granted.grant },
+      ),
+    ).resolves.toEqual({ ok: false, reason: "approval-expired" });
   });
 });

--- a/apps/electron/src/main/agent-files.test.ts
+++ b/apps/electron/src/main/agent-files.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerAgentFileIpc, saveAgentDownload } from "./agent-files";
+
+let downloadsDir: string | undefined;
+
+afterEach(() => {
+  if (downloadsDir) rmSync(downloadsDir, { recursive: true, force: true });
+  downloadsDir = undefined;
+});
+
+describe("agent Downloads saves", () => {
+  it("writes UTF-8 content under the supplied Downloads folder", async () => {
+    downloadsDir = mkdtempSync(path.join(tmpdir(), "agent-downloads-"));
+
+    await expect(
+      saveAgentDownload(
+        { filename: "plan.md", content: "\u00a1Hola, Freestyle!" },
+        { downloadsDir },
+      ),
+    ).resolves.toEqual({ ok: true, filename: "plan.md" });
+
+    expect(readFileSync(path.join(downloadsDir, "plan.md"), "utf8")).toBe(
+      "\u00a1Hola, Freestyle!",
+    );
+  });
+
+  it("rejects path traversal without writing a file", async () => {
+    downloadsDir = mkdtempSync(path.join(tmpdir(), "agent-downloads-"));
+
+    await expect(
+      saveAgentDownload(
+        { filename: "../outside.md", content: "do not write" },
+        { downloadsDir },
+      ),
+    ).resolves.toEqual({ ok: false, reason: "invalid-filename" });
+  });
+
+  it("registers the IPC handler with Electron's Downloads directory", async () => {
+    const handle = vi.fn();
+    const getDownloadsPath = vi.fn(() => "/safe/downloads");
+    const writeFile = vi.fn().mockResolvedValue(undefined);
+
+    registerAgentFileIpc({ handle }, getDownloadsPath, { writeFile });
+
+    const handler = handle.mock.calls[0]?.[1] as (
+      event: unknown,
+      input: unknown,
+    ) => Promise<unknown>;
+    await expect(
+      handler({}, { filename: "report.txt", content: "safe" }),
+    ).resolves.toEqual({ ok: true, filename: "report.txt" });
+
+    expect(getDownloadsPath).toHaveBeenCalledOnce();
+    expect(writeFile).toHaveBeenCalledWith(
+      "/safe/downloads/report.txt",
+      "safe",
+      "utf8",
+    );
+  });
+});

--- a/apps/electron/src/main/agent-files.ts
+++ b/apps/electron/src/main/agent-files.ts
@@ -1,10 +1,14 @@
+import { createHash, randomUUID } from "node:crypto";
 import { writeFile as writeFileToDisk } from "node:fs/promises";
 import path from "node:path";
+
+const GRANT_TTL_MS = 30_000;
+const MAX_FILENAME_COLLISIONS = 1_000;
 
 type AgentFileWrite = (
   file: string,
   content: string,
-  encoding: "utf8",
+  options: { encoding: "utf8"; flag: "wx" },
 ) => Promise<void>;
 
 export type AgentDownloadResult =
@@ -19,9 +23,34 @@ export type AgentDownloadResult =
         | "write-failed";
     };
 
+export type AgentFileGrantResult =
+  | { ok: true; grant: string }
+  | {
+      ok: false;
+      reason:
+        | "bad-args"
+        | "user-declined"
+        | "approval-denied"
+        | "approval-required"
+        | "approval-used"
+        | "approval-expired";
+    };
+
+interface AgentFileIntent {
+  toolCallId: string;
+  filename: string;
+  content: string;
+}
+
 interface SaveAgentDownloadOptions {
   downloadsDir: string;
   writeFile?: AgentFileWrite;
+}
+
+interface AgentFileGrantOptions {
+  now?: () => number;
+  issueToken?: () => string;
+  ttlMs?: number;
 }
 
 function safeDownloadFilename(input: unknown): string | null {
@@ -41,6 +70,122 @@ function safeDownloadFilename(input: unknown): string | null {
   return input;
 }
 
+function parseAgentFileIntent(input: unknown): AgentFileIntent | null {
+  if (!input || typeof input !== "object") return null;
+  const {
+    toolCallId,
+    filename: rawFilename,
+    content,
+  } = input as Record<string, unknown>;
+  const filename = safeDownloadFilename(rawFilename);
+  if (
+    typeof toolCallId !== "string" ||
+    toolCallId.length === 0 ||
+    toolCallId.length > 200 ||
+    !filename ||
+    typeof content !== "string"
+  ) {
+    return null;
+  }
+  return { toolCallId, filename, content };
+}
+
+function intentFingerprint(intent: AgentFileIntent): string {
+  return createHash("sha256")
+    .update(intent.toolCallId)
+    .update("\0")
+    .update(intent.filename)
+    .update("\0")
+    .update(intent.content)
+    .digest("hex");
+}
+
+function collisionName(filename: string, index: number): string {
+  if (index === 0) return filename;
+  const { name, ext } = path.parse(filename);
+  return `${name} (${index})${ext}`;
+}
+
+export class AgentFileSaveGrants {
+  readonly #pending = new Map<
+    string,
+    { sender: unknown; fingerprint: string; expiresAt: number }
+  >();
+  readonly #used = new Map<string, number>();
+  readonly #expired = new Map<string, number>();
+  readonly #now: () => number;
+  readonly #issueToken: () => string;
+  readonly #ttlMs: number;
+
+  constructor({
+    now = Date.now,
+    issueToken = randomUUID,
+    ttlMs = GRANT_TTL_MS,
+  }: AgentFileGrantOptions = {}) {
+    this.#now = now;
+    this.#issueToken = issueToken;
+    this.#ttlMs = ttlMs;
+  }
+
+  issue(sender: unknown, intent: AgentFileIntent): string {
+    this.#clearExpired();
+    const grant = this.#issueToken();
+    this.#pending.set(grant, {
+      sender,
+      fingerprint: intentFingerprint(intent),
+      expiresAt: this.#now() + this.#ttlMs,
+    });
+    return grant;
+  }
+
+  consume(
+    sender: unknown,
+    intent: AgentFileIntent,
+    grant: unknown,
+  ): Exclude<AgentFileGrantResult, { ok: true }> | { ok: true } {
+    this.#clearExpired();
+    if (typeof grant !== "string" || grant.length === 0) {
+      return { ok: false, reason: "approval-required" };
+    }
+    const record = this.#pending.get(grant);
+    if (!record) {
+      return {
+        ok: false,
+        reason: this.#used.has(grant)
+          ? "approval-used"
+          : this.#expired.has(grant)
+            ? "approval-expired"
+            : "approval-required",
+      };
+    }
+    if (
+      record.sender !== sender ||
+      record.fingerprint !== intentFingerprint(intent)
+    ) {
+      return { ok: false, reason: "approval-denied" };
+    }
+    this.#pending.delete(grant);
+    this.#used.set(grant, record.expiresAt);
+    return { ok: true };
+  }
+
+  #clearExpired(): void {
+    const now = this.#now();
+    for (const [grant, record] of this.#pending) {
+      if (record.expiresAt <= now) {
+        this.#pending.delete(grant);
+        this.#expired.set(grant, now + this.#ttlMs);
+      }
+    }
+    for (const [grant, expiresAt] of this.#used) {
+      if (expiresAt <= now) this.#used.delete(grant);
+    }
+    for (const [grant, expiresAt] of this.#expired) {
+      if (expiresAt <= now) this.#expired.delete(grant);
+    }
+  }
+}
+
 export async function saveAgentDownload(
   input: unknown,
   { downloadsDir, writeFile = writeFileToDisk }: SaveAgentDownloadOptions,
@@ -53,35 +198,84 @@ export async function saveAgentDownload(
   if (!filename) return { ok: false, reason: "invalid-filename" };
   if (typeof content !== "string") return { ok: false, reason: "bad-args" };
 
-  try {
-    await writeFile(path.join(downloadsDir, filename), content, "utf8");
-    return { ok: true, filename };
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException)?.code;
-    if (code === "EACCES" || code === "EPERM") {
-      return { ok: false, reason: "permission-denied" };
+  for (let index = 0; index < MAX_FILENAME_COLLISIONS; index += 1) {
+    const finalFilename = collisionName(filename, index);
+    try {
+      await writeFile(path.join(downloadsDir, finalFilename), content, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      return { ok: true, filename: finalFilename };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === "EEXIST") continue;
+      if (code === "EACCES" || code === "EPERM") {
+        return { ok: false, reason: "permission-denied" };
+      }
+      if (code === "ENOENT") return { ok: false, reason: "not-found" };
+      return { ok: false, reason: "write-failed" };
     }
-    if (code === "ENOENT") return { ok: false, reason: "not-found" };
-    return { ok: false, reason: "write-failed" };
   }
+  return { ok: false, reason: "write-failed" };
 }
 
 interface IpcMainLike {
   handle: (
     channel: string,
-    listener: (event: unknown, input: unknown) => Promise<AgentDownloadResult>,
+    listener: (event: unknown, input: unknown) => Promise<unknown>,
   ) => void;
+}
+
+interface AgentFileIpcOptions {
+  writeFile?: AgentFileWrite;
+  isPanelSender: (sender: unknown) => boolean;
+  confirmSave: (intent: {
+    toolCallId: string;
+    filename: string;
+  }) => Promise<boolean>;
+  grants?: AgentFileSaveGrants;
+}
+
+function senderFrom(event: unknown): unknown {
+  return event && typeof event === "object"
+    ? (event as { sender?: unknown }).sender
+    : undefined;
 }
 
 export function registerAgentFileIpc(
   ipcMain: IpcMainLike,
   getDownloadsPath: () => string,
-  { writeFile }: Pick<SaveAgentDownloadOptions, "writeFile"> = {},
+  {
+    writeFile,
+    isPanelSender,
+    confirmSave,
+    grants = new AgentFileSaveGrants(),
+  }: AgentFileIpcOptions,
 ): void {
-  ipcMain.handle("agent:save-file", (_event, input) =>
-    saveAgentDownload(input, {
+  ipcMain.handle("agent:grant-file-save", async (event, input) => {
+    const sender = senderFrom(event);
+    if (!isPanelSender(sender)) return { ok: false, reason: "approval-denied" };
+    const intent = parseAgentFileIntent(input);
+    if (!intent) return { ok: false, reason: "bad-args" };
+    if (!(await confirmSave(intent)))
+      return { ok: false, reason: "user-declined" };
+    return { ok: true, grant: grants.issue(sender, intent) };
+  });
+
+  ipcMain.handle("agent:save-file", async (event, input) => {
+    const sender = senderFrom(event);
+    if (!isPanelSender(sender)) return { ok: false, reason: "approval-denied" };
+    const intent = parseAgentFileIntent(input);
+    if (!intent) return { ok: false, reason: "bad-args" };
+    const granted = grants.consume(
+      sender,
+      intent,
+      (input as Record<string, unknown>).grant,
+    );
+    if (!granted.ok) return granted;
+    return saveAgentDownload(intent, {
       downloadsDir: getDownloadsPath(),
       ...(writeFile ? { writeFile } : {}),
-    }),
-  );
+    });
+  });
 }

--- a/apps/electron/src/main/agent-files.ts
+++ b/apps/electron/src/main/agent-files.ts
@@ -1,0 +1,87 @@
+import { writeFile as writeFileToDisk } from "node:fs/promises";
+import path from "node:path";
+
+type AgentFileWrite = (
+  file: string,
+  content: string,
+  encoding: "utf8",
+) => Promise<void>;
+
+export type AgentDownloadResult =
+  | { ok: true; filename: string }
+  | {
+      ok: false;
+      reason:
+        | "bad-args"
+        | "invalid-filename"
+        | "permission-denied"
+        | "not-found"
+        | "write-failed";
+    };
+
+interface SaveAgentDownloadOptions {
+  downloadsDir: string;
+  writeFile?: AgentFileWrite;
+}
+
+function safeDownloadFilename(input: unknown): string | null {
+  if (typeof input !== "string" || input.trim().length === 0) return null;
+  if (
+    input === "." ||
+    input === ".." ||
+    input.includes("/") ||
+    input.includes("\\") ||
+    input.includes(":") ||
+    input.includes("\0") ||
+    path.basename(input) !== input ||
+    path.win32.basename(input) !== input
+  ) {
+    return null;
+  }
+  return input;
+}
+
+export async function saveAgentDownload(
+  input: unknown,
+  { downloadsDir, writeFile = writeFileToDisk }: SaveAgentDownloadOptions,
+): Promise<AgentDownloadResult> {
+  if (!input || typeof input !== "object") {
+    return { ok: false, reason: "bad-args" };
+  }
+  const { filename: rawFilename, content } = input as Record<string, unknown>;
+  const filename = safeDownloadFilename(rawFilename);
+  if (!filename) return { ok: false, reason: "invalid-filename" };
+  if (typeof content !== "string") return { ok: false, reason: "bad-args" };
+
+  try {
+    await writeFile(path.join(downloadsDir, filename), content, "utf8");
+    return { ok: true, filename };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "EACCES" || code === "EPERM") {
+      return { ok: false, reason: "permission-denied" };
+    }
+    if (code === "ENOENT") return { ok: false, reason: "not-found" };
+    return { ok: false, reason: "write-failed" };
+  }
+}
+
+interface IpcMainLike {
+  handle: (
+    channel: string,
+    listener: (event: unknown, input: unknown) => Promise<AgentDownloadResult>,
+  ) => void;
+}
+
+export function registerAgentFileIpc(
+  ipcMain: IpcMainLike,
+  getDownloadsPath: () => string,
+  { writeFile }: Pick<SaveAgentDownloadOptions, "writeFile"> = {},
+): void {
+  ipcMain.handle("agent:save-file", (_event, input) =>
+    saveAgentDownload(input, {
+      downloadsDir: getDownloadsPath(),
+      ...(writeFile ? { writeFile } : {}),
+    }),
+  );
+}

--- a/apps/electron/src/main/agent-files.ts
+++ b/apps/electron/src/main/agent-files.ts
@@ -12,7 +12,7 @@ type AgentFileWrite = (
 ) => Promise<void>;
 
 export type AgentDownloadResult =
-  | { ok: true; filename: string }
+  | { ok: true; path: string }
   | {
       ok: false;
       reason:
@@ -205,7 +205,7 @@ export async function saveAgentDownload(
         encoding: "utf8",
         flag: "wx",
       });
-      return { ok: true, filename: finalFilename };
+      return { ok: true, path: path.join(downloadsDir, finalFilename) };
     } catch (err) {
       const code = (err as NodeJS.ErrnoException)?.code;
       if (code === "EEXIST") continue;

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1653,7 +1653,25 @@ app.whenReady().then(async () => {
     },
   );
 
-  registerAgentFileIpc(ipcMain, () => app.getPath("downloads"));
+  registerAgentFileIpc(ipcMain, () => app.getPath("downloads"), {
+    isPanelSender: (sender) => sender === panelWindow?.webContents,
+    confirmSave: async ({ filename }) => {
+      const options = {
+        type: "question" as const,
+        title: "Save generated file",
+        message: `Save ${filename} to Downloads?`,
+        detail:
+          "Freestyle will save this generated file to your Downloads folder.",
+        buttons: ["Save", "Cancel"],
+        defaultId: 0,
+        cancelId: 1,
+      };
+      const response = panelWindow
+        ? await dialog.showMessageBox(panelWindow, options)
+        : await dialog.showMessageBox(options);
+      return response.response === 0;
+    },
+  });
 
   ipcMain.handle("audio:prepare", async (_event, mode: unknown) => {
     if (!isActiveAudioPlaybackMode(mode)) return;

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -119,6 +119,7 @@ import {
 import { bearerAuthHeaders } from "../shared/server-auth";
 import { SETTINGS_KEYS } from "../shared/settings-keys";
 import { SPRITES_INFO } from "../shared/sprites";
+import { registerAgentFileIpc } from "./agent-files";
 import { AudioPlaybackController } from "./audio-control/controller";
 import { recoverDuckedVolumeFromCrash } from "./audio-control/volume-ducker";
 import { HotkeyRecorder } from "./hotkey-recorder";
@@ -1651,6 +1652,8 @@ app.whenReady().then(async () => {
       await deliverOutput(text, OutputMode.Clipboard);
     },
   );
+
+  registerAgentFileIpc(ipcMain, () => app.getPath("downloads"));
 
   ipcMain.handle("audio:prepare", async (_event, mode: unknown) => {
     if (!isActiveAudioPlaybackMode(mode)) return;

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -17,6 +17,10 @@ declare global {
       platform: string;
       pasteText: (text: string, appContext?: string | null) => Promise<void>;
       copyText: (text: string, appContext?: string | null) => Promise<void>;
+      saveAgentFile: (input: {
+        filename: string;
+        content: string;
+      }) => Promise<{ ok: boolean; filename?: string; reason?: string }>;
       prepareSystemAudio: (mode: ActiveAudioPlaybackMode) => Promise<void>;
       restoreSystemAudio: () => Promise<void>;
       getServerPort: () => Promise<number>;

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -17,9 +17,16 @@ declare global {
       platform: string;
       pasteText: (text: string, appContext?: string | null) => Promise<void>;
       copyText: (text: string, appContext?: string | null) => Promise<void>;
-      saveAgentFile: (input: {
+      requestAgentFileSaveGrant: (input: {
+        toolCallId: string;
         filename: string;
         content: string;
+      }) => Promise<{ ok: boolean; grant?: string; reason?: string }>;
+      saveAgentFile: (input: {
+        toolCallId: string;
+        filename: string;
+        content: string;
+        grant: string;
       }) => Promise<{ ok: boolean; filename?: string; reason?: string }>;
       prepareSystemAudio: (mode: ActiveAudioPlaybackMode) => Promise<void>;
       restoreSystemAudio: () => Promise<void>;

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -27,7 +27,7 @@ declare global {
         filename: string;
         content: string;
         grant: string;
-      }) => Promise<{ ok: boolean; filename?: string; reason?: string }>;
+      }) => Promise<{ ok: boolean; path?: string; reason?: string }>;
       prepareSystemAudio: (mode: ActiveAudioPlaybackMode) => Promise<void>;
       restoreSystemAudio: () => Promise<void>;
       getServerPort: () => Promise<number>;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -20,6 +20,11 @@ const api = {
     ipcRenderer.invoke("paste:text", text, appContext ?? null),
   copyText: (text: string, appContext?: string | null): Promise<void> =>
     ipcRenderer.invoke("copy:text", text, appContext ?? null),
+  saveAgentFile: (input: {
+    filename: string;
+    content: string;
+  }): Promise<{ ok: boolean; filename?: string; reason?: string }> =>
+    ipcRenderer.invoke("agent:save-file", input),
   prepareSystemAudio: (mode: ActiveAudioPlaybackMode): Promise<void> =>
     ipcRenderer.invoke("audio:prepare", mode),
   restoreSystemAudio: (): Promise<void> => ipcRenderer.invoke("audio:restore"),

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -31,7 +31,7 @@ const api = {
     filename: string;
     content: string;
     grant: string;
-  }): Promise<{ ok: boolean; filename?: string; reason?: string }> =>
+  }): Promise<{ ok: boolean; path?: string; reason?: string }> =>
     ipcRenderer.invoke("agent:save-file", input),
   prepareSystemAudio: (mode: ActiveAudioPlaybackMode): Promise<void> =>
     ipcRenderer.invoke("audio:prepare", mode),

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -20,9 +20,17 @@ const api = {
     ipcRenderer.invoke("paste:text", text, appContext ?? null),
   copyText: (text: string, appContext?: string | null): Promise<void> =>
     ipcRenderer.invoke("copy:text", text, appContext ?? null),
-  saveAgentFile: (input: {
+  requestAgentFileSaveGrant: (input: {
+    toolCallId: string;
     filename: string;
     content: string;
+  }): Promise<{ ok: boolean; grant?: string; reason?: string }> =>
+    ipcRenderer.invoke("agent:grant-file-save", input),
+  saveAgentFile: (input: {
+    toolCallId: string;
+    filename: string;
+    content: string;
+    grant: string;
   }): Promise<{ ok: boolean; filename?: string; reason?: string }> =>
     ipcRenderer.invoke("agent:save-file", input),
   prepareSystemAudio: (mode: ActiveAudioPlaybackMode): Promise<void> =>

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -21,6 +21,7 @@ import {
   DECLINED_OUTPUT,
   describeAgentAction,
   executeAgentTool,
+  requestAgentFileSaveGrant,
 } from "@renderer/lib/agent-tools";
 import { capture } from "@renderer/lib/analytics";
 import { apiFetch, initApiBase, refreshApiBase } from "@renderer/lib/api";
@@ -986,7 +987,20 @@ function PanelInner({
     );
     void (async () => {
       const startedAt = Date.now();
-      const output = allowed ? await executeAgentTool(call) : DECLINED_OUTPUT;
+      const grant =
+        allowed && call.toolName === "save_file"
+          ? await requestAgentFileSaveGrant(call)
+          : null;
+      const output = !allowed
+        ? DECLINED_OUTPUT
+        : grant && grant.ok !== true
+          ? grant
+          : await executeAgentTool(call, {
+              saveFileGrant:
+                grant && typeof grant.grant === "string"
+                  ? grant.grant
+                  : undefined,
+            });
       reportAgentToolResult(call, output, startedAt);
       addToolOutput({
         tool: call.toolName,

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -16,6 +16,7 @@ import { ThreadHistory } from "@renderer/components/thread-history";
 import { TodosTab } from "@renderer/components/todos-tab";
 import {
   type AgentToolCall,
+  agentToolResultTelemetry,
   agentToolTier,
   DECLINED_OUTPUT,
   describeAgentAction,
@@ -85,6 +86,29 @@ const TAB_PLACEHOLDER: Record<PanelTab, string> = {
     "Everything Freestyle knows lives here — scheduled tasks, memories, notes, skills, todos.",
   apps: "Connect the apps you live in, and Freestyle can work them for you.",
 };
+
+function reportAgentToolResult(
+  call: AgentToolCall,
+  output: Record<string, unknown>,
+  startedAt: number,
+): void {
+  const send = (appVersion: string): void => {
+    capture(
+      "agent_tool_result",
+      agentToolResultTelemetry({
+        tool: call.toolName,
+        platform: window.api.platform,
+        appVersion,
+        durationMs: Date.now() - startedAt,
+        output,
+      }),
+    );
+  };
+  void window.api
+    .getAppVersion()
+    .then(send)
+    .catch(() => send("unknown"));
+}
 
 function ShikiJson({ value }: { value: unknown }): React.JSX.Element {
   const source = toolJson(value);
@@ -161,7 +185,7 @@ function ToolChip({
   phase?: ToolPhase;
 }): React.JSX.Element {
   const [open, setOpen] = useState(false);
-  const presentation = toolPresentation(partType, phase, input);
+  const presentation = toolPresentation(partType, phase, input, output);
   const running = phase === "running";
   const hasInput =
     input !== undefined &&
@@ -818,6 +842,7 @@ function PanelInner({
       });
     },
     onToolCall: async ({ toolCall }) => {
+      const startedAt = Date.now();
       const call: AgentToolCall = {
         toolName: toolCall.toolName,
         toolCallId: toolCall.toolCallId,
@@ -832,6 +857,7 @@ function PanelInner({
         tier === "free"
           ? await executeAgentTool(call)
           : { ok: false, reason: `unknown tool: ${call.toolName}` };
+      reportAgentToolResult(call, output, startedAt);
       addToolOutput({
         tool: toolCall.toolName,
         toolCallId: toolCall.toolCallId,
@@ -959,7 +985,9 @@ function PanelInner({
       prev.filter((a) => a.toolCallId !== call.toolCallId),
     );
     void (async () => {
+      const startedAt = Date.now();
       const output = allowed ? await executeAgentTool(call) : DECLINED_OUTPUT;
+      reportAgentToolResult(call, output, startedAt);
       addToolOutput({
         tool: call.toolName,
         toolCallId: call.toolCallId,

--- a/apps/electron/src/renderer/src/lib/agent-tools.test.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.test.ts
@@ -58,7 +58,10 @@ describe("safe Downloads saves", () => {
   afterEach(() => vi.unstubAllGlobals());
 
   it("passes a main-issued grant bound to the tool call to the Downloads IPC", async () => {
-    saveAgentFile.mockResolvedValue({ ok: true, filename: "plan.md" });
+    saveAgentFile.mockResolvedValue({
+      ok: true,
+      path: "/safe/downloads/plan.md",
+    });
 
     await expect(
       executeAgentTool(
@@ -69,7 +72,7 @@ describe("safe Downloads saves", () => {
         },
         { saveFileGrant: "main-grant" },
       ),
-    ).resolves.toEqual({ ok: true, filename: "plan.md" });
+    ).resolves.toEqual({ ok: true, path: "/safe/downloads/plan.md" });
 
     expect(saveAgentFile).toHaveBeenCalledWith({
       toolCallId: "call-1",

--- a/apps/electron/src/renderer/src/lib/agent-tools.test.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@shared/sprite-events", () => ({
   parseSpriteEmotion: vi.fn(),
 }));
 
-import { agentToolTier } from "./agent-tools";
+import {
+  agentToolResultTelemetry,
+  agentToolTier,
+  executeAgentTool,
+} from "./agent-tools";
 
 describe("agent tool approval tiers", () => {
   const call = (toolName: string) => ({
@@ -13,23 +17,84 @@ describe("agent tool approval tiers", () => {
     input: {},
   });
 
-  it("runs read-only local tools without asking", async () => {
-    await expect(agentToolTier(call("Read"))).resolves.toBe("free");
-    await expect(agentToolTier(call("Glob"))).resolves.toBe("free");
-    await expect(agentToolTier(call("Grep"))).resolves.toBe("free");
+  it("asks before every local shell or file tool", async () => {
+    await expect(agentToolTier(call("Read"))).resolves.toBe("confirmed");
+    await expect(agentToolTier(call("Glob"))).resolves.toBe("confirmed");
+    await expect(agentToolTier(call("Grep"))).resolves.toBe("confirmed");
+    await expect(agentToolTier(call("Write"))).resolves.toBe("confirmed");
+    await expect(agentToolTier(call("Edit"))).resolves.toBe("confirmed");
+    await expect(
+      agentToolTier({ ...call("Bash"), input: { command: "pwd" } }),
+    ).resolves.toBe("confirmed");
+    await expect(agentToolTier(call("save_file"))).resolves.toBe("confirmed");
   });
 
-  it("runs mutating local tools without asking too", async () => {
-    await expect(agentToolTier(call("Write"))).resolves.toBe("free");
-    await expect(agentToolTier(call("Edit"))).resolves.toBe("free");
-    await expect(
-      agentToolTier({ ...call("Bash"), input: { command: "rm -rf ./x" } }),
-    ).resolves.toBe("free");
+  it("keeps cosmetic client tools free and leaves Cloud-owned Brain tools unclaimed", async () => {
+    await expect(agentToolTier(call("current_time"))).resolves.toBe("free");
+    await expect(agentToolTier(call("emote"))).resolves.toBe("free");
+    await expect(agentToolTier(call("brain_read"))).resolves.toBeNull();
   });
 
   it("does not claim connected-app tools, which run on the server", async () => {
     await expect(
       agentToolTier(call("connector__gmail__474d41494c5f53454")),
     ).resolves.toBeNull();
+  });
+});
+
+describe("safe Downloads saves", () => {
+  const saveAgentFile = vi.fn();
+
+  beforeEach(() => {
+    saveAgentFile.mockReset();
+    vi.stubGlobal("window", { api: { saveAgentFile } });
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("passes an approved generated file to the Electron Downloads IPC", async () => {
+    saveAgentFile.mockResolvedValue({ ok: true, filename: "plan.md" });
+
+    await expect(
+      executeAgentTool({
+        toolName: "save_file",
+        toolCallId: "call-1",
+        input: { filename: "plan.md", content: "# Plan" },
+      }),
+    ).resolves.toEqual({ ok: true, filename: "plan.md" });
+
+    expect(saveAgentFile).toHaveBeenCalledWith({
+      filename: "plan.md",
+      content: "# Plan",
+    });
+  });
+});
+
+describe("agent tool telemetry", () => {
+  it("contains only stable result metadata and never local tool payloads", () => {
+    expect(
+      agentToolResultTelemetry({
+        tool: "save_file",
+        platform: "win32",
+        appVersion: "0.8.8",
+        durationMs: 12.4,
+        output: {
+          ok: false,
+          reason: "permission-denied",
+          stdout: "secret command output",
+          path: "C:\\Users\\Freestyle\\Downloads\\plan.md",
+          content: "private generated document",
+          exitCode: 5,
+        },
+      }),
+    ).toEqual({
+      tool: "save_file",
+      platform: "win32",
+      appVersion: "0.8.8",
+      durationMs: 12,
+      ok: false,
+      result: "permission-denied",
+      exitCode: 5,
+    });
   });
 });

--- a/apps/electron/src/renderer/src/lib/agent-tools.test.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.test.ts
@@ -8,6 +8,7 @@ import {
   agentToolResultTelemetry,
   agentToolTier,
   executeAgentTool,
+  requestAgentFileSaveGrant,
 } from "./agent-tools";
 
 describe("agent tool approval tiers", () => {
@@ -44,26 +45,56 @@ describe("agent tool approval tiers", () => {
 
 describe("safe Downloads saves", () => {
   const saveAgentFile = vi.fn();
+  const requestSaveGrant = vi.fn();
 
   beforeEach(() => {
     saveAgentFile.mockReset();
-    vi.stubGlobal("window", { api: { saveAgentFile } });
+    requestSaveGrant.mockReset();
+    vi.stubGlobal("window", {
+      api: { saveAgentFile, requestAgentFileSaveGrant: requestSaveGrant },
+    });
   });
 
   afterEach(() => vi.unstubAllGlobals());
 
-  it("passes an approved generated file to the Electron Downloads IPC", async () => {
+  it("passes a main-issued grant bound to the tool call to the Downloads IPC", async () => {
     saveAgentFile.mockResolvedValue({ ok: true, filename: "plan.md" });
 
     await expect(
-      executeAgentTool({
+      executeAgentTool(
+        {
+          toolName: "save_file",
+          toolCallId: "call-1",
+          input: { filename: "plan.md", content: "# Plan" },
+        },
+        { saveFileGrant: "main-grant" },
+      ),
+    ).resolves.toEqual({ ok: true, filename: "plan.md" });
+
+    expect(saveAgentFile).toHaveBeenCalledWith({
+      toolCallId: "call-1",
+      filename: "plan.md",
+      content: "# Plan",
+      grant: "main-grant",
+    });
+  });
+
+  it("asks main to grant the exact approved file operation", async () => {
+    requestSaveGrant.mockResolvedValue({
+      ok: true,
+      grant: "main-grant",
+    });
+
+    await expect(
+      requestAgentFileSaveGrant({
         toolName: "save_file",
         toolCallId: "call-1",
         input: { filename: "plan.md", content: "# Plan" },
       }),
-    ).resolves.toEqual({ ok: true, filename: "plan.md" });
+    ).resolves.toEqual({ ok: true, grant: "main-grant" });
 
-    expect(saveAgentFile).toHaveBeenCalledWith({
+    expect(requestSaveGrant).toHaveBeenCalledWith({
+      toolCallId: "call-1",
       filename: "plan.md",
       content: "# Plan",
     });

--- a/apps/electron/src/renderer/src/lib/agent-tools.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.ts
@@ -13,6 +13,24 @@ export interface AgentToolCall {
   input: unknown;
 }
 
+type ToolOutput = Record<string, unknown>;
+
+const SAFE_RESULT_CATEGORIES = new Set([
+  "bad-args",
+  "user-declined",
+  "shell-unavailable",
+  "command-failed",
+  "permission-denied",
+  "not-found",
+  "timed-out",
+  "invalid-filename",
+  "write-failed",
+  "fs-failed",
+  "is-a-directory",
+  "ambiguous",
+  "tool-failed",
+]);
+
 const str = (input: Record<string, unknown>, key: string): string =>
   typeof input[key] === "string" ? (input[key] as string) : "";
 
@@ -22,13 +40,15 @@ export async function agentToolTier(
   switch (call.toolName) {
     case "current_time":
     case "emote":
+      return "free";
     case "Bash":
     case "Read":
     case "Glob":
     case "Grep":
     case "Write":
     case "Edit":
-      return "free";
+    case "save_file":
+      return "confirmed";
     default:
       return null;
   }
@@ -62,6 +82,8 @@ export function describeAgentAction(call: AgentToolCall): string {
       return `List files under ${str(input, "path")}`;
     case "Grep":
       return `Search files under ${str(input, "path")}`;
+    case "save_file":
+      return `Save ${str(input, "filename")} to your Downloads folder`;
     default:
       return `Run ${call.toolName.replace(/_/g, " ")}.`;
   }
@@ -144,6 +166,14 @@ export async function executeAgentTool(
           query: str(input, "query"),
           path: str(input, "path") || undefined,
         });
+      case "save_file":
+        if (!str(input, "filename") || typeof input.content !== "string") {
+          return badArgs("{ filename: string, content: string }");
+        }
+        return (await window.api.saveAgentFile({
+          filename: str(input, "filename"),
+          content: input.content,
+        })) as Record<string, unknown>;
       default:
         return { ok: false, reason: `unknown tool: ${call.toolName}` };
     }
@@ -160,3 +190,50 @@ export const DECLINED_OUTPUT: Record<string, unknown> = {
   ok: false,
   reason: "user-declined",
 };
+
+export function agentToolResultTelemetry({
+  tool,
+  platform,
+  appVersion,
+  durationMs,
+  output,
+}: {
+  tool: string;
+  platform: string;
+  appVersion: string;
+  durationMs: number;
+  output: ToolOutput;
+}): {
+  tool: string;
+  platform: string;
+  appVersion: string;
+  durationMs: number;
+  ok: boolean;
+  result: string;
+  exitCode?: number;
+} {
+  const ok = output.ok !== false;
+  const rawReason =
+    typeof output.reason === "string"
+      ? output.reason
+      : typeof output.category === "string"
+        ? output.category
+        : null;
+  const result = ok
+    ? "success"
+    : rawReason && SAFE_RESULT_CATEGORIES.has(rawReason)
+      ? rawReason
+      : "tool-failed";
+  const exitCode = output.exitCode;
+  return {
+    tool,
+    platform,
+    appVersion,
+    durationMs: Math.max(0, Math.round(durationMs)),
+    ok,
+    result,
+    ...(typeof exitCode === "number" && Number.isFinite(exitCode)
+      ? { exitCode }
+      : {}),
+  };
+}

--- a/apps/electron/src/renderer/src/lib/agent-tools.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.ts
@@ -29,6 +29,10 @@ const SAFE_RESULT_CATEGORIES = new Set([
   "is-a-directory",
   "ambiguous",
   "tool-failed",
+  "approval-required",
+  "approval-denied",
+  "approval-used",
+  "approval-expired",
 ]);
 
 const str = (input: Record<string, unknown>, key: string): string =>
@@ -102,8 +106,38 @@ async function runOsTool(
   return (await res.json()) as Record<string, unknown>;
 }
 
+export interface AgentToolExecutionOptions {
+  saveFileGrant?: string;
+}
+
+function saveFileIntent(call: AgentToolCall): {
+  toolCallId: string;
+  filename: string;
+  content: string;
+} | null {
+  const input = (call.input ?? {}) as Record<string, unknown>;
+  if (!str(input, "filename") || typeof input.content !== "string") return null;
+  return {
+    toolCallId: call.toolCallId,
+    filename: str(input, "filename"),
+    content: input.content,
+  };
+}
+
+export async function requestAgentFileSaveGrant(
+  call: AgentToolCall,
+): Promise<Record<string, unknown>> {
+  const intent = saveFileIntent(call);
+  if (!intent) return { ok: false, reason: "bad-args" };
+  return (await window.api.requestAgentFileSaveGrant(intent)) as Record<
+    string,
+    unknown
+  >;
+}
+
 export async function executeAgentTool(
   call: AgentToolCall,
+  { saveFileGrant }: AgentToolExecutionOptions = {},
 ): Promise<Record<string, unknown>> {
   const input = (call.input ?? {}) as Record<string, unknown>;
   const badArgs = (expected: string): Record<string, unknown> => ({
@@ -170,9 +204,12 @@ export async function executeAgentTool(
         if (!str(input, "filename") || typeof input.content !== "string") {
           return badArgs("{ filename: string, content: string }");
         }
+        if (!saveFileGrant) return { ok: false, reason: "approval-required" };
         return (await window.api.saveAgentFile({
+          toolCallId: call.toolCallId,
           filename: str(input, "filename"),
           content: input.content,
+          grant: saveFileGrant,
         })) as Record<string, unknown>;
       default:
         return { ok: false, reason: `unknown tool: ${call.toolName}` };

--- a/apps/electron/src/renderer/src/lib/tool-presentation.test.ts
+++ b/apps/electron/src/renderer/src/lib/tool-presentation.test.ts
@@ -35,9 +35,17 @@ describe("tool phases", () => {
     expect(toolPresentation("tool-paste", "declined").title).toBe(
       "Didn't paste — you declined",
     );
-    expect(toolPresentation("tool-Bash", "failed").title).toContain(
-      "didn't work",
-    );
+  });
+
+  it("uses a specific collapsed label for a local tool failure", () => {
+    expect(
+      toolPresentation(
+        "tool-Bash",
+        "failed",
+        { command: "Get-Location" },
+        { ok: false, reason: "shell-unavailable", stderr: "private detail" },
+      ).title,
+    ).toBe("Couldn't start the command shell");
   });
 
   it("carries the phase through connector tools", () => {

--- a/apps/electron/src/renderer/src/lib/tool-presentation.ts
+++ b/apps/electron/src/renderer/src/lib/tool-presentation.ts
@@ -18,6 +18,7 @@ const TOOL_LABELS: Record<string, string> = {
   "tool-Edit": "Edited a file",
   "tool-Glob": "Listed files",
   "tool-Grep": "Searched files",
+  "tool-save_file": "Saved a file to Downloads",
   "tool-brain_read": "Recalled a memory",
   "tool-brain_write": "Saved a memory",
   "tool-brain_edit": "Updated a memory",
@@ -45,6 +46,7 @@ const RUNNING_LABELS: Record<string, string> = {
   "tool-Edit": "Editing a file",
   "tool-Glob": "Listing files",
   "tool-Grep": "Searching files",
+  "tool-save_file": "Saving a file to Downloads",
   "tool-brain_read": "Recalling a memory",
   "tool-brain_write": "Saving a memory",
   "tool-brain_edit": "Updating a memory",
@@ -62,6 +64,9 @@ const DECLINED_LABELS: Record<string, string> = {
   "tool-Write": "Didn't write that file — you declined",
   "tool-Edit": "Didn't edit that file — you declined",
   "tool-Read": "Didn't read that file — you declined",
+  "tool-Glob": "Didn't list those files — you declined",
+  "tool-Grep": "Didn't search those files — you declined",
+  "tool-save_file": "Didn't save that file — you declined",
 };
 
 const APP_NAMES: Record<string, string> = {
@@ -108,6 +113,7 @@ export function toolPresentation(
   partType: string,
   phase: ToolPhase = "done",
   input?: unknown,
+  output?: unknown,
 ): {
   title: string;
   detail: string | undefined;
@@ -143,8 +149,31 @@ export function toolPresentation(
     };
   }
   if (phase === "failed") {
+    const reason =
+      output && typeof output === "object"
+        ? ((output as { reason?: unknown; category?: unknown }).reason ??
+          (output as { category?: unknown }).category)
+        : undefined;
+    const specific =
+      reason === "shell-unavailable"
+        ? "Couldn't start the command shell"
+        : reason === "command-failed"
+          ? "Command failed"
+          : reason === "permission-denied"
+            ? "Permission denied"
+            : reason === "not-found"
+              ? "Couldn't find that file or command"
+              : reason === "timed-out"
+                ? "Command timed out"
+                : reason === "invalid-filename"
+                  ? "Couldn't save that filename"
+                  : reason === "write-failed"
+                    ? "Couldn't save that file"
+                    : undefined;
     return {
-      title: `${TOOL_LABELS[partType] ?? sentence(words(name))} — didn't work`,
+      title:
+        specific ??
+        `${TOOL_LABELS[partType] ?? sentence(words(name))} — didn't work`,
       detail: undefined,
     };
   }

--- a/apps/server/src/lib/agent-os.ts
+++ b/apps/server/src/lib/agent-os.ts
@@ -1,4 +1,4 @@
-import { exec } from "node:child_process";
+import { exec, execFile } from "node:child_process";
 import {
   mkdirSync,
   readdirSync,
@@ -17,10 +17,67 @@ const GREP_MAX_MATCHES = 60;
 const GREP_FILE_MAX_BYTES = 262_144;
 const SKIP_DIRS = new Set(["node_modules", ".git", ".Trash", "Library"]);
 
+export type AgentCommandCategory =
+  | "success"
+  | "shell-unavailable"
+  | "command-failed"
+  | "permission-denied"
+  | "not-found"
+  | "timed-out";
+
+export interface AgentCommandResult {
+  ok: boolean;
+  category: AgentCommandCategory;
+  reason?: AgentCommandCategory;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  truncated: boolean;
+  timedOut: boolean;
+}
+
+type AgentCommandError = NodeJS.ErrnoException & {
+  killed?: boolean;
+  signal?: string;
+};
+type AgentCommandCallback = (
+  error: AgentCommandError | null,
+  stdout: string,
+  stderr: string,
+) => void;
+type ShellExecutor = (
+  command: string,
+  options: {
+    cwd: string;
+    timeout: number;
+    maxBuffer: number;
+    shell: string;
+  },
+  callback: AgentCommandCallback,
+) => unknown;
+type FileExecutor = (
+  file: string,
+  args: string[],
+  options: { cwd: string; timeout: number; maxBuffer: number },
+  callback: AgentCommandCallback,
+) => unknown;
+
+export interface AgentCommandOptions {
+  platform?: NodeJS.Platform;
+  exec?: ShellExecutor;
+  execFile?: FileExecutor;
+}
+
 export function resolveAgentPath(input: string): { full: string } {
-  const full = path.isAbsolute(input)
-    ? path.resolve(input)
-    : path.resolve(homedir(), input);
+  const expanded =
+    input === "~"
+      ? homedir()
+      : input.startsWith("~/") || input.startsWith("~\\")
+        ? path.join(homedir(), input.slice(2))
+        : input;
+  const full = path.isAbsolute(expanded)
+    ? path.resolve(expanded)
+    : path.resolve(homedir(), expanded);
   return { full };
 }
 
@@ -176,43 +233,70 @@ export function grepAgentFiles(
   return matches;
 }
 
-export function runAgentBash(command: string): Promise<{
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-  truncated: boolean;
-  timedOut: boolean;
-}> {
+export function runAgentBash(
+  command: string,
+  options: AgentCommandOptions = {},
+): Promise<AgentCommandResult> {
   return new Promise((resolve) => {
-    exec(
+    const platform = options.platform ?? process.platform;
+    const complete: AgentCommandCallback = (err, stdout, stderr) => {
+      const timedOut =
+        !!err &&
+        (err.code === "ETIMEDOUT" ||
+          (err.killed === true && !/maxBuffer/i.test(err.message)));
+      const errorCode = err?.code;
+      const category: AgentCommandCategory = !err
+        ? "success"
+        : timedOut
+          ? "timed-out"
+          : errorCode === "ENOENT"
+            ? platform === "win32"
+              ? "shell-unavailable"
+              : "not-found"
+            : errorCode === "EACCES" || errorCode === "EPERM"
+              ? "permission-denied"
+              : "command-failed";
+      const exitCode = !err
+        ? 0
+        : timedOut
+          ? 124
+          : typeof errorCode === "number"
+            ? errorCode
+            : 1;
+      resolve({
+        ok: !err,
+        category,
+        ...(err ? { reason: category } : {}),
+        stdout: stdout.slice(0, BASH_OUTPUT_CAP),
+        stderr: stderr.slice(0, BASH_OUTPUT_CAP),
+        exitCode,
+        truncated:
+          stdout.length > BASH_OUTPUT_CAP || stderr.length > BASH_OUTPUT_CAP,
+        timedOut,
+      });
+    };
+    const common = {
+      cwd: homedir(),
+      timeout: BASH_TIMEOUT_MS,
+      maxBuffer: 4 * 1024 * 1024,
+    };
+
+    if (platform === "win32") {
+      const run = (options.execFile ?? execFile) as FileExecutor;
+      run(
+        "powershell.exe",
+        ["-NoProfile", "-NonInteractive", "-Command", command],
+        common,
+        complete,
+      );
+      return;
+    }
+
+    const run = (options.exec ?? exec) as ShellExecutor;
+    run(
       command,
-      {
-        cwd: homedir(),
-        timeout: BASH_TIMEOUT_MS,
-        maxBuffer: 4 * 1024 * 1024,
-        shell: process.env.SHELL || "/bin/sh",
-      },
-      (err, stdout, stderr) => {
-        const timedOut =
-          !!err &&
-          (err as { killed?: boolean }).killed === true &&
-          (err as { signal?: string }).signal === "SIGTERM" &&
-          !/maxBuffer/i.test(err.message);
-        const code =
-          err && typeof (err as { code?: number }).code === "number"
-            ? ((err as { code?: number }).code as number)
-            : err
-              ? 1
-              : 0;
-        resolve({
-          stdout: stdout.slice(0, BASH_OUTPUT_CAP),
-          stderr: stderr.slice(0, BASH_OUTPUT_CAP),
-          exitCode: timedOut ? 124 : code,
-          truncated:
-            stdout.length > BASH_OUTPUT_CAP || stderr.length > BASH_OUTPUT_CAP,
-          timedOut,
-        });
-      },
+      { ...common, shell: process.env.SHELL || "/bin/sh" },
+      complete,
     );
   });
 }

--- a/apps/server/src/lib/agent-os.ts
+++ b/apps/server/src/lib/agent-os.ts
@@ -68,6 +68,13 @@ export interface AgentCommandOptions {
   execFile?: FileExecutor;
 }
 
+function powerShellCommand(command: string): string {
+  // A native executable's failure only updates `$LASTEXITCODE`; PowerShell
+  // itself otherwise exits successfully (or with the generic code 1). Carry
+  // that status through so the agent gets the actual Windows command result.
+  return `$ErrorActionPreference = 'Stop'; & { ${command} }; if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE }; exit 0`;
+}
+
 export function resolveAgentPath(input: string): { full: string } {
   const expanded =
     input === "~"
@@ -285,7 +292,12 @@ export function runAgentBash(
       const run = (options.execFile ?? execFile) as FileExecutor;
       run(
         "powershell.exe",
-        ["-NoProfile", "-NonInteractive", "-Command", command],
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          powerShellCommand(command),
+        ],
         common,
         complete,
       );

--- a/apps/server/src/routes/agent-os.ts
+++ b/apps/server/src/routes/agent-os.ts
@@ -126,7 +126,7 @@ const agentOsRoute = new Hono()
       try {
         const { command } = c.req.valid("json");
         const result = await runAgentBash(command);
-        return c.json({ ok: true, ...result });
+        return c.json(result);
       } catch (err) {
         return c.json(failure(err));
       }

--- a/apps/server/src/routes/agent.ts
+++ b/apps/server/src/routes/agent.ts
@@ -45,6 +45,10 @@ const agentRoute = new Hono().post(
           messages,
           ...(threadId || id ? { threadId: threadId ?? id } : {}),
           ...(firstTurn ? { firstTurn: true } : {}),
+          client: {
+            platform: process.platform,
+            supportsDownloadsSave: true,
+          },
         }),
         signal: c.req.raw.signal,
       });

--- a/apps/server/tests/agent-os.test.ts
+++ b/apps/server/tests/agent-os.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   editAgentFile,
   globAgentFiles,
@@ -27,6 +27,12 @@ describe("path resolution", () => {
     expect(resolveAgentPath("/etc/hosts").full).toBe("/etc/hosts");
     expect(resolveAgentPath("Documents/x.txt").full).toBe(
       path.join(homedir(), "Documents", "x.txt"),
+    );
+  });
+
+  it("expands a leading tilde into the user's home directory", () => {
+    expect(resolveAgentPath("~/Documents/agent-notes.md").full).toBe(
+      path.join(homedir(), "Documents", "agent-notes.md"),
     );
   });
 });
@@ -55,6 +61,60 @@ describe("file ops", () => {
 });
 
 describe("bash", () => {
+  it("uses a non-interactive PowerShell command on Windows", async () => {
+    const powershell = vi.fn(
+      (
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => callback(null, "C:\\Users\\Freestyle", ""),
+    );
+
+    const res = await runAgentBash("Get-Location", {
+      platform: "win32",
+      execFile: powershell,
+    } as never);
+
+    expect(powershell).toHaveBeenCalledWith(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", "Get-Location"],
+      expect.objectContaining({ cwd: homedir(), timeout: 30_000 }),
+      expect.any(Function),
+    );
+    expect(res).toMatchObject({
+      ok: true,
+      category: "success",
+      exitCode: 0,
+    });
+  });
+
+  it("normalizes a missing Windows shell into a stable category", async () => {
+    const unavailable = Object.assign(new Error("not found"), {
+      code: "ENOENT",
+    });
+    const powershell = vi.fn(
+      (
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error, stdout: string, stderr: string) => void,
+      ) => callback(unavailable, "", ""),
+    );
+
+    const res = await runAgentBash("Get-Location", {
+      platform: "win32",
+      execFile: powershell,
+    } as never);
+
+    expect(res).toMatchObject({
+      ok: false,
+      category: "shell-unavailable",
+      reason: "shell-unavailable",
+      exitCode: 1,
+    });
+  });
+
   it("runs in the home cwd and captures output", async () => {
     const res = await runAgentBash("pwd");
     expect(res.exitCode).toBe(0);

--- a/apps/server/tests/agent-os.test.ts
+++ b/apps/server/tests/agent-os.test.ts
@@ -23,8 +23,11 @@ afterEach(() => {
 });
 
 describe("path resolution", () => {
-  it("absolute paths pass through; relative resolve against home", () => {
-    expect(resolveAgentPath("/etc/hosts").full).toBe("/etc/hosts");
+  it("resolves native absolute paths and relative paths against home", () => {
+    const absolutePath = path.resolve(
+      process.platform === "win32" ? "C:\\etc\\hosts" : "/etc/hosts",
+    );
+    expect(resolveAgentPath(absolutePath).full).toBe(absolutePath);
     expect(resolveAgentPath("Documents/x.txt").full).toBe(
       path.join(homedir(), "Documents", "x.txt"),
     );

--- a/apps/server/tests/agent-os.test.ts
+++ b/apps/server/tests/agent-os.test.ts
@@ -81,7 +81,12 @@ describe("bash", () => {
 
     expect(powershell).toHaveBeenCalledWith(
       "powershell.exe",
-      ["-NoProfile", "-NonInteractive", "-Command", "Get-Location"],
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        expect.stringContaining("Get-Location"),
+      ],
       expect.objectContaining({ cwd: homedir(), timeout: 30_000 }),
       expect.any(Function),
     );

--- a/apps/server/tests/agent-os.test.ts
+++ b/apps/server/tests/agent-os.test.ts
@@ -116,15 +116,17 @@ describe("bash", () => {
   });
 
   it("runs in the home cwd and captures output", async () => {
-    const res = await runAgentBash("pwd");
+    const res = await runAgentBash('node -p "process.cwd()"');
     expect(res.exitCode).toBe(0);
     expect(res.stdout.trim()).toBe(homedir());
   });
 
   it("reports failures and caps output", async () => {
-    const fail = await runAgentBash("exit 3");
+    const fail = await runAgentBash('node -e "process.exit(3)"');
     expect(fail.exitCode).toBe(3);
-    const big = await runAgentBash("yes x | head -c 20000");
+    const big = await runAgentBash(
+      "node -e \"process.stdout.write('x'.repeat(20000))\"",
+    );
     expect(big.stdout.length).toBeLessThanOrEqual(8192);
     expect(big.truncated).toBe(true);
   });

--- a/apps/server/tests/connectors.test.ts
+++ b/apps/server/tests/connectors.test.ts
@@ -20,7 +20,7 @@ describe("connector proxy", () => {
     });
   });
 
-  it("forwards the stable chat thread id to Cloud", async () => {
+  it("forwards the stable chat thread id and trusted desktop capabilities to Cloud", async () => {
     setSession({
       token: "cloud-session",
       user: { id: "user-1", email: "user@example.com" },
@@ -47,6 +47,10 @@ describe("connector proxy", () => {
     const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect(JSON.parse(request.body as string)).toMatchObject({
       threadId: "stable-thread-id",
+      client: {
+        platform: process.platform,
+        supportsDownloadsSave: true,
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary
- Use PowerShell safely on Windows and normalize local-tool failures.
- Require local-action approvals, add the Downloads-only collision-safe save_file tool, and keep tool telemetry privacy-safe.
- Run the cross-platform agent OS suite before Windows packaging.

## Validation
- Server tests: 415 passed.
- Electron tests: 128 passed.
- Electron production build passed.
- Focused agent OS suite: 8 passed.

## Release order
Merge and deploy the paired Cloud compatibility PR first, then publish this desktop hotfix. Hosted Windows CI must pass before release.