### PR TITLE
feat(chat): Present structured agent turn briefs

### DIFF
--- a/apps/electron/src/renderer/src/components/connect-suggestions.test.ts
+++ b/apps/electron/src/renderer/src/components/connect-suggestions.test.ts
@@ -1,0 +1,42 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@renderer/components/connected-apps", () => ({
+  ApiKeyForm: () => null,
+  ConnectorLogo: ({ name }: { name: string }) =>
+    createElement("span", null, name),
+  DEFAULT_AUTH_FIELDS: [],
+}));
+vi.mock("@renderer/lib/analytics", () => ({ captureSuggestion: vi.fn() }));
+vi.mock("@renderer/lib/connectors", () => ({ disconnectToolkit: vi.fn() }));
+vi.mock("@renderer/lib/use-connector-connect", () => ({
+  useConnectorConnect: () => ({
+    connect: vi.fn(),
+    connectWithCredentials: vi.fn(),
+    cancel: vi.fn(),
+    phases: {},
+    error: null,
+  }),
+}));
+
+import { ConnectSuggestions } from "./connect-suggestions";
+
+describe("ConnectSuggestions", () => {
+  it("keeps connection cards to one primary Connect action", () => {
+    const markup = renderToStaticMarkup(
+      createElement(ConnectSuggestions, {
+        output: {
+          suggestions: [
+            { slug: "google", name: "Google", description: "Search your mail" },
+          ],
+        },
+      }),
+    );
+
+    expect(markup).toContain(">Connect</button>");
+    expect(markup).not.toContain("Not now");
+    expect(markup).not.toContain(">Cancel</button>");
+    expect(markup.match(/<button/g)).toHaveLength(1);
+  });
+});

--- a/apps/electron/src/renderer/src/components/connect-suggestions.tsx
+++ b/apps/electron/src/renderer/src/components/connect-suggestions.tsx
@@ -4,10 +4,7 @@ import {
   DEFAULT_AUTH_FIELDS,
 } from "@renderer/components/connected-apps";
 import { captureSuggestion } from "@renderer/lib/analytics";
-import {
-  type ConnectorAuthField,
-  disconnectToolkit,
-} from "@renderer/lib/connectors";
+import type { ConnectorAuthField } from "@renderer/lib/connectors";
 import { useConnectorConnect } from "@renderer/lib/use-connector-connect";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
