### PR TITLE
feat(panel): Polish workspace navigation

### DIFF
--- a/apps/electron/src/renderer/src/components/brain-files.tsx
+++ b/apps/electron/src/renderer/src/components/brain-files.tsx
@@ -328,42 +328,51 @@ export function BrainFiles({
           {...(onOpenThread ? { onOpenThread } : {})}
         />
       ) : null}
-      {filesQuery.isLoading ? (
-        <DataSkeleton label="Loading Brain files" />
-      ) : filesQuery.isError ? (
-        <div className="tavern-empty">
-          <p>Couldn&apos;t load Brain files.</p>
-          <button type="button" onClick={() => void filesQuery.refetch()}>
-            Try again
-          </button>
-        </div>
-      ) : files.length === 0 ? (
-        <div className="tavern-empty">{emptyText}</div>
-      ) : (
-        <div className="tavern-tree">
-          <FileTree
-            dir={buildTree(files)}
-            depth={0}
-            collapsed={collapsed}
-            onToggle={(path) =>
-              setCollapsed((prev) => {
-                const next = new Set(prev);
-                if (next.has(path)) next.delete(path);
-                else next.add(path);
-                return next;
-              })
-            }
-            onOpen={openFile}
-          />
-        </div>
-      )}
-      <button
-        type="button"
-        className="tavern-file-new"
-        onClick={() => setView({ kind: "create", name: "", draft: "" })}
+      <section
+        className={`tavern-brain-files${scheduled ? " has-scheduled" : ""}`}
+        aria-label="Brain files"
       >
-        ＋ {newLabel}
-      </button>
+        <div className="tavern-brain-files-head">
+          <span>Files</span>
+          {filesQuery.isSuccess ? <em>{files.length}</em> : null}
+        </div>
+        {filesQuery.isLoading ? (
+          <DataSkeleton label="Loading Brain files" />
+        ) : filesQuery.isError ? (
+          <div className="tavern-empty">
+            <p>Couldn&apos;t load Brain files.</p>
+            <button type="button" onClick={() => void filesQuery.refetch()}>
+              Try again
+            </button>
+          </div>
+        ) : files.length === 0 ? (
+          <div className="tavern-empty">{emptyText}</div>
+        ) : (
+          <div className="tavern-tree">
+            <FileTree
+              dir={buildTree(files)}
+              depth={0}
+              collapsed={collapsed}
+              onToggle={(path) =>
+                setCollapsed((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(path)) next.delete(path);
+                  else next.add(path);
+                  return next;
+                })
+              }
+              onOpen={openFile}
+            />
+          </div>
+        )}
+        <button
+          type="button"
+          className="tavern-file-new"
+          onClick={() => setView({ kind: "create", name: "", draft: "" })}
+        >
+          + {newLabel}
+        </button>
+      </section>
     </>
   );
 }

