### PR TITLE
refactor: make Chat a conversation workspace

### DIFF
--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -46,6 +46,10 @@ import {
   type ToolPhase,
   toolPresentation,
 } from "@renderer/lib/tool-presentation";
+import {
+  compactActivitySummary,
+  workspaceNavigationMode,
+} from "@renderer/lib/workspace-navigation";
 import { SpriteBadge } from "@renderer/sprites/badge";
 import { type CompanionForm, DEFAULT_COMPANION_FORM } from "@shared/companion";
 import {
@@ -87,6 +91,102 @@ const TAB_PLACEHOLDER: Record<PanelTab, string> = {
     "Everything Freestyle knows lives here — scheduled tasks, memories, notes, skills, todos.",
   apps: "Connect the apps you live in, and Freestyle can work them for you.",
 };
+
+const SECONDARY_TABS = PANEL_TABS.filter(
+  (tab): tab is Exclude<PanelTab, "chat" | "history"> =>
+    tab !== "chat" && tab !== "history",
+);
+
+function useWorkspaceNavigationMode(): "rail" | "drawer" {
+  const [mode, setMode] = useState(() =>
+    workspaceNavigationMode(window.innerWidth),
+  );
+
+  useEffect(() => {
+    const update = (): void =>
+      setMode(workspaceNavigationMode(window.innerWidth));
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  return mode;
+}
+
+function WorkspaceDrawer({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    closeRef.current?.focus();
+  }, []);
+
+  return (
+    <div className="tavern-workspace-drawer-layer">
+      <button
+        type="button"
+        className="tavern-workspace-drawer-scrim"
+        aria-label={`Close ${title.toLowerCase()}`}
+        onClick={onClose}
+      />
+      <aside
+        className="tavern-workspace-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onKeyDown={(event) => {
+          if (event.key !== "Escape") return;
+          event.stopPropagation();
+          onClose();
+        }}
+      >
+        <div className="tavern-workspace-drawer-head">
+          <span>{title}</span>
+          <button
+            ref={closeRef}
+            type="button"
+            className="tavern-close"
+            aria-label={`Close ${title.toLowerCase()}`}
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </div>
+        <div className="tavern-workspace-drawer-body">{children}</div>
+      </aside>
+    </div>
+  );
+}
+
+function SecondaryNavigation({
+  active,
+  onSelect,
+}: {
+  active: PanelTab;
+  onSelect: (tab: Exclude<PanelTab, "chat" | "history">) => void;
+}): React.JSX.Element {
+  return (
+    <nav className="tavern-secondary-nav" aria-label="Workspace tools">
+      <span className="tavern-label">Workspace</span>
+      {SECONDARY_TABS.map((tab) => (
+        <button
+          key={tab}
+          type="button"
+          className={`tavern-secondary-nav-item${active === tab ? " is-active" : ""}`}
+          onClick={() => onSelect(tab)}
+        >
+          {TAB_LABELS[tab]}
+        </button>
+      ))}
+    </nav>
+  );
+}
 
 function reportAgentToolResult(
   call: AgentToolCall,
@@ -254,6 +354,76 @@ function ToolChip({
         </div>
       ) : null}
     </div>
+  );
+}
+
+function ToolActivity({
+  parts,
+}: {
+  parts: UIMessage["parts"];
+}): React.JSX.Element | null {
+  const tools = parts.filter(
+    (part) =>
+      part.type.startsWith("tool-") && part.type !== "tool-suggest_connections",
+  );
+  if (tools.length === 0) return null;
+
+  const items = tools.map((part) => {
+    const tool = part as {
+      state?: string;
+      input?: unknown;
+      output?: { ok?: boolean; reason?: string };
+    };
+    const phase: ToolPhase =
+      tool.state === "input-streaming" || tool.state === "input-available"
+        ? "running"
+        : tool.state === "output-error"
+          ? "failed"
+          : tool.output?.ok === false
+            ? tool.output.reason === "user-declined"
+              ? "declined"
+              : "failed"
+            : "done";
+    return {
+      part,
+      input: tool.input,
+      output: tool.output,
+      phase,
+      title: toolPresentation(part.type, phase, tool.input, tool.output).title,
+    };
+  });
+  const summary = compactActivitySummary(items);
+
+  return (
+    <details className="tavern-tool-activity" open={summary.running}>
+      <summary>
+        <span className="tavern-tool-mark" aria-hidden="true">
+          ✦
+        </span>
+        <span>
+          {summary.running ? "Working · " : "Activity · "}
+          {summary.label}
+        </span>
+        {summary.running ? (
+          <span
+            className="tavern-tool-spinner"
+            role="status"
+            aria-label="Working"
+          />
+        ) : null}
+      </summary>
+      <div className="tavern-tool-activity-list">
+        {items.map(({ part, input, output, phase }, index) => (
+          <ToolChip
+            key={`${part.type}-${index}`}
+            partType={part.type}
+            input={input}
+            output={output}
+            phase={phase}
+          />
+        ))}
+      </div>
+    </details>
   );
 }
 
@@ -434,55 +604,22 @@ function ChatMessage({
             );
           }
           if (part.type.startsWith("tool-")) {
-            const tool = part as {
-              state?: string;
-              input?: unknown;
-              output?: { ok?: boolean; reason?: string };
-            };
-            // Rendering only completed calls left a 16-step run looking like
-            // one pulsing dot, and hid every refusal from the transcript.
+            const previous = message.parts[i - 1];
             if (
-              tool.state === "input-streaming" ||
-              tool.state === "input-available"
-            ) {
-              return (
-                <ToolChip
-                  key={`${message.id}-${i}`}
-                  partType={part.type}
-                  input={tool.input}
-                  output={undefined}
-                  phase="running"
-                />
-              );
+              previous?.type.startsWith("tool-") &&
+              previous.type !== "tool-suggest_connections"
+            )
+              return null;
+            const group: UIMessage["parts"] = [];
+            for (const candidate of message.parts.slice(i)) {
+              if (
+                !candidate.type.startsWith("tool-") ||
+                candidate.type === "tool-suggest_connections"
+              )
+                break;
+              group.push(candidate);
             }
-            if (tool.state === "output-error") {
-              return (
-                <ToolChip
-                  key={`${message.id}-${i}`}
-                  partType={part.type}
-                  input={tool.input}
-                  output={tool.output}
-                  phase="failed"
-                />
-              );
-            }
-            if (tool.state !== "output-available") return null;
-            const failed = tool.output?.ok === false;
-            return (
-              <ToolChip
-                key={`${message.id}-${i}`}
-                partType={part.type}
-                input={tool.input}
-                output={tool.output}
-                phase={
-                  failed
-                    ? tool.output?.reason === "user-declined"
-                      ? "declined"
-                      : "failed"
-                    : "done"
-                }
-              />
-            );
+            return <ToolActivity key={`${message.id}-${i}`} parts={group} />;
           }
           return null;
         })}
