### PR TITLE
fix(tray): Preserve Retina icon rendering

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -169,6 +169,7 @@ import {
   resolveSpriteImpact,
   resolveSpritePerformDone,
 } from "./sprite-travel";
+import { createTrayImage } from "./tray-image";
 
 // Test isolation: E2E/probe runs in the unpackaged dev binary would otherwise
 // share the real "Electron" userData (settings.json included) with a running
@@ -1488,13 +1489,7 @@ function buildTrayContextMenu(): Menu {
 }
 
 function createTray(): void {
-  // Give the Freestyle mark enough presence in system trays while staying
-  // within the standard macOS menu-bar icon height.
-  const trayImage = nativeImage
-    .createFromPath(trayIconPath)
-    .resize({ width: 20, height: 20, quality: "best" });
-  // Mark as template so macOS adapts to menu bar light/dark
-  trayImage.setTemplateImage(true);
+  const trayImage = createTrayImage(nativeImage, trayIconPath);
 
   tray = new Tray(trayImage);
   tray.setToolTip("Freestyle");

--- a/apps/electron/src/main/tray-image.test.ts
+++ b/apps/electron/src/main/tray-image.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { createTrayImage } from "./tray-image";
+
+describe("createTrayImage", () => {
+  it("keeps the native template image intact so macOS can select its Retina representation", () => {
+    let loadedPath: string | undefined;
+    const image = {
+      isTemplate: false,
+      setTemplateImage(template: boolean) {
+        this.isTemplate = template;
+      },
+    };
+
+    const trayImage = createTrayImage(
+      {
+        createFromPath(path) {
+          loadedPath = path;
+          return image;
+        },
+      },
+      "/app/resources/tray/logoTemplate.png",
+    );
+
+    expect(loadedPath).toBe("/app/resources/tray/logoTemplate.png");
+    expect(trayImage).toBe(image);
+    expect(image.isTemplate).toBe(true);
+  });
+});

--- a/apps/electron/src/main/tray-image.ts
+++ b/apps/electron/src/main/tray-image.ts
@@ -1,0 +1,16 @@
+type TemplateImage = {
+  setTemplateImage(template: boolean): void;
+};
+
+/**
+ * Load the template image without resizing it. Electron preserves the adjacent
+ * @2x representation, which lets macOS draw a crisp 16-point menu-bar mark.
+ */
+export function createTrayImage<T extends TemplateImage>(
+  nativeImage: { createFromPath(path: string): T },
+  trayIconPath: string,
+): T {
+  const trayImage = nativeImage.createFromPath(trayIconPath);
+  trayImage.setTemplateImage(true);
+  return trayImage;
+}


### PR DESCRIPTION
Freestyle now keeps its native template tray image at its standard logical size rather than flattening it to 20 physical pixels. This preserves the packaged 1x and Retina @2x representations so the mark remains crisp and correctly sized in macOS menu bars.

The regression test prevents a forced resize from being reintroduced.