--- a/apps/electron/src/renderer/src/components/capabilities.tsx
+++ b/apps/electron/src/renderer/src/components/capabilities.tsx
@@ -29,38 +29,62 @@ export function Capabilities({
   onOpenApps: () => void;
 }): React.JSX.Element {
   const [groups, setGroups] = useState<CapabilityGroup[] | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [loadAttempt, setLoadAttempt] = useState(0);
   const [applied, setApplied] = useState<ReadonlySet<string>>(new Set());
   const [failed, setFailed] = useState<ReadonlySet<string>>(new Set());
 
   useEffect(() => {
     let cancelled = false;
-    void apiFetch("/api/suggestions/capabilities")
-      .then(async (res) =>
-        res.ok
-          ? ((await res.json()) as { groups: CapabilityGroup[] }).groups
-          : [],
-      )
-      .catch(() => [])
-      .then((next) => {
+    if (loadAttempt > 0) setLoadFailed(false);
+    void (async () => {
+      try {
+        const res = await apiFetch("/api/suggestions/capabilities");
+        if (!res.ok)
+          throw new Error(`capabilities fetch failed: ${res.status}`);
+        const payload = (await res.json()) as { groups?: unknown };
+        if (!Array.isArray(payload.groups)) {
+          throw new Error("capabilities response did not include groups");
+        }
+        if (cancelled) return;
+        const next = payload.groups as CapabilityGroup[];
         if (cancelled) return;
         setGroups(next);
+        setLoadFailed(false);
         capture("capabilities_opened", {
           groups: next.map((group) => group.id),
           items: next.reduce((total, group) => total + group.items.length, 0),
         });
-      });
+      } catch {
+        if (cancelled) return;
+        setLoadFailed(true);
+      }
+    })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loadAttempt]);
 
-  if (groups === null) return <div className="tavern-empty">Loading…</div>;
-  if (groups.length === 0)
+  if (loadFailed)
     return (
-      <div className="tavern-empty">
-        Couldn't load this right now. Ask in chat instead.
+      <div className="tavern-empty" role="alert">
+        <p>Couldn&apos;t load the available shortcuts.</p>
+        <button
+          type="button"
+          className="tavern-retry"
+          onClick={() => {
+            setGroups(null);
+            setLoadFailed(false);
+            setLoadAttempt((attempt) => attempt + 1);
+          }}
+        >
+          Try again
+        </button>
       </div>
     );
+  if (groups === null) return <div className="tavern-empty">Loading…</div>;
+  if (groups.length === 0)
+    return <div className="tavern-empty">No shortcuts are available yet.</div>;
 
   const run = (item: CapabilityItem): void => {
     captureSuggestion("accepted", "capability", { id: item.id });

--- a/apps/electron/src/renderer/src/components/connected-apps.tsx
+++ b/apps/electron/src/renderer/src/components/connected-apps.tsx
@@ -28,6 +28,24 @@ import {
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
 
+function SearchIcon(): React.JSX.Element {
+  return (
+    <svg
+      className="connector-search-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.9"
+      strokeLinecap="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <circle cx="10.8" cy="10.8" r="5.8" />
+      <path d="m15.2 15.2 4 4" />
+    </svg>
+  );
+}
+
 export function ConnectorLogo({
   name,
   logo,
@@ -609,7 +627,8 @@ export function ConnectedApps({
     connect(toolkit);
   };
 
-  const searching = search.length > 0;
+  const searching = query.trim().length > 0;
+  const searchPending = searching && search !== query.trim();
 
   const [loadMoreEl, setLoadMoreEl] = useState<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -637,10 +656,12 @@ export function ConnectedApps({
     searching,
   ]);
 
+  // Present the directory as one coherent surface rather than letting each
+  // source shift the page as it happens to arrive.
   const initialLoading =
-    (suggestedQuery.isLoading || connectionsQuery.isLoading) &&
-    connectedItems.length === 0 &&
-    suggested.length === 0;
+    connectionsQuery.isLoading ||
+    suggestedQuery.isLoading ||
+    browseQuery.isLoading;
   const error =
     actionError ??
     connectError ??
@@ -688,9 +709,16 @@ export function ConnectedApps({
     ));
 
   return (
-    <section className="connected-apps" aria-busy={browseQuery.isFetching}>
+    <section
+      className="connected-apps"
+      aria-busy={
+        connectionsQuery.isFetching ||
+        suggestedQuery.isFetching ||
+        browseQuery.isFetching
+      }
+    >
       <label className="connector-search" htmlFor="connector-search">
-        <span aria-hidden="true">⌕</span>
+        <SearchIcon />
         <input
           id="connector-search"
           aria-label="Search all apps"
@@ -742,7 +770,7 @@ export function ConnectedApps({
             <span>Results</span>
             <em>{searchResults.length}</em>
           </div>
-          {searchQuery.isLoading ? (
+          {searchPending || searchQuery.isLoading ? (
             <ConnectedAppsSkeleton />
           ) : searchResults.length > 0 ? (
             <>

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -10,7 +10,11 @@ import { Markdown } from "@renderer/components/markdown";
 import { NotesTab } from "@renderer/components/notes-tab";
 import { OnboardingGate, useOnboarding } from "@renderer/components/onboarding";
 import { OpenerCards } from "@renderer/components/opener-cards";
-import { SettingsView } from "@renderer/components/settings-view";
+import {
+  SETTINGS_PAGE_TITLES,
+  type SettingsPage,
+  SettingsView,
+} from "@renderer/components/settings-view";
 import { Spark } from "@renderer/components/spark";
 import { ThreadHistory } from "@renderer/components/thread-history";
 import { TodosTab } from "@renderer/components/todos-tab";
@@ -58,18 +62,10 @@ import {
   type ToolPhase,
   toolPresentation,
 } from "@renderer/lib/tool-presentation";
-import {
-  compactActivitySummary,
-  workspaceNavigationMode,
-} from "@renderer/lib/workspace-navigation";
+import { compactActivitySummary } from "@renderer/lib/workspace-navigation";
 import { SpriteBadge } from "@renderer/sprites/badge";
 import { type CompanionForm, DEFAULT_COMPANION_FORM } from "@shared/companion";
-import {
-  PANEL_MAX_WIDTH,
-  PANEL_MIN_WIDTH,
-  PANEL_TABS,
-  type PanelTab,
-} from "@shared/panel";
+import { PANEL_MAX_WIDTH, PANEL_MIN_WIDTH, type PanelTab } from "@shared/panel";
 import { SPRITES_INFO } from "@shared/sprites";
 import {
   QueryClientProvider,
@@ -85,16 +81,9 @@ import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 
-const TAB_LABELS: Record<PanelTab, string> = {
-  chat: "Chat",
-  history: "History",
-  todos: "Todos",
-  notes: "Notes",
-  brain: "Brain",
-  apps: "Apps",
-};
+type WorkspaceView = PanelTab;
 
-const TAB_PLACEHOLDER: Record<PanelTab, string> = {
+const TAB_PLACEHOLDER: Record<WorkspaceView, string> = {
   chat: "Ask anything, or point at something on screen.",
   history: "Past conversations land here — pick one to continue it.",
   todos: "Nothing to do yet.",
@@ -104,99 +93,70 @@ const TAB_PLACEHOLDER: Record<PanelTab, string> = {
   apps: "Connect the apps you live in, and Freestyle can work them for you.",
 };
 
-const SECONDARY_TABS = PANEL_TABS.filter(
-  (tab): tab is Exclude<PanelTab, "chat" | "history"> =>
-    tab !== "chat" && tab !== "history",
-);
+type WorkspaceIconName =
+  | "history"
+  | "settings"
+  | "close"
+  | "plus"
+  | "send"
+  | "stop";
+const WORKSPACE_VIEW_LABELS: Record<WorkspaceView, string> = {
+  chat: "Chat",
+  history: "History",
+  todos: "Tasks",
+  notes: "Notes",
+  brain: "Brain",
+  apps: "Apps",
+};
 
-function useWorkspaceNavigationMode(): "rail" | "drawer" {
-  const [mode, setMode] = useState(() =>
-    workspaceNavigationMode(window.innerWidth),
-  );
+const WORKSPACE_TOP_VIEWS: WorkspaceView[] = [
+  "chat",
+  "history",
+  "todos",
+  "notes",
+  "brain",
+  "apps",
+];
 
-  useEffect(() => {
-    const update = (): void =>
-      setMode(workspaceNavigationMode(window.innerWidth));
-    window.addEventListener("resize", update);
-    return () => window.removeEventListener("resize", update);
-  }, []);
-
-  return mode;
-}
-
-function WorkspaceDrawer({
-  title,
-  onClose,
-  children,
+/** A small, consistent icon set for the compact workspace controls. */
+function WorkspaceIcon({
+  name,
 }: {
-  title: string;
-  onClose: () => void;
-  children: React.ReactNode;
+  name: WorkspaceIconName;
 }): React.JSX.Element {
-  const closeRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    closeRef.current?.focus();
-  }, []);
+  const paths: Record<WorkspaceIconName, React.ReactNode> = {
+    history: (
+      <>
+        <path d="M4.5 8.5A8 8 0 1 1 4 13" />
+        <path d="M4 4v4.5h4.5M12 7.5V12l3 2" />
+      </>
+    ),
+    settings: (
+      <>
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.06.06-2.68 2.68-.06-.06a1.7 1.7 0 0 0-1.88-.34 1.7 1.7 0 0 0-1.03 1.56V21h-3.8v-.09a1.7 1.7 0 0 0-1.03-1.56 1.7 1.7 0 0 0-1.88.34l-.06.06-2.68-2.68.06-.06A1.7 1.7 0 0 0 5.12 15a1.7 1.7 0 0 0-1.56-1.03H3.5v-3.8h.06A1.7 1.7 0 0 0 5.12 9.14a1.7 1.7 0 0 0-.34-1.88l-.06-.06 2.68-2.68.06.06a1.7 1.7 0 0 0 1.88.34 1.7 1.7 0 0 0 1.03-1.56V3.3h3.8v.06a1.7 1.7 0 0 0 1.03 1.56 1.7 1.7 0 0 0 1.88-.34l.06-.06 2.68 2.68-.06.06a1.7 1.7 0 0 0-.34 1.88 1.7 1.7 0 0 0 1.56 1.03h.09v3.8h-.09A1.7 1.7 0 0 0 19.4 15Z" />
+      </>
+    ),
+    close: <path d="m7 7 10 10M17 7 7 17" />,
+    plus: <path d="M12 5v14M5 12h14" />,
+    send: <path d="M12 18V6m0 0-4 4m4-4 4 4" />,
+    stop: <rect x="7.5" y="7.5" width="9" height="9" rx="1.2" />,
+  };
 
   return (
-    <div className="tavern-workspace-drawer-layer">
-      <button
-        type="button"
-        className="tavern-workspace-drawer-scrim"
-        aria-label={`Close ${title.toLowerCase()}`}
-        onClick={onClose}
-      />
-      <aside
-        className="tavern-workspace-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label={title}
-        onKeyDown={(event) => {
-          if (event.key !== "Escape") return;
-          event.stopPropagation();
-          onClose();
-        }}
-      >
-        <div className="tavern-workspace-drawer-head">
-          <span>{title}</span>
-          <button
-            ref={closeRef}
-            type="button"
-            className="tavern-close"
-            aria-label={`Close ${title.toLowerCase()}`}
-            onClick={onClose}
-          >
-            ×
-          </button>
-        </div>
-        <div className="tavern-workspace-drawer-body">{children}</div>
-      </aside>
-    </div>
-  );
-}
-
-function SecondaryNavigation({
-  active,
-  onSelect,
-}: {
-  active: PanelTab;
-  onSelect: (tab: Exclude<PanelTab, "chat" | "history">) => void;
-}): React.JSX.Element {
-  return (
-    <nav className="tavern-secondary-nav" aria-label="Workspace tools">
-      <span className="tavern-label">Workspace</span>
-      {SECONDARY_TABS.map((tab) => (
-        <button
-          key={tab}
-          type="button"
-          className={`tavern-secondary-nav-item${active === tab ? " is-active" : ""}`}
-          onClick={() => onSelect(tab)}
-        >
-          {TAB_LABELS[tab]}
-        </button>
-      ))}
-    </nav>
+    <svg
+      className="tavern-workspace-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {paths[name]}
+    </svg>
   );
 }
 
@@ -806,7 +766,7 @@ function SignInGate(): React.JSX.Element {
         aria-label="Close"
         onClick={() => window.api.panelClose()}
       >
-        ×
+        <WorkspaceIcon name="close" />
       </button>
       <div className="tavern-gate-body">
         <div className="tavern-gate-lockup">
@@ -909,9 +869,7 @@ function PanelRoot(): React.JSX.Element {
   }, [latestQuery.data, latestQuery.isPending]);
 
   if (!thread) return <div className="tavern tavern-panel" />;
-  return (
-    <PanelInner key={thread.id} thread={thread} onSwitchThread={switchThread} />
-  );
+  return <PanelInner thread={thread} onSwitchThread={switchThread} />;
 }
 
 function PanelNotificationAuthBridge({
@@ -937,12 +895,7 @@ function PanelInner({
   thread: ThreadState;
   onSwitchThread: (thread: ThreadState) => void;
 }): React.JSX.Element {
-  const [tab, setTab] = useState<PanelTab>("chat");
-  const navigationMode = useWorkspaceNavigationMode();
-  const [railCollapsed, setRailCollapsed] = useState(false);
-  const [historyDrawerOpen, setHistoryDrawerOpen] = useState(false);
-  const [activityDrawerOpen, setActivityDrawerOpen] = useState(false);
-  const [workspaceDrawerOpen, setWorkspaceDrawerOpen] = useState(false);
+  const [tab, setTab] = useState<WorkspaceView>("chat");
   const queryClient = useQueryClient();
   const auth = useCloudAuth();
   const onboarding = useOnboarding(!!auth.user);
@@ -985,6 +938,7 @@ function PanelInner({
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsPage, setSettingsPage] = useState<SettingsPage>("root");
   const [capabilitiesOpen, setCapabilitiesOpen] = useState(false);
   const bodyRef = useRef<HTMLDivElement>(null);
   const dictationBaseRef = useRef<string | null>(null);
@@ -1084,6 +1038,24 @@ function PanelInner({
     },
   });
 
+  const resetThreadRef = useRef(thread.id);
+  useEffect(() => {
+    if (resetThreadRef.current === thread.id) return;
+    resetThreadRef.current = thread.id;
+    setTab("chat");
+    setDraft("");
+    setNotice(null);
+    setApprovals([]);
+    setCopiedMessageId(null);
+    setEditingMessageId(null);
+    setEditDraft("");
+    setSettingsOpen(false);
+    setSettingsPage("root");
+    setCapabilitiesOpen(false);
+    dictationBaseRef.current = null;
+    dictatedRef.current = false;
+  }, [thread.id]);
+
   useEffect(() => {
     if (status === "submitted" || status === "streaming") return;
     if (thread.messages.length > messages.length) setMessages(thread.messages);
@@ -1096,6 +1068,12 @@ function PanelInner({
   }, [durableRuntime.data?.thread, messages.length, setMessages, status]);
 
   const startedRef = useRef(thread.messages.length > 0);
+  const startedThreadRef = useRef(thread.id);
+  useEffect(() => {
+    if (startedThreadRef.current === thread.id) return;
+    startedThreadRef.current = thread.id;
+    startedRef.current = thread.messages.length > 0;
+  }, [thread.id, thread.messages.length]);
   useEffect(() => {
     if (startedRef.current || messages.length === 0) return;
     startedRef.current = true;
@@ -1404,21 +1382,19 @@ function PanelInner({
 
   const chatActive = tab === "chat";
   const showChat = chatActive && messages.length > 0;
-  const selectSecondary = (
-    next: Exclude<PanelTab, "chat" | "history">,
-  ): void => {
-    capture("panel_tab_opened", { tab: next });
+  const startNewChat = (): void => {
+    setTab("chat");
     setSettingsOpen(false);
+    setSettingsPage("root");
     setCapabilitiesOpen(false);
-    setWorkspaceDrawerOpen(false);
-    setTab(next);
-  };
-  const openHistory = (): void => {
-    if (navigationMode === "rail") {
-      setRailCollapsed((collapsed) => !collapsed);
-      return;
-    }
-    setHistoryDrawerOpen(true);
+    setDraft("");
+    setNotice(null);
+    dictationBaseRef.current = null;
+    dictatedRef.current = false;
+    onSwitchThread(newThread());
+    requestAnimationFrame(() =>
+      document.getElementById("panel-composer")?.focus(),
+    );
   };
 
   // Signed out, the gate is the entire panel — no head, no tabs, no way to
@@ -1475,23 +1451,6 @@ function PanelInner({
     <div className="tavern-shell">
       <div className="tavern tavern-panel">
         <div className="tavern-head tavern-workspace-head">
-          <button
-            type="button"
-            className="tavern-workspace-icon-btn"
-            aria-label={
-              navigationMode === "rail"
-                ? railCollapsed
-                  ? "Show conversation history"
-                  : "Collapse conversation history"
-                : "Open conversation history"
-            }
-            aria-expanded={
-              navigationMode === "rail" ? !railCollapsed : historyDrawerOpen
-            }
-            onClick={openHistory}
-          >
-            ☰
-          </button>
           <SpriteBadge form={spriteForm} working={busy} size={22} />
           <span className="tavern-head-name">
             freestyle<i>.</i>
@@ -1528,21 +1487,26 @@ function PanelInner({
           ) : null}
           <button
             type="button"
-            className="tavern-head-new"
-            title="New conversation"
+            className="tavern-workspace-icon-btn"
+            aria-label="Start new chat"
+            title="New chat"
             disabled={pinned}
-            onClick={() => onSwitchThread(newThread())}
+            onClick={startNewChat}
           >
-            ＋ New chat
+            <WorkspaceIcon name="plus" />
           </button>
           <button
             type="button"
             className="tavern-workspace-icon-btn"
-            aria-label="Open activity"
-            aria-expanded={activityDrawerOpen}
-            onClick={() => setActivityDrawerOpen(true)}
+            aria-label="Open conversations"
+            aria-pressed={tab === "history"}
+            onClick={() => {
+              setSettingsOpen(false);
+              setSettingsPage("root");
+              setTab("history");
+            }}
           >
-            ◷
+            <WorkspaceIcon name="history" />
           </button>
           <button
             type="button"
@@ -1551,10 +1515,13 @@ function PanelInner({
             aria-pressed={settingsOpen}
             onClick={() => {
               setCapabilitiesOpen(false);
-              setSettingsOpen((open) => !open);
+              setSettingsOpen((open) => {
+                if (open) setSettingsPage("root");
+                return !open;
+              });
             }}
           >
-            ⚙
+            <WorkspaceIcon name="settings" />
           </button>
           <button
             type="button"
@@ -1562,50 +1529,59 @@ function PanelInner({
             aria-label="Close"
             onClick={() => window.api.panelClose()}
           >
-            ×
+            <WorkspaceIcon name="close" />
           </button>
         </div>
         <div className="tavern-workspace">
-          {navigationMode === "rail" && !railCollapsed ? (
-            <aside
-              className="tavern-history-rail"
-              aria-label="Conversation history"
-            >
-              <button
-                type="button"
-                className="tavern-history-new"
-                disabled={pinned}
-                onClick={() => onSwitchThread(newThread())}
-              >
-                ＋ New chat
-              </button>
-              <div className="tavern-history-rail-list">
-                <ThreadHistory
-                  currentId={thread.id}
-                  onPick={(picked) => {
-                    setTab("chat");
-                    if (picked.id !== thread.id) onSwitchThread(picked);
-                  }}
-                />
-              </div>
-              <SecondaryNavigation active={tab} onSelect={selectSecondary} />
-            </aside>
-          ) : null}
           <div className="tavern-workspace-main">
-            <div className="tavern-workspace-mobile-tools">
-              <button type="button" onClick={openHistory}>
-                Conversations
-              </button>
-              <button type="button" onClick={() => setActivityDrawerOpen(true)}>
-                Activity
-              </button>
-              <button
-                type="button"
-                onClick={() => setWorkspaceDrawerOpen(true)}
+            {settingsOpen ? (
+              <div className="tavern-settings-context">
+                <div className="tavern-settings-context-path">
+                  {settingsPage === "root" ? (
+                    <span>Settings</span>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => setSettingsPage("root")}
+                      >
+                        Settings
+                      </button>
+                      <span aria-hidden="true">/</span>
+                      <strong>{SETTINGS_PAGE_TITLES[settingsPage]}</strong>
+                    </>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSettingsOpen(false);
+                    setSettingsPage("root");
+                  }}
+                >
+                  Done
+                </button>
+              </div>
+            ) : (
+              <nav
+                className="tavern-workspace-mobile-tools"
+                aria-label="Workspace"
               >
-                Workspace
-              </button>
-            </div>
+                {WORKSPACE_TOP_VIEWS.map((view) => (
+                  <button
+                    key={view}
+                    type="button"
+                    role="tab"
+                    aria-selected={tab === view}
+                    onClick={() => setTab(view)}
+                  >
+                    {view === "history"
+                      ? "Conversations"
+                      : WORKSPACE_VIEW_LABELS[view]}
+                  </button>
+                ))}
+              </nav>
+            )}
             <div
               className="tavern-body tavern-conversation"
               role="tabpanel"
@@ -1634,9 +1610,11 @@ function PanelInner({
                 </>
               ) : settingsOpen ? (
                 <SettingsView
-                  onClose={() => setSettingsOpen(false)}
+                  page={settingsPage}
+                  onPageChange={setSettingsPage}
                   onOpenThread={(threadId) => {
                     setSettingsOpen(false);
+                    setSettingsPage("root");
                     setTab("chat");
                     void openThreadById(threadId).then((picked) => {
                       if (picked) onSwitchThread(picked);
@@ -1649,6 +1627,14 @@ function PanelInner({
                   onReplayIntro={() => {
                     setSettingsOpen(false);
                     onboarding.replay();
+                  }}
+                />
+              ) : tab === "history" ? (
+                <ThreadHistory
+                  currentId={thread.id}
+                  onPick={(picked) => {
+                    setTab("chat");
+                    if (picked.id !== thread.id) onSwitchThread(picked);
                   }}
                 />
               ) : tab === "apps" ? (
@@ -1840,63 +1826,13 @@ function PanelInner({
                   title={action === "stop" ? "Stop generating" : "Send"}
                   onClick={action === "stop" ? stopGeneration : send}
                 >
-                  {action === "stop" ? "■" : "↑"}
+                  <WorkspaceIcon name={action === "stop" ? "stop" : "send"} />
                 </button>
               </div>
             ) : null}
           </div>
         </div>
       </div>
-      {navigationMode === "drawer" && historyDrawerOpen ? (
-        <WorkspaceDrawer
-          title="Conversations"
-          onClose={() => setHistoryDrawerOpen(false)}
-        >
-          <button
-            type="button"
-            className="tavern-history-new"
-            disabled={pinned}
-            onClick={() => {
-              setHistoryDrawerOpen(false);
-              onSwitchThread(newThread());
-            }}
-          >
-            ＋ New chat
-          </button>
-          <ThreadHistory
-            currentId={thread.id}
-            onPick={(picked) => {
-              setHistoryDrawerOpen(false);
-              setTab("chat");
-              if (picked.id !== thread.id) onSwitchThread(picked);
-            }}
-          />
-        </WorkspaceDrawer>
-      ) : null}
-      {activityDrawerOpen ? (
-        <WorkspaceDrawer
-          title="Activity"
-          onClose={() => setActivityDrawerOpen(false)}
-        >
-          <ThreadHistory
-            currentId={thread.id}
-            initialOrigin="scheduled"
-            onPick={(picked) => {
-              setActivityDrawerOpen(false);
-              setTab("chat");
-              if (picked.id !== thread.id) onSwitchThread(picked);
-            }}
-          />
-        </WorkspaceDrawer>
-      ) : null}
-      {workspaceDrawerOpen ? (
-        <WorkspaceDrawer
-          title="Workspace"
-          onClose={() => setWorkspaceDrawerOpen(false)}
-        >
-          <SecondaryNavigation active={tab} onSelect={selectSecondary} />
-        </WorkspaceDrawer>
-      ) : null}
       <PanelTail />
       <PanelResizeHandle />
     </div>

--- a/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
+++ b/apps/electron/src/renderer/src/components/scheduled-tasks.tsx
@@ -468,7 +468,7 @@ export function ScheduledTasks({
       {refreshFailed}
       {runNotices(tasks.map((t) => t.id))}
       {tasks.length === 0 ? (
-        <div className="tavern-empty">
+        <div className="tavern-empty tavern-sched-empty">
           Nothing scheduled. Ask {mascot} to do something regularly — "check the
           stocks every weekday morning" — and it lands here.
         </div>
@@ -509,7 +509,7 @@ export function ScheduledTasks({
       )}
       <button
         type="button"
-        className="tavern-file-new"
+        className="tavern-file-new tavern-sched-new"
         onClick={() => setView({ kind: "create", draft: emptyDraft() })}
       >
         ＋ New scheduled task

--- a/apps/electron/src/renderer/src/components/settings-view.tsx
+++ b/apps/electron/src/renderer/src/components/settings-view.tsx
@@ -46,7 +46,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-type SettingsPage =
+export type SettingsPage =
   | "root"
   | "profile"
   | "billing"
@@ -57,7 +57,10 @@ type SettingsPage =
   | "permissions"
   | "data";
 
-const PAGE_TITLES: Record<Exclude<SettingsPage, "root">, string> = {
+export const SETTINGS_PAGE_TITLES: Record<
+  Exclude<SettingsPage, "root">,
+  string
+> = {
   profile: "Profile",
   billing: "Billing & Usage",
   notifications: "Notifications",
@@ -1513,17 +1516,18 @@ function DataPage({
 }
 
 export function SettingsView({
-  onClose,
+  page,
+  onPageChange: setPage,
   onThreadsCleared,
   onReplayIntro,
   onOpenThread,
 }: {
-  onClose: () => void;
+  page: SettingsPage;
+  onPageChange: (page: SettingsPage) => void;
   onThreadsCleared: () => void;
   onReplayIntro: () => void;
   onOpenThread?: (threadId: string) => void;
 }): React.JSX.Element {
-  const [page, setPage] = useState<SettingsPage>("root");
   const { settings, setSetting } = useServerSettings();
   const auth = useCloudAuth();
   const usage = useCloudUsage(!!auth.user);
@@ -1545,13 +1549,6 @@ export function SettingsView({
   if (page !== "root") {
     return (
       <>
-        <button
-          type="button"
-          className="tavern-file-back"
-          onClick={() => setPage("root")}
-        >
-          ← {PAGE_TITLES[page]}
-        </button>
         {page === "profile" ? (
           <ProfilePage />
         ) : page === "billing" ? (
@@ -1599,9 +1596,6 @@ export function SettingsView({
 
   return (
     <>
-      <button type="button" className="tavern-file-back" onClick={onClose}>
-        ← Settings
-      </button>
       <AccountCard onOpenProfile={() => setPage("profile")} />
       <NavRow
         label="Billing & Usage"

--- a/apps/electron/src/renderer/src/components/thread-history.tsx
+++ b/apps/electron/src/renderer/src/components/thread-history.tsx
@@ -67,7 +67,7 @@ export function ThreadHistory({
     return (
       <>
         {filter}
-        <div className="tavern-empty">
+        <div className="tavern-empty tavern-thread-empty">
           {origin === "user" ? "Loading conversations…" : "Loading activity…"}
         </div>
       </>
@@ -76,10 +76,15 @@ export function ThreadHistory({
     return (
       <>
         {filter}
-        <div className="tavern-empty">
-          {origin === "user"
-            ? "No conversations yet."
-            : "No briefs yet. Scheduled tasks write what they find here."}
+        <div className="tavern-empty tavern-thread-empty">
+          <strong>
+            {origin === "user" ? "No conversations yet" : "No briefs yet"}
+          </strong>
+          <span>
+            {origin === "user"
+              ? "Start a chat and it will be saved here."
+              : "Scheduled tasks will add their updates here."}
+          </span>
         </div>
       </>
     );

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -179,27 +179,6 @@
   color: var(--tavern-lantern);
 }
 
-.tavern-head-new {
-  font: inherit;
-  font-size: 12.5px;
-  font-weight: 700;
-  border: none;
-  background: none;
-  color: var(--tavern-mute);
-  cursor: pointer;
-  padding: 2px 4px;
-  white-space: nowrap;
-}
-
-.tavern-head-new:hover:not(:disabled) {
-  color: var(--tavern-ink);
-}
-
-.tavern-head-new:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
 .tavern-head-update {
   font: inherit;
   font-size: 11.5px;
@@ -452,6 +431,30 @@
   text-align: center;
   font-size: 12px;
   color: var(--tavern-mute);
+}
+
+.tavern-empty > p {
+  margin: 0 0 10px;
+}
+
+.tavern-retry {
+  font: inherit;
+  font-size: 12px;
+  color: var(--tavern-ink);
+  background: var(--tavern-parchment);
+  border: 1px solid var(--tavern-rule);
+  border-radius: 7px;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+.tavern-retry:hover {
+  background: var(--tavern-wash);
+}
+
+.tavern-retry:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: 2px;
 }
 
 .tavern-msg-user {
@@ -904,6 +907,11 @@
   border-color: var(--tavern-mute);
 }
 
+.tavern-file-new:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: 2px;
+}
+
 .tavern-todo {
   display: flex;
   align-items: center;
@@ -1179,30 +1187,46 @@
 }
 
 .tavern-btn {
-  width: 31px;
-  height: 31px;
-  border-radius: 9px;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
   display: grid;
   place-items: center;
-  font-size: 14px;
   flex: none;
   background: var(--tavern-parchment);
   border: 1px solid var(--tavern-rule);
-  /* gamified: the send key is solid ink */
   color: var(--tavern-mute);
   cursor: pointer;
+  transition: transform 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.tavern-btn .tavern-workspace-icon {
+  width: 17px;
+  height: 17px;
+  stroke-width: 2.2;
 }
 
 .tavern-btn-send {
   background: var(--tavern-ink);
   color: var(--tavern-parchment);
   border-color: var(--tavern-ink);
+  box-shadow: 0 1px 2px rgba(42, 33, 20, .22);
+}
+
+.tavern-btn-send:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--tavern-ink) 88%, var(--tavern-lantern));
+  box-shadow: 0 3px 7px rgba(42, 33, 20, .2);
+}
+
+.tavern-btn:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: 2px;
 }
 
 .tavern-btn-send.is-stop {
   background: var(--tavern-rust);
   border-color: var(--tavern-rust);
-  font-size: 11px;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1373,16 +1397,21 @@
 
 .tavern-thread-filter {
   display: flex;
-  gap: 6px;
-  margin-bottom: 10px;
+  gap: 2px;
+  width: fit-content;
+  margin-bottom: 2px;
+  padding: 3px;
+  border: 1px solid var(--tavern-rule);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--tavern-wash) 42%, var(--tavern-card));
 }
 
 .tavern-thread-filter-tab {
   font: inherit;
   font-size: 11.5px;
-  padding: 3px 10px;
-  border-radius: 999px;
-  border: 1px solid var(--tavern-rule);
+  padding: 4px 9px;
+  border-radius: 7px;
+  border: 1px solid transparent;
   background: none;
   color: var(--tavern-mute);
   cursor: pointer;
@@ -1393,10 +1422,11 @@
 }
 
 .tavern-thread-filter-tab[aria-selected="true"] {
-  background: var(--tavern-wash);
-  border-color: var(--tavern-ink);
+  background: var(--tavern-card);
+  border-color: color-mix(in srgb, var(--tavern-rule) 82%, var(--tavern-card));
   color: var(--tavern-ink);
   font-weight: 700;
+  box-shadow: 0 1px 2px rgba(42, 33, 20, .11);
 }
 
 .tavern-thread-filter-tab:focus-visible {
@@ -1421,10 +1451,10 @@
 .tavern-thread-row {
   font: inherit;
   text-align: left;
-  padding: 6px 11px;
-  border: 1px solid var(--tavern-rule);
-  border-radius: 8px;
-  background: var(--tavern-parchment);
+  padding: 8px 9px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
   color: var(--tavern-ink);
   cursor: pointer;
   overflow: hidden;
@@ -1433,17 +1463,33 @@
   flex-shrink: 0;
 }
 
-.tavern-thread-row + .tavern-thread-row {
-  margin-top: -5px;
-}
-
 .tavern-thread-row:hover {
-  background: var(--tavern-wash);
+  background: color-mix(in srgb, var(--tavern-wash) 68%, var(--tavern-card));
 }
 
 .tavern-thread-row.is-current {
-  border: 2px solid var(--tavern-ink);
-  box-shadow: 2px 2px 0 var(--tavern-lantern);
+  border-color: var(--tavern-rule);
+  background: var(--tavern-wash);
+  box-shadow: inset 3px 0 0 var(--tavern-lantern);
+  font-weight: 700;
+}
+
+.tavern-thread-empty {
+  display: grid;
+  place-items: center;
+  gap: 4px;
+  min-height: 88px;
+  padding: 18px;
+  background: color-mix(in srgb, var(--tavern-card) 68%, var(--tavern-parchment));
+}
+
+.tavern-thread-empty strong {
+  color: var(--tavern-ink);
+  font-size: 12.5px;
+}
+
+.tavern-thread-empty span {
+  max-width: 210px;
 }
 
 .tavern-head-spacer {
@@ -1451,8 +1497,8 @@
 }
 
 /* Conversation-first workspace ------------------------------------------------
-   The paper panel stays recognizably Freestyle, but conversation content now
-   gets the calm reading column. Navigation retreats to a rail or drawer. */
+   Sections replace the reading surface in place; navigation stays in one
+   compact, persistent tab row. */
 .tavern-workspace-head {
   gap: 7px;
   padding-bottom: 11px;
@@ -1467,12 +1513,16 @@
   flex: none;
   padding: 0;
   border: 1px solid var(--tavern-rule);
-  border-radius: 8px;
-  background: var(--tavern-card);
+  border-radius: 7px;
+  background: transparent;
   color: var(--tavern-mute);
   cursor: pointer;
-  font-family: var(--tavern-mono);
-  font-size: 14px;
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+}
+
+.tavern-workspace-icon {
+  width: 15px;
+  height: 15px;
 }
 
 .tavern-workspace-icon-btn:hover,
@@ -1483,9 +1533,7 @@
 }
 
 .tavern-workspace-icon-btn:focus-visible,
-.tavern-workspace-mobile-tools button:focus-visible,
-.tavern-secondary-nav-item:focus-visible,
-.tavern-history-new:focus-visible {
+.tavern-workspace-mobile-tools button:focus-visible {
   outline: 2px solid var(--tavern-lantern);
   outline-offset: 2px;
 }
@@ -1508,151 +1556,96 @@
   padding: 20px clamp(16px, 4vw, 36px);
 }
 
-.tavern-history-rail {
+.tavern-workspace-mobile-tools {
   display: flex;
-  width: 190px;
-  min-width: 190px;
-  min-height: 0;
-  flex-direction: column;
-  gap: 10px;
-  padding: 12px;
-  border-right: 1px solid var(--tavern-rule);
-  background: color-mix(in srgb, var(--tavern-wash) 54%, var(--tavern-card));
+  align-items: center;
+  gap: 3px;
+  overflow-x: auto;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--tavern-rule);
+  scrollbar-width: none;
 }
 
-.tavern-history-new {
-  width: 100%;
-  border: 1px solid var(--tavern-ink);
-  border-radius: 8px;
-  padding: 7px 9px;
-  background: var(--tavern-lantern);
-  box-shadow: 2px 2px 0 var(--tavern-ink);
-  color: var(--tavern-card);
-  cursor: pointer;
-  font: inherit;
-  font-size: 11.5px;
+.tavern-workspace-mobile-tools::-webkit-scrollbar { display: none; }
+
+.tavern-settings-context {
+  display: flex;
+  min-height: 37px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--tavern-rule);
+}
+
+.tavern-settings-context-path {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.tavern-settings-context-path > span,
+.tavern-settings-context-path strong {
+  color: var(--tavern-ink);
+  font-size: 11px;
   font-weight: 700;
 }
 
-.tavern-history-new:disabled {
-  cursor: default;
-  opacity: .5;
-}
-
-.tavern-history-rail-list,
-.tavern-workspace-drawer-body {
-  display: flex;
-  min-height: 0;
-  flex: 1;
-  flex-direction: column;
-  overflow-y: auto;
-}
-
-.tavern-history-rail-list .tavern-thread-row {
-  padding: 5px 8px;
-  font-size: 11.5px;
-}
-
-.tavern-history-rail-list .tavern-thread-filter {
-  gap: 4px;
-}
-
-.tavern-history-rail-list .tavern-thread-filter-tab {
-  padding: 3px 7px;
-  font-size: 10px;
-}
-
-.tavern-secondary-nav {
-  display: grid;
-  gap: 3px;
-  border-top: 1px solid var(--tavern-rule);
-  padding-top: 9px;
-}
-
-.tavern-secondary-nav .tavern-label {
-  margin: 0 4px 2px;
-  font-size: 9px;
-}
-
-.tavern-secondary-nav-item {
+.tavern-settings-context-path > button,
+.tavern-settings-context > button {
   border: 0;
-  border-radius: 6px;
-  padding: 5px 7px;
+  padding: 5px 0;
   background: none;
   color: var(--tavern-mute);
   cursor: pointer;
   font: inherit;
-  font-size: 11.5px;
-  text-align: left;
+  font-size: 11px;
+  font-weight: 700;
 }
 
-.tavern-secondary-nav-item:hover,
-.tavern-secondary-nav-item.is-active {
-  background: var(--tavern-card);
+.tavern-settings-context-path > button:hover,
+.tavern-settings-context > button:hover {
   color: var(--tavern-ink);
 }
 
-.tavern-workspace-mobile-tools {
-  display: none;
+.tavern-settings-context-path > button:focus-visible,
+.tavern-settings-context > button:focus-visible {
+  outline: 2px solid var(--tavern-lantern);
+  outline-offset: 2px;
 }
 
-.tavern-workspace-drawer-layer {
-  position: absolute;
-  inset: 0;
-  z-index: 20;
-}
-
-.tavern-workspace-drawer-scrim {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+.tavern-workspace-mobile-tools button {
+  position: relative;
+  flex: 0 0 auto;
   border: 0;
-  background: rgba(42, 33, 20, .24);
-  cursor: default;
+  padding: 11px 7px 10px;
+  background: none;
+  color: var(--tavern-mute);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  line-height: 1;
+  white-space: nowrap;
 }
 
-.tavern-workspace-drawer {
+.tavern-workspace-mobile-tools button:hover,
+.tavern-workspace-mobile-tools button[aria-selected="true"] {
+  color: var(--tavern-ink);
+}
+
+.tavern-workspace-mobile-tools button[aria-selected="true"] {
+  font-weight: 700;
+}
+
+.tavern-workspace-mobile-tools button[aria-selected="true"]::after {
   position: absolute;
-  top: 8px;
-  bottom: 8px;
-  left: 8px;
-  display: flex;
-  width: min(292px, calc(100% - 16px));
-  flex-direction: column;
-  overflow: hidden;
-  border: 2px solid var(--tavern-ink);
-  border-radius: 13px;
-  background: var(--tavern-card);
-  box-shadow: 5px 5px 0 rgba(42, 33, 20, .72);
-  animation: tavern-workspace-drawer-in 160ms ease-out;
-}
-
-@keyframes tavern-workspace-drawer-in {
-  from { transform: translateX(-12px); opacity: 0; }
-  to { transform: translateX(0); opacity: 1; }
-}
-
-.tavern-workspace-drawer-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 13px 9px;
-  border-bottom: 1px solid var(--tavern-rule);
-  font-family: var(--tavern-px);
-  font-size: 15px;
-}
-
-.tavern-workspace-drawer-body {
-  gap: 10px;
-  padding: 12px;
-}
-
-.tavern-workspace-drawer-body .tavern-secondary-nav {
-  flex: 1;
-  align-content: start;
-  border-top: 0;
-  padding-top: 0;
+  right: 7px;
+  bottom: -1px;
+  left: 7px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--tavern-lantern);
+  content: "";
 }
 
 .tavern-tool-activity {
@@ -1688,46 +1681,43 @@
 
 @media (max-width: 639px) {
   .tavern-workspace-mobile-tools {
-    display: flex;
-    gap: 6px;
-    padding: 7px 14px;
-    border-bottom: 1px solid var(--tavern-rule);
+    padding: 0 10px;
+  }
+
+  .tavern-settings-context {
+    padding: 0 10px;
   }
 
   .tavern-workspace-mobile-tools button {
-    border: 0;
-    padding: 0;
-    background: none;
-    color: var(--tavern-mute);
-    cursor: pointer;
-    font: inherit;
     font-size: 10.5px;
   }
 
   .tavern-conversation { padding: 16px; }
-  .tavern-head-new { display: none; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .tavern-workspace-drawer { animation: none; }
 }
 
 .tavern-close {
+  box-sizing: border-box;
   width: 24px;
   height: 24px;
   flex: none;
   display: grid;
   place-items: center;
-  border: none;
+  padding: 0;
+  border: 1px solid transparent;
   border-radius: 7px;
   background: transparent;
   color: var(--tavern-mute);
-  font-size: 17px;
-  line-height: 1;
   cursor: pointer;
 }
 
+.tavern-close .tavern-workspace-icon {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+
 .tavern-close:hover {
+  border-color: var(--tavern-rule);
   background: var(--tavern-wash);
   color: var(--tavern-ink);
 }
@@ -1740,6 +1730,8 @@
 .tavern-tree {
   display: flex;
   flex-direction: column;
+  gap: 1px;
+  padding: 3px 0;
 }
 
 .tavern-tree-row {
@@ -1749,7 +1741,8 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 3px 8px;
+  min-height: 28px;
+  padding: 4px 8px;
   border: none;
   border-radius: 6px;
   background: none;
@@ -1766,6 +1759,7 @@
 
 .tavern-tree-dir {
   font-weight: 700;
+  letter-spacing: .01em;
 }
 
 .tavern-tree-caret {
@@ -2323,11 +2317,11 @@
   box-shadow: 0 0 0 2px #d98e2b24;
 }
 
-.connector-search > span {
+.connector-search-icon {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
   color: var(--tavern-mute);
-  font-family: var(--tavern-mono);
-  font-size: 16px;
-  line-height: 1;
 }
 
 .connector-search input {
@@ -3840,7 +3834,51 @@
 }
 
 .tavern-sched-section {
-  margin-bottom: 14px;
+  margin-bottom: 20px;
+}
+
+.tavern-sched-empty {
+  line-height: 1.45;
+}
+
+.tavern-sched-new {
+  margin-top: 10px;
+}
+
+.tavern-brain-files {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tavern-brain-files.has-scheduled {
+  padding-top: 1px;
+}
+
+.tavern-brain-files-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 1px 1px;
+  color: var(--tavern-mute);
+  font-family: var(--tavern-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+.tavern-brain-files-head em {
+  min-width: 17px;
+  border-radius: 999px;
+  padding: 1px 5px;
+  background: var(--tavern-wash);
+  color: var(--tavern-mute);
+  font-family: inherit;
+  font-size: 9px;
+  font-style: normal;
+  letter-spacing: 0;
+  text-align: center;
 }
 
 .tavern-sched-label {
@@ -4179,10 +4217,10 @@
   color: #a04d3c;
 }
 
-/* ── Experiment: wider panel, two-column app grid ─────────────────────── */
+/* ── Apps directory: compact, single-column rows ───────────────────────── */
 
 .connector-group {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   gap: 8px;
 }
 
@@ -4193,13 +4231,13 @@
 }
 
 .connector-card {
-  grid-template-columns: minmax(0, 1fr);
-  align-content: start;
-  row-gap: 8px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 10px;
 }
 
 .connector-card .connector-action {
-  width: 100%;
+  width: auto;
 }
 
 /* ── Cancel/remove for stuck connections ─────────────────────────────── */
@@ -4273,7 +4311,7 @@
   color: var(--tavern-lantern);
 }
 
-/* ── Experiment: tighter cards for the narrower two-column grid ──────── */
+/* ── Tighter app-card details ─────────────────────────────────────────── */
 
 .connector-card {
   padding: 8px;

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -99,8 +99,10 @@ const apiRouter = new Hono()
   .route("/dismissed-notifications", dismissedNotifications)
   .route("/vocabulary", vocabulary)
   .route("/post-process", postProcessRoute)
-  .route("/agent", agentRoute)
+  // This must precede /agent: that router has a dynamic /thread/:threadId
+  // route which would otherwise treat the literal "list" and "latest" as ids.
   .route("/agent/thread", agentThreadsRoute)
+  .route("/agent", agentRoute)
   .route("/agent-os", agentOsRoute)
   .route("/brain", brainRoute)
   .route("/notifications", notificationsRoute)

--- a/apps/server/tests/agent-threads-proxy.test.ts
+++ b/apps/server/tests/agent-threads-proxy.test.ts
@@ -5,11 +5,13 @@ vi.mock("../src/lib/sessions.js", () => ({
   invalidateSession: vi.fn(),
 }));
 
-vi.mock("../src/lib/freestyle-cloud.js", () => ({
+vi.mock("../src/lib/freestyle-cloud.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/lib/freestyle-cloud.js")>()),
   freestyleCloudUrl: () => "https://cloud.test",
 }));
 
 import agentThreadsRoute from "../src/routes/agent-threads.js";
+import routes from "../src/routes/index.js";
 
 describe("agent thread list proxy", () => {
   afterEach(() => {
@@ -36,5 +38,29 @@ describe("agent thread list proxy", () => {
       limit: "24",
       cursor: "1700000000000",
     });
+  });
+
+  it("reserves list and latest before the generic thread snapshot route", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ threads: [], nextCursor: null }), {
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await routes.request("/api/agent/thread/list?origin=user");
+
+    expect(res.status).toBe(200);
+    expect(new URL(fetchMock.mock.calls[0][0] as string).pathname).toBe(
+      "/v2/threads",
+    );
+
+    const latest = await routes.request("/api/agent/thread/latest");
+
+    expect(latest.status).toBe(200);
+    expect(new URL(fetchMock.mock.calls[1][0] as string).pathname).toBe(
+      "/v2/threads/latest",
+    );
   });
 });

--- a/apps/server/tests/suggestions-proxy.test.ts
+++ b/apps/server/tests/suggestions-proxy.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import createApp from "../src/index.js";
+import { freestyleCloudUrl } from "../src/lib/freestyle-cloud.js";
+import { clearSession, setSession } from "../src/lib/sessions.js";
+
+const app = createApp();
+
+afterEach(() => {
+  clearSession();
+  vi.unstubAllGlobals();
+});
+
+describe("suggestions proxy", () => {
+  it("requires the server-owned Freestyle Cloud session", async () => {
+    const response = await app.request("/api/suggestions/capabilities");
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "cloud_auth_required",
+    });
+  });
+
+  it("forwards the capabilities request to Cloud", async () => {
+    setSession({
+      token: "cloud-session",
+      user: { id: "user-1", email: "user@example.com" },
+      host: freestyleCloudUrl(),
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ groups: [] }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/suggestions/capabilities");
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${freestyleCloudUrl()}/v2/suggestions/capabilities`,
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer cloud-session",
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- replace side drawers with in-place workspace pages and a persistent active-chat tab
- refine settings breadcrumbs, conversation history, Brain, Apps, and control icons
- repair agent-thread routing and make the capabilities failure state actionable

## Validation
- pnpm test (full workspace: 59 server files / 419 tests; 36 Electron files / 143 tests)
- pnpm --filter @freestyle-voice/electron typecheck:web
- Biome check and git diff --check