@@ -747,6 +884,11 @@ function PanelInner({
   onSwitchThread: (thread: ThreadState) => void;
 }): React.JSX.Element {
   const [tab, setTab] = useState<PanelTab>("chat");
+  const navigationMode = useWorkspaceNavigationMode();
+  const [railCollapsed, setRailCollapsed] = useState(false);
+  const [historyDrawerOpen, setHistoryDrawerOpen] = useState(false);
+  const [activityDrawerOpen, setActivityDrawerOpen] = useState(false);
+  const [workspaceDrawerOpen, setWorkspaceDrawerOpen] = useState(false);
   const queryClient = useQueryClient();
   const auth = useCloudAuth();
   const onboarding = useOnboarding(!!auth.user);
@@ -1100,6 +1242,22 @@ function PanelInner({
 
   const chatActive = tab === "chat";
   const showChat = chatActive && messages.length > 0;
+  const selectSecondary = (
+    next: Exclude<PanelTab, "chat" | "history">,
+  ): void => {
+    capture("panel_tab_opened", { tab: next });
+    setSettingsOpen(false);
+    setCapabilitiesOpen(false);
+    setWorkspaceDrawerOpen(false);
+    setTab(next);
+  };
+  const openHistory = (): void => {
+    if (navigationMode === "rail") {
+      setRailCollapsed((collapsed) => !collapsed);
+      return;
+    }
+    setHistoryDrawerOpen(true);
+  };
 
   // Signed out, the gate is the entire panel — no head, no tabs, no way to
   // reach the agent. While auth status resolves, show nothing rather than
@@ -1154,7 +1312,24 @@ function PanelInner({
   return (
     <div className="tavern-shell">
       <div className="tavern tavern-panel">
-        <div className="tavern-head">
+        <div className="tavern-head tavern-workspace-head">
+          <button
+            type="button"
+            className="tavern-workspace-icon-btn"
+            aria-label={
+              navigationMode === "rail"
+                ? railCollapsed
+                  ? "Show conversation history"
+                  : "Collapse conversation history"
+                : "Open conversation history"
+            }
+            aria-expanded={
+              navigationMode === "rail" ? !railCollapsed : historyDrawerOpen
+            }
+            onClick={openHistory}
+          >
+            ☰
+          </button>
           <SpriteBadge form={spriteForm} working={busy} size={22} />
           <span className="tavern-head-name">
             freestyle<i>.</i>
@@ -1196,7 +1371,28 @@ function PanelInner({
             disabled={pinned}
             onClick={() => onSwitchThread(newThread())}
           >
-            ＋ New
+            ＋ New chat
+          </button>
+          <button
+            type="button"
+            className="tavern-workspace-icon-btn"
+            aria-label="Open activity"
+            aria-expanded={activityDrawerOpen}
+            onClick={() => setActivityDrawerOpen(true)}
+          >
+            ◷
+          </button>
+          <button
+            type="button"
+            className={`tavern-workspace-icon-btn${settingsOpen ? " is-active" : ""}`}
+            aria-label="Settings"
+            aria-pressed={settingsOpen}
+            onClick={() => {
+              setCapabilitiesOpen(false);
+              setSettingsOpen((open) => !open);
+            }}
+          >
+            ⚙
           </button>
           <button
             type="button"
@@ -1207,217 +1403,274 @@ function PanelInner({
             ×
           </button>
         </div>
-
-        <div className="tavern-tabs" role="tablist">
-          {PANEL_TABS.map((id) => (
-            <button
-              key={id}
-              type="button"
-              role="tab"
-              aria-selected={!settingsOpen && tab === id}
-              className="tavern-tab"
-              onClick={() => {
-                capture("panel_tab_opened", { tab: id });
-                setSettingsOpen(false);
-                setCapabilitiesOpen(false);
-                setTab(id);
-              }}
+        <div className="tavern-workspace">
+          {navigationMode === "rail" && !railCollapsed ? (
+            <aside
+              className="tavern-history-rail"
+              aria-label="Conversation history"
             >
-              {TAB_LABELS[id]}
-            </button>
-          ))}
-          <span className="tavern-head-spacer" />
-          <button
-            type="button"
-            role="tab"
-            aria-selected={settingsOpen}
-            aria-label="Settings"
-            title="Settings"
-            className="tavern-tab tavern-tab-gear"
-            onClick={() => setSettingsOpen((v) => !v)}
-          >
-            ⚙
-          </button>
-        </div>
-
-        <div className="tavern-body" role="tabpanel" ref={bodyRef}>
-          {capabilitiesOpen ? (
-            <>
               <button
                 type="button"
-                className="tavern-file-back"
-                onClick={() => setCapabilitiesOpen(false)}
+                className="tavern-history-new"
+                disabled={pinned}
+                onClick={() => onSwitchThread(newThread())}
               >
-                ← What Freestyle can do
+                ＋ New chat
               </button>
-              <Capabilities
-                onPrompt={(text) => {
-                  setCapabilitiesOpen(false);
-                  setNotice(null);
-                  void sendMessage({ text });
-                }}
-                onOpenApps={() => {
-                  setCapabilitiesOpen(false);
-                  setTab("apps");
-                }}
-              />
-            </>
-          ) : settingsOpen ? (
-            <SettingsView
-              onClose={() => setSettingsOpen(false)}
-              onOpenThread={(threadId) => {
-                setSettingsOpen(false);
-                setTab("chat");
-                void openThreadById(threadId).then((picked) => {
-                  if (picked) onSwitchThread(picked);
-                });
-              }}
-              onThreadsCleared={() => {
-                void invalidateThreads(queryClient);
-                onSwitchThread(newThread());
-              }}
-              onReplayIntro={() => {
-                setSettingsOpen(false);
-                onboarding.replay();
-              }}
-            />
-          ) : tab === "history" ? (
-            <ThreadHistory
-              currentId={thread.id}
-              onPick={(picked) => {
-                if (picked.id === thread.id) setTab("chat");
-                else onSwitchThread(picked);
-              }}
-            />
-          ) : tab === "apps" ? (
-            <ConnectedApps
-              onUseWorkflow={(prompt) => {
-                setTab("chat");
-                // Sending past a pending approval strands the tool call, which
-                // leaves an unanswerable tool_use in the thread forever.
-                if (pinned) return;
-                setNotice(null);
-                void sendMessage({ text: prompt });
-              }}
-            />
-          ) : showChat ? (
-            <>
-              {messages.map((m) => (
-                <ChatMessage
-                  key={m.id}
-                  message={m}
-                  copied={copiedMessageId === m.id}
-                  disabled={pinned}
-                  editing={editingMessageId === m.id}
-                  editDraft={editDraft}
-                  onCopy={() => copyMessage(m)}
-                  onEdit={() => startEditingMessage(m)}
-                  onEditDraftChange={setEditDraft}
-                  onCancelEdit={cancelEditingMessage}
-                  onResendEdit={resendEditedMessage}
-                  onRegenerate={() => regenerateMessage(m)}
+              <div className="tavern-history-rail-list">
+                <ThreadHistory
+                  currentId={thread.id}
+                  onPick={(picked) => {
+                    setTab("chat");
+                    if (picked.id !== thread.id) onSwitchThread(picked);
+                  }}
                 />
-              ))}
-              {approvals.map((call) => (
-                <div key={call.toolCallId} className="tavern-approve">
-                  <span className="tavern-approve-title">
-                    {SPRITES_INFO[spriteForm].label.toLowerCase()} wants to act
-                  </span>
-                  <div className="tavern-approve-text">
-                    {describeAgentAction(call)}
-                  </div>
-                  <div className="tavern-approve-actions">
-                    <button
-                      type="button"
-                      className="tavern-approve-btn tavern-approve-allow"
-                      onClick={() => resolveApproval(call, true)}
-                    >
-                      Allow
-                    </button>
-                    <button
-                      type="button"
-                      className="tavern-approve-btn"
-                      onClick={() => resolveApproval(call, false)}
-                    >
-                      Don't allow
-                    </button>
-                  </div>
-                </div>
-              ))}
-              {awaitingText ? (
-                <div
-                  className="tavern-stream-wait"
-                  role="status"
-                  aria-label="Thinking"
-                >
-                  <Spark state="idle" size={11} />
-                </div>
-              ) : null}
-            </>
-          ) : tab === "todos" ? (
-            <TodosTab mascot={SPRITES_INFO[spriteForm].label} />
-          ) : tab === "notes" ? (
-            <NotesTab />
-          ) : tab === "brain" ? (
-            <BrainFiles
-              root=""
-              emptyText={TAB_PLACEHOLDER.brain}
-              newLabel="New file"
-              onOpenThread={(threadId) => {
-                setTab("chat");
-                void openThreadById(threadId).then((picked) => {
-                  if (picked) onSwitchThread(picked);
-                });
-              }}
-            />
-          ) : chatActive ? (
-            <OpenerCards
-              busy={busy}
-              onShowAll={() => setCapabilitiesOpen(true)}
-              onPrompt={(text) => {
-                setNotice(null);
-                void sendMessage({ text });
-              }}
-            />
-          ) : (
-            <div className="tavern-empty">{TAB_PLACEHOLDER[tab]}</div>
-          )}
-          {notice ? <p className="tavern-notice">{notice}</p> : null}
-        </div>
-
-        {chatActive && !settingsOpen && !capabilitiesOpen ? (
-          <div className="tavern-composer">
-            <textarea
-              id="panel-composer"
-              className="tavern-input"
-              value={draft}
-              rows={1}
-              placeholder="Ask anything"
-              onMouseDown={() => window.api.panelRequestFocus()}
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (
-                  e.key === "Enter" &&
-                  !e.shiftKey &&
-                  !e.nativeEvent.isComposing
-                ) {
-                  e.preventDefault();
-                  send();
-                }
-              }}
-            />
-            <button
-              type="button"
-              className={`tavern-btn tavern-btn-send${action === "stop" ? " is-stop" : ""}`}
-              aria-label={action === "stop" ? "Stop generating" : "Send"}
-              title={action === "stop" ? "Stop generating" : "Send"}
-              onClick={action === "stop" ? stopGeneration : send}
+              </div>
+              <SecondaryNavigation active={tab} onSelect={selectSecondary} />
+            </aside>
+          ) : null}
+          <div className="tavern-workspace-main">
+            <div className="tavern-workspace-mobile-tools">
+              <button type="button" onClick={openHistory}>
+                Conversations
+              </button>
+              <button type="button" onClick={() => setActivityDrawerOpen(true)}>
+                Activity
+              </button>
+              <button
+                type="button"
+                onClick={() => setWorkspaceDrawerOpen(true)}
+              >
+                Workspace
+              </button>
+            </div>
+            <div
+              className="tavern-body tavern-conversation"
+              role="tabpanel"
+              ref={bodyRef}
             >
-              {action === "stop" ? "■" : "↑"}
-            </button>
+              {capabilitiesOpen ? (
+                <>
+                  <button
+                    type="button"
+                    className="tavern-file-back"
+                    onClick={() => setCapabilitiesOpen(false)}
+                  >
+                    ← What Freestyle can do
+                  </button>
+                  <Capabilities
+                    onPrompt={(text) => {
+                      setCapabilitiesOpen(false);
+                      setNotice(null);
+                      void sendMessage({ text });
+                    }}
+                    onOpenApps={() => {
+                      setCapabilitiesOpen(false);
+                      setTab("apps");
+                    }}
+                  />
+                </>
+              ) : settingsOpen ? (
+                <SettingsView
+                  onClose={() => setSettingsOpen(false)}
+                  onOpenThread={(threadId) => {
+                    setSettingsOpen(false);
+                    setTab("chat");
+                    void openThreadById(threadId).then((picked) => {
+                      if (picked) onSwitchThread(picked);
+                    });
+                  }}
+                  onThreadsCleared={() => {
+                    void invalidateThreads(queryClient);
+                    onSwitchThread(newThread());
+                  }}
+                  onReplayIntro={() => {
+                    setSettingsOpen(false);
+                    onboarding.replay();
+                  }}
+                />
+              ) : tab === "apps" ? (
+                <ConnectedApps
+                  onUseWorkflow={(prompt) => {
+                    setTab("chat");
+                    // Sending past a pending approval strands the tool call, which
+                    // leaves an unanswerable tool_use in the thread forever.
+                    if (pinned) return;
+                    setNotice(null);
+                    void sendMessage({ text: prompt });
+                  }}
+                />
+              ) : showChat ? (
+                <>
+                  {messages.map((m) => (
+                    <ChatMessage
+                      key={m.id}
+                      message={m}
+                      copied={copiedMessageId === m.id}
+                      disabled={pinned}
+                      editing={editingMessageId === m.id}
+                      editDraft={editDraft}
+                      onCopy={() => copyMessage(m)}
+                      onEdit={() => startEditingMessage(m)}
+                      onEditDraftChange={setEditDraft}
+                      onCancelEdit={cancelEditingMessage}
+                      onResendEdit={resendEditedMessage}
+                      onRegenerate={() => regenerateMessage(m)}
+                    />
+                  ))}
+                  {approvals.map((call) => (
+                    <div key={call.toolCallId} className="tavern-approve">
+                      <span className="tavern-approve-title">
+                        {SPRITES_INFO[spriteForm].label.toLowerCase()} wants to
+                        act
+                      </span>
+                      <div className="tavern-approve-text">
+                        {describeAgentAction(call)}
+                      </div>
+                      <div className="tavern-approve-actions">
+                        <button
+                          type="button"
+                          className="tavern-approve-btn tavern-approve-allow"
+                          onClick={() => resolveApproval(call, true)}
+                        >
+                          Allow
+                        </button>
+                        <button
+                          type="button"
+                          className="tavern-approve-btn"
+                          onClick={() => resolveApproval(call, false)}
+                        >
+                          Don't allow
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                  {awaitingText ? (
+                    <div
+                      className="tavern-stream-wait"
+                      role="status"
+                      aria-label="Thinking"
+                    >
+                      <Spark state="idle" size={11} />
+                    </div>
+                  ) : null}
+                </>
+              ) : tab === "todos" ? (
+                <TodosTab mascot={SPRITES_INFO[spriteForm].label} />
+              ) : tab === "notes" ? (
+                <NotesTab />
+              ) : tab === "brain" ? (
+                <BrainFiles
+                  root=""
+                  emptyText={TAB_PLACEHOLDER.brain}
+                  newLabel="New file"
+                  onOpenThread={(threadId) => {
+                    setTab("chat");
+                    void openThreadById(threadId).then((picked) => {
+                      if (picked) onSwitchThread(picked);
+                    });
+                  }}
+                />
+              ) : chatActive ? (
+                <OpenerCards
+                  busy={busy}
+                  onShowAll={() => setCapabilitiesOpen(true)}
+                  onPrompt={(text) => {
+                    setNotice(null);
+                    void sendMessage({ text });
+                  }}
+                />
+              ) : (
+                <div className="tavern-empty">{TAB_PLACEHOLDER[tab]}</div>
+              )}
+              {notice ? <p className="tavern-notice">{notice}</p> : null}
+            </div>
+
+            {chatActive && !settingsOpen && !capabilitiesOpen ? (
+              <div className="tavern-composer">
+                <textarea
+                  id="panel-composer"
+                  className="tavern-input"
+                  value={draft}
+                  rows={1}
+                  placeholder="Message Freestyle"
+                  onMouseDown={() => window.api.panelRequestFocus()}
+                  onChange={(e) => setDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === "Enter" &&
+                      !e.shiftKey &&
+                      !e.nativeEvent.isComposing
+                    ) {
+                      e.preventDefault();
+                      send();
+                    }
+                  }}
+                />
+                <button
+                  type="button"
+                  className={`tavern-btn tavern-btn-send${action === "stop" ? " is-stop" : ""}`}
+                  aria-label={action === "stop" ? "Stop generating" : "Send"}
+                  title={action === "stop" ? "Stop generating" : "Send"}
+                  onClick={action === "stop" ? stopGeneration : send}
+                >
+                  {action === "stop" ? "■" : "↑"}
+                </button>
+              </div>
+            ) : null}
           </div>
-        ) : null}
+        </div>
       </div>
+      {navigationMode === "drawer" && historyDrawerOpen ? (
+        <WorkspaceDrawer
+          title="Conversations"
+          onClose={() => setHistoryDrawerOpen(false)}
+        >
+          <button
+            type="button"
+            className="tavern-history-new"
+            disabled={pinned}
+            onClick={() => {
+              setHistoryDrawerOpen(false);
+              onSwitchThread(newThread());
+            }}
+          >
+            ＋ New chat
+          </button>
+          <ThreadHistory
+            currentId={thread.id}
+            onPick={(picked) => {
+              setHistoryDrawerOpen(false);
+              setTab("chat");
+              if (picked.id !== thread.id) onSwitchThread(picked);
+            }}
+          />
+        </WorkspaceDrawer>
+      ) : null}
+      {activityDrawerOpen ? (
+        <WorkspaceDrawer
+          title="Activity"
+          onClose={() => setActivityDrawerOpen(false)}
+        >
+          <ThreadHistory
+            currentId={thread.id}
+            initialOrigin="scheduled"
+            onPick={(picked) => {
+              setActivityDrawerOpen(false);
+              setTab("chat");
+              if (picked.id !== thread.id) onSwitchThread(picked);
+            }}
+          />
+        </WorkspaceDrawer>
+      ) : null}
+      {workspaceDrawerOpen ? (
+        <WorkspaceDrawer
+          title="Workspace"
+          onClose={() => setWorkspaceDrawerOpen(false)}
+        >
+          <SecondaryNavigation active={tab} onSelect={selectSecondary} />
+        </WorkspaceDrawer>
+      ) : null}
       <PanelTail />
       <PanelResizeHandle />
     </div>

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -39,7 +39,13 @@ import {
 } from "@renderer/lib/query";
 import { installGlobalErrorHandlers } from "@renderer/lib/report-error";
 import { useSpriteEmitter } from "@renderer/lib/sprite-emitter";
-import { getThread, type ThreadState } from "@renderer/lib/threads";
+import {
+  type DurableThreadAction,
+  getThread,
+  getThreadRuntime,
+  sendDurableTurnCommand,
+  type ThreadState,
+} from "@renderer/lib/threads";
 import { highlightToolJson, toolJson } from "@renderer/lib/tool-json";
 import {
   connectorToolkitSlug,
@@ -656,6 +662,15 @@ function newThread(): ThreadState {
   return { id: crypto.randomUUID(), messages: [] };
 }
 
+function durableDesktopClientId(): string {
+  const key = "freestyle.durable-desktop-client-id";
+  const existing = window.localStorage.getItem(key);
+  if (existing) return existing;
+  const next = `desktop-${crypto.randomUUID()}`;
+  window.localStorage.setItem(key, next);
+  return next;
+}
+
 function touchesBrain(message: UIMessage): boolean {
   return message.parts.some(
     (part) =>
@@ -921,7 +936,12 @@ function PanelInner({
   const [draft, setDraft] = useState("");
 
   const [notice, setNotice] = useState<string | null>(null);
-  const [approvals, setApprovals] = useState<AgentToolCall[]>([]);
+  const [approvals, setApprovals] = useState<
+    Array<{
+      call: AgentToolCall;
+      durable?: { turnId: string; actionId: string };
+    }>
+  >([]);
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
@@ -931,6 +951,16 @@ function PanelInner({
   const dictationBaseRef = useRef<string | null>(null);
   // Whether the current draft arrived by voice, so message_sent can say so.
   const dictatedRef = useRef(false);
+
+  const durableRuntime = useQuery({
+    queryKey: ["durable-thread-runtime", thread.id],
+    queryFn: () => getThreadRuntime(thread.id),
+    retry: false,
+    refetchInterval: (query) =>
+      query.state.data?.activeTurn || query.state.data?.pendingAction
+        ? 1_000
+        : false,
+  });
 
   const transport = useMemo(
     () =>
@@ -993,7 +1023,7 @@ function PanelInner({
       };
       const tier = await agentToolTier(call);
       if (tier === "confirmed") {
-        setApprovals((prev) => [...prev, call]);
+        setApprovals((prev) => [...prev, { call }]);
         return;
       }
       const output =
@@ -1025,6 +1055,12 @@ function PanelInner({
     if (status === "submitted" || status === "streaming") return;
     if (thread.messages.length > messages.length) setMessages(thread.messages);
   }, [thread.messages, messages.length, setMessages, status]);
+
+  useEffect(() => {
+    const synced = durableRuntime.data?.thread;
+    if (!synced || status === "submitted" || status === "streaming") return;
+    if (synced.messages.length >= messages.length) setMessages(synced.messages);
+  }, [durableRuntime.data?.thread, messages.length, setMessages, status]);
 
   const startedRef = useRef(thread.messages.length > 0);
   useEffect(() => {
@@ -1122,10 +1158,17 @@ function PanelInner({
     });
   };
 
-  const resolveApproval = (call: AgentToolCall, allowed: boolean): void => {
+  const resolveApproval = (
+    approval: {
+      call: AgentToolCall;
+      durable?: { turnId: string; actionId: string };
+    },
+    allowed: boolean,
+  ): void => {
+    const call = approval.call;
     capture("approval_resolved", { tool: call.toolName, allowed });
     setApprovals((prev) =>
-      prev.filter((a) => a.toolCallId !== call.toolCallId),
+      prev.filter((item) => item.call.toolCallId !== call.toolCallId),
     );
     void (async () => {
       const startedAt = Date.now();
@@ -1144,12 +1187,76 @@ function PanelInner({
                   : undefined,
             });
       reportAgentToolResult(call, output, startedAt);
-      addToolOutput({
-        tool: call.toolName,
-        toolCallId: call.toolCallId,
-        output,
-      });
+      if (approval.durable) {
+        await sendDurableTurnCommand(approval.durable.turnId, {
+          type: "desktop_complete",
+          actionId: approval.durable.actionId,
+          clientId: durableDesktopClientId(),
+          result: output,
+        });
+        await durableRuntime.refetch();
+      } else {
+        addToolOutput({
+          tool: call.toolName,
+          toolCallId: call.toolCallId,
+          output,
+        });
+      }
     })();
+  };
+
+  const resolveDurableConnector = (
+    action: DurableThreadAction,
+    allowed: boolean,
+  ): void => {
+    void sendDurableTurnCommand(action.turnId, {
+      type: allowed ? "approve" : "decline",
+      actionId: action.id,
+    })
+      .then(() => durableRuntime.refetch())
+      .catch(() => setNotice("Couldn't resolve this connected-app action."));
+  };
+
+  const claimDurableDesktopAction = (action: DurableThreadAction): void => {
+    void (async () => {
+      const response = (await sendDurableTurnCommand(action.turnId, {
+        type: "desktop_claim",
+        actionId: action.id,
+        clientId: durableDesktopClientId(),
+        client: {
+          platform: window.api.platform,
+          supportsDownloadsSave: true,
+        },
+      })) as { action?: { id?: string; toolName?: string; input?: unknown } };
+      if (!response.action?.id || !response.action.toolName) {
+        throw new Error("The desktop action was no longer available.");
+      }
+      const call: AgentToolCall = {
+        toolCallId: response.action.id,
+        toolName: response.action.toolName,
+        input: response.action.input,
+      };
+      const tier = await agentToolTier(call);
+      if (tier === "confirmed") {
+        setApprovals((previous) => [
+          ...previous,
+          { call, durable: { turnId: action.turnId, actionId: action.id } },
+        ]);
+        return;
+      }
+      const output =
+        tier === "free"
+          ? await executeAgentTool(call)
+          : { ok: false, reason: `unknown tool: ${call.toolName}` };
+      reportAgentToolResult(call, output, Date.now());
+      await sendDurableTurnCommand(action.turnId, {
+        type: "desktop_complete",
+        actionId: action.id,
+        clientId: durableDesktopClientId(),
+        result: output,
+      });
+      await durableRuntime.refetch();
+    })().catch(() => setNotice("Couldn't run that desktop action."));
   };
 
   useEffect(() => {
@@ -1518,33 +1625,97 @@ function PanelInner({
                       onRegenerate={() => regenerateMessage(m)}
                     />
                   ))}
-                  {approvals.map((call) => (
-                    <div key={call.toolCallId} className="tavern-approve">
+                  {approvals.map((approval) => (
+                    <div
+                      key={approval.call.toolCallId}
+                      className="tavern-approve"
+                    >
                       <span className="tavern-approve-title">
                         {SPRITES_INFO[spriteForm].label.toLowerCase()} wants to
                         act
                       </span>
                       <div className="tavern-approve-text">
-                        {describeAgentAction(call)}
+                        {describeAgentAction(approval.call)}
                       </div>
                       <div className="tavern-approve-actions">
                         <button
                           type="button"
                           className="tavern-approve-btn tavern-approve-allow"
-                          onClick={() => resolveApproval(call, true)}
+                          onClick={() => resolveApproval(approval, true)}
                         >
                           Allow
                         </button>
                         <button
                           type="button"
                           className="tavern-approve-btn"
-                          onClick={() => resolveApproval(call, false)}
+                          onClick={() => resolveApproval(approval, false)}
                         >
                           Don't allow
                         </button>
                       </div>
                     </div>
                   ))}
+                  {durableRuntime.data?.pendingAction?.kind === "connector" &&
+                  durableRuntime.data.pendingAction.status === "pending" ? (
+                    <div className="tavern-approve">
+                      <span className="tavern-approve-title">
+                        connected app action needs approval
+                      </span>
+                      <div className="tavern-approve-text">
+                        {durableRuntime.data.pendingAction.display}
+                      </div>
+                      <div className="tavern-approve-actions">
+                        <button
+                          type="button"
+                          className="tavern-approve-btn tavern-approve-allow"
+                          onClick={() =>
+                            resolveDurableConnector(
+                              durableRuntime.data!.pendingAction!,
+                              true,
+                            )
+                          }
+                        >
+                          Allow
+                        </button>
+                        <button
+                          type="button"
+                          className="tavern-approve-btn"
+                          onClick={() =>
+                            resolveDurableConnector(
+                              durableRuntime.data!.pendingAction!,
+                              false,
+                            )
+                          }
+                        >
+                          Don't allow
+                        </button>
+                      </div>
+                    </div>
+                  ) : null}
+                  {durableRuntime.data?.pendingAction?.kind === "desktop" &&
+                  durableRuntime.data.pendingAction.status === "pending" ? (
+                    <div className="tavern-approve">
+                      <span className="tavern-approve-title">
+                        desktop action waiting
+                      </span>
+                      <div className="tavern-approve-text">
+                        {durableRuntime.data.pendingAction.display}
+                      </div>
+                      <div className="tavern-approve-actions">
+                        <button
+                          type="button"
+                          className="tavern-approve-btn tavern-approve-allow"
+                          onClick={() =>
+                            claimDurableDesktopAction(
+                              durableRuntime.data!.pendingAction!,
+                            )
+                          }
+                        >
+                          Run on this desktop
+                        </button>
+                      </div>
+                    </div>
+                  ) : null}
                   {awaitingText ? (
                     <div
                       className="tavern-stream-wait"

--- a/apps/electron/src/renderer/src/components/thread-history.test.ts
+++ b/apps/electron/src/renderer/src/components/thread-history.test.ts
@@ -34,4 +34,25 @@ describe("ThreadHistory", () => {
     expect(html).toContain("Briefs");
     expect(html).toContain("Loading conversations…");
   });
+
+  it("can open directly on activity briefs from the compact workspace drawer", () => {
+    useInfiniteQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+    });
+    useQueryClient.mockReturnValue({ fetchQuery: vi.fn() });
+
+    const html = renderToStaticMarkup(
+      createElement(ThreadHistory, {
+        currentId: "active-thread",
+        initialOrigin: "scheduled",
+        onPick: vi.fn(),
+      }),
+    );
+
+    expect(html).toContain("Loading activity…");
+  });
 });

--- a/apps/electron/src/renderer/src/components/thread-history.tsx
+++ b/apps/electron/src/renderer/src/components/thread-history.tsx
@@ -31,12 +31,15 @@ function dateGroup(ts: number): string {
 export function ThreadHistory({
   onPick,
   currentId,
+  initialOrigin = "user",
 }: {
   onPick: (thread: ThreadState) => void;
   currentId: string;
+  /** Lets the Activity drawer start on scheduled briefs without a tab hop. */
+  initialOrigin?: ThreadOrigin;
 }): React.JSX.Element {
   const queryClient = useQueryClient();
-  const [origin, setOrigin] = useState<ThreadOrigin>("user");
+  const [origin, setOrigin] = useState<ThreadOrigin>(initialOrigin);
   const historyQuery = useInfiniteQuery(
     threadHistoryInfiniteQueryOptions(origin),
   );
@@ -64,7 +67,9 @@ export function ThreadHistory({
     return (
       <>
         {filter}
-        <div className="tavern-empty">Loading conversations…</div>
+        <div className="tavern-empty">
+          {origin === "user" ? "Loading conversations…" : "Loading activity…"}
+        </div>
       </>
     );
   if (threads.length === 0)

--- a/apps/electron/src/renderer/src/lib/threads.ts
+++ b/apps/electron/src/renderer/src/lib/threads.ts
@@ -3,6 +3,29 @@ import type { UIMessage } from "ai";
 
 export type ThreadState = { id: string; messages: UIMessage[] };
 
+export type DurableThreadAction = {
+  id: string;
+  turnId: string;
+  kind: "connector" | "desktop";
+  status:
+    | "pending"
+    | "claimed"
+    | "completed"
+    | "declined"
+    | "expired"
+    | "failed";
+  toolName: string;
+  display: string;
+  capability: string | null;
+  expiresAt: string;
+};
+
+export type DurableThreadRuntime = {
+  thread: ThreadState;
+  activeTurn: { id: string; status: string; error: string | null } | null;
+  pendingAction: DurableThreadAction | null;
+};
+
 export type ThreadOrigin = "user" | "scheduled";
 
 export const THREAD_ORIGINS: ThreadOrigin[] = ["user", "scheduled"];
@@ -58,4 +81,28 @@ export async function getThread(id: string): Promise<ThreadState | null> {
     await apiFetch(`/api/agent/thread/${encodeURIComponent(id)}`),
   );
   return data.thread;
+}
+
+/** The ordinary thread remains D1 history; this optional envelope adds only
+ * durable execution state and never contains server-side tool inputs. */
+export async function getThreadRuntime(
+  id: string,
+): Promise<DurableThreadRuntime | null> {
+  const data = await responseJson<DurableThreadRuntime>(
+    await apiFetch(`/api/agent/thread/${encodeURIComponent(id)}`),
+  );
+  return data.thread ? data : null;
+}
+
+export async function sendDurableTurnCommand(
+  turnId: string,
+  command: Record<string, unknown>,
+): Promise<unknown> {
+  return responseJson<unknown>(
+    await apiFetch(`/api/agent/turn/${encodeURIComponent(turnId)}/commands`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(command),
+    }),
+  );
 }

--- a/apps/electron/src/renderer/src/lib/workspace-navigation.test.ts
+++ b/apps/electron/src/renderer/src/lib/workspace-navigation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compactActivitySummary,
+  workspaceNavigationMode,
+} from "./workspace-navigation";
+
+describe("workspaceNavigationMode", () => {
+  it("keeps conversation history in a persistent rail when the panel is wide enough", () => {
+    expect(workspaceNavigationMode(720)).toBe("rail");
+  });
+
+  it("uses an accessible drawer trigger when the panel is narrow", () => {
+    expect(workspaceNavigationMode(480)).toBe("drawer");
+  });
+});
+
+describe("compactActivitySummary", () => {
+  it("summarizes multiple tool events without hiding their individual details", () => {
+    expect(
+      compactActivitySummary([
+        { title: "Searched the web", phase: "done" },
+        { title: "Read calendar", phase: "running" },
+        { title: "Drafted reply", phase: "done" },
+      ]),
+    ).toEqual({ label: "3 actions", running: true });
+  });
+
+  it("uses a singular, readable label for one completed action", () => {
+    expect(
+      compactActivitySummary([{ title: "Searched the web", phase: "done" }]),
+    ).toEqual({ label: "Searched the web", running: false });
+  });
+});

--- a/apps/electron/src/renderer/src/lib/workspace-navigation.ts
+++ b/apps/electron/src/renderer/src/lib/workspace-navigation.ts
@@ -1,0 +1,29 @@
+/** The panel only has room for a persistent rail above this width. */
+export const WORKSPACE_RAIL_MIN_WIDTH = 640;
+
+export type WorkspaceNavigationMode = "rail" | "drawer";
+
+export function workspaceNavigationMode(
+  width: number,
+): WorkspaceNavigationMode {
+  return width >= WORKSPACE_RAIL_MIN_WIDTH ? "rail" : "drawer";
+}
+
+export interface ActivitySummaryItem {
+  title: string;
+  phase: "done" | "running" | "failed" | "declined";
+}
+
+/**
+ * Keeps a busy agent legible in the transcript: the compact row communicates
+ * progress, while its expanded contents retain each request/result.
+ */
+export function compactActivitySummary(items: ActivitySummaryItem[]): {
+  label: string;
+  running: boolean;
+} {
+  const running = items.some((item) => item.phase === "running");
+  if (items.length === 1)
+    return { label: items[0]?.title ?? "Activity", running };
+  return { label: `${items.length} actions`, running };
+}

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1427,6 +1427,268 @@
   flex: 1;
 }
 
+/* Conversation-first workspace ------------------------------------------------
+   The paper panel stays recognizably Freestyle, but conversation content now
+   gets the calm reading column. Navigation retreats to a rail or drawer. */
+.tavern-workspace-head {
+  gap: 7px;
+  padding-bottom: 11px;
+  border-bottom: 1px solid var(--tavern-rule);
+}
+
+.tavern-workspace-icon-btn {
+  display: grid;
+  width: 27px;
+  height: 27px;
+  place-items: center;
+  flex: none;
+  padding: 0;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 8px;
+  background: var(--tavern-card);
+  color: var(--tavern-mute);
+  cursor: pointer;
+  font-family: var(--tavern-mono);
+  font-size: 14px;
+}
+
+.tavern-workspace-icon-btn:hover,
+.tavern-workspace-icon-btn.is-active {
+  color: var(--tavern-ink);
+  border-color: var(--tavern-ink);
+  background: var(--tavern-wash);
+}
+
+.tavern-workspace-icon-btn:focus-visible,
+.tavern-workspace-mobile-tools button:focus-visible,
+.tavern-secondary-nav-item:focus-visible,
+.tavern-history-new:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: 2px;
+}
+
+.tavern-workspace {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.tavern-workspace-main {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.tavern-conversation {
+  padding: 20px clamp(16px, 4vw, 36px);
+}
+
+.tavern-history-rail {
+  display: flex;
+  width: 190px;
+  min-width: 190px;
+  min-height: 0;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border-right: 1px solid var(--tavern-rule);
+  background: color-mix(in srgb, var(--tavern-wash) 54%, var(--tavern-card));
+}
+
+.tavern-history-new {
+  width: 100%;
+  border: 1px solid var(--tavern-ink);
+  border-radius: 8px;
+  padding: 7px 9px;
+  background: var(--tavern-lantern);
+  box-shadow: 2px 2px 0 var(--tavern-ink);
+  color: var(--tavern-card);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 700;
+}
+
+.tavern-history-new:disabled {
+  cursor: default;
+  opacity: .5;
+}
+
+.tavern-history-rail-list,
+.tavern-workspace-drawer-body {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.tavern-history-rail-list .tavern-thread-row {
+  padding: 5px 8px;
+  font-size: 11.5px;
+}
+
+.tavern-history-rail-list .tavern-thread-filter {
+  gap: 4px;
+}
+
+.tavern-history-rail-list .tavern-thread-filter-tab {
+  padding: 3px 7px;
+  font-size: 10px;
+}
+
+.tavern-secondary-nav {
+  display: grid;
+  gap: 3px;
+  border-top: 1px solid var(--tavern-rule);
+  padding-top: 9px;
+}
+
+.tavern-secondary-nav .tavern-label {
+  margin: 0 4px 2px;
+  font-size: 9px;
+}
+
+.tavern-secondary-nav-item {
+  border: 0;
+  border-radius: 6px;
+  padding: 5px 7px;
+  background: none;
+  color: var(--tavern-mute);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11.5px;
+  text-align: left;
+}
+
+.tavern-secondary-nav-item:hover,
+.tavern-secondary-nav-item.is-active {
+  background: var(--tavern-card);
+  color: var(--tavern-ink);
+}
+
+.tavern-workspace-mobile-tools {
+  display: none;
+}
+
+.tavern-workspace-drawer-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+}
+
+.tavern-workspace-drawer-scrim {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: rgba(42, 33, 20, .24);
+  cursor: default;
+}
+
+.tavern-workspace-drawer {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: 8px;
+  display: flex;
+  width: min(292px, calc(100% - 16px));
+  flex-direction: column;
+  overflow: hidden;
+  border: 2px solid var(--tavern-ink);
+  border-radius: 13px;
+  background: var(--tavern-card);
+  box-shadow: 5px 5px 0 rgba(42, 33, 20, .72);
+  animation: tavern-workspace-drawer-in 160ms ease-out;
+}
+
+@keyframes tavern-workspace-drawer-in {
+  from { transform: translateX(-12px); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+.tavern-workspace-drawer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 13px 9px;
+  border-bottom: 1px solid var(--tavern-rule);
+  font-family: var(--tavern-px);
+  font-size: 15px;
+}
+
+.tavern-workspace-drawer-body {
+  gap: 10px;
+  padding: 12px;
+}
+
+.tavern-workspace-drawer-body .tavern-secondary-nav {
+  flex: 1;
+  align-content: start;
+  border-top: 0;
+  padding-top: 0;
+}
+
+.tavern-tool-activity {
+  align-self: stretch;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--tavern-parchment) 78%, var(--tavern-card));
+}
+
+.tavern-tool-activity > summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  color: var(--tavern-mute);
+  cursor: pointer;
+  font-size: 11px;
+  list-style: none;
+}
+
+.tavern-tool-activity > summary::-webkit-details-marker { display: none; }
+
+.tavern-tool-activity[open] > summary {
+  border-bottom: 1px solid var(--tavern-rule);
+  color: var(--tavern-ink);
+}
+
+.tavern-tool-activity-list {
+  display: grid;
+  gap: 5px;
+  padding: 7px 8px;
+}
+
+@media (max-width: 639px) {
+  .tavern-workspace-mobile-tools {
+    display: flex;
+    gap: 6px;
+    padding: 7px 14px;
+    border-bottom: 1px solid var(--tavern-rule);
+  }
+
+  .tavern-workspace-mobile-tools button {
+    border: 0;
+    padding: 0;
+    background: none;
+    color: var(--tavern-mute);
+    cursor: pointer;
+    font: inherit;
+    font-size: 10.5px;
+  }
+
+  .tavern-conversation { padding: 16px; }
+  .tavern-head-new { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tavern-workspace-drawer { animation: none; }
+}
+
 .tavern-close {
   width: 24px;
   height: 24px;

--- a/apps/mobile/ios-keyboard/DictationBridge.swift
+++ b/apps/mobile/ios-keyboard/DictationBridge.swift
@@ -77,6 +77,7 @@ struct FreestyleDictationBridge {
     static let appGroupID = "group.com.freestylevoice.app"
     static let stateKey = "com.freestylevoice.dictation.state"
     static let commandKey = "com.freestylevoice.dictation.command"
+    static let stateDarwinName = "com.freestylevoice.dictation.state" as CFString
     static let commandDarwinName = "com.freestylevoice.dictation.command" as CFString
     /// Timestamp the keyboard extension stamps each time it loads. A value here
     /// at all proves the keyboard was added to the Keyboards list AND that it
@@ -97,7 +98,12 @@ struct FreestyleDictationBridge {
 
     // MARK: State channel
 
-    func loadState() -> FreestyleDictationState {
+    func loadState(refresh: Bool = true) -> FreestyleDictationState {
+        // App Group defaults are backed by two processes. Refresh before each
+        // read so a state notification always observes the app's latest final.
+        if refresh {
+            defaults.synchronize()
+        }
         guard let data = defaults.data(forKey: Self.stateKey),
               let state = try? JSONDecoder().decode(FreestyleDictationState.self, from: data)
         else {
@@ -106,12 +112,24 @@ struct FreestyleDictationBridge {
         return state
     }
 
-    func writeState(_ mutate: (inout FreestyleDictationState) -> Void) {
-        var state = loadState()
+    func writeState(
+        _ mutate: (inout FreestyleDictationState) -> Void,
+        notifyKeyboard: Bool = true
+    ) {
+        // The app is the sole state writer. Avoid synchronizing for every meter
+        // frame; meaningful state transitions flush below before notifying the
+        // keyboard.
+        var state = loadState(refresh: false)
         mutate(&state)
         state.updatedAt = Date().timeIntervalSince1970
         if let data = try? JSONEncoder().encode(state) {
             defaults.set(data, forKey: Self.stateKey)
+        }
+        // A completed transcript must not wait for UserDefaults' asynchronous
+        // cross-process propagation or the keyboard's fallback poll.
+        if notifyKeyboard {
+            defaults.synchronize()
+            Self.postStateNotification()
         }
     }
 
@@ -119,6 +137,8 @@ struct FreestyleDictationBridge {
         if let data = try? JSONEncoder().encode(FreestyleDictationState()) {
             defaults.set(data, forKey: Self.stateKey)
         }
+        defaults.synchronize()
+        Self.postStateNotification()
     }
 
     // MARK: Keyboard installation handshake
@@ -144,6 +164,10 @@ struct FreestyleDictationBridge {
     // MARK: Command channel
 
     func loadCommand() -> FreestyleKeyboardCommand {
+        // The keyboard's Darwin notification can arrive before another process
+        // naturally refreshes its App Group cache, so make the command visible
+        // before the app's immediate event handler reads it.
+        defaults.synchronize()
         guard let data = defaults.data(forKey: Self.commandKey),
               let command = try? JSONDecoder().decode(FreestyleKeyboardCommand.self, from: data)
         else {
@@ -167,6 +191,7 @@ struct FreestyleDictationBridge {
             defaults.set(data, forKey: Self.commandKey)
         }
 
+        defaults.synchronize()
         Self.postCommandNotification()
         return command
     }
@@ -175,6 +200,17 @@ struct FreestyleDictationBridge {
         if let data = try? JSONEncoder().encode(FreestyleKeyboardCommand()) {
             defaults.set(data, forKey: Self.commandKey)
         }
+    }
+
+    /// Wakes the keyboard as soon as the app publishes a meaningful state.
+    static func postStateNotification() {
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(stateDarwinName),
+            nil,
+            nil,
+            true
+        )
     }
 
     /// Wakes or nudges the containing app when the keyboard posts a command.

--- a/apps/mobile/ios-keyboard/KeyboardViewController.swift
+++ b/apps/mobile/ios-keyboard/KeyboardViewController.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import SwiftUI
 import UIKit
 
@@ -90,6 +91,7 @@ final class KeyboardViewController: UIInputViewController {
     private let bridge = FreestyleDictationBridge()
     private let keyboardModeKey = "com.freestylevoice.keyboard.mode"
     private var statePollTimer: Timer?
+    private var observingSharedState = false
     private var lastInsertedToken = ""
     /// Cached so we only rebuild the mic control when the phase or liveness
     /// actually changes, not on every 0.3s poll tick.
@@ -151,13 +153,19 @@ final class KeyboardViewController: UIInputViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        startObservingSharedState()
         startPollingSharedState()
         syncSharedState()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        stopObservingSharedState()
         stopPollingSharedState()
+    }
+
+    deinit {
+        stopObservingSharedState()
     }
 
     override func traitCollectionDidChange(_ previous: UITraitCollection?) {
@@ -482,6 +490,41 @@ final class KeyboardViewController: UIInputViewController {
     }
 
     // MARK: - Shared state polling (app → keyboard)
+
+    /// The app posts this after publishing a meaningful state transition. In
+    /// particular, it makes final-text insertion event-driven; polling remains
+    /// only as a recovery path when iOS drops a Darwin notification.
+    private func startObservingSharedState() {
+        guard !observingSharedState else { return }
+        observingSharedState = true
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        let observer = Unmanaged.passUnretained(self).toOpaque()
+        CFNotificationCenterAddObserver(
+            center,
+            observer,
+            { (_, observer, _, _, _) in
+                guard let observer else { return }
+                let controller = Unmanaged<KeyboardViewController>
+                    .fromOpaque(observer)
+                    .takeUnretainedValue()
+                DispatchQueue.main.async { [weak controller] in
+                    controller?.syncSharedState()
+                }
+            },
+            FreestyleDictationBridge.stateDarwinName,
+            nil,
+            .deliverImmediately
+        )
+    }
+
+    private func stopObservingSharedState() {
+        guard observingSharedState else { return }
+        observingSharedState = false
+        CFNotificationCenterRemoveEveryObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            Unmanaged.passUnretained(self).toOpaque()
+        )
+    }
 
     private func startPollingSharedState() {
         guard statePollTimer == nil else { return }

--- a/apps/mobile/modules/freestyle-shared-store/ios/DictationBridge.swift
+++ b/apps/mobile/modules/freestyle-shared-store/ios/DictationBridge.swift
@@ -77,6 +77,7 @@ struct FreestyleDictationBridge {
     static let appGroupID = "group.com.freestylevoice.app"
     static let stateKey = "com.freestylevoice.dictation.state"
     static let commandKey = "com.freestylevoice.dictation.command"
+    static let stateDarwinName = "com.freestylevoice.dictation.state" as CFString
     static let commandDarwinName = "com.freestylevoice.dictation.command" as CFString
     /// Timestamp the keyboard extension stamps each time it loads. A value here
     /// at all proves the keyboard was added to the Keyboards list AND that it
@@ -97,7 +98,12 @@ struct FreestyleDictationBridge {
 
     // MARK: State channel
 
-    func loadState() -> FreestyleDictationState {
+    func loadState(refresh: Bool = true) -> FreestyleDictationState {
+        // App Group defaults are backed by two processes. Refresh before each
+        // read so a state notification always observes the app's latest final.
+        if refresh {
+            defaults.synchronize()
+        }
         guard let data = defaults.data(forKey: Self.stateKey),
               let state = try? JSONDecoder().decode(FreestyleDictationState.self, from: data)
         else {
@@ -106,12 +112,24 @@ struct FreestyleDictationBridge {
         return state
     }
 
-    func writeState(_ mutate: (inout FreestyleDictationState) -> Void) {
-        var state = loadState()
+    func writeState(
+        _ mutate: (inout FreestyleDictationState) -> Void,
+        notifyKeyboard: Bool = true
+    ) {
+        // The app is the sole state writer. Avoid synchronizing for every meter
+        // frame; meaningful state transitions flush below before notifying the
+        // keyboard.
+        var state = loadState(refresh: false)
         mutate(&state)
         state.updatedAt = Date().timeIntervalSince1970
         if let data = try? JSONEncoder().encode(state) {
             defaults.set(data, forKey: Self.stateKey)
+        }
+        // A completed transcript must not wait for UserDefaults' asynchronous
+        // cross-process propagation or the keyboard's fallback poll.
+        if notifyKeyboard {
+            defaults.synchronize()
+            Self.postStateNotification()
         }
     }
 
@@ -119,6 +137,8 @@ struct FreestyleDictationBridge {
         if let data = try? JSONEncoder().encode(FreestyleDictationState()) {
             defaults.set(data, forKey: Self.stateKey)
         }
+        defaults.synchronize()
+        Self.postStateNotification()
     }
 
     // MARK: Keyboard installation handshake
@@ -144,6 +164,10 @@ struct FreestyleDictationBridge {
     // MARK: Command channel
 
     func loadCommand() -> FreestyleKeyboardCommand {
+        // The keyboard's Darwin notification can arrive before another process
+        // naturally refreshes its App Group cache, so make the command visible
+        // before the app's immediate event handler reads it.
+        defaults.synchronize()
         guard let data = defaults.data(forKey: Self.commandKey),
               let command = try? JSONDecoder().decode(FreestyleKeyboardCommand.self, from: data)
         else {
@@ -167,6 +191,7 @@ struct FreestyleDictationBridge {
             defaults.set(data, forKey: Self.commandKey)
         }
 
+        defaults.synchronize()
         Self.postCommandNotification()
         return command
     }
@@ -175,6 +200,17 @@ struct FreestyleDictationBridge {
         if let data = try? JSONEncoder().encode(FreestyleKeyboardCommand()) {
             defaults.set(data, forKey: Self.commandKey)
         }
+    }
+
+    /// Wakes the keyboard as soon as the app publishes a meaningful state.
+    static func postStateNotification() {
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(stateDarwinName),
+            nil,
+            nil,
+            true
+        )
     }
 
     /// Wakes or nudges the containing app when the keyboard posts a command.

--- a/apps/mobile/modules/freestyle-shared-store/ios/FreestyleSharedStoreModule.swift
+++ b/apps/mobile/modules/freestyle-shared-store/ios/FreestyleSharedStoreModule.swift
@@ -48,15 +48,18 @@ public class FreestyleSharedStoreModule: Module {
         /// Refresh only the mic level + heartbeat. Called frequently while
         /// capturing (per audio frame), so it avoids rewriting the whole state.
         Function("updateLevel") { (level: Double) -> Void in
-            self.bridge.writeState { state in
+            self.bridge.writeState({ state in
                 state.level = level
                 state.heartbeat = Date().timeIntervalSince1970
-            }
+            }, notifyKeyboard: false)
         }
 
         /// Refresh only the heartbeat (cheap keep-alive between full writes).
         Function("touchHeartbeat") { () -> Void in
-            self.bridge.writeState { $0.heartbeat = Date().timeIntervalSince1970 }
+            self.bridge.writeState(
+                { $0.heartbeat = Date().timeIntervalSince1970 },
+                notifyKeyboard: false
+            )
         }
 
         Function("resetState") { () -> Void in

--- a/apps/mobile/src/app/(app)/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/index.tsx
@@ -1,9 +1,18 @@
 import * as Clipboard from "expo-clipboard";
 import * as Haptics from "expo-haptics";
 import { useIsFocused, useLocalSearchParams, useRouter } from "expo-router";
-import { ArrowUp, Menu, Mic, Settings, Square } from "lucide-react-native";
+import {
+  ArrowUp,
+  Check,
+  Menu,
+  Mic,
+  Settings,
+  Square,
+  X,
+} from "lucide-react-native";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  ActivityIndicator,
   Animated,
   Keyboard,
   KeyboardAvoidingView,
@@ -352,8 +361,18 @@ function RemixHome({
   const { threadId: selectedThreadId } = useLocalSearchParams<{
     threadId?: string;
   }>();
-  const { messages, status, error, activeTool, send, stop, loadThread } =
-    thread;
+  const {
+    messages,
+    status,
+    error,
+    activeTool,
+    pendingApproval,
+    approvalState,
+    decideApproval,
+    send,
+    stop,
+    loadThread,
+  } = thread;
   const [draft, setDraft] = useState("");
   const inputRef = useRef<TextInput>(null);
   const busy = status === "streaming";
@@ -456,6 +475,13 @@ function RemixHome({
             {activeTool}…
           </ThemedText>
         ) : null}
+        {pendingApproval ? (
+          <ConnectorApprovalCard
+            approval={pendingApproval}
+            state={approvalState}
+            onDecide={decideApproval}
+          />
+        ) : null}
         {error ? (
           <ThemedText style={[styles.error, { color: theme.destructive }]}>
             {error}
@@ -476,7 +502,14 @@ function RemixHome({
           ref={inputRef}
           value={voiceControl.value}
           onChangeText={setDraft}
-          editable={!busy && voiceState === "idle"}
+          editable={
+            !busy &&
+            !(
+              pendingApproval &&
+              !["approved", "declined"].includes(approvalState)
+            ) &&
+            voiceState === "idle"
+          }
           autoCapitalize="sentences"
           placeholder="Message Remix"
           placeholderTextColor={theme.mutedForeground}
@@ -486,7 +519,12 @@ function RemixHome({
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={voiceControl.label}
-          disabled={voiceControl.action === "waiting-for-transcript"}
+          disabled={
+            Boolean(
+              pendingApproval &&
+                !["approved", "declined"].includes(approvalState),
+            ) || voiceControl.action === "waiting-for-transcript"
+          }
           onPress={handleComposerAction}
           style={[
             styles.send,
@@ -532,6 +570,88 @@ function RemixHome({
           )}
         </Pressable>
       </View>
+    </View>
+  );
+}
+
+function ConnectorApprovalCard({
+  approval,
+  state,
+  onDecide,
+}: {
+  approval: import("@/lib/remix/types").PendingConnectorApproval;
+  state:
+    | "idle"
+    | "approving"
+    | "approved"
+    | "declining"
+    | "declined"
+    | "failed";
+  onDecide: (approved: boolean) => Promise<boolean>;
+}) {
+  const theme = useTheme();
+  const resolved = state === "approved" || state === "declined";
+  return (
+    <View
+      style={[
+        styles.approvalCard,
+        { backgroundColor: theme.secondary, borderColor: theme.border },
+      ]}
+    >
+      <ThemedText type="eyebrow" themeColor="mutedForeground">
+        CONNECTED APP ACTION
+      </ThemedText>
+      <ThemedText style={styles.approvalTitle}>
+        {state === "approved"
+          ? "Action approved"
+          : state === "declined"
+            ? "Action declined"
+            : `Allow ${approval.toolkitName}?`}
+      </ThemedText>
+      <ThemedText themeColor="mutedForeground" style={styles.approvalHint}>
+        {state === "approved"
+          ? "Freestyle sent this action to your connected account."
+          : state === "declined"
+            ? "Nothing was changed."
+            : `Review this action before Freestyle sends it: ${approval.actionDescription}.`}
+      </ThemedText>
+      {resolved ? (
+        <View style={styles.approvalResolved}>
+          {state === "approved" ? (
+            <Check color={theme.primary} size={18} />
+          ) : (
+            <X color={theme.mutedForeground} size={18} />
+          )}
+        </View>
+      ) : (
+        <View style={styles.approvalActions}>
+          <Pressable
+            onPress={() => void onDecide(false)}
+            disabled={state !== "idle" && state !== "failed"}
+            style={[styles.approvalDecline, { borderColor: theme.border }]}
+          >
+            <ThemedText style={styles.approvalDeclineText}>Decline</ThemedText>
+          </Pressable>
+          <Pressable
+            onPress={() => void onDecide(true)}
+            disabled={state !== "idle" && state !== "failed"}
+            style={[styles.approvalAllow, { backgroundColor: theme.primary }]}
+          >
+            {state === "approving" ? (
+              <ActivityIndicator color={theme.primaryForeground} size="small" />
+            ) : (
+              <ThemedText
+                style={[
+                  styles.approvalAllowText,
+                  { color: theme.primaryForeground },
+                ]}
+              >
+                Allow
+              </ThemedText>
+            )}
+          </Pressable>
+        </View>
+      )}
     </View>
   );
 }
@@ -611,6 +731,38 @@ const styles = StyleSheet.create({
     fontSize: 11,
     paddingHorizontal: Spacing.one,
   },
+  approvalCard: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: Radius.xl,
+    marginTop: Spacing.two,
+    padding: Spacing.three,
+    gap: Spacing.two,
+  },
+  approvalTitle: { fontFamily: Fonts.sansSemiBold, fontSize: 17 },
+  approvalHint: { fontSize: 14, lineHeight: 20 },
+  approvalActions: {
+    flexDirection: "row",
+    gap: Spacing.two,
+    marginTop: Spacing.one,
+  },
+  approvalDecline: {
+    flex: 1,
+    height: 42,
+    borderWidth: 1,
+    borderRadius: Radius.full,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  approvalDeclineText: { fontFamily: Fonts.sansMedium, fontSize: 14 },
+  approvalAllow: {
+    flex: 1,
+    height: 42,
+    borderRadius: Radius.full,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  approvalAllowText: { fontFamily: Fonts.sansSemiBold, fontSize: 14 },
+  approvalResolved: { alignItems: "flex-start", paddingTop: Spacing.one },
   error: { fontSize: 13, lineHeight: 19, paddingHorizontal: Spacing.one },
   composer: {
     flexDirection: "row",

--- a/apps/mobile/src/app/(app)/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/index.tsx
@@ -471,6 +471,14 @@ function RemixHome({
     return () => cancelAnimationFrame(frame);
   }, [messages.length]);
 
+  // iOS does not always emit another content-size event after a controlled
+  // multiline field is cleared (for example after Send or a voice final). Keep
+  // the next empty draft compact instead of leaving an invisible, stale
+  // multi-line input height in the composer.
+  useEffect(() => {
+    if (!draft) setInputHeight(REMIX_COMPOSER_MIN_INPUT_HEIGHT);
+  }, [draft]);
+
   const submit = useCallback(async () => {
     const sent =
       editingCurrentThread && editingMessage
@@ -510,7 +518,15 @@ function RemixHome({
 
   const onInputContentSizeChange = useCallback(
     ({ nativeEvent }: { nativeEvent: { contentSize: { height: number } } }) => {
-      setInputHeight(remixComposerInputHeight(nativeEvent.contentSize.height));
+      const nextHeight = remixComposerInputHeight(
+        nativeEvent.contentSize.height,
+      );
+      // A rendered height can itself trigger another content-size event on iOS.
+      // Avoid turning that feedback into a resize loop that makes long drafts
+      // jump while the keyboard is open.
+      setInputHeight((currentHeight) =>
+        currentHeight === nextHeight ? currentHeight : nextHeight,
+      );
     },
     [],
   );

--- a/apps/mobile/src/app/(app)/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/index.tsx
@@ -43,6 +43,11 @@ import { useTheme } from "@/hooks/use-theme";
 import { useDictation } from "@/lib/audio/use-dictation";
 import { composerBottomPadding } from "@/lib/composer-spacing";
 import {
+  REMIX_COMPOSER_MAX_INPUT_HEIGHT,
+  REMIX_COMPOSER_MIN_INPUT_HEIGHT,
+  remixComposerInputHeight,
+} from "@/lib/remix/composer-sizing";
+import {
   appendVoiceTranscript,
   remixComposerVoiceState,
 } from "@/lib/remix/composer-voice-state";
@@ -374,6 +379,9 @@ function RemixHome({
     loadThread,
   } = thread;
   const [draft, setDraft] = useState("");
+  const [inputHeight, setInputHeight] = useState(
+    REMIX_COMPOSER_MIN_INPUT_HEIGHT,
+  );
   const inputRef = useRef<TextInput>(null);
   const busy = status === "streaming";
   const hasDraft = draft.trim().length > 0;
@@ -422,13 +430,23 @@ function RemixHome({
         break;
       case "listen":
       case "finish-listening":
-        Keyboard.dismiss();
         toggleVoiceInput();
+        // Do not dismiss or swap out the field here. The keyboard remains
+        // available while the microphone streams, just like a native chat
+        // composer, and dictated text appends to the same draft when ready.
+        requestAnimationFrame(() => inputRef.current?.focus());
         break;
       case "waiting-for-transcript":
         break;
     }
   }, [stop, submit, toggleVoiceInput, voiceControl.action]);
+
+  const onInputContentSizeChange = useCallback(
+    ({ nativeEvent }: { nativeEvent: { contentSize: { height: number } } }) => {
+      setInputHeight(remixComposerInputHeight(nativeEvent.contentSize.height));
+    },
+    [],
+  );
 
   return (
     <View
@@ -507,14 +525,18 @@ function RemixHome({
             !(
               pendingApproval &&
               !["approved", "declined"].includes(approvalState)
-            ) &&
-            voiceState === "idle"
+            )
           }
           autoCapitalize="sentences"
-          placeholder="Message Remix"
+          placeholder={voiceControl.placeholder}
           placeholderTextColor={theme.mutedForeground}
           multiline
-          style={[styles.input, { color: theme.foreground }]}
+          scrollEnabled={inputHeight >= REMIX_COMPOSER_MAX_INPUT_HEIGHT}
+          onContentSizeChange={onInputContentSizeChange}
+          style={[
+            styles.input,
+            { color: theme.foreground, height: inputHeight },
+          ]}
         />
         <Pressable
           accessibilityRole="button"

--- a/apps/mobile/src/app/(app)/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/index.tsx
@@ -23,6 +23,7 @@ import {
 
 import { ChatSidebar } from "@/components/chat-sidebar";
 import { MicButton } from "@/components/mic-button";
+import { MobileMarkdown } from "@/components/mobile-markdown";
 import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
 import { TranscriptView } from "@/components/transcript-view";
@@ -439,12 +440,12 @@ function RemixHome({
             <ThemedText type="eyebrow" themeColor="mutedForeground">
               {message.role === "user" ? "YOU" : "REMIX"}
             </ThemedText>
-            <ThemedText style={styles.turnText}>
-              {message.parts
+            <MobileMarkdown
+              text={message.parts
                 .filter((part) => part.type === "text")
                 .map((part) => part.text)
                 .join("")}
-            </ThemedText>
+            />
           </View>
         ))}
         {activeTool ? (
@@ -602,7 +603,6 @@ const styles = StyleSheet.create({
     borderRadius: Radius.xl,
     padding: Spacing.three,
   },
-  turnText: { fontSize: 15, lineHeight: 22 },
   toolStatus: {
     fontFamily: Fonts.mono,
     fontSize: 11,

--- a/apps/mobile/src/app/(app)/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/index.tsx
@@ -410,7 +410,6 @@ function RemixHome({
   const {
     micState: voiceState,
     partial: voicePartial,
-    level: voiceLevel,
     toggle: toggleVoiceInput,
   } = useDictation({
     signedIn,
@@ -421,7 +420,6 @@ function RemixHome({
   });
   const voiceControl = remixComposerVoiceState({
     draft,
-    partial: voicePartial,
     micState: voiceState,
     remixBusy: busy,
   });
@@ -637,17 +635,19 @@ function RemixHome({
           {
             backgroundColor: theme.card,
             borderColor:
-              voiceState === "recording" ? theme.destructive : theme.border,
+              voiceState === "recording" ? theme.primary : theme.border,
           },
         ]}
       >
         {voiceState !== "idle" ? (
-          <View
-            accessibilityLiveRegion="polite"
-            style={[styles.voiceStatus, { backgroundColor: theme.secondary }]}
-          >
+          <View accessibilityLiveRegion="polite" style={styles.voiceStatus}>
             {voiceState === "recording" ? (
-              <Waveform level={voiceLevel} active compact />
+              <View
+                style={[
+                  styles.voiceStatusDot,
+                  { backgroundColor: theme.primary },
+                ]}
+              />
             ) : (
               <ActivityIndicator color={theme.primary} size="small" />
             )}
@@ -657,86 +657,78 @@ function RemixHome({
               numberOfLines={1}
             >
               {voiceState === "recording"
-                ? voicePartial || "Listening — keep typing or tap stop"
-                : "Adding your voice…"}
+                ? voicePartial || "Listening"
+                : "Adding your voice"}
             </ThemedText>
           </View>
         ) : null}
-        <TextInput
-          ref={inputRef}
-          value={voiceControl.value}
-          onChangeText={setDraft}
-          editable={
-            !busy &&
-            !(
-              pendingApproval &&
-              !["approved", "declined"].includes(approvalState)
-            )
-          }
-          autoCapitalize="sentences"
-          placeholder={voiceControl.placeholder}
-          placeholderTextColor={theme.mutedForeground}
-          multiline
-          scrollEnabled={inputHeight >= REMIX_COMPOSER_MAX_INPUT_HEIGHT}
-          onContentSizeChange={onInputContentSizeChange}
-          style={[
-            styles.input,
-            { color: theme.foreground, height: inputHeight },
-          ]}
-        />
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={voiceControl.label}
-          disabled={
-            Boolean(
-              pendingApproval &&
-                !["approved", "declined"].includes(approvalState),
-            ) || voiceControl.action === "waiting-for-transcript"
-          }
-          onPress={handleComposerAction}
-          style={[
-            styles.send,
-            {
-              backgroundColor:
-                voiceState === "recording"
-                  ? theme.destructive
-                  : hasDraft || busy
+        <View style={styles.composerInputRow}>
+          <TextInput
+            ref={inputRef}
+            value={voiceControl.value}
+            onChangeText={setDraft}
+            editable={
+              !busy &&
+              !(
+                pendingApproval &&
+                !["approved", "declined"].includes(approvalState)
+              )
+            }
+            autoCapitalize="sentences"
+            placeholder={voiceControl.placeholder}
+            placeholderTextColor={theme.mutedForeground}
+            multiline
+            scrollEnabled={inputHeight >= REMIX_COMPOSER_MAX_INPUT_HEIGHT}
+            onContentSizeChange={onInputContentSizeChange}
+            style={[
+              styles.input,
+              { color: theme.foreground, height: inputHeight },
+            ]}
+          />
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={voiceControl.label}
+            disabled={
+              Boolean(
+                pendingApproval &&
+                  !["approved", "declined"].includes(approvalState),
+              ) || voiceControl.action === "waiting-for-transcript"
+            }
+            onPress={handleComposerAction}
+            style={[
+              styles.send,
+              {
+                backgroundColor:
+                  voiceState === "recording" || hasDraft || busy
                     ? theme.primary
                     : theme.secondary,
-            },
-          ]}
-        >
-          {busy || voiceState === "recording" ? (
-            <Square
-              color={
-                voiceState === "recording"
-                  ? theme.foreground
-                  : theme.primaryForeground
-              }
-              fill={
-                voiceState === "recording"
-                  ? theme.foreground
-                  : theme.primaryForeground
-              }
-              size={15}
-            />
-          ) : hasDraft ? (
-            <ArrowUp
-              color={theme.primaryForeground}
-              size={19}
-              strokeWidth={2.5}
-            />
-          ) : (
-            <Mic
-              color={
-                voiceState === "finalizing"
-                  ? theme.mutedForeground
-                  : theme.foreground
-              }
-              size={20}
-            />
-          )}
-        </Pressable>
+              },
+            ]}
+          >
+            {busy || voiceState === "recording" ? (
+              <Square
+                color={theme.primaryForeground}
+                fill={theme.primaryForeground}
+                size={15}
+              />
+            ) : hasDraft ? (
+              <ArrowUp
+                color={theme.primaryForeground}
+                size={19}
+                strokeWidth={2.5}
+              />
+            ) : (
+              <Mic
+                color={
+                  voiceState === "finalizing"
+                    ? theme.mutedForeground
+                    : theme.foreground
+                }
+                size={20}
+              />
+            )}
+          </Pressable>
+        </View>
       </View>
     </View>
   );
@@ -1051,38 +1043,37 @@ const styles = StyleSheet.create({
   },
   editingCopy: { flex: 1, fontSize: 12, lineHeight: 17 },
   composer: {
-    flexDirection: "row",
-    alignItems: "flex-end",
     gap: Spacing.two,
     borderWidth: 1,
     borderRadius: Radius["2xl"],
     padding: Spacing.two,
-    minHeight: 64,
+    minHeight: 60,
   },
   voiceStatus: {
-    position: "absolute",
-    left: Spacing.three,
-    right: 58,
-    top: Spacing.two,
-    minHeight: 44,
     flexDirection: "row",
     alignItems: "center",
     gap: Spacing.two,
-    borderRadius: Radius.md,
-    paddingHorizontal: Spacing.two,
-    zIndex: 1,
+    minHeight: 24,
+    paddingHorizontal: Spacing.one,
   },
+  voiceStatusDot: { width: 8, height: 8, borderRadius: Radius.full },
   voiceStatusText: { flex: 1, fontFamily: Fonts.sansMedium, fontSize: 13 },
+  composerInputRow: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: Spacing.two,
+  },
   input: {
     flex: 1,
-    minHeight: 38,
-    maxHeight: 104,
+    minHeight: REMIX_COMPOSER_MIN_INPUT_HEIGHT,
+    maxHeight: REMIX_COMPOSER_MAX_INPUT_HEIGHT,
     fontFamily: Fonts.sans,
     fontSize: 15,
     lineHeight: 21,
     paddingHorizontal: Spacing.one,
-    paddingVertical: Spacing.one,
-    textAlignVertical: "center",
+    paddingTop: Spacing.one + 2,
+    paddingBottom: Spacing.one + 1,
+    textAlignVertical: "top",
   },
   send: {
     width: 44,

--- a/apps/mobile/src/app/(app)/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/index.tsx
@@ -185,26 +185,25 @@ export default function VoiceScreen() {
                 />
               ) : (
                 <>
-                  <View
-                    style={[
-                      styles.dictationStage,
-                      {
-                        backgroundColor: theme.card,
-                        borderColor: theme.border,
-                      },
-                    ]}
-                  >
-                    <ThemedText
-                      type="eyebrow"
-                      themeColor="mutedForeground"
-                      style={styles.dictationEyebrow}
-                    >
-                      DICTATE
-                    </ThemedText>
+                  <View style={[styles.dictationStage]}>
+                    <View style={styles.dictationLead}>
+                      <ThemedText type="eyebrow" themeColor="mutedForeground">
+                        DICTATE
+                      </ThemedText>
+                      {!text && !partial ? (
+                        <ThemedText
+                          themeColor="mutedForeground"
+                          style={styles.dictationPrompt}
+                        >
+                          Speak naturally. Freestyle keeps the words clear and
+                          ready to use.
+                        </ThemedText>
+                      ) : null}
+                    </View>
                     <TranscriptView
                       text={text}
                       partial={partial}
-                      placeholder="Tap the mic, then speak naturally. Your words will appear here."
+                      placeholder="Your words will appear here."
                     />
                   </View>
 
@@ -251,26 +250,30 @@ export default function VoiceScreen() {
                     style={[
                       styles.dictationDock,
                       {
-                        backgroundColor: theme.card,
                         borderColor: theme.border,
                         paddingBottom: insets.bottom + Spacing.three,
                       },
                     ]}
                   >
-                    <Waveform level={level} active={micState === "recording"} />
-                    <ThemedText
-                      themeColor="mutedForeground"
-                      style={styles.status}
-                    >
-                      {status}
-                    </ThemedText>
                     <MicButton
                       state={micState}
-                      size={76}
+                      size={72}
                       level={level}
                       onPressIn={onPressIn}
                       onPressOut={onPressOut}
                     />
+                    <View style={styles.dictationStatus}>
+                      <Waveform
+                        level={level}
+                        active={micState === "recording"}
+                      />
+                      <ThemedText
+                        themeColor="mutedForeground"
+                        style={styles.status}
+                      >
+                        {status}
+                      </ThemedText>
+                    </View>
                   </View>
                 </>
               )}
@@ -657,18 +660,24 @@ const styles = StyleSheet.create({
   dictationStage: {
     flex: 1,
     minHeight: 0,
-    borderWidth: 1,
-    borderRadius: Radius["2xl"],
     paddingHorizontal: Spacing.three,
+    paddingTop: Spacing.four,
   },
-  dictationEyebrow: { paddingTop: Spacing.three },
+  dictationLead: { gap: Spacing.two, paddingBottom: Spacing.three },
+  dictationPrompt: { fontSize: 16, lineHeight: 23, maxWidth: 290 },
   dictationDock: {
+    flexDirection: "row",
     alignItems: "center",
-    gap: Spacing.two,
-    marginTop: Spacing.two,
-    borderWidth: 1,
-    borderRadius: Radius["2xl"],
-    paddingTop: Spacing.two,
+    justifyContent: "center",
+    gap: Spacing.three,
+    marginTop: Spacing.one,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingTop: Spacing.three,
+  },
+  dictationStatus: {
+    alignItems: "flex-start",
+    gap: Spacing.one,
+    minWidth: 132,
   },
   status: {
     fontFamily: Fonts.mono,

--- a/apps/mobile/src/app/(app)/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/index.tsx
@@ -1,3 +1,4 @@
+import type { UIMessage } from "ai";
 import * as Clipboard from "expo-clipboard";
 import * as Haptics from "expo-haptics";
 import { useIsFocused, useLocalSearchParams, useRouter } from "expo-router";
@@ -51,14 +52,21 @@ import {
   appendVoiceTranscript,
   remixComposerVoiceState,
 } from "@/lib/remix/composer-voice-state";
+import {
+  loadRemixDrafts,
+  type RemixDrafts,
+  saveRemixDrafts,
+  updateRemixDraft,
+} from "@/lib/remix/drafts";
 import { DEFAULT_HOME_MODE } from "@/lib/remix/home-mode";
+import { messageText } from "@/lib/remix/thread";
 import type { RemixMode } from "@/lib/remix/types";
 import { useRemixThread } from "@/lib/remix/use-remix-thread";
 
 export default function VoiceScreen() {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
-  const { signedIn } = useAuth();
+  const { signedIn, user } = useAuth();
   const router = useRouter();
   const { width } = useWindowDimensions();
   // This home screen stays mounted while the resident keyboard session runs in the
@@ -194,6 +202,7 @@ export default function VoiceScreen() {
                 <RemixHome
                   thread={remixThread}
                   signedIn={signedIn && focused}
+                  userId={user?.id}
                   keyboardVisible={keyboardVisible}
                   bottomInset={insets.bottom}
                 />
@@ -354,11 +363,13 @@ function ModeSwitch({
 function RemixHome({
   thread,
   signedIn,
+  userId,
   keyboardVisible,
   bottomInset,
 }: {
   thread: ReturnType<typeof useRemixThread>;
   signedIn: boolean;
+  userId: string | undefined;
   keyboardVisible: boolean;
   bottomInset: number;
 }) {
@@ -375,19 +386,31 @@ function RemixHome({
     approvalState,
     decideApproval,
     send,
+    resend,
+    retryLastTurn,
     stop,
     loadThread,
   } = thread;
-  const [draft, setDraft] = useState("");
+  const [drafts, setDrafts] = useState<RemixDrafts>({});
+  const draftsRef = useRef<RemixDrafts>({});
+  const draftWriteQueue = useRef<Promise<void>>(Promise.resolve());
+  const [editingMessage, setEditingMessage] = useState<{
+    id: string;
+    text: string;
+    threadId: string;
+  } | null>(null);
   const [inputHeight, setInputHeight] = useState(
     REMIX_COMPOSER_MIN_INPUT_HEIGHT,
   );
   const inputRef = useRef<TextInput>(null);
+  const draft = drafts[thread.threadId] ?? "";
+  const editingCurrentThread = editingMessage?.threadId === thread.threadId;
   const busy = status === "streaming";
   const hasDraft = draft.trim().length > 0;
   const {
     micState: voiceState,
     partial: voicePartial,
+    level: voiceLevel,
     toggle: toggleVoiceInput,
   } = useDictation({
     signedIn,
@@ -404,6 +427,41 @@ function RemixHome({
   });
 
   useEffect(() => {
+    let cancelled = false;
+    void loadRemixDrafts(userId)
+      .then((stored) => {
+        if (cancelled) return;
+        draftsRef.current = stored;
+        setDrafts(stored);
+      })
+      .catch(() => {
+        // Draft recovery is best-effort. Storage should never block chat.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const setDraft = useCallback(
+    (value: string | ((current: string) => string)) => {
+      const current = draftsRef.current[thread.threadId] ?? "";
+      const nextValue = typeof value === "function" ? value(current) : value;
+      const next = updateRemixDraft(
+        draftsRef.current,
+        thread.threadId,
+        nextValue,
+      );
+      draftsRef.current = next;
+      setDrafts(next);
+      draftWriteQueue.current = draftWriteQueue.current
+        .catch(() => {})
+        .then(() => saveRemixDrafts(userId, next))
+        .catch(() => {});
+    },
+    [thread.threadId, userId],
+  );
+
+  useEffect(() => {
     if (selectedThreadId) void loadThread(selectedThreadId);
   }, [loadThread, selectedThreadId]);
 
@@ -416,9 +474,20 @@ function RemixHome({
   }, [messages.length]);
 
   const submit = useCallback(async () => {
-    const sent = await send(draft);
-    if (sent) setDraft("");
-  }, [draft, send]);
+    const sent =
+      editingCurrentThread && editingMessage
+        ? await resend(editingMessage.id, draft)
+        : await send(draft);
+    if (sent) {
+      setDraft("");
+      setEditingMessage(null);
+    }
+  }, [draft, editingCurrentThread, editingMessage, resend, send, setDraft]);
+
+  const copyMessage = useCallback(async (text: string) => {
+    await Clipboard.setStringAsync(text);
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  }, []);
 
   const handleComposerAction = useCallback(() => {
     switch (voiceControl.action) {
@@ -465,7 +534,7 @@ function RemixHome({
         contentContainerStyle={styles.remixScroll}
         keyboardShouldPersistTaps="handled"
       >
-        {messages.map((message) => (
+        {messages.map((message, index) => (
           <View
             key={message.id}
             style={[
@@ -480,18 +549,36 @@ function RemixHome({
             <ThemedText type="eyebrow" themeColor="mutedForeground">
               {message.role === "user" ? "YOU" : "REMIX"}
             </ThemedText>
-            <MobileMarkdown
-              text={message.parts
-                .filter((part) => part.type === "text")
-                .map((part) => part.text)
-                .join("")}
+            <MobileMarkdown text={messageText(message)} />
+            <MessageActions
+              message={message}
+              isLatest={index === messages.length - 1}
+              onCopy={copyMessage}
+              onEdit={(text) => {
+                setEditingMessage({
+                  id: message.id,
+                  text,
+                  threadId: thread.threadId,
+                });
+                setDraft(text);
+                requestAnimationFrame(() => inputRef.current?.focus());
+              }}
+              onRegenerate={() => void retryLastTurn()}
             />
           </View>
         ))}
         {activeTool ? (
-          <ThemedText themeColor="mutedForeground" style={styles.toolStatus}>
-            {activeTool}…
-          </ThemedText>
+          <View
+            style={[styles.toolStatus, { backgroundColor: theme.secondary }]}
+          >
+            <ActivityIndicator color={theme.primary} size="small" />
+            <ThemedText
+              themeColor="mutedForeground"
+              style={styles.toolStatusText}
+            >
+              {activeTool}
+            </ThemedText>
+          </View>
         ) : null}
         {pendingApproval ? (
           <ConnectorApprovalCard
@@ -501,11 +588,49 @@ function RemixHome({
           />
         ) : null}
         {error ? (
-          <ThemedText style={[styles.error, { color: theme.destructive }]}>
-            {error}
-          </ThemedText>
+          <View
+            style={[
+              styles.recovery,
+              { backgroundColor: theme.secondary, borderColor: theme.border },
+            ]}
+          >
+            <ThemedText style={[styles.error, { color: theme.destructive }]}>
+              {error}
+            </ThemedText>
+            <Pressable
+              onPress={() => void retryLastTurn()}
+              accessibilityRole="button"
+              accessibilityLabel="Retry last Remix message"
+              style={[styles.retry, { backgroundColor: theme.primary }]}
+            >
+              <ThemedText
+                style={[styles.retryText, { color: theme.primaryForeground }]}
+              >
+                Retry
+              </ThemedText>
+            </Pressable>
+          </View>
         ) : null}
       </ScrollView>
+      {editingCurrentThread ? (
+        <View
+          style={[styles.editingBanner, { backgroundColor: theme.secondary }]}
+        >
+          <ThemedText themeColor="mutedForeground" style={styles.editingCopy}>
+            Editing an earlier message. Sending will replace the reply after it.
+          </ThemedText>
+          <Pressable
+            onPress={() => {
+              setEditingMessage(null);
+              setDraft("");
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Cancel editing message"
+          >
+            <X color={theme.mutedForeground} size={16} />
+          </Pressable>
+        </View>
+      ) : null}
       <View
         style={[
           styles.composer,
@@ -516,6 +641,27 @@ function RemixHome({
           },
         ]}
       >
+        {voiceState !== "idle" ? (
+          <View
+            accessibilityLiveRegion="polite"
+            style={[styles.voiceStatus, { backgroundColor: theme.secondary }]}
+          >
+            {voiceState === "recording" ? (
+              <Waveform level={voiceLevel} active compact />
+            ) : (
+              <ActivityIndicator color={theme.primary} size="small" />
+            )}
+            <ThemedText
+              themeColor="mutedForeground"
+              style={styles.voiceStatusText}
+              numberOfLines={1}
+            >
+              {voiceState === "recording"
+                ? voicePartial || "Listening — keep typing or tap stop"
+                : "Adding your voice…"}
+            </ThemedText>
+          </View>
+        ) : null}
         <TextInput
           ref={inputRef}
           value={voiceControl.value}
@@ -592,6 +738,82 @@ function RemixHome({
           )}
         </Pressable>
       </View>
+    </View>
+  );
+}
+
+function MessageActions({
+  message,
+  isLatest,
+  onCopy,
+  onEdit,
+  onRegenerate,
+}: {
+  message: UIMessage;
+  isLatest: boolean;
+  onCopy: (text: string) => Promise<void>;
+  onEdit: (text: string) => void;
+  onRegenerate: () => void;
+}) {
+  const theme = useTheme();
+  const text = messageText(message);
+  if (!text) return null;
+  return (
+    <View style={styles.messageActions}>
+      <Pressable
+        onPress={() => void onCopy(text)}
+        accessibilityRole="button"
+        accessibilityLabel="Copy message"
+        style={({ pressed }) => [
+          styles.messageAction,
+          { borderColor: theme.border },
+          pressed && styles.pressed,
+        ]}
+      >
+        <ThemedText
+          themeColor="mutedForeground"
+          style={styles.messageActionText}
+        >
+          Copy
+        </ThemedText>
+      </Pressable>
+      {message.role === "user" ? (
+        <Pressable
+          onPress={() => onEdit(text)}
+          accessibilityRole="button"
+          accessibilityLabel="Edit and resend message"
+          style={({ pressed }) => [
+            styles.messageAction,
+            { borderColor: theme.border },
+            pressed && styles.pressed,
+          ]}
+        >
+          <ThemedText
+            themeColor="mutedForeground"
+            style={styles.messageActionText}
+          >
+            Edit
+          </ThemedText>
+        </Pressable>
+      ) : isLatest ? (
+        <Pressable
+          onPress={onRegenerate}
+          accessibilityRole="button"
+          accessibilityLabel="Regenerate last Remix response"
+          style={({ pressed }) => [
+            styles.messageAction,
+            { borderColor: theme.border },
+            pressed && styles.pressed,
+          ]}
+        >
+          <ThemedText
+            themeColor="mutedForeground"
+            style={styles.messageActionText}
+          >
+            Regenerate
+          </ThemedText>
+        </Pressable>
+      ) : null}
     </View>
   );
 }
@@ -748,11 +970,30 @@ const styles = StyleSheet.create({
     borderRadius: Radius.xl,
     padding: Spacing.three,
   },
-  toolStatus: {
-    fontFamily: Fonts.mono,
-    fontSize: 11,
-    paddingHorizontal: Spacing.one,
+  messageActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.two,
+    paddingTop: Spacing.one,
   },
+  messageAction: {
+    minHeight: 28,
+    justifyContent: "center",
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: Radius.full,
+    paddingHorizontal: Spacing.two,
+  },
+  messageActionText: { fontFamily: Fonts.sansMedium, fontSize: 12 },
+  toolStatus: {
+    alignSelf: "flex-start",
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.two,
+    borderRadius: Radius.full,
+    paddingHorizontal: Spacing.three,
+    paddingVertical: Spacing.two,
+  },
+  toolStatusText: { fontFamily: Fonts.sansMedium, fontSize: 13 },
   approvalCard: {
     borderWidth: StyleSheet.hairlineWidth,
     borderRadius: Radius.xl,
@@ -785,7 +1026,30 @@ const styles = StyleSheet.create({
   },
   approvalAllowText: { fontFamily: Fonts.sansSemiBold, fontSize: 14 },
   approvalResolved: { alignItems: "flex-start", paddingTop: Spacing.one },
-  error: { fontSize: 13, lineHeight: 19, paddingHorizontal: Spacing.one },
+  recovery: {
+    gap: Spacing.two,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: Radius.lg,
+    padding: Spacing.three,
+  },
+  error: { fontSize: 13, lineHeight: 19 },
+  retry: {
+    alignSelf: "flex-start",
+    minHeight: 34,
+    justifyContent: "center",
+    borderRadius: Radius.full,
+    paddingHorizontal: Spacing.three,
+  },
+  retryText: { fontFamily: Fonts.sansSemiBold, fontSize: 13 },
+  editingBanner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.two,
+    borderRadius: Radius.md,
+    paddingHorizontal: Spacing.three,
+    paddingVertical: Spacing.two,
+  },
+  editingCopy: { flex: 1, fontSize: 12, lineHeight: 17 },
   composer: {
     flexDirection: "row",
     alignItems: "flex-end",
@@ -795,6 +1059,20 @@ const styles = StyleSheet.create({
     padding: Spacing.two,
     minHeight: 64,
   },
+  voiceStatus: {
+    position: "absolute",
+    left: Spacing.three,
+    right: 58,
+    top: Spacing.two,
+    minHeight: 44,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.two,
+    borderRadius: Radius.md,
+    paddingHorizontal: Spacing.two,
+    zIndex: 1,
+  },
+  voiceStatusText: { flex: 1, fontFamily: Fonts.sansMedium, fontSize: 13 },
   input: {
     flex: 1,
     minHeight: 38,
@@ -813,6 +1091,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
+  pressed: { opacity: 0.62 },
   actions: {
     flexDirection: "row",
     justifyContent: "center",

--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -43,6 +43,7 @@ export default function AppLayout() {
                 <Stack.Screen name="(tabs)" />
                 <Stack.Screen name="onboarding" />
                 <Stack.Screen name="settings" />
+                <Stack.Screen name="settings/approvals" />
                 <Stack.Screen name="profile" />
                 <Stack.Screen name="history" />
                 <Stack.Screen name="vocabulary" />

--- a/apps/mobile/src/app/(app)/profile.tsx
+++ b/apps/mobile/src/app/(app)/profile.tsx
@@ -11,7 +11,9 @@ import {
   CalendarClock,
   Check,
   ChevronDown,
+  ChevronRight,
   LogOut,
+  Pencil,
   PlugZap,
   SlidersHorizontal,
   Sparkles,
@@ -21,6 +23,7 @@ import {
   ActivityIndicator,
   Alert,
   Image,
+  Modal,
   Pressable,
   StyleSheet,
   Switch,
@@ -69,6 +72,7 @@ export function ProfileContent() {
   const { user, signedIn, signOut } = useAuth();
   const queryClient = useQueryClient();
   const [busy, setBusy] = useState(false);
+  const [nameEditorOpen, setNameEditorOpen] = useState(false);
 
   const { data: usage, isLoading: usageLoading } = useQuery({
     queryKey: ["cloud-usage"],
@@ -139,22 +143,44 @@ export function ProfileContent() {
 
   const content = (
     <>
-      <View style={styles.accountHero}>
-        {user?.image ? (
-          <Image
-            source={{ uri: user.image }}
-            style={styles.avatarImage}
-            accessibilityIgnoresInvertColors
-          />
-        ) : (
-          <View style={[styles.avatar, { backgroundColor: theme.accent }]}>
-            <ThemedText
-              style={[styles.avatarText, { color: theme.accentForeground }]}
+      <Pressable
+        onPress={() => setNameEditorOpen(true)}
+        disabled={!signedIn}
+        accessibilityRole="button"
+        accessibilityLabel="Edit name"
+        accessibilityState={{ disabled: !signedIn }}
+        style={({ pressed }) => [
+          styles.accountHero,
+          pressed && signedIn && styles.accountHeroPressed,
+        ]}
+      >
+        <View style={styles.avatarWrap}>
+          {user?.image ? (
+            <Image
+              source={{ uri: user.image }}
+              style={styles.avatarImage}
+              accessibilityIgnoresInvertColors
+            />
+          ) : (
+            <View style={[styles.avatar, { backgroundColor: theme.accent }]}>
+              <ThemedText
+                style={[styles.avatarText, { color: theme.accentForeground }]}
+              >
+                {user ? initialsFor(user) : "?"}
+              </ThemedText>
+            </View>
+          )}
+          {signedIn ? (
+            <View
+              style={[
+                styles.nameEditBadge,
+                { backgroundColor: theme.secondary },
+              ]}
             >
-              {user ? initialsFor(user) : "?"}
-            </ThemedText>
-          </View>
-        )}
+              <Pencil color={theme.mutedForeground} size={14} />
+            </View>
+          ) : null}
+        </View>
         <View style={styles.accountInfo}>
           <ThemedText style={styles.accountName} numberOfLines={1}>
             {user?.name ?? "Signed in"}
@@ -169,9 +195,9 @@ export function ProfileContent() {
             </ThemedText>
           ) : null}
         </View>
-      </View>
+      </Pressable>
 
-      <SettingsGroup title="Freestyle">
+      <SettingsGroup>
         <SettingsNavRow
           icon={SlidersHorizontal}
           label="Dictation settings"
@@ -198,9 +224,6 @@ export function ProfileContent() {
           last
         />
       </SettingsGroup>
-
-      {/* Personal information */}
-      {signedIn ? <NameCard currentName={user?.name ?? ""} /> : null}
 
       {/* Professional details */}
       {signedIn ? <ProfileDetailsCard /> : null}
@@ -327,6 +350,12 @@ export function ProfileContent() {
           Sign out
         </ThemedText>
       </Pressable>
+
+      <NameEditorSheet
+        visible={nameEditorOpen}
+        currentName={user?.name ?? ""}
+        onClose={() => setNameEditorOpen(false)}
+      />
     </>
   );
 
@@ -345,8 +374,16 @@ const PROVIDER_META: {
   { id: "apple", label: "Apple", Icon: AppleIcon },
 ];
 
-/** Editable display-name card. */
-function NameCard({ currentName }: { currentName: string }) {
+/** A small native sheet keeps editing out of the everyday account surface. */
+function NameEditorSheet({
+  visible,
+  currentName,
+  onClose,
+}: {
+  visible: boolean;
+  currentName: string;
+  onClose: () => void;
+}) {
   const theme = useTheme();
   const [name, setName] = useState(currentName);
   const [saving, setSaving] = useState(false);
@@ -371,54 +408,77 @@ function NameCard({ currentName }: { currentName: string }) {
       return;
     }
     setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
-  }, [canSave, trimmed]);
+    setTimeout(() => {
+      setSaved(false);
+      onClose();
+    }, 550);
+  }, [canSave, onClose, trimmed]);
 
   return (
-    <Card>
-      <ThemedText type="eyebrow" themeColor="mutedForeground">
-        NAME
-      </ThemedText>
-      <TextInput
-        value={name}
-        onChangeText={setName}
-        placeholder="Your name"
-        placeholderTextColor={theme.mutedForeground}
-        maxLength={120}
-        returnKeyType="done"
-        onSubmitEditing={() => void onSave()}
-        style={[
-          styles.input,
-          { borderColor: theme.border, color: theme.foreground },
-        ]}
-      />
-      <Pressable
-        onPress={() => void onSave()}
-        disabled={!canSave}
-        style={({ pressed }) => [
-          styles.primaryButton,
-          { backgroundColor: theme.primary },
-          pressed && canSave ? { opacity: 0.9 } : null,
-          !canSave ? styles.buttonDisabled : null,
-        ]}
-      >
-        {saving ? (
-          <ActivityIndicator color={theme.primaryForeground} />
-        ) : (
-          <>
-            {saved ? <Check color={theme.primaryForeground} size={16} /> : null}
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <Pressable style={styles.sheetBackdrop} onPress={onClose} />
+      <View style={[styles.nameSheet, { backgroundColor: theme.card }]}>
+        <View style={[styles.sheetHandle, { backgroundColor: theme.border }]} />
+        <View style={styles.nameSheetHeader}>
+          <ThemedText style={styles.nameSheetTitle}>Edit name</ThemedText>
+          <Pressable onPress={onClose} accessibilityLabel="Close name editor">
             <ThemedText
-              style={[
-                styles.primaryButtonText,
-                { color: theme.primaryForeground },
-              ]}
+              style={[styles.nameSheetDone, { color: theme.primary }]}
             >
-              {saved ? "Saved" : "Save changes"}
+              Cancel
             </ThemedText>
-          </>
-        )}
-      </Pressable>
-    </Card>
+          </Pressable>
+        </View>
+        <TextInput
+          value={name}
+          onChangeText={setName}
+          placeholder="Your name"
+          placeholderTextColor={theme.mutedForeground}
+          maxLength={120}
+          autoFocus
+          returnKeyType="done"
+          onSubmitEditing={() => void onSave()}
+          style={[
+            styles.input,
+            { borderColor: theme.border, color: theme.foreground },
+          ]}
+        />
+        <Pressable
+          onPress={() => void onSave()}
+          disabled={!canSave}
+          style={({ pressed }) => [
+            styles.primaryButton,
+            { backgroundColor: theme.primary },
+            pressed && canSave ? { opacity: 0.9 } : null,
+            !canSave ? styles.buttonDisabled : null,
+          ]}
+        >
+          {saving ? (
+            <ActivityIndicator color={theme.primaryForeground} />
+          ) : (
+            <>
+              {saved ? (
+                <Check color={theme.primaryForeground} size={16} />
+              ) : null}
+              <ThemedText
+                style={[
+                  styles.primaryButtonText,
+                  { color: theme.primaryForeground },
+                ]}
+              >
+                {saved ? "Saved" : "Save"}
+              </ThemedText>
+            </>
+          )}
+        </Pressable>
+      </View>
+    </Modal>
   );
 }
 
@@ -435,6 +495,7 @@ function ProfileDetailsCard() {
   const [updatePreferences, setUpdatePreferences] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [editing, setEditing] = useState(false);
 
   const { data: profile, isLoading } = useQuery({
     queryKey: ["cloud-profile-fields"],
@@ -464,8 +525,8 @@ function ProfileDetailsCard() {
     company.trim() !== (profile?.company ?? "");
   const canSave = dirty && !saving;
 
-  const onSave = useCallback(async () => {
-    if (!canSave) return;
+  const onSave = useCallback(async (): Promise<boolean> => {
+    if (!canSave) return false;
     setSaving(true);
     setSaved(false);
     try {
@@ -490,11 +551,13 @@ function ProfileDetailsCard() {
       }
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
+      return true;
     } catch (e) {
       Alert.alert(
         "Couldn't update profile",
         e instanceof Error ? e.message : "Try again.",
       );
+      return false;
     } finally {
       setSaving(false);
     }
@@ -510,20 +573,34 @@ function ProfileDetailsCard() {
 
   if (isLoading) {
     return (
-      <Card>
-        <ThemedText type="eyebrow" themeColor="mutedForeground">
-          PROFESSIONAL DETAILS
-        </ThemedText>
+      <SettingsGroup title="Personalization">
         <Skeleton width={180} height={20} />
-      </Card>
+      </SettingsGroup>
+    );
+  }
+
+  if (!editing) {
+    return (
+      <SettingsGroup title="Personalization">
+        <SettingsNavRow
+          icon={SlidersHorizontal}
+          label="Work profile"
+          value={
+            industry
+              ? INDUSTRY_LABELS[industry]
+              : jobTitle || company
+                ? "Details added"
+                : "Optional"
+          }
+          onPress={() => setEditing(true)}
+          last
+        />
+      </SettingsGroup>
     );
   }
 
   return (
-    <Card>
-      <ThemedText type="eyebrow" themeColor="mutedForeground">
-        INDUSTRY
-      </ThemedText>
+    <SettingsGroup title="Work profile">
       <Pressable
         onPress={() => setIndustryPickerOpen(true)}
         accessibilityRole="button"
@@ -618,7 +695,11 @@ function ProfileDetailsCard() {
       />
 
       <Pressable
-        onPress={() => void onSave()}
+        onPress={() => {
+          void onSave().then((didSave) => {
+            if (didSave) setEditing(false);
+          });
+        }}
         disabled={!canSave}
         style={({ pressed }) => [
           styles.primaryButton,
@@ -643,7 +724,16 @@ function ProfileDetailsCard() {
           </>
         )}
       </Pressable>
-    </Card>
+      <Pressable
+        onPress={() => setEditing(false)}
+        accessibilityRole="button"
+        style={styles.cancelEditButton}
+      >
+        <ThemedText themeColor="mutedForeground" style={styles.cancelEditText}>
+          Cancel
+        </ThemedText>
+      </Pressable>
+    </SettingsGroup>
   );
 }
 
@@ -708,76 +798,64 @@ function ConnectedAccountsCard() {
   const busy = linking !== null || unlinking !== null;
 
   return (
-    <Card>
-      <ThemedText type="eyebrow" themeColor="mutedForeground">
-        CONNECTED ACCOUNTS
-      </ThemedText>
+    <SettingsGroup title="Sign-in methods">
       {isLoading ? (
         <Skeleton width={160} height={20} />
       ) : (
-        PROVIDER_META.map(({ id, label, Icon }) => {
+        PROVIDER_META.map(({ id, label, Icon }, index) => {
           const isConnected = linked?.includes(id) ?? false;
           const isOnlyMethod = isConnected && connectedCount <= 1;
           return (
-            <View
+            <Pressable
               key={id}
-              style={[styles.providerRow, { borderColor: theme.border }]}
+              onPress={() =>
+                isConnected ? onUnlink(id, label) : void onLink(id)
+              }
+              disabled={busy || isOnlyMethod}
+              accessibilityRole="button"
+              accessibilityLabel={
+                isOnlyMethod
+                  ? `${label} is your primary sign-in method`
+                  : `${isConnected ? "Manage" : "Connect"} ${label}`
+              }
+              style={({ pressed }) => [
+                styles.providerRow,
+                index < PROVIDER_META.length - 1 && {
+                  borderBottomWidth: StyleSheet.hairlineWidth,
+                  borderBottomColor: theme.border,
+                },
+                pressed && !busy && !isOnlyMethod
+                  ? styles.providerPressed
+                  : null,
+                (busy || isOnlyMethod) && styles.buttonDisabled,
+              ]}
             >
               <Icon size={20} color={theme.foreground} />
-              <ThemedText style={styles.providerLabel}>{label}</ThemedText>
-              {isConnected ? (
-                <Pressable
-                  onPress={() => onUnlink(id, label)}
-                  disabled={busy || isOnlyMethod}
-                  style={({ pressed }) => [
-                    styles.connectButton,
-                    { borderColor: theme.border },
-                    pressed && !busy && !isOnlyMethod
-                      ? { backgroundColor: theme.secondary }
-                      : null,
-                    busy || isOnlyMethod ? styles.buttonDisabled : null,
-                  ]}
+              <View style={styles.providerContent}>
+                <ThemedText style={styles.providerLabel}>{label}</ThemedText>
+                <ThemedText
+                  themeColor="mutedForeground"
+                  style={styles.providerState}
                 >
-                  {unlinking === id ? (
-                    <ActivityIndicator color={theme.foreground} size="small" />
-                  ) : (
-                    <ThemedText
-                      style={[
-                        styles.connectButtonText,
-                        { color: theme.mutedForeground },
-                      ]}
-                    >
-                      Disconnect
-                    </ThemedText>
-                  )}
-                </Pressable>
+                  {isConnected
+                    ? isOnlyMethod
+                      ? "Primary sign-in"
+                      : "Connected"
+                    : "Not connected"}
+                </ThemedText>
+              </View>
+              {linking === id || unlinking === id ? (
+                <ActivityIndicator color={theme.foreground} size="small" />
+              ) : isOnlyMethod ? (
+                <Check color={theme.primary} size={18} />
               ) : (
-                <Pressable
-                  onPress={() => void onLink(id)}
-                  disabled={busy}
-                  style={({ pressed }) => [
-                    styles.connectButton,
-                    { borderColor: theme.border },
-                    pressed && !busy
-                      ? { backgroundColor: theme.secondary }
-                      : null,
-                    busy ? styles.buttonDisabled : null,
-                  ]}
-                >
-                  {linking === id ? (
-                    <ActivityIndicator color={theme.foreground} size="small" />
-                  ) : (
-                    <ThemedText style={styles.connectButtonText}>
-                      Connect
-                    </ThemedText>
-                  )}
-                </Pressable>
+                <ChevronRight color={theme.mutedForeground} size={18} />
               )}
-            </View>
+            </Pressable>
           );
         })
       )}
-    </Card>
+    </SettingsGroup>
   );
 }
 
@@ -798,9 +876,11 @@ function OrganizationCard() {
     queryFn: listOrganizations,
     retry: 1,
   });
+  const hasMultiple = (orgs?.length ?? 0) > 1;
   const { data: activeOrg, isLoading: activeLoading } = useQuery({
     queryKey: ["cloud-active-org"],
     queryFn: getActiveOrganization,
+    enabled: hasMultiple,
     retry: 1,
   });
 
@@ -830,67 +910,48 @@ function OrganizationCard() {
     [activeOrg?.id, queryClient],
   );
 
-  // Nothing to show until we know the user belongs to at least one org.
-  if (!orgsLoading && (orgs?.length ?? 0) === 0) return null;
-
-  const hasMultiple = (orgs?.length ?? 0) > 1;
+  // A default personal organization is an implementation detail. Surface a
+  // workspace switcher only when it gives the person a real choice.
+  if (orgsLoading || activeLoading || !hasMultiple) return null;
 
   return (
-    <Card>
-      <ThemedText type="eyebrow" themeColor="mutedForeground">
-        ORGANIZATION
-      </ThemedText>
-      {orgsLoading || activeLoading ? (
-        <Skeleton width={160} height={20} />
-      ) : hasMultiple ? (
-        <>
-          <Pressable
-            onPress={() => setPickerOpen(true)}
-            disabled={switching !== null}
-            accessibilityRole="button"
-            accessibilityLabel="Choose organization"
-            accessibilityValue={{ text: activeOrg?.name ?? "Not set" }}
-            style={({ pressed }) => [
-              styles.orgRow,
-              { borderColor: theme.border },
-              pressed &&
-                switching === null && { backgroundColor: theme.secondary },
-            ]}
-          >
-            <Building2 size={18} color={theme.foreground} />
-            <ThemedText style={styles.orgName} numberOfLines={1}>
-              {activeOrg?.name ?? "Choose organization"}
-            </ThemedText>
-            {switching ? (
-              <ActivityIndicator color={theme.foreground} size="small" />
-            ) : (
-              <ChevronDown color={theme.mutedForeground} size={18} />
-            )}
-          </Pressable>
-          <SelectSheet
-            visible={pickerOpen}
-            title="Organization"
-            options={(orgs ?? []).map((org) => ({
-              value: org.id,
-              label: org.name,
-            }))}
-            selectedValue={activeOrg?.id}
-            onSelect={(organizationId) => {
-              setPickerOpen(false);
-              void onSwitch(organizationId);
-            }}
-            onClose={() => setPickerOpen(false)}
-          />
-        </>
-      ) : (
-        <View style={[styles.orgRow, { borderColor: theme.border }]}>
-          <Building2 size={18} color={theme.foreground} />
-          <ThemedText style={styles.orgName} numberOfLines={1}>
-            {activeOrg?.name ?? orgs?.[0]?.name ?? "—"}
-          </ThemedText>
-        </View>
-      )}
-    </Card>
+    <SettingsGroup title="Workspace">
+      <Pressable
+        onPress={() => setPickerOpen(true)}
+        disabled={switching !== null}
+        accessibilityRole="button"
+        accessibilityLabel="Choose organization"
+        accessibilityValue={{ text: activeOrg?.name ?? "Not set" }}
+        style={({ pressed }) => [
+          styles.orgRow,
+          pressed && switching === null && styles.providerPressed,
+        ]}
+      >
+        <Building2 size={20} color={theme.foreground} />
+        <ThemedText style={styles.orgName} numberOfLines={1}>
+          {activeOrg?.name ?? "Choose organization"}
+        </ThemedText>
+        {switching ? (
+          <ActivityIndicator color={theme.foreground} size="small" />
+        ) : (
+          <ChevronRight color={theme.mutedForeground} size={18} />
+        )}
+      </Pressable>
+      <SelectSheet
+        visible={pickerOpen}
+        title="Organization"
+        options={(orgs ?? []).map((org) => ({
+          value: org.id,
+          label: org.name,
+        }))}
+        selectedValue={activeOrg?.id}
+        onSelect={(organizationId) => {
+          setPickerOpen(false);
+          void onSwitch(organizationId);
+        }}
+        onClose={() => setPickerOpen(false)}
+      />
+    </SettingsGroup>
   );
 }
 
@@ -898,8 +959,10 @@ const styles = StyleSheet.create({
   accountHero: {
     alignItems: "center",
     gap: Spacing.two,
-    paddingVertical: Spacing.two,
+    paddingVertical: Spacing.three,
   },
+  accountHeroPressed: { opacity: 0.7 },
+  avatarWrap: { position: "relative" },
   avatar: {
     width: 76,
     height: 76,
@@ -913,6 +976,16 @@ const styles = StyleSheet.create({
     borderRadius: Radius.full,
   },
   avatarText: { fontFamily: Fonts.sansSemiBold, fontSize: 24 },
+  nameEditBadge: {
+    position: "absolute",
+    right: -5,
+    bottom: -4,
+    width: 28,
+    height: 28,
+    borderRadius: Radius.full,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   accountInfo: { alignItems: "center" },
   accountName: { fontFamily: Fonts.sansSemiBold, fontSize: 22, lineHeight: 27 },
   accountEmail: { fontSize: 14, marginTop: 2 },
@@ -964,6 +1037,32 @@ const styles = StyleSheet.create({
     fontSize: 15,
     marginTop: Spacing.two,
   },
+  sheetBackdrop: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+  },
+  nameSheet: {
+    marginTop: "auto",
+    borderTopLeftRadius: Radius["2xl"],
+    borderTopRightRadius: Radius["2xl"],
+    paddingHorizontal: Spacing.four,
+    paddingTop: Spacing.two,
+    paddingBottom: Spacing.four,
+  },
+  sheetHandle: {
+    width: 36,
+    height: 4,
+    borderRadius: Radius.full,
+    alignSelf: "center",
+  },
+  nameSheetHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: Spacing.three,
+  },
+  nameSheetTitle: { fontFamily: Fonts.sansSemiBold, fontSize: 18 },
+  nameSheetDone: { fontFamily: Fonts.sansMedium, fontSize: 15 },
   selectField: {
     minHeight: 52,
     flexDirection: "row",
@@ -997,35 +1096,27 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: Spacing.three,
-    borderWidth: 1,
-    borderRadius: Radius.lg,
-    paddingHorizontal: Spacing.three,
-    paddingVertical: Spacing.three,
-    marginTop: Spacing.two,
-  },
-  providerLabel: { fontFamily: Fonts.sansMedium, fontSize: 15 },
-  connectButton: {
-    marginLeft: "auto",
-    borderWidth: 1,
-    borderRadius: Radius.full,
-    paddingHorizontal: Spacing.three,
+    minHeight: 60,
     paddingVertical: Spacing.two,
-    minWidth: 84,
-    alignItems: "center",
   },
-  connectButtonText: { fontFamily: Fonts.sansMedium, fontSize: 14 },
+  providerPressed: { opacity: 0.6 },
+  providerContent: { flex: 1 },
+  providerLabel: { fontFamily: Fonts.sansMedium, fontSize: 15 },
+  providerState: { fontSize: 13, marginTop: 1 },
   orgRow: {
     flexDirection: "row",
     alignItems: "center",
     gap: Spacing.three,
-    borderWidth: 1,
-    borderRadius: Radius.lg,
-    paddingHorizontal: Spacing.three,
-    paddingVertical: Spacing.three,
-    marginTop: Spacing.two,
+    minHeight: 60,
+    paddingVertical: Spacing.two,
   },
   orgName: { flex: 1, fontFamily: Fonts.sansMedium, fontSize: 15 },
-  orgTrailing: { marginLeft: "auto" },
+  cancelEditButton: {
+    minHeight: 40,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cancelEditText: { fontFamily: Fonts.sansMedium, fontSize: 15 },
   signOutCard: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/src/app/(app)/profile.tsx
+++ b/apps/mobile/src/app/(app)/profile.tsx
@@ -2,6 +2,7 @@ import {
   INDUSTRY_LABELS,
   type Industry,
   industrySchema,
+  type ProfileInput,
 } from "@freestyle-voice/validations";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
@@ -10,8 +11,6 @@ import {
   Building2,
   CalendarClock,
   Check,
-  ChevronDown,
-  ChevronRight,
   LogOut,
   Pencil,
   PlugZap,
@@ -21,13 +20,15 @@ import {
 } from "lucide-react-native";
 import { useCallback, useEffect, useState } from "react";
 import {
+  ActionSheetIOS,
   ActivityIndicator,
   Alert,
   Image,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
   StyleSheet,
-  Switch,
   TextInput,
   View,
 } from "react-native";
@@ -38,6 +39,7 @@ import {
   SettingsGroup,
   SettingsNavRow,
   SettingsScreenScaffold,
+  SettingsValueRow,
 } from "@/components/settings-ui";
 import { Skeleton } from "@/components/skeleton";
 import { ThemedText } from "@/components/themed-text";
@@ -144,18 +146,18 @@ export function ProfileContent() {
 
   const content = (
     <>
-      <Pressable
-        onPress={() => setNameEditorOpen(true)}
-        disabled={!signedIn}
-        accessibilityRole="button"
-        accessibilityLabel="Edit name"
-        accessibilityState={{ disabled: !signedIn }}
-        style={({ pressed }) => [
-          styles.accountHero,
-          pressed && signedIn && styles.accountHeroPressed,
-        ]}
-      >
-        <View style={styles.avatarWrap}>
+      <View style={styles.accountHero}>
+        <Pressable
+          onPress={() => setNameEditorOpen(true)}
+          disabled={!signedIn}
+          accessibilityRole="button"
+          accessibilityLabel="Edit name"
+          accessibilityState={{ disabled: !signedIn }}
+          style={({ pressed }) => [
+            styles.avatarWrap,
+            pressed && signedIn && styles.accountHeroPressed,
+          ]}
+        >
           {user?.image ? (
             <Image
               source={{ uri: user.image }}
@@ -181,7 +183,7 @@ export function ProfileContent() {
               <Pencil color={theme.mutedForeground} size={14} />
             </View>
           ) : null}
-        </View>
+        </Pressable>
         <View style={styles.accountInfo}>
           <ThemedText style={styles.accountName} numberOfLines={1}>
             {user?.name ?? "Signed in"}
@@ -196,7 +198,20 @@ export function ProfileContent() {
             </ThemedText>
           ) : null}
         </View>
-      </Pressable>
+      </View>
+
+      <SettingsGroup title="Account">
+        <SettingsValueRow
+          label="Name"
+          value={user?.name ?? "Not set"}
+          onPress={() => setNameEditorOpen(true)}
+        />
+        <SettingsValueRow
+          label="Email"
+          value={user?.email ?? "Not available"}
+          last
+        />
+      </SettingsGroup>
 
       <SettingsGroup>
         <SettingsNavRow
@@ -383,7 +398,7 @@ const PROVIDER_META: {
   { id: "apple", label: "Apple", Icon: AppleIcon },
 ];
 
-/** A small native sheet keeps editing out of the everyday account surface. */
+/** Keyboard-safe native sheet used for the small, focused account edits. */
 function NameEditorSheet({
   visible,
   currentName,
@@ -393,246 +408,218 @@ function NameEditorSheet({
   currentName: string;
   onClose: () => void;
 }) {
+  return (
+    <TextEditorSheet
+      visible={visible}
+      title="Edit name"
+      value={currentName}
+      placeholder="Your name"
+      onClose={onClose}
+      onSave={async (name) => {
+        const { error } = await updateName(name);
+        if (error) throw new Error(error);
+      }}
+    />
+  );
+}
+
+function TextEditorSheet({
+  visible,
+  title,
+  value,
+  placeholder,
+  allowEmpty = false,
+  onClose,
+  onSave,
+}: {
+  visible: boolean;
+  title: string;
+  value: string;
+  placeholder: string;
+  allowEmpty?: boolean;
+  onClose: () => void;
+  onSave: (value: string) => Promise<void>;
+}) {
   const theme = useTheme();
-  const [name, setName] = useState(currentName);
+  const [draft, setDraft] = useState(value);
   const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
 
   useEffect(() => {
-    setName(currentName);
-  }, [currentName]);
+    if (visible) setDraft(value);
+  }, [value, visible]);
 
-  const trimmed = name.trim();
-  const dirty = trimmed !== currentName.trim();
-  const canSave = dirty && trimmed.length > 0 && !saving;
-
-  const onSave = useCallback(async () => {
+  const trimmed = draft.trim();
+  const canSave =
+    !saving && trimmed !== value.trim() && (allowEmpty || trimmed.length > 0);
+  const save = useCallback(async () => {
     if (!canSave) return;
     setSaving(true);
-    setSaved(false);
-    const { error } = await updateName(trimmed);
-    setSaving(false);
-    if (error) {
-      Alert.alert("Couldn't update name", error);
-      return;
-    }
-    setSaved(true);
-    setTimeout(() => {
-      setSaved(false);
+    try {
+      await onSave(trimmed);
       onClose();
-    }, 550);
-  }, [canSave, onClose, trimmed]);
+    } catch (error) {
+      Alert.alert(
+        `Couldn't update ${title.toLowerCase()}`,
+        error instanceof Error ? error.message : "Try again.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }, [canSave, onClose, onSave, title, trimmed]);
 
   return (
     <Modal
       visible={visible}
-      transparent
       animationType="slide"
+      presentationStyle="formSheet"
       onRequestClose={onClose}
-      statusBarTranslucent
     >
-      <Pressable style={styles.sheetBackdrop} onPress={onClose} />
-      <View style={[styles.nameSheet, { backgroundColor: theme.card }]}>
-        <View style={[styles.sheetHandle, { backgroundColor: theme.border }]} />
-        <View style={styles.nameSheetHeader}>
-          <ThemedText style={styles.nameSheetTitle}>Edit name</ThemedText>
-          <Pressable onPress={onClose} accessibilityLabel="Close name editor">
+      <KeyboardAvoidingView
+        // iOS form sheets already track the software keyboard. Let the
+        // native presentation own that transition; Android still needs the
+        // standard height adjustment for its full-screen modal fallback.
+        enabled={Platform.OS !== "ios"}
+        behavior="height"
+        style={[styles.editorSheet, { backgroundColor: theme.background }]}
+      >
+        <View style={styles.editorNav}>
+          <Pressable onPress={onClose} hitSlop={10} accessibilityLabel="Cancel">
             <ThemedText
-              style={[styles.nameSheetDone, { color: theme.primary }]}
+              style={[styles.editorNavAction, { color: theme.primary }]}
             >
               Cancel
             </ThemedText>
           </Pressable>
+          <ThemedText style={styles.editorTitle}>{title}</ThemedText>
+          <Pressable
+            onPress={() => void save()}
+            disabled={!canSave}
+            hitSlop={10}
+            accessibilityLabel={`Save ${title.toLowerCase()}`}
+          >
+            {saving ? (
+              <ActivityIndicator color={theme.primary} size="small" />
+            ) : (
+              <ThemedText
+                style={[
+                  styles.editorNavAction,
+                  { color: canSave ? theme.primary : theme.mutedForeground },
+                ]}
+              >
+                Save
+              </ThemedText>
+            )}
+          </Pressable>
         </View>
         <TextInput
-          value={name}
-          onChangeText={setName}
-          placeholder="Your name"
+          value={draft}
+          onChangeText={setDraft}
+          placeholder={placeholder}
           placeholderTextColor={theme.mutedForeground}
           maxLength={120}
           autoFocus
           returnKeyType="done"
-          onSubmitEditing={() => void onSave()}
+          onSubmitEditing={() => void save()}
           style={[
-            styles.input,
-            { borderColor: theme.border, color: theme.foreground },
+            styles.editorInput,
+            { backgroundColor: theme.secondary, color: theme.foreground },
           ]}
         />
-        <Pressable
-          onPress={() => void onSave()}
-          disabled={!canSave}
-          style={({ pressed }) => [
-            styles.primaryButton,
-            { backgroundColor: theme.primary },
-            pressed && canSave ? { opacity: 0.9 } : null,
-            !canSave ? styles.buttonDisabled : null,
-          ]}
-        >
-          {saving ? (
-            <ActivityIndicator color={theme.primaryForeground} />
-          ) : (
-            <>
-              {saved ? (
-                <Check color={theme.primaryForeground} size={16} />
-              ) : null}
-              <ThemedText
-                style={[
-                  styles.primaryButtonText,
-                  { color: theme.primaryForeground },
-                ]}
-              >
-                {saved ? "Saved" : "Save"}
-              </ThemedText>
-            </>
-          )}
-        </Pressable>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }
 
-/** Professional details: industry, job title, company + detected location. */
+/** Small, focused account details instead of one large legacy profile form. */
 function ProfileDetailsCard() {
-  const theme = useTheme();
   const queryClient = useQueryClient();
-  const [industry, setIndustry] = useState<Industry | undefined>(undefined);
   const [industryPickerOpen, setIndustryPickerOpen] = useState(false);
-  const [jobTitle, setJobTitle] = useState("");
-  const [company, setCompany] = useState("");
-  // Re-seed tone + vocabulary defaults for the new industry (opt-out). Only
-  // surfaced while the industry is actually changing. Mirrors the dashboard.
-  const [updatePreferences, setUpdatePreferences] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
-  const [editing, setEditing] = useState(false);
-
+  const [editingField, setEditingField] = useState<
+    "jobTitle" | "company" | null
+  >(null);
   const { data: profile, isLoading } = useQuery({
     queryKey: ["cloud-profile-fields"],
     queryFn: getProfileFields,
     retry: 1,
   });
-
-  useEffect(() => {
-    if (!profile) return;
-    const parsed = industrySchema.safeParse(profile.industry);
-    setIndustry(parsed.success ? parsed.data : undefined);
-    setJobTitle(profile.jobTitle ?? "");
-    setCompany(profile.company ?? "");
-    setUpdatePreferences(true);
-  }, [profile]);
-
-  const savedIndustry = industrySchema.safeParse(profile?.industry).success
+  const industry = industrySchema.safeParse(profile?.industry).success
     ? (profile?.industry as Industry)
     : undefined;
-  // Show the re-seed toggle only when switching to a real industry (clearing it
-  // never reseeds).
-  const industryWillChange =
-    industry !== savedIndustry && industry !== undefined;
-  const dirty =
-    industry !== savedIndustry ||
-    jobTitle.trim() !== (profile?.jobTitle ?? "") ||
-    company.trim() !== (profile?.company ?? "");
-  const canSave = dirty && !saving;
 
-  const onSave = useCallback(async (): Promise<boolean> => {
-    if (!canSave) return false;
-    setSaving(true);
-    setSaved(false);
-    try {
-      const updated = await updateProfileFields({
-        // Send `null` (not `undefined`) to clear a field — `undefined` is
-        // dropped by JSON serialization, which the server reads as "unchanged".
-        industry: industry ?? null,
-        jobTitle: jobTitle.trim() || null,
-        company: company.trim() || null,
-        // Only meaningful on an industry change; harmless otherwise.
-        updatePreferences,
-      });
+  const saveProfile = useCallback(
+    async (input: ProfileInput) => {
+      const updated = await updateProfileFields(input);
       queryClient.setQueryData(["cloud-profile-fields"], updated);
-      // The cloud re-seeds tone/vocabulary defaults into member_preferences on
-      // ANY industry change (unless opted out). Invalidate the preferences query
-      // so the seeded values are pulled in immediately.
-      const industryChanged = (savedIndustry ?? null) !== (industry ?? null);
-      if (industryChanged && industry && updatePreferences) {
-        void queryClient.invalidateQueries({
-          queryKey: ["cloud-preferences"],
-        });
+      if (input.industry && input.updatePreferences !== false) {
+        void queryClient.invalidateQueries({ queryKey: ["cloud-preferences"] });
       }
-      setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
-      return true;
-    } catch (e) {
+    },
+    [queryClient],
+  );
+
+  const selectIndustry = useCallback(
+    (next?: Industry) => {
+      setIndustryPickerOpen(false);
+      if (next === industry) return;
+      const update = (updatePreferences: boolean) => {
+        void saveProfile({ industry: next ?? null, updatePreferences }).catch(
+          (error) =>
+            Alert.alert(
+              "Couldn't update industry",
+              error instanceof Error ? error.message : "Try again.",
+            ),
+        );
+      };
+      if (!next) {
+        update(false);
+        return;
+      }
       Alert.alert(
-        "Couldn't update profile",
-        e instanceof Error ? e.message : "Try again.",
+        "Update writing defaults?",
+        "You can also update your default tone and vocabulary for this industry.",
+        [
+          { text: "Keep current", onPress: () => update(false) },
+          { text: "Update defaults", onPress: () => update(true) },
+        ],
       );
-      return false;
-    } finally {
-      setSaving(false);
-    }
-  }, [
-    canSave,
-    industry,
-    savedIndustry,
-    jobTitle,
-    company,
-    updatePreferences,
-    queryClient,
-  ]);
+    },
+    [industry, saveProfile],
+  );
 
   if (isLoading) {
     return (
-      <SettingsGroup title="Personalization">
+      <SettingsGroup title="Work profile">
         <Skeleton width={180} height={20} />
       </SettingsGroup>
     );
   }
 
-  if (!editing) {
-    return (
-      <SettingsGroup title="Personalization">
-        <SettingsNavRow
-          icon={SlidersHorizontal}
-          label="Work profile"
-          value={
-            industry
-              ? INDUSTRY_LABELS[industry]
-              : jobTitle || company
-                ? "Details added"
-                : "Optional"
-          }
-          onPress={() => setEditing(true)}
+  const fieldValue = editingField ? (profile?.[editingField] ?? "") : "";
+  const fieldTitle =
+    editingField === "company" ? "Edit company" : "Edit job title";
+  const fieldPlaceholder =
+    editingField === "company" ? "e.g. Acme Inc." : "e.g. Product Manager";
+
+  return (
+    <>
+      <SettingsGroup title="Work profile">
+        <SettingsValueRow
+          label="Industry"
+          value={industry ? INDUSTRY_LABELS[industry] : "Not set"}
+          onPress={() => setIndustryPickerOpen(true)}
+        />
+        <SettingsValueRow
+          label="Job title"
+          value={profile?.jobTitle || "Not set"}
+          onPress={() => setEditingField("jobTitle")}
+        />
+        <SettingsValueRow
+          label="Company"
+          value={profile?.company || "Not set"}
+          onPress={() => setEditingField("company")}
           last
         />
       </SettingsGroup>
-    );
-  }
-
-  return (
-    <SettingsGroup title="Work profile">
-      <Pressable
-        onPress={() => setIndustryPickerOpen(true)}
-        accessibilityRole="button"
-        accessibilityLabel="Choose industry"
-        accessibilityValue={{
-          text: industry ? INDUSTRY_LABELS[industry] : "Not set",
-        }}
-        style={({ pressed }) => [
-          styles.selectField,
-          { borderColor: theme.border },
-          pressed && { backgroundColor: theme.secondary },
-        ]}
-      >
-        <ThemedText
-          style={[
-            styles.selectFieldLabel,
-            !industry && { color: theme.mutedForeground },
-          ]}
-        >
-          {industry ? INDUSTRY_LABELS[industry] : "Choose an industry"}
-        </ThemedText>
-        <ChevronDown color={theme.mutedForeground} size={18} />
-      </Pressable>
       <SelectSheet
         visible={industryPickerOpen}
         title="Industry"
@@ -641,108 +628,23 @@ function ProfileDetailsCard() {
           label: INDUSTRY_LABELS[value],
         }))}
         selectedValue={industry}
-        onSelect={(value) => {
-          setIndustry(value as Industry);
-          setIndustryPickerOpen(false);
-        }}
-        onClear={() => {
-          setIndustry(undefined);
-          setIndustryPickerOpen(false);
-        }}
+        onSelect={(value) => selectIndustry(value as Industry)}
+        onClear={() => selectIndustry(undefined)}
         onClose={() => setIndustryPickerOpen(false)}
       />
-
-      {industryWillChange ? (
-        <View style={[styles.reseedRow, { borderColor: theme.border }]}>
-          <ThemedText style={styles.reseedLabel}>
-            Update tone and vocabulary to match the new industry's defaults
-          </ThemedText>
-          <Switch
-            value={updatePreferences}
-            onValueChange={setUpdatePreferences}
-            trackColor={{ true: theme.primary, false: theme.secondary }}
-          />
-        </View>
-      ) : null}
-
-      <ThemedText
-        type="eyebrow"
-        themeColor="mutedForeground"
-        style={styles.detailsLabel}
-      >
-        JOB TITLE
-      </ThemedText>
-      <TextInput
-        value={jobTitle}
-        onChangeText={setJobTitle}
-        placeholder="e.g. Product Manager"
-        placeholderTextColor={theme.mutedForeground}
-        maxLength={120}
-        style={[
-          styles.input,
-          { borderColor: theme.border, color: theme.foreground },
-        ]}
-      />
-
-      <ThemedText
-        type="eyebrow"
-        themeColor="mutedForeground"
-        style={styles.detailsLabel}
-      >
-        COMPANY
-      </ThemedText>
-      <TextInput
-        value={company}
-        onChangeText={setCompany}
-        placeholder="e.g. Acme Inc."
-        placeholderTextColor={theme.mutedForeground}
-        maxLength={120}
-        style={[
-          styles.input,
-          { borderColor: theme.border, color: theme.foreground },
-        ]}
-      />
-
-      <Pressable
-        onPress={() => {
-          void onSave().then((didSave) => {
-            if (didSave) setEditing(false);
-          });
+      <TextEditorSheet
+        visible={editingField !== null}
+        title={fieldTitle}
+        value={fieldValue}
+        placeholder={fieldPlaceholder}
+        allowEmpty
+        onClose={() => setEditingField(null)}
+        onSave={async (value) => {
+          if (!editingField) return;
+          await saveProfile({ [editingField]: value || null });
         }}
-        disabled={!canSave}
-        style={({ pressed }) => [
-          styles.primaryButton,
-          { backgroundColor: theme.primary },
-          pressed && canSave ? { opacity: 0.9 } : null,
-          !canSave ? styles.buttonDisabled : null,
-        ]}
-      >
-        {saving ? (
-          <ActivityIndicator color={theme.primaryForeground} />
-        ) : (
-          <>
-            {saved ? <Check color={theme.primaryForeground} size={16} /> : null}
-            <ThemedText
-              style={[
-                styles.primaryButtonText,
-                { color: theme.primaryForeground },
-              ]}
-            >
-              {saved ? "Saved" : "Save changes"}
-            </ThemedText>
-          </>
-        )}
-      </Pressable>
-      <Pressable
-        onPress={() => setEditing(false)}
-        accessibilityRole="button"
-        style={styles.cancelEditButton}
-      >
-        <ThemedText themeColor="mutedForeground" style={styles.cancelEditText}>
-          Cancel
-        </ThemedText>
-      </Pressable>
-    </SettingsGroup>
+      />
+    </>
   );
 }
 
@@ -815,52 +717,28 @@ function ConnectedAccountsCard() {
           const isConnected = linked?.includes(id) ?? false;
           const isOnlyMethod = isConnected && connectedCount <= 1;
           return (
-            <Pressable
+            <SettingsValueRow
               key={id}
-              onPress={() =>
-                isConnected ? onUnlink(id, label) : void onLink(id)
+              icon={Icon}
+              label={label}
+              value={
+                isConnected ? (isOnlyMethod ? "Primary" : "Connected") : "Add"
               }
-              disabled={busy || isOnlyMethod}
-              accessibilityRole="button"
-              accessibilityLabel={
+              onPress={
                 isOnlyMethod
-                  ? `${label} is your primary sign-in method`
-                  : `${isConnected ? "Manage" : "Connect"} ${label}`
+                  ? undefined
+                  : () => (isConnected ? onUnlink(id, label) : void onLink(id))
               }
-              style={({ pressed }) => [
-                styles.providerRow,
-                index < PROVIDER_META.length - 1 && {
-                  borderBottomWidth: StyleSheet.hairlineWidth,
-                  borderBottomColor: theme.border,
-                },
-                pressed && !busy && !isOnlyMethod
-                  ? styles.providerPressed
-                  : null,
-                (busy || isOnlyMethod) && styles.buttonDisabled,
-              ]}
-            >
-              <Icon size={20} color={theme.foreground} />
-              <View style={styles.providerContent}>
-                <ThemedText style={styles.providerLabel}>{label}</ThemedText>
-                <ThemedText
-                  themeColor="mutedForeground"
-                  style={styles.providerState}
-                >
-                  {isConnected
-                    ? isOnlyMethod
-                      ? "Primary sign-in"
-                      : "Connected"
-                    : "Not connected"}
-                </ThemedText>
-              </View>
-              {linking === id || unlinking === id ? (
-                <ActivityIndicator color={theme.foreground} size="small" />
-              ) : isOnlyMethod ? (
-                <Check color={theme.primary} size={18} />
-              ) : (
-                <ChevronRight color={theme.mutedForeground} size={18} />
-              )}
-            </Pressable>
+              disabled={busy}
+              last={index === PROVIDER_META.length - 1}
+              trailing={
+                linking === id || unlinking === id ? (
+                  <ActivityIndicator color={theme.foreground} size="small" />
+                ) : isOnlyMethod ? (
+                  <Check color={theme.primary} size={18} />
+                ) : undefined
+              }
+            />
           );
         })
       )}
@@ -868,12 +746,7 @@ function ConnectedAccountsCard() {
   );
 }
 
-/**
- * Active-organization card with an inline switcher. Every signed-in user has a
- * default org set active by the cloud, so the active row always shows; the
- * other orgs are only listed (tappable to switch) when the user belongs to
- * more than one.
- */
+/** A native workspace menu, only visible when the person has a real choice. */
 function OrganizationCard() {
   const theme = useTheme();
   const queryClient = useQueryClient();
@@ -903,6 +776,10 @@ function OrganizationCard() {
         Alert.alert("Couldn't switch organization", error);
         return;
       }
+      const selected = orgs?.find((org) => org.id === organizationId);
+      if (selected) {
+        queryClient.setQueryData(["cloud-active-org"], selected);
+      }
       // Plans are org-scoped on the cloud, so switching orgs can change the
       // plan — refresh both the active org and usage so the PLAN card updates.
       void queryClient.invalidateQueries({ queryKey: ["cloud-active-org"] });
@@ -916,8 +793,27 @@ function OrganizationCard() {
         queryKey: ["cloud-profile-fields"],
       });
     },
-    [activeOrg?.id, queryClient],
+    [activeOrg?.id, orgs, queryClient],
   );
+
+  const showWorkspacePicker = useCallback(() => {
+    if (Platform.OS !== "ios") {
+      setPickerOpen(true);
+      return;
+    }
+    const choices = orgs ?? [];
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        title: "Choose workspace",
+        message: "Your profile, preferences, and plan follow this workspace.",
+        options: ["Cancel", ...choices.map((org) => org.name)],
+        cancelButtonIndex: 0,
+      },
+      (index) => {
+        if (index > 0) void onSwitch(choices[index - 1].id);
+      },
+    );
+  }, [onSwitch, orgs]);
 
   // A default personal organization is an implementation detail. Surface a
   // workspace switcher only when it gives the person a real choice.
@@ -925,41 +821,35 @@ function OrganizationCard() {
 
   return (
     <SettingsGroup title="Workspace">
-      <Pressable
-        onPress={() => setPickerOpen(true)}
+      <SettingsValueRow
+        icon={Building2}
+        label="Current workspace"
+        value={activeOrg?.name ?? "Choose workspace"}
+        onPress={showWorkspacePicker}
         disabled={switching !== null}
-        accessibilityRole="button"
-        accessibilityLabel="Choose organization"
-        accessibilityValue={{ text: activeOrg?.name ?? "Not set" }}
-        style={({ pressed }) => [
-          styles.orgRow,
-          pressed && switching === null && styles.providerPressed,
-        ]}
-      >
-        <Building2 size={20} color={theme.foreground} />
-        <ThemedText style={styles.orgName} numberOfLines={1}>
-          {activeOrg?.name ?? "Choose organization"}
-        </ThemedText>
-        {switching ? (
-          <ActivityIndicator color={theme.foreground} size="small" />
-        ) : (
-          <ChevronRight color={theme.mutedForeground} size={18} />
-        )}
-      </Pressable>
-      <SelectSheet
-        visible={pickerOpen}
-        title="Organization"
-        options={(orgs ?? []).map((org) => ({
-          value: org.id,
-          label: org.name,
-        }))}
-        selectedValue={activeOrg?.id}
-        onSelect={(organizationId) => {
-          setPickerOpen(false);
-          void onSwitch(organizationId);
-        }}
-        onClose={() => setPickerOpen(false)}
+        last
+        trailing={
+          switching ? (
+            <ActivityIndicator color={theme.foreground} size="small" />
+          ) : undefined
+        }
       />
+      {Platform.OS !== "ios" ? (
+        <SelectSheet
+          visible={pickerOpen}
+          title="Workspace"
+          options={(orgs ?? []).map((org) => ({
+            value: org.id,
+            label: org.name,
+          }))}
+          selectedValue={activeOrg?.id}
+          onSelect={(organizationId) => {
+            setPickerOpen(false);
+            void onSwitch(organizationId);
+          }}
+          onClose={() => setPickerOpen(false)}
+        />
+      ) : null}
     </SettingsGroup>
   );
 }
@@ -1037,95 +927,27 @@ const styles = StyleSheet.create({
   },
   outlineButtonText: { fontFamily: Fonts.sansMedium, fontSize: 15 },
   buttonDisabled: { opacity: 0.6 },
-  input: {
-    borderWidth: 1,
-    borderRadius: Radius.lg,
-    paddingHorizontal: Spacing.three,
-    paddingVertical: Spacing.two + 2,
-    fontFamily: Fonts.sans,
-    fontSize: 15,
-    marginTop: Spacing.two,
-  },
-  sheetBackdrop: {
-    ...StyleSheet.absoluteFill,
-    backgroundColor: "rgba(0, 0, 0, 0.5)",
-  },
-  nameSheet: {
-    marginTop: "auto",
-    borderTopLeftRadius: Radius["2xl"],
-    borderTopRightRadius: Radius["2xl"],
+  editorSheet: {
+    flex: 1,
     paddingHorizontal: Spacing.four,
-    paddingTop: Spacing.two,
-    paddingBottom: Spacing.four,
+    paddingTop: Spacing.three,
   },
-  sheetHandle: {
-    width: 36,
-    height: 4,
-    borderRadius: Radius.full,
-    alignSelf: "center",
-  },
-  nameSheetHeader: {
+  editorNav: {
+    minHeight: 44,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
+  },
+  editorTitle: { fontFamily: Fonts.sansSemiBold, fontSize: 17 },
+  editorNavAction: { fontFamily: Fonts.sansMedium, fontSize: 16 },
+  editorInput: {
+    minHeight: 52,
+    borderRadius: Radius.lg,
+    paddingHorizontal: Spacing.three,
+    fontFamily: Fonts.sans,
+    fontSize: 16,
     marginTop: Spacing.three,
   },
-  nameSheetTitle: { fontFamily: Fonts.sansSemiBold, fontSize: 18 },
-  nameSheetDone: { fontFamily: Fonts.sansMedium, fontSize: 15 },
-  selectField: {
-    minHeight: 52,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: Spacing.three,
-    borderWidth: 1,
-    borderRadius: Radius.lg,
-    paddingHorizontal: Spacing.three,
-    marginTop: Spacing.two,
-  },
-  selectFieldLabel: { flex: 1, fontFamily: Fonts.sans, fontSize: 15 },
-  detailsLabel: { marginTop: Spacing.four },
-  reseedRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: Spacing.three,
-    borderWidth: 1,
-    borderRadius: Radius.lg,
-    paddingHorizontal: Spacing.three,
-    paddingVertical: Spacing.three,
-    marginTop: Spacing.two,
-  },
-  reseedLabel: {
-    flex: 1,
-    fontFamily: Fonts.sans,
-    fontSize: 14,
-    lineHeight: 19,
-  },
-  providerRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: Spacing.three,
-    minHeight: 60,
-    paddingVertical: Spacing.two,
-  },
-  providerPressed: { opacity: 0.6 },
-  providerContent: { flex: 1 },
-  providerLabel: { fontFamily: Fonts.sansMedium, fontSize: 15 },
-  providerState: { fontSize: 13, marginTop: 1 },
-  orgRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: Spacing.three,
-    minHeight: 60,
-    paddingVertical: Spacing.two,
-  },
-  orgName: { flex: 1, fontFamily: Fonts.sansMedium, fontSize: 15 },
-  cancelEditButton: {
-    minHeight: 40,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  cancelEditText: { fontFamily: Fonts.sansMedium, fontSize: 15 },
   signOutCard: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/src/app/(app)/profile.tsx
+++ b/apps/mobile/src/app/(app)/profile.tsx
@@ -12,26 +12,28 @@ import {
   CalendarClock,
   Check,
   LogOut,
-  Pencil,
   PlugZap,
   ShieldCheck,
   SlidersHorizontal,
   Sparkles,
 } from "lucide-react-native";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
-  ActionSheetIOS,
   ActivityIndicator,
   Alert,
   Image,
   KeyboardAvoidingView,
   Modal,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   TextInput,
   View,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AppleIcon, GitHubIcon, GoogleIcon } from "@/components/provider-icons";
 import { SelectSheet } from "@/components/select-sheet";
 import {
@@ -147,17 +149,7 @@ export function ProfileContent() {
   const content = (
     <>
       <View style={styles.accountHero}>
-        <Pressable
-          onPress={() => setNameEditorOpen(true)}
-          disabled={!signedIn}
-          accessibilityRole="button"
-          accessibilityLabel="Edit name"
-          accessibilityState={{ disabled: !signedIn }}
-          style={({ pressed }) => [
-            styles.avatarWrap,
-            pressed && signedIn && styles.accountHeroPressed,
-          ]}
-        >
+        <View style={styles.avatarWrap}>
           {user?.image ? (
             <Image
               source={{ uri: user.image }}
@@ -173,17 +165,7 @@ export function ProfileContent() {
               </ThemedText>
             </View>
           )}
-          {signedIn ? (
-            <View
-              style={[
-                styles.nameEditBadge,
-                { backgroundColor: theme.secondary },
-              ]}
-            >
-              <Pencil color={theme.mutedForeground} size={14} />
-            </View>
-          ) : null}
-        </Pressable>
+        </View>
         <View style={styles.accountInfo}>
           <ThemedText style={styles.accountName} numberOfLines={1}>
             {user?.name ?? "Signed in"}
@@ -746,7 +728,7 @@ function ConnectedAccountsCard() {
   );
 }
 
-/** A native workspace menu, only visible when the person has a real choice. */
+/** A native-style workspace wheel, only visible when the person has a real choice. */
 function OrganizationCard() {
   const theme = useTheme();
   const queryClient = useQueryClient();
@@ -796,25 +778,6 @@ function OrganizationCard() {
     [activeOrg?.id, orgs, queryClient],
   );
 
-  const showWorkspacePicker = useCallback(() => {
-    if (Platform.OS !== "ios") {
-      setPickerOpen(true);
-      return;
-    }
-    const choices = orgs ?? [];
-    ActionSheetIOS.showActionSheetWithOptions(
-      {
-        title: "Choose workspace",
-        message: "Your profile, preferences, and plan follow this workspace.",
-        options: ["Cancel", ...choices.map((org) => org.name)],
-        cancelButtonIndex: 0,
-      },
-      (index) => {
-        if (index > 0) void onSwitch(choices[index - 1].id);
-      },
-    );
-  }, [onSwitch, orgs]);
-
   // A default personal organization is an implementation detail. Surface a
   // workspace switcher only when it gives the person a real choice.
   if (orgsLoading || activeLoading || !hasMultiple) return null;
@@ -825,7 +788,7 @@ function OrganizationCard() {
         icon={Building2}
         label="Current workspace"
         value={activeOrg?.name ?? "Choose workspace"}
-        onPress={showWorkspacePicker}
+        onPress={() => setPickerOpen(true)}
         disabled={switching !== null}
         last
         trailing={
@@ -834,23 +797,225 @@ function OrganizationCard() {
           ) : undefined
         }
       />
-      {Platform.OS !== "ios" ? (
-        <SelectSheet
-          visible={pickerOpen}
-          title="Workspace"
-          options={(orgs ?? []).map((org) => ({
-            value: org.id,
-            label: org.name,
-          }))}
-          selectedValue={activeOrg?.id}
-          onSelect={(organizationId) => {
-            setPickerOpen(false);
-            void onSwitch(organizationId);
-          }}
-          onClose={() => setPickerOpen(false)}
-        />
-      ) : null}
+      <WorkspacePickerSheet
+        visible={pickerOpen}
+        organizations={orgs ?? []}
+        selectedOrganizationId={activeOrg?.id}
+        onSelect={(organizationId) => {
+          setPickerOpen(false);
+          void onSwitch(organizationId);
+        }}
+        onClose={() => setPickerOpen(false)}
+      />
     </SettingsGroup>
+  );
+}
+
+const WORKSPACE_WHEEL_ITEM_HEIGHT = 52;
+const WORKSPACE_WHEEL_VISIBLE_ITEMS = 5;
+type Organization = Awaited<ReturnType<typeof listOrganizations>>[number];
+
+/**
+ * The operating-system picker visual is important here: a workspace is a
+ * durable context change, so choosing it happens in an explicit bottom sheet
+ * rather than the transient iOS action sheet used for one-off commands.
+ */
+function WorkspacePickerSheet({
+  visible,
+  organizations,
+  selectedOrganizationId,
+  onSelect,
+  onClose,
+}: {
+  visible: boolean;
+  organizations: Organization[];
+  selectedOrganizationId?: string;
+  onSelect: (organizationId: string) => void;
+  onClose: () => void;
+}) {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const scrollRef = useRef<ScrollView>(null);
+  const [pendingOrganizationId, setPendingOrganizationId] = useState(
+    selectedOrganizationId ?? organizations[0]?.id ?? "",
+  );
+  const selectedIndex = Math.max(
+    0,
+    organizations.findIndex((org) => org.id === pendingOrganizationId),
+  );
+
+  useEffect(() => {
+    if (!visible) return;
+    const initialId = selectedOrganizationId ?? organizations[0]?.id ?? "";
+    setPendingOrganizationId(initialId);
+    const initialIndex = Math.max(
+      0,
+      organizations.findIndex((org) => org.id === initialId),
+    );
+    const frame = requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({
+        y: initialIndex * WORKSPACE_WHEEL_ITEM_HEIGHT,
+        animated: false,
+      });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [organizations, selectedOrganizationId, visible]);
+
+  const settleAtOffset = useCallback(
+    (offsetY: number) => {
+      const index = Math.max(
+        0,
+        Math.min(
+          organizations.length - 1,
+          Math.round(offsetY / WORKSPACE_WHEEL_ITEM_HEIGHT),
+        ),
+      );
+      const next = organizations[index];
+      if (next) setPendingOrganizationId(next.id);
+    },
+    [organizations],
+  );
+
+  const onScrollEnd = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      settleAtOffset(event.nativeEvent.contentOffset.y);
+    },
+    [settleAtOffset],
+  );
+
+  const selectOrganization = useCallback(
+    (organization: Organization, index: number) => {
+      setPendingOrganizationId(organization.id);
+      scrollRef.current?.scrollTo({
+        y: index * WORKSPACE_WHEEL_ITEM_HEIGHT,
+        animated: true,
+      });
+    },
+    [],
+  );
+
+  const confirm = useCallback(() => {
+    if (pendingOrganizationId) onSelect(pendingOrganizationId);
+  }, [onSelect, pendingOrganizationId]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      presentationStyle="overFullScreen"
+      onRequestClose={onClose}
+    >
+      <View style={styles.workspacePickerOverlay}>
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close workspace picker"
+        />
+        <View
+          style={[
+            styles.workspacePickerSheet,
+            {
+              backgroundColor: theme.card,
+              borderColor: theme.cardRing,
+              paddingBottom: Math.max(insets.bottom, Spacing.five),
+            },
+          ]}
+        >
+          <View
+            style={[
+              styles.workspacePickerHandle,
+              { backgroundColor: theme.border },
+            ]}
+          />
+          <View style={styles.workspacePickerNav}>
+            <Pressable
+              onPress={onClose}
+              hitSlop={10}
+              accessibilityRole="button"
+              accessibilityLabel="Cancel workspace selection"
+            >
+              <ThemedText
+                style={[styles.workspacePickerAction, { color: theme.primary }]}
+              >
+                Cancel
+              </ThemedText>
+            </Pressable>
+            <ThemedText style={styles.workspacePickerTitle}>
+              Workspace
+            </ThemedText>
+            <Pressable
+              onPress={confirm}
+              hitSlop={10}
+              accessibilityRole="button"
+              accessibilityLabel="Confirm workspace selection"
+            >
+              <ThemedText
+                style={[styles.workspacePickerAction, { color: theme.primary }]}
+              >
+                Done
+              </ThemedText>
+            </Pressable>
+          </View>
+          <View style={styles.workspaceWheel}>
+            <View
+              pointerEvents="none"
+              style={[
+                styles.workspaceWheelSelection,
+                { backgroundColor: theme.secondary, borderColor: theme.border },
+              ]}
+            />
+            <ScrollView
+              ref={scrollRef}
+              showsVerticalScrollIndicator={false}
+              snapToInterval={WORKSPACE_WHEEL_ITEM_HEIGHT}
+              snapToAlignment="start"
+              decelerationRate="fast"
+              disableIntervalMomentum
+              onMomentumScrollEnd={onScrollEnd}
+              onScrollEndDrag={onScrollEnd}
+              contentContainerStyle={styles.workspaceWheelContent}
+            >
+              {organizations.map((organization, index) => {
+                const selected = index === selectedIndex;
+                return (
+                  <Pressable
+                    key={organization.id}
+                    onPress={() => selectOrganization(organization, index)}
+                    accessibilityRole="radio"
+                    accessibilityState={{ selected }}
+                    accessibilityLabel={organization.name}
+                    style={styles.workspaceWheelRow}
+                  >
+                    <ThemedText
+                      numberOfLines={1}
+                      style={[
+                        styles.workspaceWheelLabel,
+                        {
+                          color: selected
+                            ? theme.foreground
+                            : theme.mutedForeground,
+                        },
+                        !selected && styles.workspaceWheelLabelMuted,
+                      ]}
+                    >
+                      {organization.name}
+                    </ThemedText>
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+          </View>
+          <ThemedText
+            themeColor="mutedForeground"
+            style={styles.workspacePickerHint}
+          >
+            Your profile, preferences, and plan follow this workspace.
+          </ThemedText>
+        </View>
+      </View>
+    </Modal>
   );
 }
 
@@ -860,7 +1025,6 @@ const styles = StyleSheet.create({
     gap: Spacing.two,
     paddingVertical: Spacing.three,
   },
-  accountHeroPressed: { opacity: 0.7 },
   avatarWrap: { position: "relative" },
   avatar: {
     width: 76,
@@ -875,16 +1039,6 @@ const styles = StyleSheet.create({
     borderRadius: Radius.full,
   },
   avatarText: { fontFamily: Fonts.sansSemiBold, fontSize: 24 },
-  nameEditBadge: {
-    position: "absolute",
-    right: -5,
-    bottom: -4,
-    width: 28,
-    height: 28,
-    borderRadius: Radius.full,
-    alignItems: "center",
-    justifyContent: "center",
-  },
   accountInfo: { alignItems: "center" },
   accountName: { fontFamily: Fonts.sansSemiBold, fontSize: 22, lineHeight: 27 },
   accountEmail: { fontSize: 14, marginTop: 2 },
@@ -947,6 +1101,71 @@ const styles = StyleSheet.create({
     fontFamily: Fonts.sans,
     fontSize: 16,
     marginTop: Spacing.three,
+  },
+  workspacePickerOverlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0, 0, 0, 0.44)",
+  },
+  workspacePickerSheet: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopLeftRadius: Radius["2xl"],
+    borderTopRightRadius: Radius["2xl"],
+    paddingHorizontal: Spacing.four,
+    paddingTop: Spacing.two,
+    paddingBottom: Spacing.five,
+  },
+  workspacePickerHandle: {
+    alignSelf: "center",
+    width: 36,
+    height: 4,
+    borderRadius: Radius.full,
+    marginBottom: Spacing.two,
+  },
+  workspacePickerNav: {
+    minHeight: 40,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  workspacePickerTitle: { fontFamily: Fonts.sansSemiBold, fontSize: 17 },
+  workspacePickerAction: { fontFamily: Fonts.sansMedium, fontSize: 16 },
+  workspaceWheel: {
+    height: WORKSPACE_WHEEL_ITEM_HEIGHT * WORKSPACE_WHEEL_VISIBLE_ITEMS,
+    marginTop: Spacing.two,
+    overflow: "hidden",
+  },
+  workspaceWheelSelection: {
+    position: "absolute",
+    top: WORKSPACE_WHEEL_ITEM_HEIGHT * 2,
+    left: 0,
+    right: 0,
+    height: WORKSPACE_WHEEL_ITEM_HEIGHT,
+    borderRadius: Radius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  workspaceWheelContent: {
+    paddingVertical: WORKSPACE_WHEEL_ITEM_HEIGHT * 2,
+  },
+  workspaceWheelRow: {
+    height: WORKSPACE_WHEEL_ITEM_HEIGHT,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: Spacing.three,
+  },
+  workspaceWheelLabel: {
+    fontFamily: Fonts.sansMedium,
+    fontSize: 17,
+    lineHeight: 22,
+    textAlign: "center",
+  },
+  workspaceWheelLabelMuted: { opacity: 0.42, transform: [{ scale: 0.92 }] },
+  workspacePickerHint: {
+    fontSize: 13,
+    lineHeight: 18,
+    textAlign: "center",
+    marginTop: Spacing.two,
+    marginBottom: Spacing.one,
   },
   signOutCard: {
     flexDirection: "row",

--- a/apps/mobile/src/app/(app)/profile.tsx
+++ b/apps/mobile/src/app/(app)/profile.tsx
@@ -15,6 +15,7 @@ import {
   LogOut,
   Pencil,
   PlugZap,
+  ShieldCheck,
   SlidersHorizontal,
   Sparkles,
 } from "lucide-react-native";
@@ -209,6 +210,14 @@ export function ProfileContent() {
           label="Connected apps & MCPs"
           value="Give Remix access to your tools"
           onPress={() => router.push("/(app)/connected-apps")}
+        />
+        <SettingsNavRow
+          icon={ShieldCheck}
+          label="Action approvals"
+          value="Confirm connected-app changes"
+          // Expo's generated route declarations refresh when Metro starts; keep
+          // this new nested settings route usable in a clean typecheck too.
+          onPress={() => router.push("/(app)/settings/approvals" as never)}
         />
         <SettingsNavRow
           icon={CalendarClock}

--- a/apps/mobile/src/app/(app)/settings/approvals.tsx
+++ b/apps/mobile/src/app/(app)/settings/approvals.tsx
@@ -1,0 +1,103 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ShieldCheck } from "lucide-react-native";
+import {
+  ActivityIndicator,
+  Alert,
+  StyleSheet,
+  Switch,
+  View,
+} from "react-native";
+
+import {
+  Card,
+  SectionTitle,
+  SettingsScreenScaffold,
+} from "@/components/settings-ui";
+import { ThemedText } from "@/components/themed-text";
+import { Spacing } from "@/constants/theme";
+import { useTheme } from "@/hooks/use-theme";
+import {
+  getConnectorApprovalPreference,
+  setConnectorApprovalPreference,
+} from "@/lib/cloud/connector-approvals";
+
+export default function ActionApprovalsScreen() {
+  const theme = useTheme();
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ["connector-approval-preference"],
+    queryFn: getConnectorApprovalPreference,
+    retry: 1,
+  });
+  const autoApprove = data?.autoApproveMutations ?? false;
+  const mutation = useMutation({
+    mutationFn: setConnectorApprovalPreference,
+    onSuccess: (preference) => {
+      queryClient.setQueryData(["connector-approval-preference"], preference);
+    },
+    onError: () => {
+      Alert.alert(
+        "Couldn't update approvals",
+        "Your previous setting is still active. Try again in a moment.",
+      );
+    },
+  });
+
+  const onChange = (next: boolean) => {
+    if (mutation.isPending) return;
+    if (!next) return mutation.mutate(false);
+    Alert.alert(
+      "Allow connected-app changes automatically?",
+      "Remix will be able to make changes in connected apps without showing an approval card. You can turn this off at any time.",
+      [
+        { text: "Keep asking", style: "cancel" },
+        {
+          text: "Allow automatically",
+          style: "destructive",
+          onPress: () => mutation.mutate(true),
+        },
+      ],
+    );
+  };
+
+  return (
+    <SettingsScreenScaffold title="Action approvals">
+      <Card>
+        <SectionTitle icon={ShieldCheck} title="Connected apps" />
+        <ThemedText themeColor="mutedForeground">
+          Freestyle always asks before a connected app changes something. This
+          keeps actions visible in your Remix conversation.
+        </ThemedText>
+        <View style={styles.row}>
+          <View style={styles.copy}>
+            <ThemedText>Allow automatically</ThemedText>
+            <ThemedText themeColor="mutedForeground" style={styles.caption}>
+              Skip approval cards for connected-app changes.
+            </ThemedText>
+          </View>
+          {isLoading ? (
+            <ActivityIndicator color={theme.mutedForeground} />
+          ) : (
+            <Switch
+              value={autoApprove}
+              onValueChange={onChange}
+              disabled={mutation.isPending}
+              trackColor={{ true: theme.primary, false: theme.secondary }}
+            />
+          )}
+        </View>
+      </Card>
+    </SettingsScreenScaffold>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: Spacing.one,
+  },
+  copy: { flex: 1, gap: 2, paddingRight: Spacing.four },
+  caption: { fontSize: 13 },
+});

--- a/apps/mobile/src/components/chat-sidebar.tsx
+++ b/apps/mobile/src/components/chat-sidebar.tsx
@@ -1,13 +1,15 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { MessageSquarePlus } from "lucide-react-native";
+import { MessageSquarePlus, Search, Trash2 } from "lucide-react-native";
 import { useEffect, useRef, useState } from "react";
 import {
+  Alert,
   Animated,
   Modal,
   Pressable,
   ScrollView,
   StyleSheet,
+  TextInput,
   useWindowDimensions,
   View,
 } from "react-native";
@@ -17,7 +19,7 @@ import { ThemedText } from "@/components/themed-text";
 import { Fonts, Radius, Spacing } from "@/constants/theme";
 import { useTheme } from "@/hooks/use-theme";
 import { useHistory } from "@/lib/history";
-import { listThreads } from "@/lib/remix/client";
+import { deleteThread, listThreads } from "@/lib/remix/client";
 import { remixQueryKeys } from "@/lib/remix/query";
 import type { RemixMode } from "@/lib/remix/types";
 
@@ -45,11 +47,13 @@ export function ChatSidebar({
 }: ChatSidebarProps) {
   const theme = useTheme();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { history } = useHistory();
   const { width } = useWindowDimensions();
   const insets = useSafeAreaInsets();
   const panelWidth = Math.min(360, Math.round(width * 0.88));
   const [mounted, setMounted] = useState(visible);
+  const [search, setSearch] = useState("");
   const progress = useRef(new Animated.Value(visible ? 1 : 0)).current;
   const { data, isLoading } = useQuery({
     queryKey: remixQueryKeys.recentSessions,
@@ -93,6 +97,34 @@ export function ChatSidebar({
     onClose();
     router.replace({ pathname: "/(app)/(tabs)", params: { threadId: id } });
   };
+  const removeThread = (id: string, title: string) => {
+    Alert.alert(
+      "Delete conversation?",
+      `“${title || "Untitled chat"}” will be removed from your history.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: () => {
+            void deleteThread(id)
+              .then(() => {
+                void queryClient.invalidateQueries({
+                  queryKey: remixQueryKeys.threads,
+                });
+                if (id === currentThreadId) onNewChat();
+              })
+              .catch(() => {
+                Alert.alert(
+                  "Couldn't delete conversation",
+                  "Check your connection and try again.",
+                );
+              });
+          },
+        },
+      ],
+    );
+  };
   const startNewChat = () => {
     onNewChat();
     onClose();
@@ -101,6 +133,9 @@ export function ChatSidebar({
     inputRange: [0, 1],
     outputRange: [-panelWidth, 0],
   });
+  const threads = (data?.threads ?? []).filter((thread) =>
+    thread.title.toLowerCase().includes(search.trim().toLowerCase()),
+  );
 
   return (
     <Modal
@@ -150,6 +185,22 @@ export function ChatSidebar({
                 {mode === "dictate" ? "RECENT DICTATIONS" : "RECENT CHATS"}
               </ThemedText>
             </View>
+            {mode === "remix" ? (
+              <View
+                style={[styles.search, { backgroundColor: theme.secondary }]}
+              >
+                <Search color={theme.mutedForeground} size={16} />
+                <TextInput
+                  value={search}
+                  onChangeText={setSearch}
+                  placeholder="Search conversations"
+                  placeholderTextColor={theme.mutedForeground}
+                  accessibilityLabel="Search conversations"
+                  style={[styles.searchInput, { color: theme.foreground }]}
+                  returnKeyType="search"
+                />
+              </View>
+            ) : null}
             <ScrollView
               style={styles.sessionScroll}
               contentContainerStyle={styles.sessionList}
@@ -159,32 +210,54 @@ export function ChatSidebar({
                 <ThemedText themeColor="mutedForeground" style={styles.empty}>
                   Loading conversations…
                 </ThemedText>
-              ) : mode === "remix" && data?.threads.length ? (
-                data.threads.slice(0, MAX_RECENT_SESSIONS).map((thread) => {
+              ) : mode === "remix" && threads.length ? (
+                threads.slice(0, MAX_RECENT_SESSIONS).map((thread) => {
                   const selected = thread.id === currentThreadId;
                   return (
-                    <Pressable
+                    <View
                       key={thread.id}
-                      onPress={() => selectThread(thread.id)}
-                      accessibilityRole="button"
-                      accessibilityState={{ selected }}
-                      accessibilityLabel={thread.title || "Untitled chat"}
-                      style={({ pressed }) => [
-                        styles.session,
+                      style={[
+                        styles.sessionRow,
                         selected && { backgroundColor: theme.accent },
-                        pressed && styles.pressed,
                       ]}
                     >
-                      <ThemedText
-                        numberOfLines={1}
-                        style={[
-                          styles.sessionTitle,
-                          selected && { color: theme.accentForeground },
+                      <Pressable
+                        onPress={() => selectThread(thread.id)}
+                        accessibilityRole="button"
+                        accessibilityState={{ selected }}
+                        accessibilityLabel={thread.title || "Untitled chat"}
+                        style={({ pressed }) => [
+                          styles.session,
+                          pressed && styles.pressed,
                         ]}
                       >
-                        {thread.title || "Untitled chat"}
-                      </ThemedText>
-                    </Pressable>
+                        <ThemedText
+                          numberOfLines={1}
+                          style={[
+                            styles.sessionTitle,
+                            selected && { color: theme.accentForeground },
+                          ]}
+                        >
+                          {thread.title || "Untitled chat"}
+                        </ThemedText>
+                      </Pressable>
+                      <Pressable
+                        onPress={() => removeThread(thread.id, thread.title)}
+                        hitSlop={8}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Delete ${thread.title || "conversation"}`}
+                        style={styles.deleteSession}
+                      >
+                        <Trash2
+                          color={
+                            selected
+                              ? theme.accentForeground
+                              : theme.mutedForeground
+                          }
+                          size={15}
+                        />
+                      </Pressable>
+                    </View>
                   );
                 })
               ) : mode === "dictate" && history.length ? (
@@ -218,12 +291,18 @@ export function ChatSidebar({
                     />
                   </View>
                   <ThemedText style={styles.emptyTitle}>
-                    {mode === "dictate" ? "No dictations yet" : "No chats yet"}
+                    {mode === "dictate"
+                      ? "No dictations yet"
+                      : search
+                        ? "No matching chats"
+                        : "No chats yet"}
                   </ThemedText>
                   <ThemedText themeColor="mutedForeground" style={styles.empty}>
                     {mode === "dictate"
                       ? "Your recent dictations will appear here."
-                      : "Start a chat and it will stay here for next time."}
+                      : search
+                        ? "Try a different search."
+                        : "Start a chat and it will stay here for next time."}
                   </ThemedText>
                 </View>
               )}
@@ -275,13 +354,36 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.four,
   },
   sessionsLabel: { paddingBottom: Spacing.three },
+  search: {
+    minHeight: 42,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.two,
+    paddingHorizontal: Spacing.three,
+    borderRadius: Radius.md,
+    marginBottom: Spacing.three,
+  },
+  searchInput: { flex: 1, fontFamily: Fonts.sans, fontSize: 14 },
   sessionScroll: { flex: 1, minHeight: 0 },
   sessionList: { gap: Spacing.half, paddingBottom: Spacing.two },
+  sessionRow: {
+    minHeight: 42,
+    borderRadius: Radius.md,
+    flexDirection: "row",
+    alignItems: "center",
+  },
   session: {
+    flex: 1,
     minHeight: 42,
     justifyContent: "center",
-    paddingHorizontal: Spacing.two,
-    borderRadius: Radius.md,
+    paddingLeft: Spacing.two,
+    paddingRight: Spacing.one,
+  },
+  deleteSession: {
+    width: 36,
+    height: 42,
+    alignItems: "center",
+    justifyContent: "center",
   },
   sessionTitle: { fontFamily: Fonts.sansMedium, fontSize: 14 },
   empty: {

--- a/apps/mobile/src/components/mobile-markdown.tsx
+++ b/apps/mobile/src/components/mobile-markdown.tsx
@@ -1,0 +1,124 @@
+import { StyleSheet, Text, View } from "react-native";
+
+import { Fonts, Spacing } from "@/constants/theme";
+import { useTheme } from "@/hooks/use-theme";
+import { markdownBlocks } from "@/lib/remix/markdown";
+
+function InlineMarkdown({ text }: { text: string }) {
+  const theme = useTheme();
+  const segments = text.split(/(`[^`]+`|\*\*[^*]+\*\*|__[^_]+__)/g);
+  return (
+    <Text style={[styles.body, { color: theme.foreground }]}>
+      {segments.map((segment, index) => {
+        if (segment.startsWith("`") && segment.endsWith("`")) {
+          return (
+            <Text
+              key={index}
+              style={[styles.inlineCode, { backgroundColor: theme.secondary }]}
+            >
+              {segment.slice(1, -1)}
+            </Text>
+          );
+        }
+        if (
+          (segment.startsWith("**") && segment.endsWith("**")) ||
+          (segment.startsWith("__") && segment.endsWith("__"))
+        ) {
+          return (
+            <Text key={index} style={styles.strong}>
+              {segment.slice(2, -2)}
+            </Text>
+          );
+        }
+        return segment;
+      })}
+    </Text>
+  );
+}
+
+export function MobileMarkdown({ text }: { text: string }) {
+  const theme = useTheme();
+  return (
+    <View style={styles.root}>
+      {markdownBlocks(text).map((block, index) => {
+        if (block.kind === "heading") {
+          return (
+            <Text
+              key={index}
+              style={[
+                styles.heading,
+                block.level === 1 && styles.headingOne,
+                { color: theme.foreground },
+              ]}
+            >
+              {block.text}
+            </Text>
+          );
+        }
+        if (block.kind === "code") {
+          return (
+            <Text
+              key={index}
+              style={[
+                styles.code,
+                { color: theme.foreground, backgroundColor: theme.secondary },
+              ]}
+            >
+              {block.text}
+            </Text>
+          );
+        }
+        if (block.kind === "list") {
+          return (
+            <View key={index} style={styles.list}>
+              {block.items.map((item, itemIndex) => (
+                <View key={itemIndex} style={styles.listRow}>
+                  <Text
+                    style={[styles.marker, { color: theme.mutedForeground }]}
+                  >
+                    {block.ordered ? `${itemIndex + 1}.` : "•"}
+                  </Text>
+                  <View style={styles.listText}>
+                    <InlineMarkdown text={item} />
+                  </View>
+                </View>
+              ))}
+            </View>
+          );
+        }
+        return <InlineMarkdown key={index} text={block.text} />;
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { gap: Spacing.two },
+  body: { fontFamily: Fonts.sans, fontSize: 15, lineHeight: 22 },
+  strong: { fontFamily: Fonts.sansSemiBold },
+  inlineCode: {
+    fontFamily: Fonts.mono,
+    fontSize: 13,
+    borderRadius: 4,
+    paddingHorizontal: 3,
+  },
+  heading: { fontFamily: Fonts.sansSemiBold, fontSize: 17, lineHeight: 23 },
+  headingOne: { fontSize: 20, lineHeight: 26 },
+  code: {
+    fontFamily: Fonts.mono,
+    fontSize: 12,
+    lineHeight: 18,
+    borderRadius: 8,
+    padding: Spacing.two,
+  },
+  list: { gap: Spacing.one },
+  listRow: { flexDirection: "row", gap: Spacing.two },
+  marker: {
+    width: 18,
+    fontFamily: Fonts.sansMedium,
+    fontSize: 14,
+    lineHeight: 22,
+    textAlign: "right",
+  },
+  listText: { flex: 1 },
+});

--- a/apps/mobile/src/components/select-sheet.tsx
+++ b/apps/mobile/src/components/select-sheet.tsx
@@ -1,5 +1,12 @@
 import { Check } from "lucide-react-native";
-import { Modal, Pressable, ScrollView, StyleSheet, View } from "react-native";
+import {
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { ThemedText } from "@/components/themed-text";
@@ -8,7 +15,7 @@ import { useTheme } from "@/hooks/use-theme";
 
 export type SelectSheetOption = { value: string; label: string };
 
-/** A compact single-choice picker for long profile and workspace option lists. */
+/** A native iOS sheet with a compact cross-platform fallback for long lists. */
 export function SelectSheet({
   visible,
   title,
@@ -34,20 +41,23 @@ export function SelectSheet({
   return (
     <Modal
       visible={visible}
-      transparent
+      transparent={Platform.OS !== "ios"}
       animationType="slide"
+      presentationStyle={Platform.OS === "ios" ? "formSheet" : "fullScreen"}
       onRequestClose={onClose}
-      statusBarTranslucent
     >
-      <Pressable
-        style={styles.backdrop}
-        onPress={onClose}
-        accessibilityRole="button"
-        accessibilityLabel={`Close ${title} picker`}
-      />
+      {Platform.OS !== "ios" ? (
+        <Pressable
+          style={styles.backdrop}
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel={`Close ${title} picker`}
+        />
+      ) : null}
       <View
         style={[
           styles.sheet,
+          Platform.OS === "ios" && styles.iosSheet,
           {
             backgroundColor: theme.card,
             borderColor: theme.cardRing,
@@ -149,6 +159,13 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     paddingTop: Spacing.two,
     paddingHorizontal: Spacing.four,
+  },
+  iosSheet: {
+    position: "relative",
+    flex: 1,
+    maxHeight: undefined,
+    borderRadius: 0,
+    borderWidth: 0,
   },
   handle: {
     alignSelf: "center",

--- a/apps/mobile/src/components/settings-ui.tsx
+++ b/apps/mobile/src/components/settings-ui.tsx
@@ -8,7 +8,7 @@
 import { useRouter } from "expo-router";
 import type { LucideIcon } from "lucide-react-native";
 import { ChevronLeft, ChevronRight, RotateCw } from "lucide-react-native";
-import type { ReactNode } from "react";
+import type { ComponentType, ReactNode } from "react";
 import type { AccessibilityRole, ViewStyle } from "react-native";
 import { Pressable, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -66,6 +66,8 @@ export function SettingsScreenScaffold({
         </View>
         <ScrollView
           contentContainerStyle={[styles.body, styles.centerColumn]}
+          contentInsetAdjustmentBehavior="automatic"
+          automaticallyAdjustKeyboardInsets
           showsVerticalScrollIndicator={false}
           keyboardShouldPersistTaps="handled"
         >
@@ -227,6 +229,76 @@ export function SettingsNavRow({
         </ThemedText>
       </View>
       <ChevronRight color={theme.mutedForeground} size={18} />
+    </Pressable>
+  );
+}
+
+/**
+ * An iOS-style account row: the setting name stays on the left and its current
+ * value is immediately scannable on the right. Use this for editable profile
+ * and account fields, not for descriptive navigation.
+ */
+export function SettingsValueRow({
+  icon: Icon,
+  label,
+  value,
+  onPress,
+  last = false,
+  disabled = false,
+  trailing,
+}: {
+  icon?: LucideIcon | ComponentType<{ color?: string; size?: number }>;
+  label: string;
+  value: string;
+  onPress?: () => void;
+  last?: boolean;
+  disabled?: boolean;
+  trailing?: ReactNode;
+}) {
+  const theme = useTheme();
+  const content = (
+    <>
+      {Icon ? <Icon color={theme.mutedForeground} size={20} /> : null}
+      <ThemedText style={styles.valueRowLabel} numberOfLines={1}>
+        {label}
+      </ThemedText>
+      <ThemedText
+        themeColor="mutedForeground"
+        style={styles.valueRowValue}
+        numberOfLines={1}
+      >
+        {value}
+      </ThemedText>
+      {trailing ??
+        (onPress ? (
+          <ChevronRight color={theme.mutedForeground} size={18} />
+        ) : null)}
+    </>
+  );
+  const rowStyle = [
+    styles.valueRow,
+    !last && {
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: theme.border,
+    },
+    disabled && styles.valueRowDisabled,
+  ];
+
+  if (!onPress) return <View style={rowStyle}>{content}</View>;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={`${label}: ${value}`}
+      accessibilityState={{ disabled }}
+      style={({ pressed }) => [
+        rowStyle,
+        pressed && !disabled && { opacity: 0.6 },
+      ]}
+    >
+      {content}
     </Pressable>
   );
 }
@@ -395,6 +467,21 @@ const styles = StyleSheet.create({
   navRowContent: { flex: 1 },
   navRowLabel: { fontFamily: Fonts.sansMedium, fontSize: 15 },
   navRowValue: { fontSize: 13, marginTop: 1 },
+
+  valueRow: {
+    minHeight: 54,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.two,
+  },
+  valueRowDisabled: { opacity: 0.55 },
+  valueRowLabel: { flex: 1, fontFamily: Fonts.sansMedium, fontSize: 16 },
+  valueRowValue: {
+    maxWidth: "48%",
+    fontFamily: Fonts.sans,
+    fontSize: 15,
+    textAlign: "right",
+  },
 
   option: {
     flexDirection: "row",

--- a/apps/mobile/src/components/settings-ui.tsx
+++ b/apps/mobile/src/components/settings-ui.tsx
@@ -106,16 +106,18 @@ export function SettingsGroup({
   children,
   style,
 }: {
-  title: string;
+  title?: string;
   children: ReactNode;
   style?: ViewStyle;
 }) {
   const theme = useTheme();
   return (
     <View style={styles.group}>
-      <ThemedText themeColor="mutedForeground" style={styles.groupTitle}>
-        {title}
-      </ThemedText>
+      {title ? (
+        <ThemedText themeColor="mutedForeground" style={styles.groupTitle}>
+          {title}
+        </ThemedText>
+      ) : null}
       <View
         style={[
           styles.groupSurface,

--- a/apps/mobile/src/components/waveform.tsx
+++ b/apps/mobile/src/components/waveform.tsx
@@ -5,6 +5,7 @@ import Animated, {
   type SharedValue,
   useAnimatedStyle,
   useDerivedValue,
+  useReducedMotion,
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
@@ -12,9 +13,9 @@ import Animated, {
 import { Radius } from "@/constants/theme";
 import { useTheme } from "@/hooks/use-theme";
 
-const BAR_COUNT = 27;
-const MIN_HEIGHT = 4;
-const MAX_HEIGHT = 40;
+const DEFAULT_BAR_COUNT = 27;
+const DEFAULT_MIN_HEIGHT = 4;
+const DEFAULT_MAX_HEIGHT = 40;
 
 // Asymmetric smoothing (mirrors the desktop pill): bars snap up quickly toward
 // a louder level and fall back gently — the classic "fast attack, slow decay"
@@ -27,22 +28,30 @@ interface WaveformProps {
   /** Live input level [0, 1], shared for smooth UI-thread animation. */
   level: SharedValue<number>;
   active: boolean;
+  /** A compact meter for the live chat composer. */
+  compact?: boolean;
 }
 
 function Bar({
   level,
   active,
   index,
+  barCount,
+  minHeight,
+  maxHeight,
 }: {
   level: SharedValue<number>;
   active: SharedValue<number>;
   index: number;
+  barCount: number;
+  minHeight: number;
+  maxHeight: number;
 }) {
   const theme = useTheme();
 
   // A bell curve so the middle bars are tallest, tapering to the edges — the
   // silhouette matches the desktop pill's Gaussian shape.
-  const center = (BAR_COUNT - 1) / 2;
+  const center = (barCount - 1) / 2;
   const falloff = 1 - Math.abs(index - center) / center;
   const shape = 0.35 + 0.65 * falloff;
 
@@ -54,8 +63,8 @@ function Bar({
     // Height is driven purely by loudness (× the bar's static shape). When the
     // user is silent the level is ~0, so bars sit at MIN_HEIGHT — no motion.
     const energy = level.value * shape * jitter;
-    const target = MIN_HEIGHT + energy * (MAX_HEIGHT - MIN_HEIGHT);
-    const height = interpolate(active.value, [0, 1], [MIN_HEIGHT, target]);
+    const target = minHeight + energy * (maxHeight - minHeight);
+    const height = interpolate(active.value, [0, 1], [minHeight, target]);
     return {
       height,
       // Louder → more opaque, so intensity reads even at a glance.
@@ -81,8 +90,9 @@ function Bar({
  * flat when silent. Mirrors the desktop pill's level-driven, fast-attack /
  * slow-decay behavior.
  */
-export function Waveform({ level, active }: WaveformProps) {
+export function Waveform({ level, active, compact = false }: WaveformProps) {
   const activeSv = useSharedValue(0);
+  const reduceMotion = useReducedMotion();
   // Smoothed loudness with asymmetric attack/decay. Kept in its own shared
   // value (rather than reading a derived value's own prior output) so the UI
   // thread has a stable, well-typed accumulator.
@@ -95,13 +105,28 @@ export function Waveform({ level, active }: WaveformProps) {
   });
 
   useEffect(() => {
-    activeSv.value = withTiming(active ? 1 : 0, { duration: 260 });
-  }, [active, activeSv]);
+    activeSv.value = reduceMotion
+      ? active
+        ? 1
+        : 0
+      : withTiming(active ? 1 : 0, { duration: 260 });
+  }, [active, activeSv, reduceMotion]);
 
+  const barCount = compact ? 12 : DEFAULT_BAR_COUNT;
+  const minHeight = compact ? 3 : DEFAULT_MIN_HEIGHT;
+  const maxHeight = compact ? 18 : DEFAULT_MAX_HEIGHT;
   return (
-    <View style={styles.row}>
-      {Array.from({ length: BAR_COUNT }).map((_, i) => (
-        <Bar key={i} level={smoothed} active={activeSv} index={i} />
+    <View style={[styles.row, { height: maxHeight + 8, gap: compact ? 2 : 4 }]}>
+      {Array.from({ length: barCount }).map((_, i) => (
+        <Bar
+          key={i}
+          level={smoothed}
+          active={activeSv}
+          index={i}
+          barCount={barCount}
+          minHeight={minHeight}
+          maxHeight={maxHeight}
+        />
       ))}
     </View>
   );
@@ -112,8 +137,6 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    gap: 4,
-    height: MAX_HEIGHT + 8,
   },
   bar: { width: 3.5, borderRadius: Radius.full },
 });

--- a/apps/mobile/src/lib/cloud/connector-approvals.ts
+++ b/apps/mobile/src/lib/cloud/connector-approvals.ts
@@ -1,0 +1,36 @@
+import { cloud } from "./client";
+
+export type ConnectorApprovalPreference = {
+  autoApproveMutations: boolean;
+};
+
+export function getConnectorApprovalPreference() {
+  return cloud.json<ConnectorApprovalPreference>(
+    "/v2/connectors/approval-preferences",
+  );
+}
+
+export function setConnectorApprovalPreference(autoApproveMutations: boolean) {
+  return cloud.json<ConnectorApprovalPreference>(
+    "/v2/connectors/approval-preferences",
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ autoApproveMutations }),
+    },
+  );
+}
+
+export function executeConnectorApproval(token: string) {
+  return cloud.json<{ ok: true; output: unknown }>(
+    `/v2/connectors/approvals/${encodeURIComponent(token)}/execute`,
+    { method: "POST" },
+  );
+}
+
+export function declineConnectorApproval(token: string) {
+  return cloud.json<{ ok: true }>(
+    `/v2/connectors/approvals/${encodeURIComponent(token)}/decline`,
+    { method: "POST" },
+  );
+}

--- a/apps/mobile/src/lib/home-layout.test.ts
+++ b/apps/mobile/src/lib/home-layout.test.ts
@@ -34,6 +34,16 @@ describe("Remix home layout", () => {
     expect(styles).toMatch(/borderBottomLeftRadius: 38/);
   });
 
+  it("keeps Dictate as a quiet, chat-adjacent voice surface rather than another card stack", () => {
+    expect(screen).toMatch(
+      /Speak naturally\. Freestyle keeps the words clear and\s+ready to use\./,
+    );
+    expect(screen).toContain('placeholder="Your words will appear here."');
+    expect(styles).toMatch(
+      /dictationDock:[\s\S]*?borderTopWidth: StyleSheet\.hairlineWidth/,
+    );
+  });
+
   it("dismisses the keyboard before opening the session drawer", () => {
     expect(screen).toMatch(
       /const openSidebar[\s\S]*?Keyboard\.dismiss\(\)[\s\S]*?setSidebarOpen\(true\)/,

--- a/apps/mobile/src/lib/home-layout.test.ts
+++ b/apps/mobile/src/lib/home-layout.test.ts
@@ -68,6 +68,15 @@ describe("Remix home layout", () => {
     expect(styles).toMatch(/textAlignVertical: "top"/);
   });
 
+  it("resets a cleared controlled draft and ignores redundant resize events", () => {
+    expect(screen).toContain(
+      "if (!draft) setInputHeight(REMIX_COMPOSER_MIN_INPUT_HEIGHT);",
+    );
+    expect(screen).toContain(
+      "currentHeight === nextHeight ? currentHeight : nextHeight",
+    );
+  });
+
   it("keeps live dictation inside the composer flow instead of covering the draft", () => {
     expect(screen).toContain("<View style={styles.composerInputRow}>");
     expect(styles).not.toMatch(/voiceStatus:[\\s\\S]*?position: "absolute"/);

--- a/apps/mobile/src/lib/home-layout.test.ts
+++ b/apps/mobile/src/lib/home-layout.test.ts
@@ -50,4 +50,20 @@ describe("Remix home layout", () => {
     );
     expect(screen).toMatch(/onPress=\{openSidebar\}/);
   });
+
+  it("keeps the system keyboard up while inline voice listening begins", () => {
+    expect(screen).toMatch(
+      /case "listen":[\s\S]*?toggleVoiceInput\(\);[\s\S]*?inputRef\.current\?\.focus\(\)/,
+    );
+    expect(screen).not.toMatch(
+      /function RemixHome[\s\S]*?case "listen":[\s\S]*?Keyboard\.dismiss\(\)/,
+    );
+  });
+
+  it("grows the composer through four lines before enabling its input scroll", () => {
+    expect(screen).toContain("onContentSizeChange={onInputContentSizeChange}");
+    expect(screen).toContain(
+      "scrollEnabled={inputHeight >= REMIX_COMPOSER_MAX_INPUT_HEIGHT}",
+    );
+  });
 });

--- a/apps/mobile/src/lib/home-layout.test.ts
+++ b/apps/mobile/src/lib/home-layout.test.ts
@@ -21,8 +21,8 @@ describe("Remix home layout", () => {
     expect(screen).toMatch(
       /<View style=\{styles\.header\}>[\s\S]*?<ModeSwitch/,
     );
-    expect(styles).not.toMatch(
-      /modeSwitch:\s*\{[\s\S]*?position:\s*"absolute"/,
+    expect(styles).toMatch(
+      /modeSwitch:\s*\{[\s\S]*?flexDirection:\s*"row"[\s\S]*?\n {2}\},\n {2}modeOption:/,
     );
   });
 
@@ -65,5 +65,11 @@ describe("Remix home layout", () => {
     expect(screen).toContain(
       "scrollEnabled={inputHeight >= REMIX_COMPOSER_MAX_INPUT_HEIGHT}",
     );
+  });
+
+  it("keeps an interrupted thread recoverable with durable drafts and retry", () => {
+    expect(screen).toContain("loadRemixDrafts(userId)");
+    expect(screen).toContain("Retry last Remix message");
+    expect(screen).toContain("retryLastTurn()");
   });
 });

--- a/apps/mobile/src/lib/home-layout.test.ts
+++ b/apps/mobile/src/lib/home-layout.test.ts
@@ -65,6 +65,13 @@ describe("Remix home layout", () => {
     expect(screen).toContain(
       "scrollEnabled={inputHeight >= REMIX_COMPOSER_MAX_INPUT_HEIGHT}",
     );
+    expect(styles).toMatch(/textAlignVertical: "top"/);
+  });
+
+  it("keeps live dictation inside the composer flow instead of covering the draft", () => {
+    expect(screen).toContain("<View style={styles.composerInputRow}>");
+    expect(styles).not.toMatch(/voiceStatus:[\\s\\S]*?position: "absolute"/);
+    expect(styles).not.toMatch(/voiceStatus:[\\s\\S]*?zIndex:/);
   });
 
   it("keeps an interrupted thread recoverable with durable drafts and retry", () => {

--- a/apps/mobile/src/lib/keyboard/keyboard-handshake.test.ts
+++ b/apps/mobile/src/lib/keyboard/keyboard-handshake.test.ts
@@ -1,13 +1,17 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-const extensionBridge = readFileSync(
-  new URL(
-    "../../../ios/FreestyleKeyboard/DictationBridge.swift",
-    import.meta.url,
-  ),
-  "utf8",
+const generatedBridge = new URL(
+  "../../../ios/FreestyleKeyboard/DictationBridge.swift",
+  import.meta.url,
 );
+// ios/FreestyleKeyboard is generated immediately before a device build. It is
+// intentionally absent from a fresh checkout, so keep the source-contract
+// test runnable before that sync while still checking a generated copy when it
+// is present locally.
+const extensionBridge = existsSync(generatedBridge)
+  ? readFileSync(generatedBridge, "utf8")
+  : null;
 const moduleBridge = readFileSync(
   new URL(
     "../../../modules/freestyle-shared-store/ios/DictationBridge.swift",
@@ -19,13 +23,13 @@ const mirroredBridge = readFileSync(
   new URL("../../../ios-keyboard/DictationBridge.swift", import.meta.url),
   "utf8",
 );
-const keyboardController = readFileSync(
-  new URL(
-    "../../../ios/FreestyleKeyboard/KeyboardViewController.swift",
-    import.meta.url,
-  ),
-  "utf8",
+const generatedController = new URL(
+  "../../../ios/FreestyleKeyboard/KeyboardViewController.swift",
+  import.meta.url,
 );
+const keyboardController = existsSync(generatedController)
+  ? readFileSync(generatedController, "utf8")
+  : null;
 const mirroredKeyboardController = readFileSync(
   new URL(
     "../../../ios-keyboard/KeyboardViewController.swift",
@@ -54,12 +58,14 @@ describe("keyboard readiness handshake", () => {
   });
 
   it("restamps after Full Access can change and synchronizes both processes", () => {
-    for (const controller of [keyboardController, mirroredKeyboardController]) {
+    for (const controller of [mirroredKeyboardController, keyboardController]) {
+      if (!controller) continue;
       expect(controller).toMatch(
         /override func viewWillAppear[\s\S]*?bridge\.markKeyboardActive\(\)/,
       );
     }
-    for (const source of [extensionBridge, moduleBridge, mirroredBridge]) {
+    for (const source of [moduleBridge, mirroredBridge, extensionBridge]) {
+      if (!source) continue;
       expect(source).toMatch(
         /func markKeyboardActive[\s\S]*?defaults\.synchronize\(\)/,
       );

--- a/apps/mobile/src/lib/keyboard/keyboard-handshake.test.ts
+++ b/apps/mobile/src/lib/keyboard/keyboard-handshake.test.ts
@@ -23,6 +23,13 @@ const mirroredBridge = readFileSync(
   new URL("../../../ios-keyboard/DictationBridge.swift", import.meta.url),
   "utf8",
 );
+const sharedStoreModule = readFileSync(
+  new URL(
+    "../../../modules/freestyle-shared-store/ios/FreestyleSharedStoreModule.swift",
+    import.meta.url,
+  ),
+  "utf8",
+);
 const generatedController = new URL(
   "../../../ios/FreestyleKeyboard/KeyboardViewController.swift",
   import.meta.url,
@@ -42,6 +49,11 @@ const mobilePackage = JSON.parse(
 ) as { scripts: Record<string, string> };
 
 describe("keyboard readiness handshake", () => {
+  it("keeps the app and keyboard copies of the wire protocol identical", () => {
+    expect(moduleBridge).toBe(mirroredBridge);
+    if (extensionBridge) expect(extensionBridge).toBe(mirroredBridge);
+  });
+
   it("keeps keyboard preference optional chains valid Swift", () => {
     expect(mirroredKeyboardController).toMatch(
       /UserDefaults\(suiteName: FreestyleDictationBridge\.appGroupID\)\?\s*\.string/,
@@ -76,5 +88,31 @@ describe("keyboard readiness handshake", () => {
         /func keyboardLastActive[\s\S]*?return defaults\.double\(forKey: Self\.keyboardActiveKey\)/,
       );
     }
+  });
+
+  it("delivers a final transcript immediately instead of waiting for the keyboard poll", () => {
+    for (const source of [moduleBridge, mirroredBridge, extensionBridge]) {
+      if (!source) continue;
+      expect(source).toMatch(
+        /static let stateDarwinName = "com\.freestylevoice\.dictation\.state" as CFString/,
+      );
+      expect(source).toMatch(
+        /func writeState\([\s\S]*?defaults\.synchronize\(\)[\s\S]*?Self\.postStateNotification\(\)/,
+      );
+    }
+
+    for (const controller of [mirroredKeyboardController, keyboardController]) {
+      if (!controller) continue;
+      expect(controller).toMatch(
+        /override func viewDidAppear[\s\S]*?startObservingSharedState\(\)/,
+      );
+      expect(controller).toMatch(
+        /func startObservingSharedState\(\)[\s\S]*?CFNotificationCenterAddObserver[\s\S]*?FreestyleDictationBridge\.stateDarwinName/,
+      );
+    }
+
+    expect(sharedStoreModule).toMatch(
+      /Function\("updateLevel"\)[\s\S]*?notifyKeyboard: false/,
+    );
   });
 });

--- a/apps/mobile/src/lib/profile-layout.test.ts
+++ b/apps/mobile/src/lib/profile-layout.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const screen = readFileSync(
+  new URL("../app/(app)/profile.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("Profile settings layout", () => {
+  it("uses a compact account editor instead of an always-open name form", () => {
+    expect(screen).toContain("NameEditorSheet");
+    expect(screen).toContain('accessibilityLabel="Edit name"');
+    expect(screen).not.toContain("function NameCard");
+  });
+
+  it("removes the redundant Freestyle group label and keeps work details collapsed", () => {
+    expect(screen).not.toContain('<SettingsGroup title="Freestyle">');
+    expect(screen).toContain('<SettingsGroup title="Personalization">');
+    expect(screen).toContain('label="Work profile"');
+  });
+
+  it("only exposes a workspace switcher when the person has a choice", () => {
+    expect(screen).toContain("enabled: hasMultiple");
+    expect(screen).toContain(
+      "if (orgsLoading || activeLoading || !hasMultiple) return null;",
+    );
+  });
+});

--- a/apps/mobile/src/lib/profile-layout.test.ts
+++ b/apps/mobile/src/lib/profile-layout.test.ts
@@ -9,7 +9,9 @@ const screen = readFileSync(
 describe("Profile settings layout", () => {
   it("uses a compact account editor instead of an always-open name form", () => {
     expect(screen).toContain("NameEditorSheet");
-    expect(screen).toContain('accessibilityLabel="Edit name"');
+    expect(screen).toContain('label="Name"');
+    expect(screen).not.toContain('accessibilityLabel="Edit name"');
+    expect(screen).not.toContain("nameEditBadge");
     expect(screen).not.toContain("function NameCard");
   });
 
@@ -29,6 +31,8 @@ describe("Profile settings layout", () => {
     expect(screen).toContain(
       "if (orgsLoading || activeLoading || !hasMultiple) return null;",
     );
-    expect(screen).toContain("ActionSheetIOS.showActionSheetWithOptions");
+    expect(screen).toContain("WorkspacePickerSheet");
+    expect(screen).toContain("snapToInterval={WORKSPACE_WHEEL_ITEM_HEIGHT}");
+    expect(screen).not.toContain("ActionSheetIOS.showActionSheetWithOptions");
   });
 });

--- a/apps/mobile/src/lib/profile-layout.test.ts
+++ b/apps/mobile/src/lib/profile-layout.test.ts
@@ -13,10 +13,15 @@ describe("Profile settings layout", () => {
     expect(screen).not.toContain("function NameCard");
   });
 
-  it("removes the redundant Freestyle group label and keeps work details collapsed", () => {
+  it("shows work details as direct value rows instead of a collapsed legacy form", () => {
     expect(screen).not.toContain('<SettingsGroup title="Freestyle">');
-    expect(screen).toContain('<SettingsGroup title="Personalization">');
-    expect(screen).toContain('label="Work profile"');
+    expect(screen).not.toContain('<SettingsGroup title="Personalization">');
+    expect(screen).toContain('<SettingsGroup title="Work profile">');
+    expect(screen).toContain('label="Industry"');
+    expect(screen).toContain('label="Job title"');
+    expect(screen).toContain('label="Company"');
+    expect(screen).toContain("TextEditorSheet");
+    expect(screen).toContain('presentationStyle="formSheet"');
   });
 
   it("only exposes a workspace switcher when the person has a choice", () => {
@@ -24,5 +29,6 @@ describe("Profile settings layout", () => {
     expect(screen).toContain(
       "if (orgsLoading || activeLoading || !hasMultiple) return null;",
     );
+    expect(screen).toContain("ActionSheetIOS.showActionSheetWithOptions");
   });
 });

--- a/apps/mobile/src/lib/remix/client.test.ts
+++ b/apps/mobile/src/lib/remix/client.test.ts
@@ -10,11 +10,14 @@ vi.mock("@/lib/cloud/client", () => ({ cloud: { json, request } }));
 vi.mock("react-native", () => ({ Platform: { OS: "ios" } }));
 
 import {
+  commandDurableTurn,
   deleteThread,
+  getDurableTurn,
   getLatestThread,
   getThread,
   listThreads,
   runRemixTurn,
+  sendDurableRemixTurn,
 } from "./client";
 
 function responseWithEvents(events: object[]): Response {
@@ -64,6 +67,68 @@ describe("mobile Remix cloud client", () => {
       messages: [],
     });
     expect(json).toHaveBeenCalledWith("/v2/threads/thread-1");
+  });
+
+  it("submits an idempotent durable app turn and reads its server-owned state", async () => {
+    json
+      .mockResolvedValueOnce({
+        turn: {
+          id: "turn-1",
+          threadId: "thread-1",
+          status: "queued",
+          error: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        turn: {
+          id: "turn-1",
+          threadId: "thread-1",
+          status: "completed",
+          error: null,
+        },
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    await expect(
+      sendDurableRemixTurn({
+        messages: [
+          {
+            id: "user-1",
+            role: "user",
+            parts: [{ type: "text", text: "Write a reply" }],
+          },
+        ],
+        threadId: "thread-1",
+        firstTurn: true,
+        clientRequestId: "turn-retry-safe-1",
+      }),
+    ).resolves.toEqual(expect.objectContaining({ id: "turn-1" }));
+    await expect(getDurableTurn("turn-1")).resolves.toEqual(
+      expect.objectContaining({ status: "completed" }),
+    );
+    await commandDurableTurn("turn-1", {
+      type: "approve",
+      actionId: "action-1",
+    });
+
+    expect(json).toHaveBeenNthCalledWith(
+      1,
+      "/v2/threads/thread-1/turns",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(json.mock.calls[0]?.[1]?.body as string) as {
+      clientRequestId?: string;
+      client?: { platform?: string; supportsConnectorApprovals?: boolean };
+    };
+    expect(body.clientRequestId).toBe("turn-retry-safe-1");
+    expect(body.client?.platform).toMatch(/^(ios|android)$/);
+    expect(body.client?.supportsConnectorApprovals).toBe(true);
+    expect(json).toHaveBeenNthCalledWith(2, "/v2/turns/turn-1");
+    expect(json).toHaveBeenNthCalledWith(
+      3,
+      "/v2/turns/turn-1/commands",
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
   it("deletes a durable conversation from session management", async () => {

--- a/apps/mobile/src/lib/remix/client.test.ts
+++ b/apps/mobile/src/lib/remix/client.test.ts
@@ -104,9 +104,10 @@ describe("mobile Remix cloud client", () => {
       expect.objectContaining({ method: "POST" }),
     );
     const body = JSON.parse(request.mock.calls[0]?.[1]?.body as string) as {
-      client?: { platform?: string };
+      client?: { platform?: string; supportsConnectorApprovals?: boolean };
     };
     expect(body.client?.platform).toMatch(/^(ios|android)$/);
+    expect(body.client?.supportsConnectorApprovals).toBe(true);
   });
 
   it("holds an insert request for the keyboard instead of treating it as an app paste", async () => {
@@ -145,9 +146,56 @@ describe("mobile Remix cloud client", () => {
       input: { text: "Ready to paste" },
     });
     const body = JSON.parse(request.mock.calls[0]?.[1]?.body as string) as {
-      client?: { supportsKeyboardInsertion?: boolean };
+      client?: {
+        supportsKeyboardInsertion?: boolean;
+        supportsConnectorApprovals?: boolean;
+      };
     };
     expect(body.client?.supportsKeyboardInsertion).toBe(true);
+    expect(body.client?.supportsConnectorApprovals).toBeUndefined();
+  });
+
+  it("surfaces a server-bound connected-app approval instead of executing it in the app", async () => {
+    request.mockResolvedValueOnce(
+      responseWithEvents([
+        {
+          type: "tool-output-available",
+          output: {
+            approval: {
+              approvalToken: "a".repeat(32),
+              toolkit: "gmail",
+              toolkitName: "Gmail",
+              toolSlug: "GMAIL_SEND_EMAIL",
+              actionDescription: "gmail send email — to: ada@example.com",
+              expiresAt: "2026-08-25T12:00:00.000Z",
+            },
+          },
+        },
+        { type: "finish" },
+      ]),
+    );
+    const events: unknown[] = [];
+
+    await runRemixTurn({
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          parts: [{ type: "text", text: "Email Ada" }],
+        },
+      ],
+      threadId: "thread-123",
+      signal: new AbortController().signal,
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(events).toContainEqual({
+      type: "connector-approval",
+      approval: expect.objectContaining({
+        toolkit: "gmail",
+        toolSlug: "GMAIL_SEND_EMAIL",
+      }),
+    });
   });
 
   it("keeps temporary request rate limits distinct from usage limits", async () => {

--- a/apps/mobile/src/lib/remix/client.test.ts
+++ b/apps/mobile/src/lib/remix/client.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/cloud/client", () => ({ cloud: { json, request } }));
 vi.mock("react-native", () => ({ Platform: { OS: "ios" } }));
 
 import {
+  deleteThread,
   getLatestThread,
   getThread,
   listThreads,
@@ -63,6 +64,15 @@ describe("mobile Remix cloud client", () => {
       messages: [],
     });
     expect(json).toHaveBeenCalledWith("/v2/threads/thread-1");
+  });
+
+  it("deletes a durable conversation from session management", async () => {
+    request.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await expect(deleteThread("thread/one")).resolves.toBeUndefined();
+    expect(request).toHaveBeenCalledWith("/v2/threads/thread%2Fone", {
+      method: "DELETE",
+    });
   });
 
   it("treats a cleared thread as unavailable instead of a load failure", async () => {

--- a/apps/mobile/src/lib/remix/client.ts
+++ b/apps/mobile/src/lib/remix/client.ts
@@ -45,6 +45,22 @@ export async function getThread(id: string): Promise<RemixThread | null> {
   }
 }
 
+/** Soft-delete one durable conversation owned by the signed-in user. */
+export async function deleteThread(id: string): Promise<void> {
+  const response = await cloud.request(
+    `/v2/threads/${encodeURIComponent(id)}`,
+    {
+      method: "DELETE",
+    },
+  );
+  if (!response.ok) {
+    throw new CloudRequestError(
+      response.status,
+      await response.text().catch(() => ""),
+    );
+  }
+}
+
 export async function listThreads({
   origin = "user",
   cursor,

--- a/apps/mobile/src/lib/remix/client.ts
+++ b/apps/mobile/src/lib/remix/client.ts
@@ -9,6 +9,7 @@ import { Platform } from "react-native";
 import { cloud } from "@/lib/cloud/client";
 
 import type {
+  PendingConnectorApproval,
   RemixStreamEvent,
   RemixThreadOrigin,
   RemixThreadPage,
@@ -66,6 +67,8 @@ type AgentStreamChunk = {
   toolName?: unknown;
   input?: unknown;
   errorText?: unknown;
+  output?: unknown;
+  result?: unknown;
 };
 
 function eventFromFrame(frame: string): AgentStreamChunk | null {
@@ -147,7 +150,12 @@ async function requestRemixTurn({
       firstTurn,
       client: {
         ...MOBILE_AGENT_CLIENT,
-        ...(keyboardInsertion ? { supportsKeyboardInsertion: true } : {}),
+        // Keyboard Remix can only insert a finished answer into the current
+        // text field. It deliberately never receives connected-app tools or
+        // their approval cards, which cannot be resolved in the compact IME.
+        ...(keyboardInsertion
+          ? { supportsKeyboardInsertion: true }
+          : { supportsConnectorApprovals: true }),
       },
     }),
     signal,
@@ -229,6 +237,27 @@ export async function runRemixTurn({
           });
         }
         break;
+      case "tool-output-available": {
+        const output = chunk.output ?? chunk.result;
+        if (!output || typeof output !== "object") break;
+        const approval = (output as { approval?: unknown }).approval;
+        if (!approval || typeof approval !== "object") break;
+        const candidate = approval as Partial<PendingConnectorApproval>;
+        if (
+          typeof candidate.approvalToken === "string" &&
+          typeof candidate.toolkit === "string" &&
+          typeof candidate.toolkitName === "string" &&
+          typeof candidate.toolSlug === "string" &&
+          typeof candidate.actionDescription === "string" &&
+          typeof candidate.expiresAt === "string"
+        ) {
+          onEvent({
+            type: "connector-approval",
+            approval: candidate as PendingConnectorApproval,
+          });
+        }
+        break;
+      }
       case "finish":
         completed = true;
         onEvent({ type: "complete" });

--- a/apps/mobile/src/lib/remix/client.ts
+++ b/apps/mobile/src/lib/remix/client.ts
@@ -24,6 +24,46 @@ const MOBILE_AGENT_CLIENT = {
 
 export type RemixThread = { id: string; messages: UIMessage[] };
 
+export type DurableTurnStatus =
+  | "queued"
+  | "running"
+  | "waiting_approval"
+  | "waiting_desktop"
+  | "needs_desktop"
+  | "completed"
+  | "failed"
+  | "canceled";
+
+export type DurableTurn = {
+  id: string;
+  threadId: string;
+  status: DurableTurnStatus;
+  error: string | null;
+};
+
+export type DurableThreadAction = {
+  id: string;
+  turnId: string;
+  kind: "connector" | "desktop";
+  status:
+    | "pending"
+    | "claimed"
+    | "completed"
+    | "declined"
+    | "expired"
+    | "failed";
+  toolName: string;
+  display: string;
+  capability: string | null;
+  expiresAt: string;
+};
+
+export type DurableThreadRuntime = {
+  thread: RemixThread;
+  activeTurn: DurableTurn | null;
+  pendingAction: DurableThreadAction | null;
+};
+
 export async function getLatestThread(): Promise<RemixThread | null> {
   const result = await cloud.json<{ thread: RemixThread | null }>(
     "/v2/threads/latest",
@@ -43,6 +83,72 @@ export async function getThread(id: string): Promise<RemixThread | null> {
     if (error instanceof CloudRequestError && error.status === 404) return null;
     throw error;
   }
+}
+
+export async function getDurableThreadRuntime(
+  id: string,
+): Promise<DurableThreadRuntime | null> {
+  try {
+    return await cloud.json<DurableThreadRuntime>(
+      `/v2/threads/${encodeURIComponent(id)}`,
+    );
+  } catch (error) {
+    if (error instanceof CloudRequestError && error.status === 404) return null;
+    throw error;
+  }
+}
+
+export async function getDurableTurn(turnId: string): Promise<DurableTurn> {
+  const result = await cloud.json<{ turn: DurableTurn }>(
+    `/v2/turns/${encodeURIComponent(turnId)}`,
+  );
+  return result.turn;
+}
+
+export async function sendDurableRemixTurn({
+  messages,
+  threadId,
+  firstTurn,
+  clientRequestId,
+}: {
+  messages: UIMessage[];
+  threadId: string;
+  firstTurn: boolean;
+  clientRequestId: string;
+}): Promise<DurableTurn> {
+  const result = await cloud.json<{ turn: DurableTurn }>(
+    `/v2/threads/${encodeURIComponent(threadId)}/turns`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "mobile-remix",
+        messages,
+        trigger: "submit-message",
+        threadId,
+        firstTurn,
+        clientRequestId,
+        client: {
+          ...MOBILE_AGENT_CLIENT,
+          supportsConnectorApprovals: true,
+        },
+      }),
+    },
+  );
+  return result.turn;
+}
+
+export async function commandDurableTurn(
+  turnId: string,
+  command:
+    | { type: "cancel" }
+    | { type: "approve" | "decline"; actionId: string },
+): Promise<void> {
+  await cloud.json(`/v2/turns/${encodeURIComponent(turnId)}/commands`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(command),
+  });
 }
 
 /** Soft-delete one durable conversation owned by the signed-in user. */

--- a/apps/mobile/src/lib/remix/composer-sizing.test.ts
+++ b/apps/mobile/src/lib/remix/composer-sizing.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REMIX_COMPOSER_MAX_INPUT_HEIGHT,
+  REMIX_COMPOSER_MIN_INPUT_HEIGHT,
+  remixComposerInputHeight,
+} from "./composer-sizing";
+
+describe("Remix composer sizing", () => {
+  it("keeps a compact one-line minimum", () => {
+    expect(remixComposerInputHeight(0)).toBe(REMIX_COMPOSER_MIN_INPUT_HEIGHT);
+  });
+
+  it("grows with the message until the four-line cap", () => {
+    expect(remixComposerInputHeight(71.2)).toBe(72);
+    expect(remixComposerInputHeight(320)).toBe(REMIX_COMPOSER_MAX_INPUT_HEIGHT);
+  });
+});

--- a/apps/mobile/src/lib/remix/composer-sizing.ts
+++ b/apps/mobile/src/lib/remix/composer-sizing.ts
@@ -1,0 +1,12 @@
+/** The native composer grows naturally from one line through four, then its
+ * own TextInput scrolls without pushing the keyboard or transcript around. */
+export const REMIX_COMPOSER_MIN_INPUT_HEIGHT = 38;
+export const REMIX_COMPOSER_MAX_INPUT_HEIGHT = 104;
+
+export function remixComposerInputHeight(contentHeight: number): number {
+  if (!Number.isFinite(contentHeight)) return REMIX_COMPOSER_MIN_INPUT_HEIGHT;
+  return Math.min(
+    REMIX_COMPOSER_MAX_INPUT_HEIGHT,
+    Math.max(REMIX_COMPOSER_MIN_INPUT_HEIGHT, Math.ceil(contentHeight)),
+  );
+}

--- a/apps/mobile/src/lib/remix/composer-sizing.ts
+++ b/apps/mobile/src/lib/remix/composer-sizing.ts
@@ -1,6 +1,6 @@
 /** The native composer grows naturally from one line through four, then its
  * own TextInput scrolls without pushing the keyboard or transcript around. */
-export const REMIX_COMPOSER_MIN_INPUT_HEIGHT = 38;
+export const REMIX_COMPOSER_MIN_INPUT_HEIGHT = 42;
 export const REMIX_COMPOSER_MAX_INPUT_HEIGHT = 104;
 
 export function remixComposerInputHeight(contentHeight: number): number {

--- a/apps/mobile/src/lib/remix/composer-voice-state.test.ts
+++ b/apps/mobile/src/lib/remix/composer-voice-state.test.ts
@@ -10,18 +10,16 @@ describe("Remix composer voice state", () => {
     expect(
       remixComposerVoiceState({
         draft: "",
-        partial: "",
         micState: "idle",
         remixBusy: false,
       }),
     ).toMatchObject({ action: "listen", label: "Start listening" });
   });
 
-  it("keeps the text field stable while showing live listening feedback", () => {
+  it("keeps the text field stable while live listening feedback is rendered separately", () => {
     expect(
       remixComposerVoiceState({
         draft: "Write this down",
-        partial: "and send it tomorrow",
         micState: "recording",
         remixBusy: false,
       }),
@@ -29,7 +27,7 @@ describe("Remix composer voice state", () => {
       action: "finish-listening",
       label: "Stop listening",
       value: "Write this down",
-      placeholder: "and send it tomorrow",
+      placeholder: "Message Remix",
     });
   });
 

--- a/apps/mobile/src/lib/remix/composer-voice-state.test.ts
+++ b/apps/mobile/src/lib/remix/composer-voice-state.test.ts
@@ -17,7 +17,7 @@ describe("Remix composer voice state", () => {
     ).toMatchObject({ action: "listen", label: "Start listening" });
   });
 
-  it("shows the live phrase and lets the user stop recording", () => {
+  it("keeps the text field stable while showing live listening feedback", () => {
     expect(
       remixComposerVoiceState({
         draft: "Write this down",
@@ -28,7 +28,8 @@ describe("Remix composer voice state", () => {
     ).toMatchObject({
       action: "finish-listening",
       label: "Stop listening",
-      value: "and send it tomorrow",
+      value: "Write this down",
+      placeholder: "and send it tomorrow",
     });
   });
 

--- a/apps/mobile/src/lib/remix/composer-voice-state.ts
+++ b/apps/mobile/src/lib/remix/composer-voice-state.ts
@@ -18,14 +18,22 @@ export function remixComposerVoiceState({
   remixBusy,
 }: RemixComposerVoiceInput) {
   if (remixBusy) {
-    return { action: "stop-remix" as const, label: "Stop Remix", value: draft };
+    return {
+      action: "stop-remix" as const,
+      label: "Stop Remix",
+      placeholder: "Message Remix",
+      value: draft,
+    };
   }
 
   if (micState === "recording") {
     return {
       action: "finish-listening" as const,
       label: "Stop listening",
-      value: partial || "Listening…",
+      // Keep the real input value stable so focus stays on the same native
+      // field while the microphone streams.
+      placeholder: partial || "Listening…",
+      value: draft,
     };
   }
 
@@ -33,13 +41,24 @@ export function remixComposerVoiceState({
     return {
       action: "waiting-for-transcript" as const,
       label: "Transcribing voice input",
-      value: "Transcribing…",
+      placeholder: "Transcribing…",
+      value: draft,
     };
   }
 
   if (draft.trim()) {
-    return { action: "send" as const, label: "Send to Remix", value: draft };
+    return {
+      action: "send" as const,
+      label: "Send to Remix",
+      placeholder: "Message Remix",
+      value: draft,
+    };
   }
 
-  return { action: "listen" as const, label: "Start listening", value: "" };
+  return {
+    action: "listen" as const,
+    label: "Start listening",
+    placeholder: "Message Remix",
+    value: "",
+  };
 }

--- a/apps/mobile/src/lib/remix/composer-voice-state.ts
+++ b/apps/mobile/src/lib/remix/composer-voice-state.ts
@@ -2,7 +2,6 @@ type ComposerMicState = "idle" | "recording" | "finalizing";
 
 type RemixComposerVoiceInput = {
   draft: string;
-  partial: string;
   micState: ComposerMicState;
   remixBusy: boolean;
 };
@@ -13,7 +12,6 @@ export function appendVoiceTranscript(draft: string, transcript: string) {
 
 export function remixComposerVoiceState({
   draft,
-  partial,
   micState,
   remixBusy,
 }: RemixComposerVoiceInput) {
@@ -30,9 +28,10 @@ export function remixComposerVoiceState({
     return {
       action: "finish-listening" as const,
       label: "Stop listening",
-      // Keep the real input value stable so focus stays on the same native
-      // field while the microphone streams.
-      placeholder: partial || "Listening…",
+      // Keep the native field stable while the live transcript is shown in the
+      // composer's status row. Replacing the placeholder with it hides the
+      // draft and makes the control look like a second, unrelated surface.
+      placeholder: "Message Remix",
       value: draft,
     };
   }

--- a/apps/mobile/src/lib/remix/drafts.test.ts
+++ b/apps/mobile/src/lib/remix/drafts.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { remixDraftStorageKey, updateRemixDraft } from "./drafts";
+
+describe("Remix draft persistence", () => {
+  it("scopes drafts to the signed-in account", () => {
+    expect(remixDraftStorageKey("user-a")).toBe("remix_drafts:user-a");
+    expect(remixDraftStorageKey(undefined)).toBe("remix_drafts");
+  });
+
+  it("keeps drafts per thread and removes blank values", () => {
+    const withFirst = updateRemixDraft({}, "thread-a", "Finish this note");
+    const withBoth = updateRemixDraft(withFirst, "thread-b", "Reply later");
+
+    expect(withBoth).toEqual({
+      "thread-a": "Finish this note",
+      "thread-b": "Reply later",
+    });
+    expect(updateRemixDraft(withBoth, "thread-a", "")).toEqual({
+      "thread-b": "Reply later",
+    });
+  });
+});

--- a/apps/mobile/src/lib/remix/drafts.ts
+++ b/apps/mobile/src/lib/remix/drafts.ts
@@ -1,0 +1,34 @@
+import { getJsonPref, setJsonPref } from "@/lib/storage";
+
+export type RemixDrafts = Record<string, string>;
+
+export function remixDraftStorageKey(
+  userId: string | null | undefined,
+): string {
+  return userId ? `remix_drafts:${userId}` : "remix_drafts";
+}
+
+export async function loadRemixDrafts(
+  userId: string | null | undefined,
+): Promise<RemixDrafts> {
+  return getJsonPref<RemixDrafts>(remixDraftStorageKey(userId), {});
+}
+
+export async function saveRemixDrafts(
+  userId: string | null | undefined,
+  drafts: RemixDrafts,
+): Promise<void> {
+  await setJsonPref(remixDraftStorageKey(userId), drafts);
+}
+
+/** A blank draft removes its entry, keeping the account-scoped preference small. */
+export function updateRemixDraft(
+  drafts: RemixDrafts,
+  threadId: string,
+  value: string,
+): RemixDrafts {
+  const next = { ...drafts };
+  if (value) next[threadId] = value;
+  else delete next[threadId];
+  return next;
+}

--- a/apps/mobile/src/lib/remix/markdown.test.ts
+++ b/apps/mobile/src/lib/remix/markdown.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { markdownBlocks } from "./markdown";
+
+describe("markdownBlocks", () => {
+  it("keeps streamed prose readable while recognising headings and lists", () => {
+    expect(
+      markdownBlocks("# Plan\n\nWrite a reply.\n- Keep it warm\n- Send it"),
+    ).toEqual([
+      { kind: "heading", level: 1, text: "Plan" },
+      { kind: "paragraph", text: "Write a reply." },
+      { kind: "list", ordered: false, items: ["Keep it warm", "Send it"] },
+    ]);
+  });
+
+  it("preserves fenced code without interpreting its contents", () => {
+    expect(markdownBlocks("Try this:\n```ts\nconst answer = 42;\n```")).toEqual(
+      [
+        { kind: "paragraph", text: "Try this:" },
+        { kind: "code", text: "const answer = 42;" },
+      ],
+    );
+  });
+});

--- a/apps/mobile/src/lib/remix/markdown.ts
+++ b/apps/mobile/src/lib/remix/markdown.ts
@@ -1,0 +1,85 @@
+export type MarkdownBlock =
+  | { kind: "heading"; level: 1 | 2 | 3; text: string }
+  | { kind: "paragraph"; text: string }
+  | { kind: "list"; ordered: boolean; items: string[] }
+  | { kind: "code"; text: string };
+
+/**
+ * Deliberately small, deterministic Markdown block parser for streamed mobile
+ * chat. It covers the response shapes Remix produces without introducing a
+ * second HTML/DOM rendering pipeline into the native app.
+ */
+export function markdownBlocks(source: string): MarkdownBlock[] {
+  const lines = source.replace(/\r\n/g, "\n").split("\n");
+  const blocks: MarkdownBlock[] = [];
+  let paragraph: string[] = [];
+  let list: { ordered: boolean; items: string[] } | null = null;
+  let code: string[] | null = null;
+
+  const flushParagraph = () => {
+    const text = paragraph.join(" ").trim();
+    if (text) blocks.push({ kind: "paragraph", text });
+    paragraph = [];
+  };
+  const flushList = () => {
+    if (list?.items.length) blocks.push({ kind: "list", ...list });
+    list = null;
+  };
+  const flushCode = () => {
+    if (code) blocks.push({ kind: "code", text: code.join("\n") });
+    code = null;
+  };
+
+  for (const line of lines) {
+    if (line.trim().startsWith("```")) {
+      if (code) flushCode();
+      else {
+        flushParagraph();
+        flushList();
+        code = [];
+      }
+      continue;
+    }
+    if (code) {
+      code.push(line);
+      continue;
+    }
+
+    const heading = /^(#{1,3})\s+(.+)$/.exec(line);
+    if (heading) {
+      flushParagraph();
+      flushList();
+      blocks.push({
+        kind: "heading",
+        level: heading[1].length as 1 | 2 | 3,
+        text: heading[2],
+      });
+      continue;
+    }
+
+    const item = /^(?:[-*+]\s+|\d+[.)]\s+)(.+)$/.exec(line);
+    if (item) {
+      flushParagraph();
+      const ordered = /^\d+[.)]\s+/.test(line);
+      if (!list || list.ordered !== ordered) {
+        flushList();
+        list = { ordered, items: [] };
+      }
+      list.items.push(item[1]);
+      continue;
+    }
+
+    if (!line.trim()) {
+      flushParagraph();
+      flushList();
+      continue;
+    }
+    flushList();
+    paragraph.push(line.trim());
+  }
+
+  flushParagraph();
+  flushList();
+  flushCode();
+  return blocks;
+}

--- a/apps/mobile/src/lib/remix/thread.test.ts
+++ b/apps/mobile/src/lib/remix/thread.test.ts
@@ -1,59 +1,47 @@
 import { describe, expect, it } from "vitest";
 
-import { appendAssistantDelta, latestThreadState } from "./thread";
+import { messagesForResend, messagesForRetry } from "./thread";
 
-describe("Remix thread updates", () => {
-  it("extends the current assistant turn instead of adding a message per stream chunk", () => {
-    const first = appendAssistantDelta([], "First", "assistant-1");
-    const second = appendAssistantDelta(first, " draft", "assistant-1");
+const messages = [
+  {
+    id: "u1",
+    role: "user" as const,
+    parts: [{ type: "text" as const, text: "First" }],
+  },
+  {
+    id: "a1",
+    role: "assistant" as const,
+    parts: [{ type: "text" as const, text: "Answer" }],
+  },
+  {
+    id: "u2",
+    role: "user" as const,
+    parts: [{ type: "text" as const, text: "Second" }],
+  },
+  {
+    id: "a2",
+    role: "assistant" as const,
+    parts: [{ type: "text" as const, text: "Another answer" }],
+  },
+];
 
-    expect(second).toEqual([
+describe("Remix resend history", () => {
+  it("retries the latest user turn without retaining a partial answer", () => {
+    expect(messagesForRetry(messages)).toEqual(messages.slice(0, 3));
+  });
+
+  it("replaces an edited user turn and truncates the discarded tail", () => {
+    expect(messagesForResend(messages, "u1", "Rewritten first")).toEqual([
       {
-        id: "assistant-1",
-        role: "assistant",
-        parts: [{ type: "text", text: "First draft" }],
+        id: "u1",
+        role: "user",
+        parts: [{ type: "text", text: "Rewritten first" }],
       },
     ]);
   });
 
-  it("keeps consecutive assistant turns uniquely keyed", () => {
-    const first = appendAssistantDelta([], "First", "assistant-1");
-    const second = appendAssistantDelta(
-      [
-        ...first,
-        {
-          id: "user-2",
-          role: "user",
-          parts: [{ type: "text", text: "Again" }],
-        },
-      ],
-      "Second",
-      "assistant-2",
-    );
-
-    expect(second.map((message) => message.id)).toEqual([
-      "assistant-1",
-      "user-2",
-      "assistant-2",
-    ]);
-  });
-
-  it("uses the latest durable thread without discarding a fresh-thread fallback", () => {
-    expect(
-      latestThreadState(
-        {
-          id: "cloud-thread",
-          messages: [{ id: "user", role: "user", parts: [] }],
-        },
-        "fresh-thread",
-      ),
-    ).toEqual({
-      threadId: "cloud-thread",
-      messages: [{ id: "user", role: "user", parts: [] }],
-    });
-    expect(latestThreadState(null, "fresh-thread")).toEqual({
-      threadId: "fresh-thread",
-      messages: [],
-    });
+  it("does not resend empty text or assistant messages", () => {
+    expect(messagesForResend(messages, "u2", "  ")).toBeNull();
+    expect(messagesForResend(messages, "a2", "Nope")).toBeNull();
   });
 });

--- a/apps/mobile/src/lib/remix/thread.ts
+++ b/apps/mobile/src/lib/remix/thread.ts
@@ -39,3 +39,32 @@ export function appendAssistantDelta(
     },
   ];
 }
+
+export function messageText(message: UIMessage): string {
+  return message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
+
+/** Keeps the edited user message and its preceding context for a clean resend. */
+export function messagesForResend(
+  messages: UIMessage[],
+  messageId: string,
+  text: string,
+): UIMessage[] | null {
+  const index = messages.findIndex(
+    (message) => message.id === messageId && message.role === "user",
+  );
+  if (index < 0 || !text.trim()) return null;
+  return [
+    ...messages.slice(0, index),
+    { ...messages[index], parts: [{ type: "text", text: text.trim() }] },
+  ];
+}
+
+/** Re-runs the latest user turn after a failed/interrupted response. */
+export function messagesForRetry(messages: UIMessage[]): UIMessage[] | null {
+  const index = messages.findLastIndex((message) => message.role === "user");
+  return index < 0 ? null : messages.slice(0, index + 1);
+}

--- a/apps/mobile/src/lib/remix/types.ts
+++ b/apps/mobile/src/lib/remix/types.ts
@@ -35,10 +35,14 @@ export type RemixStreamEvent =
   | { type: "complete" };
 
 export type PendingConnectorApproval = {
-  approvalToken: string;
-  toolkit: string;
-  toolkitName: string;
-  toolSlug: string;
+  /** Durable protocol fields. actionId/turnId are used for the shared command
+   * endpoint; legacy token fields remain optional for keyboard compatibility. */
+  actionId?: string;
+  turnId?: string;
+  approvalToken?: string;
+  toolkit?: string;
+  toolkitName?: string;
+  toolSlug?: string;
   actionDescription: string;
   expiresAt: string;
 };

--- a/apps/mobile/src/lib/remix/types.ts
+++ b/apps/mobile/src/lib/remix/types.ts
@@ -28,7 +28,20 @@ export type RemixStreamEvent =
       name: "insert_at_cursor";
       input: unknown;
     }
+  | {
+      type: "connector-approval";
+      approval: PendingConnectorApproval;
+    }
   | { type: "complete" };
+
+export type PendingConnectorApproval = {
+  approvalToken: string;
+  toolkit: string;
+  toolkitName: string;
+  toolSlug: string;
+  actionDescription: string;
+  expiresAt: string;
+};
 
 export type RemixTurnPhase = "idle" | "listening" | "question" | "ready";
 

--- a/apps/mobile/src/lib/remix/use-remix-thread.ts
+++ b/apps/mobile/src/lib/remix/use-remix-thread.ts
@@ -1,9 +1,13 @@
 import type { UIMessage } from "ai";
 import { useCallback, useEffect, useRef, useState } from "react";
-
+import {
+  declineConnectorApproval,
+  executeConnectorApproval,
+} from "@/lib/cloud/connector-approvals";
 import { getLatestThread, getThread, runRemixTurn } from "./client";
 import { createMobileId } from "./ids";
 import { appendAssistantDelta, latestThreadState } from "./thread";
+import type { PendingConnectorApproval } from "./types";
 
 export type RemixRunStatus = "idle" | "streaming" | "failed";
 
@@ -18,6 +22,11 @@ export function useRemixThread() {
   const [status, setStatus] = useState<RemixRunStatus>("idle");
   const [error, setError] = useState<string | null>(null);
   const [activeTool, setActiveTool] = useState<string | null>(null);
+  const [pendingApproval, setPendingApproval] =
+    useState<PendingConnectorApproval | null>(null);
+  const [approvalState, setApprovalState] = useState<
+    "idle" | "approving" | "approved" | "declining" | "declined" | "failed"
+  >("idle");
   const abortRef = useRef<AbortController | null>(null);
   const statusRef = useRef<RemixRunStatus>(status);
   const hydratedRef = useRef(false);
@@ -60,6 +69,8 @@ export function useRemixThread() {
     setMessages([]);
     setError(null);
     setActiveTool(null);
+    setPendingApproval(null);
+    setApprovalState("idle");
     setStatus("idle");
     hydratedRef.current = true;
   }, []);
@@ -72,6 +83,8 @@ export function useRemixThread() {
     setStatus("idle");
     setError(null);
     setActiveTool(null);
+    setPendingApproval(null);
+    setApprovalState("idle");
     try {
       const thread = await getThread(id);
       if (!thread) throw new Error("This conversation is no longer available.");
@@ -98,7 +111,13 @@ export function useRemixThread() {
   const send = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
-      if (!trimmed || status === "streaming") return false;
+      const approvalPending =
+        pendingApproval &&
+        (approvalState === "idle" ||
+          approvalState === "approving" ||
+          approvalState === "declining" ||
+          approvalState === "failed");
+      if (!trimmed || status === "streaming" || approvalPending) return false;
       const userMessage: UIMessage = {
         id: newId("user"),
         role: "user",
@@ -130,6 +149,10 @@ export function useRemixThread() {
               setActiveTool(event.name.replace(/_/g, " "));
             } else if (event.type === "tool-result-needed") {
               setActiveTool("Preparing a keyboard-ready result");
+            } else if (event.type === "connector-approval") {
+              setPendingApproval(event.approval);
+              setApprovalState("idle");
+              setActiveTool(null);
             }
           },
         });
@@ -155,7 +178,38 @@ export function useRemixThread() {
         if (abortRef.current === controller) abortRef.current = null;
       }
     },
-    [messages, status, threadId],
+    [approvalState, messages, pendingApproval, status, threadId],
+  );
+
+  const decideApproval = useCallback(
+    async (approved: boolean) => {
+      if (
+        !pendingApproval ||
+        approvalState === "approving" ||
+        approvalState === "declining"
+      )
+        return false;
+      setApprovalState(approved ? "approving" : "declining");
+      try {
+        if (approved) {
+          await executeConnectorApproval(pendingApproval.approvalToken);
+          setApprovalState("approved");
+        } else {
+          await declineConnectorApproval(pendingApproval.approvalToken);
+          setApprovalState("declined");
+        }
+        return true;
+      } catch (cause) {
+        setApprovalState("failed");
+        setError(
+          cause instanceof Error
+            ? cause.message
+            : "Couldn't resolve this connected-app action.",
+        );
+        return false;
+      }
+    },
+    [approvalState, pendingApproval],
   );
 
   return {
@@ -164,6 +218,9 @@ export function useRemixThread() {
     status,
     error,
     activeTool,
+    pendingApproval,
+    approvalState,
+    decideApproval,
     send,
     stop,
     newThread,

--- a/apps/mobile/src/lib/remix/use-remix-thread.ts
+++ b/apps/mobile/src/lib/remix/use-remix-thread.ts
@@ -6,13 +6,37 @@ import {
 } from "@/lib/cloud/connector-approvals";
 import { getLatestThread, getThread, runRemixTurn } from "./client";
 import { createMobileId } from "./ids";
-import { appendAssistantDelta, latestThreadState } from "./thread";
+import {
+  appendAssistantDelta,
+  latestThreadState,
+  messagesForResend,
+  messagesForRetry,
+} from "./thread";
 import type { PendingConnectorApproval } from "./types";
 
 export type RemixRunStatus = "idle" | "streaming" | "failed";
 
 function newId(prefix: string): string {
   return createMobileId(prefix);
+}
+
+function approvalNeedsDecision(
+  approval: PendingConnectorApproval | null,
+  state:
+    | "idle"
+    | "approving"
+    | "approved"
+    | "declining"
+    | "declined"
+    | "failed",
+): boolean {
+  return Boolean(
+    approval &&
+      (state === "idle" ||
+        state === "approving" ||
+        state === "declining" ||
+        state === "failed"),
+  );
 }
 
 export function useRemixThread() {
@@ -108,22 +132,9 @@ export function useRemixThread() {
     setActiveTool(null);
   }, []);
 
-  const send = useCallback(
-    async (text: string) => {
-      const trimmed = text.trim();
-      const approvalPending =
-        pendingApproval &&
-        (approvalState === "idle" ||
-          approvalState === "approving" ||
-          approvalState === "declining" ||
-          approvalState === "failed");
-      if (!trimmed || status === "streaming" || approvalPending) return false;
-      const userMessage: UIMessage = {
-        id: newId("user"),
-        role: "user",
-        parts: [{ type: "text", text: trimmed }],
-      };
-      const nextMessages = [...messages, userMessage];
+  const run = useCallback(
+    async (nextMessages: UIMessage[]) => {
+      if (abortRef.current) return false;
       const controller = new AbortController();
       const assistantId = newId("assistant");
       abortRef.current = controller;
@@ -135,7 +146,7 @@ export function useRemixThread() {
         await runRemixTurn({
           messages: nextMessages,
           threadId,
-          firstTurn: messages.length === 0,
+          firstTurn: nextMessages.length === 1,
           signal: controller.signal,
           onEvent: (event) => {
             if (abortRef.current !== controller || controller.signal.aborted) {
@@ -169,16 +180,58 @@ export function useRemixThread() {
         }
         setStatus("failed");
         setError(
-          cause instanceof Error
-            ? cause.message
-            : "Remix could not finish that run.",
+          cause instanceof Error && cause.message
+            ? `Connection interrupted. ${cause.message}`
+            : "Connection interrupted. Retry this message when you're back online.",
         );
         return false;
       } finally {
         if (abortRef.current === controller) abortRef.current = null;
       }
     },
-    [approvalState, messages, pendingApproval, status, threadId],
+    [threadId],
+  );
+
+  const send = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      const approvalPending = approvalNeedsDecision(
+        pendingApproval,
+        approvalState,
+      );
+      if (!trimmed || status === "streaming" || approvalPending) return false;
+      const userMessage: UIMessage = {
+        id: newId("user"),
+        role: "user",
+        parts: [{ type: "text", text: trimmed }],
+      };
+      const nextMessages = [...messages, userMessage];
+      return run(nextMessages);
+    },
+    [approvalState, messages, pendingApproval, run, status],
+  );
+
+  const retryLastTurn = useCallback(async () => {
+    if (
+      status === "streaming" ||
+      approvalNeedsDecision(pendingApproval, approvalState)
+    )
+      return false;
+    const nextMessages = messagesForRetry(messages);
+    return nextMessages ? run(nextMessages) : false;
+  }, [approvalState, messages, pendingApproval, run, status]);
+
+  const resend = useCallback(
+    async (messageId: string, text: string) => {
+      if (
+        status === "streaming" ||
+        approvalNeedsDecision(pendingApproval, approvalState)
+      )
+        return false;
+      const nextMessages = messagesForResend(messages, messageId, text);
+      return nextMessages ? run(nextMessages) : false;
+    },
+    [approvalState, messages, pendingApproval, run, status],
   );
 
   const decideApproval = useCallback(
@@ -222,6 +275,8 @@ export function useRemixThread() {
     approvalState,
     decideApproval,
     send,
+    resend,
+    retryLastTurn,
     stop,
     newThread,
     loadThread,

--- a/apps/mobile/src/lib/remix/use-remix-thread.ts
+++ b/apps/mobile/src/lib/remix/use-remix-thread.ts
@@ -1,13 +1,14 @@
 import type { UIMessage } from "ai";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
-  declineConnectorApproval,
-  executeConnectorApproval,
-} from "@/lib/cloud/connector-approvals";
-import { getLatestThread, getThread, runRemixTurn } from "./client";
+  commandDurableTurn,
+  getDurableThreadRuntime,
+  getDurableTurn,
+  getLatestThread,
+  sendDurableRemixTurn,
+} from "./client";
 import { createMobileId } from "./ids";
 import {
-  appendAssistantDelta,
   latestThreadState,
   messagesForResend,
   messagesForRetry,
@@ -52,9 +53,136 @@ export function useRemixThread() {
     "idle" | "approving" | "approved" | "declining" | "declined" | "failed"
   >("idle");
   const abortRef = useRef<AbortController | null>(null);
+  const activeTurnIdRef = useRef<string | null>(null);
+  const retryRequestRef = useRef<{ fingerprint: string; id: string } | null>(
+    null,
+  );
   const statusRef = useRef<RemixRunStatus>(status);
   const hydratedRef = useRef(false);
   statusRef.current = status;
+
+  const applyRuntime = useCallback(
+    (
+      runtime: NonNullable<Awaited<ReturnType<typeof getDurableThreadRuntime>>>,
+    ) => {
+      setMessages(runtime.thread.messages);
+      const action = runtime.pendingAction;
+      if (action?.kind === "connector" && action.status === "pending") {
+        setPendingApproval({
+          actionId: action.id,
+          turnId: action.turnId,
+          toolkitName: "Connected app",
+          toolSlug: action.toolName,
+          actionDescription: action.display,
+          expiresAt: action.expiresAt,
+        });
+        setApprovalState("idle");
+      } else {
+        setPendingApproval(null);
+      }
+      if (action?.kind === "desktop" && action.status === "pending") {
+        setActiveTool("Waiting for an available desktop");
+      }
+    },
+    [],
+  );
+
+  const waitForDurableTurn = useCallback(
+    async (
+      turnId: string,
+      observedThreadId: string,
+      controller: AbortController,
+    ) => {
+      while (!controller.signal.aborted) {
+        const [turn, runtime] = await Promise.all([
+          getDurableTurn(turnId),
+          getDurableThreadRuntime(observedThreadId),
+        ]);
+        if (runtime) applyRuntime(runtime);
+        if (
+          turn.status === "queued" ||
+          turn.status === "running" ||
+          turn.status === "waiting_desktop"
+        ) {
+          setActiveTool(
+            turn.status === "waiting_desktop"
+              ? "Waiting for an available desktop"
+              : "Remix is working",
+          );
+        }
+        if (turn.status === "waiting_approval") {
+          // `claimed` means a device already made an idempotent decision and
+          // the server-owned harness is now executing it. Keep observing that
+          // same turn rather than treating the approval card's disappearance
+          // as completion.
+          if (runtime?.pendingAction?.status === "claimed") {
+            setActiveTool("Remix is completing the approved action");
+          } else {
+            setStatus("idle");
+            setActiveTool(null);
+            return true;
+          }
+        }
+        if (turn.status === "completed") {
+          setStatus("idle");
+          setActiveTool(null);
+          return true;
+        }
+        if (turn.status === "failed" || turn.status === "needs_desktop") {
+          setStatus("failed");
+          setActiveTool(null);
+          setError(
+            turn.error ??
+              (turn.status === "needs_desktop"
+                ? "This step needs an available Freestyle desktop."
+                : "Remix couldn't finish this message."),
+          );
+          return false;
+        }
+        if (turn.status === "canceled") {
+          setStatus("idle");
+          setActiveTool(null);
+          return false;
+        }
+        await new Promise<void>((resolve) => {
+          const timeout = setTimeout(resolve, 800);
+          controller.signal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+            { once: true },
+          );
+        });
+      }
+      return false;
+    },
+    [applyRuntime],
+  );
+
+  const observeActiveTurn = useCallback(
+    (
+      runtime: NonNullable<Awaited<ReturnType<typeof getDurableThreadRuntime>>>,
+    ) => {
+      if (!runtime.activeTurn || abortRef.current) return;
+      const controller = new AbortController();
+      abortRef.current = controller;
+      activeTurnIdRef.current = runtime.activeTurn.id;
+      setStatus("streaming");
+      void waitForDurableTurn(
+        runtime.activeTurn.id,
+        runtime.thread.id,
+        controller,
+      ).finally(() => {
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+          activeTurnIdRef.current = null;
+        }
+      });
+    },
+    [waitForDurableTurn],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -65,6 +193,14 @@ export function useRemixThread() {
         const next = latestThreadState(latest, initialThreadId.current);
         setThreadId(next.threadId);
         setMessages(next.messages);
+        if (latest) {
+          void getDurableThreadRuntime(latest.id).then((runtime) => {
+            if (!cancelled && runtime) {
+              applyRuntime(runtime);
+              observeActiveTurn(runtime);
+            }
+          });
+        }
       })
       .catch(() => {
         // Home is still useful offline or before sign-in recovers. The next
@@ -73,11 +209,11 @@ export function useRemixThread() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [applyRuntime, observeActiveTurn]);
 
-  // A screen unmount or navigation change must stop the underlying fetch as well
-  // as discard its UI. Otherwise a late stream chunk can resurrect an assistant
-  // message in a different conversation.
+  // Leaving a screen stops only this device's observer. The accepted turn stays
+  // on the server; coming back reloads its canonical D1 snapshot instead of
+  // silently cancelling work because a view unmounted.
   useEffect(
     () => () => {
       abortRef.current?.abort();
@@ -96,38 +232,49 @@ export function useRemixThread() {
     setPendingApproval(null);
     setApprovalState("idle");
     setStatus("idle");
+    activeTurnIdRef.current = null;
+    retryRequestRef.current = null;
     hydratedRef.current = true;
   }, []);
 
-  const loadThread = useCallback(async (id: string) => {
-    if (!id || statusRef.current === "streaming") return false;
-    abortRef.current?.abort();
-    abortRef.current = null;
-    hydratedRef.current = true;
-    setStatus("idle");
-    setError(null);
-    setActiveTool(null);
-    setPendingApproval(null);
-    setApprovalState("idle");
-    try {
-      const thread = await getThread(id);
-      if (!thread) throw new Error("This conversation is no longer available.");
-      setThreadId(thread.id);
-      setMessages(thread.messages);
-      return true;
-    } catch (cause) {
-      setError(
-        cause instanceof Error
-          ? cause.message
-          : "Couldn't load this conversation.",
-      );
-      return false;
-    }
-  }, []);
+  const loadThread = useCallback(
+    async (id: string) => {
+      if (!id || statusRef.current === "streaming") return false;
+      abortRef.current?.abort();
+      abortRef.current = null;
+      hydratedRef.current = true;
+      setStatus("idle");
+      setError(null);
+      setActiveTool(null);
+      setPendingApproval(null);
+      setApprovalState("idle");
+      retryRequestRef.current = null;
+      try {
+        const runtime = await getDurableThreadRuntime(id);
+        if (!runtime)
+          throw new Error("This conversation is no longer available.");
+        setThreadId(runtime.thread.id);
+        applyRuntime(runtime);
+        observeActiveTurn(runtime);
+        return true;
+      } catch (cause) {
+        setError(
+          cause instanceof Error
+            ? cause.message
+            : "Couldn't load this conversation.",
+        );
+        return false;
+      }
+    },
+    [applyRuntime, observeActiveTurn],
+  );
 
   const stop = useCallback(() => {
+    const turnId = activeTurnIdRef.current;
     abortRef.current?.abort();
     abortRef.current = null;
+    activeTurnIdRef.current = null;
+    if (turnId) void commandDurableTurn(turnId, { type: "cancel" });
     setStatus("idle");
     setActiveTool(null);
   }, []);
@@ -136,43 +283,40 @@ export function useRemixThread() {
     async (nextMessages: UIMessage[]) => {
       if (abortRef.current) return false;
       const controller = new AbortController();
-      const assistantId = newId("assistant");
       abortRef.current = controller;
       setMessages(nextMessages);
       setStatus("streaming");
       setError(null);
       setActiveTool(null);
+      const fingerprint = JSON.stringify({ threadId, messages: nextMessages });
+      const clientRequestId =
+        retryRequestRef.current?.fingerprint === fingerprint
+          ? retryRequestRef.current.id
+          : newId("turn");
+      retryRequestRef.current = { fingerprint, id: clientRequestId };
+      let turnAccepted = false;
       try {
-        await runRemixTurn({
+        const turn = await sendDurableRemixTurn({
           messages: nextMessages,
           threadId,
           firstTurn: nextMessages.length === 1,
-          signal: controller.signal,
-          onEvent: (event) => {
-            if (abortRef.current !== controller || controller.signal.aborted) {
-              return;
-            }
-            if (event.type === "text") {
-              setMessages((current) =>
-                appendAssistantDelta(current, event.text, assistantId),
-              );
-            } else if (event.type === "tool") {
-              setActiveTool(event.name.replace(/_/g, " "));
-            } else if (event.type === "tool-result-needed") {
-              setActiveTool("Preparing a keyboard-ready result");
-            } else if (event.type === "connector-approval") {
-              setPendingApproval(event.approval);
-              setApprovalState("idle");
-              setActiveTool(null);
-            }
-          },
+          clientRequestId,
         });
+        turnAccepted = true;
+        activeTurnIdRef.current = turn.id;
+        const completed = await waitForDurableTurn(
+          turn.id,
+          threadId,
+          controller,
+        );
         if (abortRef.current !== controller || controller.signal.aborted) {
           return false;
         }
-        setStatus("idle");
-        setActiveTool(null);
-        return true;
+        // A terminal durable result should not be reused for an intentional
+        // retry. Keep the key only when the request/polling connection failed
+        // before this device could learn the server-owned outcome.
+        retryRequestRef.current = null;
+        return completed;
       } catch (cause) {
         if (controller.signal.aborted) {
           if (abortRef.current === controller) setStatus("idle");
@@ -184,12 +328,20 @@ export function useRemixThread() {
             ? `Connection interrupted. ${cause.message}`
             : "Connection interrupted. Retry this message when you're back online.",
         );
+        if (!turnAccepted) {
+          // Preserve this exact key for Retry: Cloud may already have accepted
+          // the request even though the response never reached the device.
+          retryRequestRef.current = { fingerprint, id: clientRequestId };
+        }
         return false;
       } finally {
-        if (abortRef.current === controller) abortRef.current = null;
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+          activeTurnIdRef.current = null;
+        }
       }
     },
-    [threadId],
+    [threadId, waitForDurableTurn],
   );
 
   const send = useCallback(
@@ -244,12 +396,22 @@ export function useRemixThread() {
         return false;
       setApprovalState(approved ? "approving" : "declining");
       try {
-        if (approved) {
-          await executeConnectorApproval(pendingApproval.approvalToken);
-          setApprovalState("approved");
-        } else {
-          await declineConnectorApproval(pendingApproval.approvalToken);
-          setApprovalState("declined");
+        if (!pendingApproval.actionId || !pendingApproval.turnId) {
+          throw new Error("This approval is no longer available.");
+        }
+        await commandDurableTurn(pendingApproval.turnId, {
+          type: approved ? "approve" : "decline",
+          actionId: pendingApproval.actionId,
+        });
+        setApprovalState(approved ? "approved" : "declined");
+        const controller = new AbortController();
+        abortRef.current = controller;
+        activeTurnIdRef.current = pendingApproval.turnId;
+        setStatus("streaming");
+        await waitForDurableTurn(pendingApproval.turnId, threadId, controller);
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+          activeTurnIdRef.current = null;
         }
         return true;
       } catch (cause) {
@@ -262,7 +424,7 @@ export function useRemixThread() {
         return false;
       }
     },
-    [approvalState, pendingApproval],
+    [approvalState, pendingApproval, threadId, waitForDurableTurn],
   );
 
   return {

--- a/apps/mobile/src/lib/settings-layout.test.ts
+++ b/apps/mobile/src/lib/settings-layout.test.ts
@@ -18,7 +18,8 @@ describe("native settings layout", () => {
   });
 
   it("uses the grouped navigation and centered account identity on the account hub", () => {
-    expect(profile).toMatch(/<SettingsGroup title="Freestyle">/);
+    expect(profile).toMatch(/<SettingsGroup>/);
+    expect(profile).not.toMatch(/<SettingsGroup title="Freestyle">/);
     expect(profile).toMatch(/styles\.accountHero/);
     expect(profile).toMatch(/title="Settings"/);
   });

--- a/apps/mobile/src/lib/settings-layout.test.ts
+++ b/apps/mobile/src/lib/settings-layout.test.ts
@@ -9,12 +9,18 @@ const profile = readFileSync(
   new URL("../app/(app)/profile.tsx", import.meta.url),
   "utf8",
 );
+const picker = readFileSync(
+  new URL("../components/select-sheet.tsx", import.meta.url),
+  "utf8",
+);
 
 describe("native settings layout", () => {
   it("uses a reusable softer grouped-settings primitive", () => {
     expect(primitives).toMatch(/export function SettingsGroup/);
+    expect(primitives).toMatch(/export function SettingsValueRow/);
     expect(primitives).toMatch(/backgroundColor: theme\.secondary/);
     expect(primitives).toMatch(/fontFamily: Fonts\.sansSemiBold/);
+    expect(primitives).toMatch(/automaticallyAdjustKeyboardInsets/);
   });
 
   it("uses the grouped navigation and centered account identity on the account hub", () => {
@@ -22,5 +28,12 @@ describe("native settings layout", () => {
     expect(profile).not.toMatch(/<SettingsGroup title="Freestyle">/);
     expect(profile).toMatch(/styles\.accountHero/);
     expect(profile).toMatch(/title="Settings"/);
+  });
+
+  it("uses native iOS sheets for profile pickers", () => {
+    expect(picker).toMatch(
+      /presentationStyle=\{Platform\.OS === "ios" \? "formSheet"/,
+    );
+    expect(picker).toMatch(/transparent=\{Platform\.OS !== "ios"\}/);
   });
 });

--- a/apps/server/src/routes/agent.ts
+++ b/apps/server/src/routes/agent.ts
@@ -24,10 +24,8 @@ const agentRequestSchema = z.object({
  * this route is a streaming proxy — the renderer never holds the cloud
  * token, so the Bearer header is injected here from the server-side session.
  */
-const agentRoute = new Hono().post(
-  "/",
-  zValidator("json", agentRequestSchema),
-  async (c) => {
+const agentRoute = new Hono()
+  .post("/", zValidator("json", agentRequestSchema), async (c) => {
     const { messages, firstTurn, id, threadId } = c.req.valid("json");
 
     const token = getSessionToken();
@@ -99,7 +97,72 @@ const agentRoute = new Hono().post(
         "x-vercel-ai-ui-message-stream": "v1",
       },
     });
-  },
-);
+  })
+  // Durable turns are an opt-in protocol. This narrow proxy lets the renderer
+  // observe, claim, and complete a cloud-paused action without ever receiving
+  // the Cloud bearer token or a direct Durable Object binding.
+  .get("/thread/:threadId", async (c) => {
+    const threadId = c.req.param("threadId");
+    if (!z.string().min(1).max(100).safeParse(threadId).success)
+      return c.json({ error: "invalid_thread" }, 400);
+    const token = getSessionToken();
+    if (!token) return c.json({ error: "cloud_auth_required" }, 401);
+    let upstream: Response;
+    try {
+      upstream = await fetch(
+        `${freestyleCloudUrl()}/v2/threads/${encodeURIComponent(threadId)}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: AbortSignal.timeout(15_000),
+        },
+      );
+    } catch (err) {
+      log.error(`Durable thread snapshot failed: ${err}`);
+      return c.json({ error: "cloud_unreachable" }, 502);
+    }
+    if (upstream.status === 401) invalidateSession();
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: {
+        "Content-Type":
+          upstream.headers.get("Content-Type") ?? "application/json",
+      },
+    });
+  })
+  .post("/turn/:turnId/commands", async (c) => {
+    const turnId = c.req.param("turnId");
+    if (!z.string().uuid().safeParse(turnId).success)
+      return c.json({ error: "invalid_turn" }, 400);
+    const token = getSessionToken();
+    if (!token) return c.json({ error: "cloud_auth_required" }, 401);
+    let upstream: Response;
+    try {
+      upstream = await fetch(
+        `${freestyleCloudUrl()}/v2/turns/${encodeURIComponent(turnId)}/commands`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: await c.req.text(),
+          // The command is durable after Cloud accepts it. The renderer may
+          // close without cancelling the server-owned turn.
+          signal: AbortSignal.timeout(15_000),
+        },
+      );
+    } catch (err) {
+      log.error(`Durable turn command failed: ${err}`);
+      return c.json({ error: "cloud_unreachable" }, 502);
+    }
+    if (upstream.status === 401) invalidateSession();
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: {
+        "Content-Type":
+          upstream.headers.get("Content-Type") ?? "application/json",
+      },
+    });
+  });
 
 export default agentRoute;


### PR DESCRIPTION
## Experience

Chat is now a conversation-first workspace on desktop and mobile. The reading surface stays single-column and quiet; history, activity, and non-chat tools move out of equal-weight tabs.

### Desktop

- adds a collapsible history rail at wider panel widths and keyboard-accessible Conversations, Activity, and Workspace drawers at narrow widths
- keeps the composer fixed and multiline beneath the transcript
- groups consecutive tool calls into an expandable activity summary while retaining prominent inline approval cards
- keeps persisted threads, streaming/Stop, copy, edit/resend, regenerate, dictation, and existing tool policy intact

### Mobile Remix

- adopts the session-first model: resume from Activity, session drawer, direct input-first Remix, compact tool progress, and keyboard-safe composer
- renders assistant Markdown with native headings, lists, inline code, and code blocks, while preserving a clear user/assistant hierarchy
- shows connected-app changes as compact inline cards with a meaningful action summary, Allow, and Decline
- adds Settings -> Action approvals, where a user can explicitly opt into automatically allowing connected-app changes
- keeps Dictate and the voice-only keyboard flow; keyboard Remix cannot access connected apps or approval cards

## Safety dependency

Depends on freestyle-voice/cloud#194. Cloud serves connectors only to approval-capable mobile builds. Each manual approval is a one-time, user-bound, thread-bound grant, and execution reads the server-stored tool input rather than client data.

## Retained contracts

Persisted threads, streaming, Stop, copy, edit/resend, regenerate, approval cards, dictation, and existing desktop agent-tool policy are retained. Mobile keeps its no-desktop-actions boundary; connected-app changes ask by default.

## Verification

- Electron tests: 29 files, 133 tests
- Electron production build
- Mobile tests: 24 files, 69 tests
- Mobile typecheck and lint
- Mobile Metro iOS export
- Mobile native iOS simulator build succeeded

## Visual review

Please review the desktop rail-to-drawer breakpoint, tool activity summaries versus approvals, mobile session drawer motion, the connected-app approval card, the Action approvals confirmation, and the composer while the system keyboard is shown.