@@ -37,20 +34,18 @@ function parseSuggestions(output: unknown): Suggestion[] {
 
 /** Renders a suggest_connections tool result as connect cards instead of the
  * generic tool chip. The part is persisted with the message, so the cards
- * survive reload; dismissal is per-session only. */
+ * survive reload. */
 export function ConnectSuggestions({
   output,
 }: {
   output: unknown;
 }): React.JSX.Element | null {
   const suggestions = parseSuggestions(output);
-  const { connect, connectWithCredentials, cancel, phases, error } =
+  const { connect, connectWithCredentials, phases, error } =
     useConnectorConnect();
-  const [dismissed, setDismissed] = useState<ReadonlySet<string>>(new Set());
   const [keyFormSlug, setKeyFormSlug] = useState<string | null>(null);
   const shownRef = useRef<string | null>(null);
   const connectedRef = useRef<ReadonlySet<string>>(new Set());
-  const visible = suggestions.filter((item) => !dismissed.has(item.slug));
 
   useEffect(() => {
     if (suggestions.length === 0) return;
@@ -77,11 +72,11 @@ export function ConnectSuggestions({
     }
   }, [phases, suggestions]);
 
-  if (visible.length === 0) return null;
+  if (suggestions.length === 0) return null;
 
   return (
     <div className="tavern-connect-cards">
-      {visible.map((suggestion) => {
+      {suggestions.map((suggestion) => {
         const phase = phases[suggestion.slug];
         const apiKey = suggestion.authMode === "api_key";
         return (
@@ -136,25 +131,6 @@ export function ConnectSuggestions({
                         : apiKey
                           ? "Add API key"
                           : "Connect"}
-                </button>
-                <button
-                  type="button"
-                  className="tavern-approve-btn"
-                  onClick={() => {
-                    // Backing out of an in-flight connect must also clear the
-                    // pending row, or the app sticks at "In progress".
-                    if (phase === "pending" || phase === "opening") {
-                      cancel(suggestion.slug);
-                      void disconnectToolkit(suggestion.slug).catch(() => {});
-                    }
-                    captureSuggestion("dismissed", "chat_connect", {
-                      slug: suggestion.slug,
-                      wasPending: phase === "pending" || phase === "opening",
-                    });
-                    setDismissed((prev) => new Set(prev).add(suggestion.slug));
-                  }}
-                >
-                  {phase === "pending" ? "Cancel" : "Not now"}
                 </button>
               </div>
             )}

--- a/apps/electron/src/renderer/src/components/opener-cards.test.ts
+++ b/apps/electron/src/renderer/src/components/opener-cards.test.ts
@@ -1,0 +1,72 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@renderer/components/connected-apps", () => ({
+  ApiKeyForm: () => null,
+  ConnectorLogo: ({ name }: { name: string }) =>
+    createElement("span", null, name),
+  DEFAULT_AUTH_FIELDS: [],
+}));
+vi.mock("@renderer/lib/analytics", () => ({
+  capture: vi.fn(),
+  captureSuggestion: vi.fn(),
+}));
+vi.mock("@renderer/lib/onboarding-core", () => ({ starterPrompts: () => [] }));
+vi.mock("@renderer/lib/openers", () => ({
+  applyOpenerTemplate: vi.fn(),
+  dismissedOpenerIds: () => [],
+  dismissOpener: vi.fn(),
+  fetchOpeners: vi.fn(),
+}));
+vi.mock("@renderer/lib/query", () => ({
+  queryKeys: { openers: ["openers"], scheduled: { tasks: ["scheduled"] } },
+}));
+vi.mock("@renderer/lib/use-connector-connect", () => ({
+  useConnectorConnect: () => ({
+    connect: vi.fn(),
+    connectWithCredentials: vi.fn(),
+    phases: {},
+    error: null,
+  }),
+}));
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({ isPending: false, isError: false, mutate: vi.fn() }),
+  useQuery: () => ({
+    isSuccess: true,
+    isError: false,
+    isFetching: false,
+    data: {
+      cards: [
+        {
+          id: "connect:google",
+          kind: "connect",
+          category: "connect",
+          title: "Connect Google",
+          subtitle: "Search your mail",
+          action: {
+            toolkitSlug: "google",
+            toolkitName: "Google",
+            authMode: "oauth",
+          },
+        },
+      ],
+      todos: [],
+    },
+  }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+import { OpenerCards } from "./opener-cards";
+
+describe("OpenerCards", () => {
+  it("gives a connect opener only its primary connection action", () => {
+    const markup = renderToStaticMarkup(
+      createElement(OpenerCards, { busy: false, onPrompt: vi.fn() }),
+    );
+
+    expect(markup).toContain("Connect Google");
+    expect(markup).not.toContain('aria-label="Dismiss: Connect Google"');
+    expect(markup.match(/<button/g)).toHaveLength(1);
+  });
+});

--- a/apps/electron/src/renderer/src/components/opener-cards.tsx
+++ b/apps/electron/src/renderer/src/components/opener-cards.tsx
@@ -62,7 +62,7 @@ function OpenerRow({
   logoName?: string | undefined;
   busy: boolean;
   onRun: () => void;
-  onDismiss: () => void;
+  onDismiss?: () => void;
   children?: React.ReactNode;
 }): React.JSX.Element {
   return (
@@ -86,14 +86,16 @@ function OpenerRow({
             →
           </span>
         </button>
-        <button
-          type="button"
-          className="tavern-opener-x"
-          aria-label={`Dismiss: ${label}`}
-          onClick={onDismiss}
-        >
-          ×
-        </button>
+        {onDismiss ? (
+          <button
+            type="button"
+            className="tavern-opener-x"
+            aria-label={`Dismiss: ${label}`}
+            onClick={onDismiss}
+          >
+            ×
+          </button>
+        ) : null}
       </div>
       {children}
     </div>
@@ -297,7 +299,6 @@ export function OpenerCards({
                   connect(slug);
                 }
               }}
-              onDismiss={() => dismiss(card)}
             >
               {apiKey && keyFormSlug === slug && phase !== "connected" ? (
                 <div className="tavern-opener-keyform">

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -15,6 +15,11 @@ import { Spark } from "@renderer/components/spark";
 import { ThreadHistory } from "@renderer/components/thread-history";
 import { TodosTab } from "@renderer/components/todos-tab";
 import {
+  agentWorkDuration,
+  toolActivityParts,
+} from "@renderer/lib/agent-activity";
+import { readAgentBrief } from "@renderer/lib/agent-brief";
+import {
   type AgentToolCall,
   agentToolResultTelemetry,
   agentToolTier,
@@ -366,8 +371,10 @@ function ToolChip({
 
 function ToolActivity({
   parts,
+  elapsedMs,
 }: {
   parts: UIMessage["parts"];
+  elapsedMs: number | null;
 }): React.JSX.Element | null {
   const tools = parts.filter(
     (part) =>
@@ -399,7 +406,7 @@ function ToolActivity({
       title: toolPresentation(part.type, phase, tool.input, tool.output).title,
     };
   });
-  const summary = compactActivitySummary(items);
+  const summary = compactActivitySummary(items, elapsedMs);
 
   return (
     <details className="tavern-tool-activity" open={summary.running}>
@@ -408,7 +415,7 @@ function ToolActivity({
           ✦
         </span>
         <span>
-          {summary.running ? "Working · " : "Activity · "}
+          {summary.running ? "Working · " : ""}
           {summary.label}
         </span>
         {summary.running ? (
@@ -431,6 +438,26 @@ function ToolActivity({
         ))}
       </div>
     </details>
+  );
+}
+
+function AgentBriefCard({
+  brief,
+}: {
+  brief: NonNullable<ReturnType<typeof readAgentBrief>>;
+}): React.JSX.Element {
+  return (
+    <section className="tavern-agent-brief" aria-label="Brief">
+      <strong>{brief.headline}</strong>
+      {brief.summary ? <p>{brief.summary}</p> : null}
+      {brief.points.length > 0 ? (
+        <ul>
+          {brief.points.map((point) => (
+            <li key={point}>{point}</li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
   );
 }
 
@@ -528,6 +555,10 @@ function ChatMessage({
   onRegenerate: () => void;
 }): React.JSX.Element {
   const text = messageText(message);
+  const brief = readAgentBrief(message.parts);
+  const activityParts = toolActivityParts(message.parts);
+  const activityAnchor = activityParts[0];
+  const elapsedMs = agentWorkDuration(message.metadata);
   const editInputRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -593,7 +624,8 @@ function ChatMessage({
       <div className="tavern-msg-assistant-content">
         {message.parts.map((part, i) => {
           if (part.type === "text") {
-            if (!part.text || isPlaceholderText(part.text)) return null;
+            if (brief || !part.text || isPlaceholderText(part.text))
+              return null;
             return (
               <div key={`${message.id}-${i}`} className="tavern-msg-assistant">
                 <Markdown text={part.text} />
@@ -610,23 +642,19 @@ function ChatMessage({
               />
             );
           }
+          if (part.type === "data-brief") {
+            return brief ? (
+              <AgentBriefCard key={`${message.id}-${i}`} brief={brief} />
+            ) : null;
+          }
           if (part.type.startsWith("tool-")) {
-            const previous = message.parts[i - 1];
-            if (
-              previous?.type.startsWith("tool-") &&
-              previous.type !== "tool-suggest_connections"
-            )
-              return null;
-            const group: UIMessage["parts"] = [];
-            for (const candidate of message.parts.slice(i)) {
-              if (
-                !candidate.type.startsWith("tool-") ||
-                candidate.type === "tool-suggest_connections"
-              )
-                break;
-              group.push(candidate);
-            }
-            return <ToolActivity key={`${message.id}-${i}`} parts={group} />;
+            return part === activityAnchor ? (
+              <ToolActivity
+                key={`${message.id}-${i}`}
+                parts={activityParts}
+                elapsedMs={elapsedMs}
+              />
+            ) : null;
           }
           return null;
         })}

--- a/apps/electron/src/renderer/src/lib/agent-activity.test.ts
+++ b/apps/electron/src/renderer/src/lib/agent-activity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { agentWorkDuration, toolActivityParts } from "./agent-activity";
+
+describe("toolActivityParts", () => {
+  it("collects every ordinary tool run in one assistant-message activity", () => {
+    const parts = [
+      { type: "tool-web_search" },
+      { type: "text", text: "I found the answer." },
+      { type: "tool-current_time" },
+      { type: "tool-suggest_connections" },
+      { type: "tool-get_context" },
+    ];
+
+    expect(toolActivityParts(parts)).toEqual([
+      { type: "tool-web_search" },
+      { type: "tool-current_time" },
+      { type: "tool-get_context" },
+    ]);
+  });
+
+  it("uses only a complete pair of persisted turn timestamps", () => {
+    expect(
+      agentWorkDuration({
+        agentTurnStartedAt: 1_000,
+        agentTurnCompletedAt: 114_000,
+      }),
+    ).toBe(113_000);
+    expect(agentWorkDuration({ agentTurnStartedAt: 1_000 })).toBeNull();
+  });
+});

--- a/apps/electron/src/renderer/src/lib/agent-activity.ts
+++ b/apps/electron/src/renderer/src/lib/agent-activity.ts
@@ -1,0 +1,28 @@
+type MessagePart = { type?: unknown };
+
+export function toolActivityParts<T extends MessagePart>(
+  parts: readonly T[],
+): T[] {
+  return parts.filter(
+    (part) =>
+      typeof part.type === "string" &&
+      part.type.startsWith("tool-") &&
+      part.type !== "tool-suggest_connections",
+  );
+}
+
+export function agentWorkDuration(metadata: unknown): number | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  const { agentTurnStartedAt, agentTurnCompletedAt } = metadata as {
+    agentTurnStartedAt?: unknown;
+    agentTurnCompletedAt?: unknown;
+  };
+  if (
+    typeof agentTurnStartedAt !== "number" ||
+    typeof agentTurnCompletedAt !== "number" ||
+    !Number.isFinite(agentTurnStartedAt) ||
+    !Number.isFinite(agentTurnCompletedAt)
+  )
+    return null;
+  return Math.max(0, agentTurnCompletedAt - agentTurnStartedAt);
+}

--- a/apps/electron/src/renderer/src/lib/agent-brief.test.ts
+++ b/apps/electron/src/renderer/src/lib/agent-brief.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { readAgentBrief } from "./agent-brief";
+
+describe("readAgentBrief", () => {
+  it("reads the cloud's compact display object and ignores malformed parts", () => {
+    expect(
+      readAgentBrief([
+        { type: "text", text: "Full persisted answer" },
+        {
+          type: "data-brief",
+          data: {
+            headline: "Rain starts at 3 PM.",
+            summary: "Bring an umbrella.",
+            points: ["Carry a compact umbrella"],
+          },
+        },
+      ]),
+    ).toEqual({
+      headline: "Rain starts at 3 PM.",
+      summary: "Bring an umbrella.",
+      points: ["Carry a compact umbrella"],
+    });
+    expect(
+      readAgentBrief([{ type: "data-brief", data: { headline: 3 } }]),
+    ).toBeNull();
+  });
+});

--- a/apps/electron/src/renderer/src/lib/agent-brief.ts
+++ b/apps/electron/src/renderer/src/lib/agent-brief.ts
@@ -1,0 +1,30 @@
+type DataPart = { type?: unknown; data?: unknown; [key: string]: unknown };
+
+export type AgentBrief = {
+  headline: string;
+  summary: string | null;
+  points: string[];
+};
+
+/** Validates the compact display projection while leaving all raw message
+ * parts available for persistence, copy, and future detail views. */
+export function readAgentBrief(parts: readonly DataPart[]): AgentBrief | null {
+  const part = parts.find((candidate) => candidate.type === "data-brief");
+  const data = part?.data;
+  if (!data || typeof data !== "object") return null;
+  const { headline, summary, points } = data as {
+    headline?: unknown;
+    summary?: unknown;
+    points?: unknown;
+  };
+  if (
+    typeof headline !== "string" ||
+    (summary !== null &&
+      summary !== undefined &&
+      typeof summary !== "string") ||
+    !Array.isArray(points) ||
+    !points.every((point) => typeof point === "string")
+  )
+    return null;
+  return { headline, summary: summary ?? null, points };
+}

--- a/apps/electron/src/renderer/src/lib/workspace-navigation.test.ts
+++ b/apps/electron/src/renderer/src/lib/workspace-navigation.test.ts
@@ -31,4 +31,13 @@ describe("compactActivitySummary", () => {
       compactActivitySummary([{ title: "Searched the web", phase: "done" }]),
     ).toEqual({ label: "Searched the web", running: false });
   });
+
+  it("uses the persisted elapsed time as the collapsed work label", () => {
+    expect(
+      compactActivitySummary(
+        [{ title: "Searched the web", phase: "done" }],
+        113_000,
+      ),
+    ).toEqual({ label: "Worked for 1m 53s", running: false });
+  });
 });

--- a/apps/electron/src/renderer/src/lib/workspace-navigation.ts
+++ b/apps/electron/src/renderer/src/lib/workspace-navigation.ts
@@ -18,11 +18,23 @@ export interface ActivitySummaryItem {
  * Keeps a busy agent legible in the transcript: the compact row communicates
  * progress, while its expanded contents retain each request/result.
  */
-export function compactActivitySummary(items: ActivitySummaryItem[]): {
+export function compactActivitySummary(
+  items: ActivitySummaryItem[],
+  elapsedMs?: number | null,
+): {
   label: string;
   running: boolean;
 } {
   const running = items.some((item) => item.phase === "running");
+  if (!running && typeof elapsedMs === "number") {
+    const seconds = Math.floor(elapsedMs / 1_000);
+    const minutes = Math.floor(seconds / 60);
+    const remainder = seconds % 60;
+    return {
+      label: `Worked for ${minutes > 0 ? `${minutes}m ` : ""}${remainder}s`,
+      running,
+    };
+  }
   if (items.length === 1)
     return { label: items[0]?.title ?? "Activity", running };
   return { label: `${items.length} actions`, running };

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -756,6 +756,29 @@
   font-weight: 700;
 }
 
+.tavern-agent-brief {
+  align-self: stretch;
+  border-left: 3px solid var(--tavern-lantern);
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--tavern-parchment) 72%, var(--tavern-card));
+  color: var(--tavern-ink);
+  line-height: 1.5;
+}
+
+.tavern-agent-brief strong {
+  display: block;
+  font-weight: 700;
+}
+
+.tavern-agent-brief p,
+.tavern-agent-brief ul {
+  margin: 5px 0 0;
+}
+
+.tavern-agent-brief ul {
+  padding-left: 17px;
+}
+
 .tavern-stream-wait {
   display: flex;
   padding: 2px 0;


### PR DESCRIPTION
Desktop conversations now render the cloud's persisted `data-brief` display object as a concise highlighted brief. Every ordinary tool call in an assistant message is grouped under a single elapsed-time accordion, while connection suggestions remain separate cards with only the primary connect action.
