### PR TITLE
feat: add Electron local-first sync foundation

### DIFF
--- a/apps/electron/src/renderer/src/dashboard.tsx
+++ b/apps/electron/src/renderer/src/dashboard.tsx
@@ -16,6 +16,7 @@ import {
   installGlobalErrorHandlers,
   reportError,
 } from "@renderer/lib/report-error";
+import { startSyncInvalidation } from "@renderer/lib/sync-events";
 import {
   DEFAULT_WORKSPACE,
   isWorkspace,
@@ -82,6 +83,11 @@ function ThemePreferenceBridge(): React.JSX.Element | null {
     appliedPreference.current = preference;
   }, [preference, setTheme]);
 
+  return null;
+}
+
+function SyncInvalidationBridge(): React.JSX.Element | null {
+  useEffect(() => startSyncInvalidation(queryClient), []);
   return null;
 }
 
@@ -267,6 +273,7 @@ function mount(): void {
             >
               <QueryClientProvider client={queryClient}>
                 <ThemePreferenceBridge />
+                <SyncInvalidationBridge />
                 <TooltipProvider>
                   <CloudAuthProvider>
                     <RemixSessionProvider>

--- a/apps/electron/src/renderer/src/lib/sync-events.ts
+++ b/apps/electron/src/renderer/src/lib/sync-events.ts
@@ -1,0 +1,45 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { getApiBase, resolveApiBase } from "./api";
+import { queryKeys } from "./query";
+
+type SyncEvent = { resource: string; entityId?: string };
+
+const resourceKeys: Record<string, readonly unknown[]> = {
+  "brain-list": queryKeys.brain.all,
+  "brain-file": queryKeys.brain.all,
+  "thread-summary": queryKeys.threads.all,
+  "thread-snapshot": queryKeys.threads.all,
+  schedules: queryKeys.scheduled.tasks,
+  connectors: queryKeys.connectors.all,
+  usage: queryKeys.cloud.usage,
+  attention: queryKeys.attention,
+  suggestions: queryKeys.openers,
+  config: queryKeys.cloud.config,
+  pricing: queryKeys.cloud.pricing,
+  profile: queryKeys.cloud.orgs,
+};
+
+/** Opens the local-only stream that makes background cache refreshes visible. */
+export function startSyncInvalidation(queryClient: QueryClient): () => void {
+  let source: EventSource | null = null;
+  let closed = false;
+  void resolveApiBase().then(() => {
+    if (closed || !getApiBase().startsWith("http://127.0.0.1")) return;
+    source = new EventSource(`${getApiBase()}/api/sync/events`);
+    source.addEventListener("sync", (message) => {
+      try {
+        const event = JSON.parse(
+          (message as MessageEvent<string>).data,
+        ) as SyncEvent;
+        const queryKey = resourceKeys[event.resource];
+        if (queryKey) void queryClient.invalidateQueries({ queryKey });
+      } catch {
+        // A malformed local event must never break the renderer's query cache.
+      }
+    });
+  });
+  return () => {
+    closed = true;
+    source?.close();
+  };
+}

--- a/apps/electron/src/renderer/src/lib/sync-events.ts
+++ b/apps/electron/src/renderer/src/lib/sync-events.ts
@@ -1,8 +1,13 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { getApiBase, resolveApiBase } from "./api";
+import { resetBrainCache } from "./brain-fs";
 import { queryKeys } from "./query";
 
-type SyncEvent = { resource: string; entityId?: string };
+type SyncEvent = {
+  resource: string;
+  entityId?: string;
+  source?: "local" | "remote";
+};
 
 const resourceKeys: Record<string, readonly unknown[]> = {
   "brain-list": queryKeys.brain.all,
@@ -33,6 +38,12 @@ export function startSyncInvalidation(queryClient: QueryClient): () => void {
         ) as SyncEvent;
         const queryKey = resourceKeys[event.resource];
         if (queryKey) void queryClient.invalidateQueries({ queryKey });
+        if (
+          event.source === "remote" &&
+          (event.resource === "brain-file" || event.resource === "brain-list")
+        ) {
+          resetBrainCache();
+        }
       } catch {
         // A malformed local event must never break the renderer's query cache.
       }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -29,6 +29,7 @@
     "@ai-sdk/mistral": "^3.0.37",
     "@ai-sdk/openai": "^3.0.65",
     "@freestyle-voice/stt": "workspace:*",
+    "@freestyle-voice/sync": "workspace:*",
     "@freestyle-voice/validations": "workspace:*",
     "@hono/node-server": "^2.0.4",
     "@hono/zod-validator": "^0.8.0",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -40,12 +40,14 @@ import {
   startOutboxDrain,
   stopOutboxDrain,
 } from "./lib/sync-outbox.js";
+import { resolveSyncScope } from "./lib/sync-scope.js";
 import { syncTimezoneToCloud } from "./lib/timezone-sync.js";
 import {
   isTrustedRendererOrigin,
   trustedOriginMiddleware,
 } from "./lib/trusted-origin.js";
 import routes from "./routes";
+import { drainBrainOperations } from "./routes/brain.js";
 
 const httpLog = createAppLogger("http");
 
@@ -244,6 +246,9 @@ export async function startServer(
   // pending local change is never overwritten by the copy it was meant to
   // update. Both are no-ops when signed out and never throw.
   void drainOutbox().then(() => pullCloudPreferences());
+  void resolveSyncScope().then((scope) => {
+    if (scope) void drainBrainOperations(scope);
+  });
 
   // Keep the cloud profile's timezone current so scheduled tasks fire on this
   // machine's clock. No-op when signed out or unchanged; never throws.

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -47,7 +47,11 @@ import {
   trustedOriginMiddleware,
 } from "./lib/trusted-origin.js";
 import routes from "./routes";
-import { drainBrainOperations } from "./routes/brain.js";
+import {
+  drainBrainOperations,
+  startBrainSyncDrain,
+  stopBrainSyncDrain,
+} from "./routes/brain.js";
 
 const httpLog = createAppLogger("http");
 
@@ -75,6 +79,7 @@ async function shutdownServer(): Promise<void> {
   stopSessionKeepAlive();
   stopHistoryRetentionSweep();
   stopOutboxDrain();
+  stopBrainSyncDrain();
   await disposeServerPlugins().catch(() => {});
   await shutdownSentry();
 }
@@ -249,6 +254,7 @@ export async function startServer(
   void resolveSyncScope().then((scope) => {
     if (scope) void drainBrainOperations(scope);
   });
+  startBrainSyncDrain();
 
   // Keep the cloud profile's timezone current so scheduled tasks fire on this
   // machine's clock. No-op when signed out or unchanged; never throws.

--- a/apps/server/src/lib/cloud-cache.ts
+++ b/apps/server/src/lib/cloud-cache.ts
@@ -1,0 +1,85 @@
+import { getDb } from "./db.js";
+import { emitSyncEvent } from "./sync-events.js";
+import { cachedSyncScope, resolveSyncScope } from "./sync-scope.js";
+import { LocalSyncStore } from "./sync-store.js";
+
+/**
+ * Caches a Cloud JSON read in the current account/org namespace.  It is kept
+ * at the local-server boundary so renderers neither see the Cloud bearer nor
+ * know about SQLite.
+ */
+export async function cachedCloudJson<T>(input: {
+  resource: string;
+  id: string;
+  maxAgeMs: number;
+  load: () => Promise<T>;
+}): Promise<T> {
+  const scope = cachedSyncScope() ?? (await resolveSyncScope());
+  return readThroughCloudCache({
+    store: new LocalSyncStore(getDb()),
+    scope,
+    resource: input.resource,
+    id: input.id,
+    maxAgeMs: input.maxAgeMs,
+    load: input.load,
+  });
+}
+
+export async function readThroughCloudCache<T>(input: {
+  store: LocalSyncStore;
+  scope: string | null;
+  resource: string;
+  id: string;
+  maxAgeMs: number;
+  load: () => Promise<T>;
+}): Promise<T> {
+  const cached = input.scope
+    ? input.store.readCached(input.scope, input.resource, input.id)
+    : null;
+  const isFresh =
+    cached !== null &&
+    Date.now() - Date.parse(cached.fetchedAt) < input.maxAgeMs;
+  if (cached !== null && isFresh) return cached.value as T;
+  if (cached !== null) {
+    void refresh(input);
+    return cached.value as T;
+  }
+  const value = await input.load();
+  if (input.scope) {
+    input.store.writeCached({
+      scope: input.scope,
+      resource: input.resource,
+      id: input.id,
+      value,
+    });
+    input.store.markRefreshed(input.scope, input.resource);
+  }
+  return value;
+}
+
+async function refresh<T>(input: {
+  store: LocalSyncStore;
+  scope: string | null;
+  resource: string;
+  id: string;
+  load: () => Promise<T>;
+}): Promise<void> {
+  if (!input.scope) return;
+  try {
+    const value = await input.load();
+    input.store.writeCached({
+      scope: input.scope,
+      resource: input.resource,
+      id: input.id,
+      value,
+    });
+    input.store.markRefreshed(input.scope, input.resource);
+    emitSyncEvent({ resource: input.resource, entityId: input.id });
+  } catch (error) {
+    input.store.markRefreshed(
+      input.scope,
+      input.resource,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -7,7 +7,7 @@ import { countFixes } from "./fixes.js";
 // and would otherwise perturb test module-mock ordering.
 const DEFAULT_CLOUD_URL = "https://service.freestylevoice.com";
 
-const SCHEMA_VERSION = 29;
+const SCHEMA_VERSION = 30;
 
 // Legacy default format-rule patterns (used only by pre-v12 migrations below):
 // domain/phrase entries match as substrings of url+title+app; bare words match
@@ -769,6 +769,48 @@ function applyMigrations(db: DatabaseSync, currentVersion: number): void {
         updated_at INTEGER NOT NULL,
         PRIMARY KEY(connection_id, original_name)
       );
+    `);
+  }
+
+  if (currentVersion < 30) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS sync_entities (
+        scope TEXT NOT NULL,
+        resource TEXT NOT NULL,
+        entity_id TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        revision INTEGER,
+        fetched_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        deleted_at TEXT,
+        PRIMARY KEY (scope, resource, entity_id)
+      );
+      CREATE TABLE IF NOT EXISTS sync_resource_state (
+        scope TEXT NOT NULL,
+        resource TEXT NOT NULL,
+        cursor TEXT,
+        last_refresh_at TEXT,
+        last_error TEXT,
+        PRIMARY KEY (scope, resource)
+      );
+      CREATE TABLE IF NOT EXISTS sync_operations (
+        operation_id TEXT PRIMARY KEY,
+        scope TEXT NOT NULL,
+        resource TEXT NOT NULL,
+        entity_id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        expected_revision INTEGER,
+        state TEXT NOT NULL,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        next_attempt_at TEXT NOT NULL,
+        last_error TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_sync_operations_due ON sync_operations (scope, state, next_attempt_at);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_operations_entity
+        ON sync_operations (scope, resource, entity_id);
     `);
   }
 

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -7,7 +7,7 @@ import { countFixes } from "./fixes.js";
 // and would otherwise perturb test module-mock ordering.
 const DEFAULT_CLOUD_URL = "https://service.freestylevoice.com";
 
-const SCHEMA_VERSION = 30;
+const SCHEMA_VERSION = 31;
 
 // Legacy default format-rule patterns (used only by pre-v12 migrations below):
 // domain/phrase entries match as substrings of url+title+app; bare words match
@@ -811,6 +811,18 @@ function applyMigrations(db: DatabaseSync, currentVersion: number): void {
       CREATE INDEX IF NOT EXISTS idx_sync_operations_due ON sync_operations (scope, state, next_attempt_at);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_operations_entity
         ON sync_operations (scope, resource, entity_id);
+    `);
+  }
+
+  if (currentVersion < 31) {
+    // v30 allowed only one operation per entity. That let a later local edit
+    // replace an in-flight request and reach Cloud out of order.
+    db.exec(`
+      DROP INDEX IF EXISTS idx_sync_operations_entity;
+      ALTER TABLE sync_operations
+        ADD COLUMN sequence INTEGER NOT NULL DEFAULT 0;
+      CREATE INDEX IF NOT EXISTS idx_sync_operations_entity_order
+        ON sync_operations (scope, resource, entity_id, sequence);
     `);
   }
 

--- a/apps/server/src/lib/sync-events.ts
+++ b/apps/server/src/lib/sync-events.ts
@@ -1,0 +1,14 @@
+export type SyncEvent = { resource: string; entityId?: string };
+
+const listeners = new Set<(event: SyncEvent) => void>();
+
+export function emitSyncEvent(event: SyncEvent): void {
+  for (const listener of listeners) listener(event);
+}
+
+export function subscribeSyncEvents(
+  listener: (event: SyncEvent) => void,
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/apps/server/src/lib/sync-events.ts
+++ b/apps/server/src/lib/sync-events.ts
@@ -1,4 +1,8 @@
-export type SyncEvent = { resource: string; entityId?: string };
+export type SyncEvent = {
+  resource: string;
+  entityId?: string;
+  source?: "local" | "remote";
+};
 
 const listeners = new Set<(event: SyncEvent) => void>();
 

--- a/apps/server/src/lib/sync-scope.ts
+++ b/apps/server/src/lib/sync-scope.ts
@@ -16,9 +16,15 @@ export function cachedSyncScope(): string | null {
 export async function resolveSyncScope(): Promise<string | null> {
   const session = getSession();
   if (!session) return null;
-  const organizationId = await resolveActiveOrgId(session.token);
-  if (!organizationId) return null;
-  const scope = syncScopeKey({ userId: session.user.id, organizationId });
-  writeSetting(settingKey(session.host, session.user.id), scope);
-  return scope;
+  try {
+    const organizationId = await resolveActiveOrgId(session.token);
+    if (!organizationId) return null;
+    const scope = syncScopeKey({ userId: session.user.id, organizationId });
+    writeSetting(settingKey(session.host, session.user.id), scope);
+    return scope;
+  } catch {
+    // Scope resolution is a cache optimization. It must not turn a public
+    // config request or a normal Cloud request into a local-server failure.
+    return null;
+  }
 }

--- a/apps/server/src/lib/sync-scope.ts
+++ b/apps/server/src/lib/sync-scope.ts
@@ -1,0 +1,24 @@
+import { syncScopeKey } from "@freestyle-voice/sync";
+import { readSetting, writeSetting } from "./db.js";
+import { resolveActiveOrgId } from "./freestyle-cloud.js";
+import { getSession } from "./sessions.js";
+
+function settingKey(host: string, userId: string): string {
+  return `sync_scope:${host}:${userId}`;
+}
+
+export function cachedSyncScope(): string | null {
+  const session = getSession();
+  if (!session) return null;
+  return readSetting(settingKey(session.host, session.user.id)) ?? null;
+}
+
+export async function resolveSyncScope(): Promise<string | null> {
+  const session = getSession();
+  if (!session) return null;
+  const organizationId = await resolveActiveOrgId(session.token);
+  if (!organizationId) return null;
+  const scope = syncScopeKey({ userId: session.user.id, organizationId });
+  writeSetting(settingKey(session.host, session.user.id), scope);
+  return scope;
+}

--- a/apps/server/src/lib/sync-store.ts
+++ b/apps/server/src/lib/sync-store.ts
@@ -1,0 +1,290 @@
+import type { DatabaseSync } from "node:sqlite";
+
+export type CachedRecord = {
+  value: unknown;
+  revision: number | null;
+  fetchedAt: string;
+};
+export type PendingSyncOperation = {
+  operationId: string;
+  resource: string;
+  entityId: string;
+  kind: "write" | "delete";
+  payload: unknown;
+  expectedRevision: number | null;
+  attempts: number;
+};
+
+const BODY_RESOURCES = new Set(["brain-file", "thread-snapshot"]);
+const BODY_CACHE_LIMIT_BYTES = 100 * 1024 * 1024;
+
+export class LocalSyncStore {
+  constructor(private readonly db: DatabaseSync) {}
+
+  writeCached(input: {
+    scope: string;
+    resource: string;
+    id: string;
+    value: unknown;
+    revision?: number | null;
+  }): void {
+    this.db
+      .prepare(
+        `INSERT INTO sync_entities (scope, resource, entity_id, payload, revision, fetched_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+       ON CONFLICT(scope, resource, entity_id) DO UPDATE SET payload = excluded.payload, revision = excluded.revision, fetched_at = excluded.fetched_at, updated_at = excluded.updated_at, deleted_at = NULL`,
+      )
+      .run(
+        input.scope,
+        input.resource,
+        input.id,
+        JSON.stringify(input.value),
+        input.revision ?? null,
+      );
+    if (BODY_RESOURCES.has(input.resource)) this.evictBodies();
+  }
+
+  readCached(scope: string, resource: string, id: string): CachedRecord | null {
+    const row = this.db
+      .prepare(
+        "SELECT payload, revision, fetched_at FROM sync_entities WHERE scope = ? AND resource = ? AND entity_id = ? AND deleted_at IS NULL",
+      )
+      .get(scope, resource, id) as
+      | { payload: string; revision: number | null; fetched_at: string }
+      | undefined;
+    return row
+      ? {
+          value: JSON.parse(row.payload),
+          revision: row.revision,
+          fetchedAt: row.fetched_at,
+        }
+      : null;
+  }
+
+  enqueue(input: {
+    scope: string;
+    resource: string;
+    entityId: string;
+    kind: "write" | "delete";
+    payload: unknown;
+    expectedRevision?: number | null;
+  }): string {
+    const operationId = crypto.randomUUID();
+    this.db
+      .prepare(
+        `INSERT INTO sync_operations (operation_id, scope, resource, entity_id, kind, payload, expected_revision, state, next_attempt_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', datetime('now'), datetime('now'), datetime('now'))
+       ON CONFLICT(scope, resource, entity_id) DO UPDATE SET
+         operation_id = excluded.operation_id,
+         kind = excluded.kind,
+         payload = excluded.payload,
+         expected_revision = excluded.expected_revision,
+         state = 'pending',
+         attempts = 0,
+         next_attempt_at = datetime('now'),
+         last_error = NULL,
+         updated_at = datetime('now')`,
+      )
+      .run(
+        operationId,
+        input.scope,
+        input.resource,
+        input.entityId,
+        input.kind,
+        JSON.stringify(input.payload),
+        input.expectedRevision ?? null,
+      );
+    return operationId;
+  }
+
+  /** Atomically changes the local replica and durable operation queue. */
+  writeAndEnqueue(input: {
+    scope: string;
+    resource: string;
+    entityId: string;
+    kind: "write" | "delete";
+    value: unknown;
+    expectedRevision?: number | null;
+  }): string {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      this.writeCached({
+        scope: input.scope,
+        resource: input.resource,
+        id: input.entityId,
+        value: input.value,
+        revision: input.expectedRevision,
+      });
+      const operationId = this.enqueue({
+        scope: input.scope,
+        resource: input.resource,
+        entityId: input.entityId,
+        kind: input.kind,
+        payload: input.value,
+        expectedRevision: input.expectedRevision,
+      });
+      this.db.exec("COMMIT");
+      return operationId;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  /** Atomically hides a locally cached entity and queues its remote deletion. */
+  deleteAndEnqueue(input: {
+    scope: string;
+    resource: string;
+    entityId: string;
+    expectedRevision?: number | null;
+  }): string {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      this.db
+        .prepare(
+          `UPDATE sync_entities SET deleted_at = datetime('now'), updated_at = datetime('now')
+         WHERE scope = ? AND resource = ? AND entity_id = ?`,
+        )
+        .run(input.scope, input.resource, input.entityId);
+      const operationId = this.enqueue({
+        scope: input.scope,
+        resource: input.resource,
+        entityId: input.entityId,
+        kind: "delete",
+        payload: { path: input.entityId },
+        expectedRevision: input.expectedRevision,
+      });
+      this.db.exec("COMMIT");
+      return operationId;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  dueOperations(scope: string): PendingSyncOperation[] {
+    const rows = this.db
+      .prepare(
+        `SELECT operation_id, resource, entity_id, kind, payload, expected_revision, attempts
+       FROM sync_operations
+       WHERE scope = ? AND state = 'pending' AND next_attempt_at <= datetime('now')
+       ORDER BY created_at ASC`,
+      )
+      .all(scope) as Array<{
+      operation_id: string;
+      resource: string;
+      entity_id: string;
+      kind: "write" | "delete";
+      payload: string;
+      expected_revision: number | null;
+      attempts: number;
+    }>;
+    return rows.map((row) => ({
+      operationId: row.operation_id,
+      resource: row.resource,
+      entityId: row.entity_id,
+      kind: row.kind,
+      payload: JSON.parse(row.payload),
+      expectedRevision: row.expected_revision,
+      attempts: row.attempts,
+    }));
+  }
+
+  completeOperation(operationId: string): void {
+    this.db
+      .prepare("DELETE FROM sync_operations WHERE operation_id = ?")
+      .run(operationId);
+  }
+
+  deferOperation(
+    operationId: string,
+    attempts: number,
+    delayMs: number,
+    error: string,
+  ): void {
+    this.db
+      .prepare(
+        `UPDATE sync_operations SET attempts = ?, state = 'pending', next_attempt_at = datetime('now', ?), last_error = ?, updated_at = datetime('now') WHERE operation_id = ?`,
+      )
+      .run(
+        attempts,
+        `+${Math.max(1, Math.round(delayMs / 1000))} seconds`,
+        error,
+        operationId,
+      );
+  }
+
+  failOperation(operationId: string, error: string): void {
+    this.db
+      .prepare(
+        "UPDATE sync_operations SET state = 'failed', last_error = ?, updated_at = datetime('now') WHERE operation_id = ?",
+      )
+      .run(error, operationId);
+  }
+
+  markRefreshed(scope: string, resource: string, error?: string): void {
+    this.db
+      .prepare(
+        `INSERT INTO sync_resource_state (scope, resource, last_refresh_at, last_error)
+       VALUES (?, ?, datetime('now'), ?)
+       ON CONFLICT(scope, resource) DO UPDATE SET last_refresh_at = excluded.last_refresh_at, last_error = excluded.last_error`,
+      )
+      .run(scope, resource, error ?? null);
+  }
+
+  getStatus(scope: string): { pending: number; failed: number } {
+    const row = this.db
+      .prepare(
+        "SELECT SUM(state IN ('pending', 'syncing')) AS pending, SUM(state = 'failed') AS failed FROM sync_operations WHERE scope = ?",
+      )
+      .get(scope) as { pending: number | null; failed: number | null };
+    return { pending: row.pending ?? 0, failed: row.failed ?? 0 };
+  }
+
+  clearScope(scope: string): void {
+    this.db.exec("BEGIN");
+    try {
+      this.db.prepare("DELETE FROM sync_entities WHERE scope = ?").run(scope);
+      this.db
+        .prepare("DELETE FROM sync_resource_state WHERE scope = ?")
+        .run(scope);
+      this.db.prepare("DELETE FROM sync_operations WHERE scope = ?").run(scope);
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  private evictBodies(): void {
+    const total = this.db
+      .prepare(
+        `SELECT COALESCE(SUM(length(payload)), 0) AS bytes FROM sync_entities
+       WHERE resource IN ('brain-file', 'thread-snapshot') AND deleted_at IS NULL`,
+      )
+      .get() as { bytes: number };
+    let excess = total.bytes - BODY_CACHE_LIMIT_BYTES;
+    if (excess <= 0) return;
+    const rows = this.db
+      .prepare(
+        `SELECT scope, resource, entity_id, length(payload) AS bytes FROM sync_entities
+       WHERE resource IN ('brain-file', 'thread-snapshot') AND deleted_at IS NULL
+       ORDER BY updated_at ASC`,
+      )
+      .all() as Array<{
+      scope: string;
+      resource: string;
+      entity_id: string;
+      bytes: number;
+    }>;
+    for (const row of rows) {
+      this.db
+        .prepare(
+          "DELETE FROM sync_entities WHERE scope = ? AND resource = ? AND entity_id = ?",
+        )
+        .run(row.scope, row.resource, row.entity_id);
+      excess -= row.bytes;
+      if (excess <= 0) return;
+    }
+  }
+}

--- a/apps/server/src/lib/sync-store.ts
+++ b/apps/server/src/lib/sync-store.ts
@@ -15,6 +15,8 @@ export type PendingSyncOperation = {
   attempts: number;
 };
 
+type BrainListFile = { path: string; size: number; modified: number };
+
 const BODY_RESOURCES = new Set(["brain-file", "thread-snapshot"]);
 const BODY_CACHE_LIMIT_BYTES = 100 * 1024 * 1024;
 
@@ -70,20 +72,26 @@ export class LocalSyncStore {
     expectedRevision?: number | null;
   }): string {
     const operationId = crypto.randomUUID();
+    // An operation being sent must remain the head of its entity's queue. Only
+    // a tail that has not left this process is safe to coalesce.
     this.db
       .prepare(
-        `INSERT INTO sync_operations (operation_id, scope, resource, entity_id, kind, payload, expected_revision, state, next_attempt_at, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', datetime('now'), datetime('now'), datetime('now'))
-       ON CONFLICT(scope, resource, entity_id) DO UPDATE SET
-         operation_id = excluded.operation_id,
-         kind = excluded.kind,
-         payload = excluded.payload,
-         expected_revision = excluded.expected_revision,
-         state = 'pending',
-         attempts = 0,
-         next_attempt_at = datetime('now'),
-         last_error = NULL,
-         updated_at = datetime('now')`,
+        `DELETE FROM sync_operations
+         WHERE scope = ? AND resource = ? AND entity_id = ?
+           AND state IN ('pending', 'failed')`,
+      )
+      .run(input.scope, input.resource, input.entityId);
+    const nextSequence = this.db
+      .prepare(
+        `SELECT COALESCE(MAX(sequence), 0) + 1 AS sequence
+         FROM sync_operations
+         WHERE scope = ? AND resource = ? AND entity_id = ?`,
+      )
+      .get(input.scope, input.resource, input.entityId) as { sequence: number };
+    this.db
+      .prepare(
+        `INSERT INTO sync_operations (operation_id, scope, resource, entity_id, kind, payload, expected_revision, sequence, state, next_attempt_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', datetime('now'), datetime('now'), datetime('now'))`,
       )
       .run(
         operationId,
@@ -93,6 +101,7 @@ export class LocalSyncStore {
         input.kind,
         JSON.stringify(input.payload),
         input.expectedRevision ?? null,
+        nextSequence.sequence,
       );
     return operationId;
   }
@@ -140,10 +149,14 @@ export class LocalSyncStore {
   }): string {
     this.db.exec("BEGIN IMMEDIATE");
     try {
+      // Keep a tombstone even when the body was never cached. List projection
+      // needs it to hide a remote file immediately after a local deletion.
       this.db
         .prepare(
-          `UPDATE sync_entities SET deleted_at = datetime('now'), updated_at = datetime('now')
-         WHERE scope = ? AND resource = ? AND entity_id = ?`,
+          `INSERT INTO sync_entities (scope, resource, entity_id, payload, fetched_at, updated_at, deleted_at)
+           VALUES (?, ?, ?, '{}', datetime('now'), datetime('now'), datetime('now'))
+           ON CONFLICT(scope, resource, entity_id) DO UPDATE SET
+             deleted_at = datetime('now'), updated_at = datetime('now')`,
         )
         .run(input.scope, input.resource, input.entityId);
       const operationId = this.enqueue({
@@ -190,10 +203,160 @@ export class LocalSyncStore {
     }));
   }
 
-  completeOperation(operationId: string): void {
+  /**
+   * Atomically claims at most one due operation per entity. A successor never
+   * leaves the durable queue until its predecessor has completed or been
+   * explicitly superseded by a new user action.
+   */
+  claimDueOperations(scope: string, resource?: string): PendingSyncOperation[] {
+    const resourceClause = resource ? " AND o.resource = ?" : "";
+    const params = resource ? [scope, resource] : [scope];
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const rows = this.db
+        .prepare(
+          `SELECT o.operation_id, o.resource, o.entity_id, o.kind, o.payload, o.expected_revision, o.attempts
+           FROM sync_operations o
+           WHERE o.scope = ? AND o.state = 'pending'
+             AND o.next_attempt_at <= datetime('now')${resourceClause}
+             AND NOT EXISTS (
+               SELECT 1 FROM sync_operations predecessor
+               WHERE predecessor.scope = o.scope
+                 AND predecessor.resource = o.resource
+                 AND predecessor.entity_id = o.entity_id
+                 AND predecessor.sequence < o.sequence
+                 AND predecessor.state IN ('pending', 'syncing', 'failed')
+             )
+           ORDER BY o.created_at ASC, o.sequence ASC, o.rowid ASC`,
+        )
+        .all(...params) as Array<{
+        operation_id: string;
+        resource: string;
+        entity_id: string;
+        kind: "write" | "delete";
+        payload: string;
+        expected_revision: number | null;
+        attempts: number;
+      }>;
+      const claim = this.db.prepare(
+        `UPDATE sync_operations
+         SET state = 'syncing', updated_at = datetime('now')
+         WHERE operation_id = ? AND state = 'pending'`,
+      );
+      const claimed = rows.filter(
+        (row) => claim.run(row.operation_id).changes === 1,
+      );
+      this.db.exec("COMMIT");
+      return claimed.map((row) => ({
+        operationId: row.operation_id,
+        resource: row.resource,
+        entityId: row.entity_id,
+        kind: row.kind,
+        payload: JSON.parse(row.payload),
+        expectedRevision: row.expected_revision,
+        attempts: row.attempts,
+      }));
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  /** Reclaims work that was in flight when a previous server process exited. */
+  recoverSyncingOperations(scope: string, resource: string): void {
     this.db
-      .prepare("DELETE FROM sync_operations WHERE operation_id = ?")
-      .run(operationId);
+      .prepare(
+        `UPDATE sync_operations
+         SET state = 'pending', next_attempt_at = datetime('now'),
+             last_error = 'server-restarted', updated_at = datetime('now')
+         WHERE scope = ? AND resource = ? AND state = 'syncing'`,
+      )
+      .run(scope, resource);
+  }
+
+  completeOperation(operationId: string, revision?: number): void {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const operation = this.db
+        .prepare(
+          `SELECT scope, resource, entity_id FROM sync_operations
+           WHERE operation_id = ? AND state = 'syncing'`,
+        )
+        .get(operationId) as
+        | { scope: string; resource: string; entity_id: string }
+        | undefined;
+      if (!operation) {
+        this.db.exec("COMMIT");
+        return;
+      }
+      this.db
+        .prepare("DELETE FROM sync_operations WHERE operation_id = ?")
+        .run(operationId);
+      if (typeof revision === "number") {
+        this.db
+          .prepare(
+            `UPDATE sync_entities SET revision = ?, updated_at = datetime('now')
+             WHERE scope = ? AND resource = ? AND entity_id = ?`,
+          )
+          .run(
+            revision,
+            operation.scope,
+            operation.resource,
+            operation.entity_id,
+          );
+        this.db
+          .prepare(
+            `UPDATE sync_operations SET expected_revision = ?, updated_at = datetime('now')
+             WHERE operation_id = (
+               SELECT operation_id FROM sync_operations
+               WHERE scope = ? AND resource = ? AND entity_id = ? AND state = 'pending'
+               ORDER BY sequence ASC LIMIT 1
+             )`,
+          )
+          .run(
+            revision,
+            operation.scope,
+            operation.resource,
+            operation.entity_id,
+          );
+      }
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  hasQueuedSuccessor(operationId: string): boolean {
+    const row = this.db
+      .prepare(
+        `SELECT EXISTS (
+           SELECT 1 FROM sync_operations successor
+           JOIN sync_operations operation
+             ON operation.scope = successor.scope
+            AND operation.resource = successor.resource
+            AND operation.entity_id = successor.entity_id
+           WHERE operation.operation_id = ?
+             AND successor.sequence > operation.sequence
+             AND successor.state IN ('pending', 'syncing')
+         ) AS exists`,
+      )
+      .get(operationId) as { exists: number };
+    return row.exists === 1;
+  }
+
+  updateCachedRevision(input: {
+    scope: string;
+    resource: string;
+    id: string;
+    revision: number;
+  }): void {
+    this.db
+      .prepare(
+        `UPDATE sync_entities SET revision = ?, updated_at = datetime('now')
+         WHERE scope = ? AND resource = ? AND entity_id = ?`,
+      )
+      .run(input.revision, input.scope, input.resource, input.id);
   }
 
   deferOperation(
@@ -204,7 +367,7 @@ export class LocalSyncStore {
   ): void {
     this.db
       .prepare(
-        `UPDATE sync_operations SET attempts = ?, state = 'pending', next_attempt_at = datetime('now', ?), last_error = ?, updated_at = datetime('now') WHERE operation_id = ?`,
+        `UPDATE sync_operations SET attempts = ?, state = 'pending', next_attempt_at = datetime('now', ?), last_error = ?, updated_at = datetime('now') WHERE operation_id = ? AND state = 'syncing'`,
       )
       .run(
         attempts,
@@ -217,7 +380,7 @@ export class LocalSyncStore {
   failOperation(operationId: string, error: string): void {
     this.db
       .prepare(
-        "UPDATE sync_operations SET state = 'failed', last_error = ?, updated_at = datetime('now') WHERE operation_id = ?",
+        "UPDATE sync_operations SET state = 'failed', last_error = ?, updated_at = datetime('now') WHERE operation_id = ? AND state = 'syncing'",
       )
       .run(error, operationId);
   }
@@ -254,6 +417,94 @@ export class LocalSyncStore {
       this.db.exec("ROLLBACK");
       throw error;
     }
+  }
+
+  clearBrain(scope: string): void {
+    this.db.exec("BEGIN");
+    try {
+      this.db
+        .prepare(
+          "DELETE FROM sync_entities WHERE scope = ? AND resource IN ('brain-file', 'brain-list', 'brain-graph')",
+        )
+        .run(scope);
+      this.db
+        .prepare(
+          "DELETE FROM sync_resource_state WHERE scope = ? AND resource IN ('brain-file', 'brain-list', 'brain-graph')",
+        )
+        .run(scope);
+      this.db
+        .prepare(
+          "DELETE FROM sync_operations WHERE scope = ? AND resource IN ('brain-file', 'brain-list', 'brain-graph')",
+        )
+        .run(scope);
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  getBrainStatus(scope: string): { pending: number; failed: number } {
+    const row = this.db
+      .prepare(
+        `SELECT SUM(state IN ('pending', 'syncing')) AS pending,
+                SUM(state = 'failed') AS failed
+         FROM sync_operations
+         WHERE scope = ? AND resource = 'brain-file'`,
+      )
+      .get(scope) as { pending: number | null; failed: number | null };
+    return { pending: row.pending ?? 0, failed: row.failed ?? 0 };
+  }
+
+  applyBrainListMutation(input: {
+    scope: string;
+    kind: "write" | "delete";
+    path: string;
+    text?: string;
+  }): void {
+    const cached = this.readCached(input.scope, "brain-list", "all");
+    if (!cached || typeof cached.value !== "object" || cached.value === null) {
+      return;
+    }
+    const payload = cached.value as Record<string, unknown>;
+    const files = new Map<string, BrainListFile>();
+    const remoteFiles = payload.files;
+    if (Array.isArray(remoteFiles)) {
+      for (const file of remoteFiles) {
+        if (
+          typeof file === "object" &&
+          file !== null &&
+          typeof (file as { path?: unknown }).path === "string"
+        ) {
+          const candidate = file as Partial<BrainListFile>;
+          files.set(candidate.path as string, {
+            path: candidate.path as string,
+            size: typeof candidate.size === "number" ? candidate.size : 0,
+            modified:
+              typeof candidate.modified === "number"
+                ? candidate.modified
+                : Date.now(),
+          });
+        }
+      }
+    }
+    if (input.kind === "delete") {
+      files.delete(input.path);
+    } else if (typeof input.text === "string") {
+      const existing = files.get(input.path);
+      files.set(input.path, {
+        path: input.path,
+        size: input.text.length,
+        modified: existing?.modified ?? Date.now(),
+      });
+    }
+    this.writeCached({
+      scope: input.scope,
+      resource: "brain-list",
+      id: "all",
+      value: { ...payload, ok: true, files: [...files.values()] },
+      revision: cached.revision,
+    });
   }
 
   private evictBodies(): void {

--- a/apps/server/src/routes/attention.ts
+++ b/apps/server/src/routes/attention.ts
@@ -1,5 +1,6 @@
 import { createAppLogger } from "@freestyle-voice/utils";
 import { Hono } from "hono";
+import { cachedCloudJson } from "../lib/cloud-cache.js";
 import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
 import { getSessionToken, invalidateSession } from "../lib/sessions.js";
 
@@ -15,22 +16,27 @@ const attention = new Hono().get("/", async (c) => {
   if (!token) return c.json({ error: "cloud_auth_required" }, 401);
 
   try {
-    const upstream = await fetch(`${freestyleCloudUrl()}/v2/attention`, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: c.req.raw.signal,
-    });
-    if (upstream.status === 401) {
-      invalidateSession();
-      return c.json({ error: "cloud_auth_required" }, 401);
-    }
-    return new Response(upstream.body, {
-      status: upstream.status,
-      headers: {
-        "Content-Type":
-          upstream.headers.get("content-type") ?? "application/json",
+    const payload = await cachedCloudJson({
+      resource: "attention",
+      id: "current",
+      maxAgeMs: 60_000,
+      load: async () => {
+        const upstream = await fetch(`${freestyleCloudUrl()}/v2/attention`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (upstream.status === 401) {
+          invalidateSession();
+          throw new Error("cloud_auth_required");
+        }
+        if (!upstream.ok) throw new Error(`attention-${upstream.status}`);
+        return (await upstream.json()) as object;
       },
     });
+    return c.json(payload);
   } catch (error) {
+    if (error instanceof Error && error.message === "cloud_auth_required") {
+      return c.json({ error: "cloud_auth_required" }, 401);
+    }
     log.debug(
       `Attention cloud request failed: ${error instanceof Error ? error.message : String(error)}`,
     );

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -7,6 +7,7 @@ import {
 } from "@freestyle-voice/validations";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
+import { getDb } from "../lib/db.js";
 import {
   clearCachedOrgSlug,
   DeviceFlowError,
@@ -42,6 +43,8 @@ import {
   setSession,
 } from "../lib/sessions.js";
 import { clearOutbox, drainOutbox } from "../lib/sync-outbox.js";
+import { cachedSyncScope, resolveSyncScope } from "../lib/sync-scope.js";
+import { LocalSyncStore } from "../lib/sync-store.js";
 import { syncTimezoneToCloud } from "../lib/timezone-sync.js";
 import { isTrustedRendererOrigin } from "../lib/trusted-origin.js";
 
@@ -97,6 +100,8 @@ const auth = new Hono()
       // Seed local cleanup preferences from the cloud snapshot (cross-device
       // sync). Fire-and-forget — sign-in must not block on it.
       void pullCloudPreferences();
+      // Establish the account/org namespace before any cloud data is cached.
+      void resolveSyncScope();
       // Let the cloud know this machine's timezone so scheduled tasks fire on
       // the user's clock. Fire-and-forget.
       void syncTimezoneToCloud();
@@ -126,6 +131,7 @@ const auth = new Hono()
   })
   .post("/sign-out", async (c) => {
     const session = getSession();
+    const scope = cachedSyncScope();
     if (session) {
       await signOutCloud(session.token).catch(() => {});
     }
@@ -134,6 +140,7 @@ const auth = new Hono()
     // Discard any preference syncs queued under this account so they aren't
     // delivered to a different account that signs in next.
     clearOutbox();
+    if (scope) new LocalSyncStore(getDb()).clearScope(scope);
     // Re-arm the one-time preference backfill so the next account to sign in on
     // this device seeds the cloud from its own snapshot.
     resetPreferencesBackfill();

--- a/apps/server/src/routes/brain.ts
+++ b/apps/server/src/routes/brain.ts
@@ -1,22 +1,39 @@
+import { syncBackoffMs } from "@freestyle-voice/sync";
 import { createAppLogger } from "@freestyle-voice/utils";
 import { Hono } from "hono";
+import { readThroughCloudCache } from "../lib/cloud-cache.js";
+import { getDb } from "../lib/db.js";
 import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
 import { getSessionToken, invalidateSession } from "../lib/sessions.js";
+import { emitSyncEvent } from "../lib/sync-events.js";
+import { cachedSyncScope, resolveSyncScope } from "../lib/sync-scope.js";
+import { LocalSyncStore } from "../lib/sync-store.js";
 
 const log = createAppLogger("brain-proxy");
 const BRAIN_REQUEST_TIMEOUT_MS = 15_000;
+const BRAIN_LIST_TTL_MS = 5 * 60_000;
+const BRAIN_BODY_TTL_MS = 24 * 60 * 60_000;
+
+type BrainWrite = { path: string; text: string; ifMatch?: number };
+type BrainDelete = { path: string };
+type CloudFailure = {
+  ok: false;
+  reason: string;
+  current?: { content: string; version: number };
+};
 
 async function forward(
   segment: string,
   method: "GET" | "POST",
   body?: unknown,
-): Promise<{ status: number; payload: unknown }> {
+): Promise<{ status: number; payload: Record<string, unknown> }> {
   const token = getSessionToken();
-  if (!token)
+  if (!token) {
     return {
       status: 401,
       payload: { ok: false, reason: "cloud_auth_required" },
     };
+  }
   try {
     const upstream = await fetch(`${freestyleCloudUrl()}/v2/brain/${segment}`, {
       method,
@@ -34,53 +51,228 @@ async function forward(
         payload: { ok: false, reason: "cloud_auth_required" },
       };
     }
-    return { status: upstream.status, payload: await upstream.json() };
-  } catch (err) {
-    log.error(`Brain proxy ${segment} failed: ${err}`);
+    return {
+      status: upstream.status,
+      payload: (await upstream.json()) as Record<string, unknown>,
+    };
+  } catch (error) {
+    log.error(`Brain proxy ${segment} failed: ${error}`);
     return { status: 502, payload: { ok: false, reason: "cloud-unreachable" } };
   }
 }
 
+function scopeForCache(): Promise<string | null> {
+  const cached = cachedSyncScope();
+  return cached ? Promise.resolve(cached) : resolveSyncScope();
+}
+
+async function drainBrainOperations(scope: string): Promise<void> {
+  const store = new LocalSyncStore(getDb());
+  const operations = store
+    .dueOperations(scope)
+    .filter((operation) => operation.resource === "brain-file");
+  await Promise.all(
+    operations.map(async (operation) => {
+      const body = operation.payload as { text?: unknown };
+      const request =
+        operation.kind === "write"
+          ? {
+              path: operation.entityId,
+              text: typeof body.text === "string" ? body.text : "",
+              ifMatch: operation.expectedRevision ?? undefined,
+              clientOperationId: operation.operationId,
+            }
+          : {
+              path: operation.entityId,
+              clientOperationId: operation.operationId,
+            };
+      const { status, payload } = await forward(
+        operation.kind === "write" ? "write" : "delete",
+        "POST",
+        request,
+      );
+      if (payload.ok === true) {
+        store.completeOperation(operation.operationId);
+        if (operation.kind === "write") {
+          const cached = store.readCached(
+            scope,
+            "brain-file",
+            operation.entityId,
+          );
+          if (cached) {
+            store.writeCached({
+              scope,
+              resource: "brain-file",
+              id: operation.entityId,
+              value: cached.value,
+              revision:
+                typeof payload.version === "number"
+                  ? payload.version
+                  : cached.revision,
+            });
+          }
+        }
+        emitSyncEvent({ resource: "brain-file", entityId: operation.entityId });
+        emitSyncEvent({ resource: "brain-list" });
+        return;
+      }
+      const reason =
+        typeof payload.reason === "string" ? payload.reason : `http-${status}`;
+      if (reason === "conflict") {
+        const current = (payload as unknown as CloudFailure).current;
+        if (current) {
+          store.writeCached({
+            scope,
+            resource: "brain-file",
+            id: operation.entityId,
+            value: {
+              ok: true,
+              text: current.content,
+              version: current.version,
+            },
+            revision: current.version,
+          });
+        }
+        store.failOperation(operation.operationId, "conflict");
+        emitSyncEvent({ resource: "brain-file", entityId: operation.entityId });
+        return;
+      }
+      if (status >= 400 && status < 500 && status !== 409) {
+        store.failOperation(operation.operationId, reason);
+        return;
+      }
+      store.deferOperation(
+        operation.operationId,
+        operation.attempts + 1,
+        syncBackoffMs(operation.attempts + 1),
+        reason,
+      );
+    }),
+  );
+}
+
+async function cachedRead(
+  scope: string | null,
+  resource: string,
+  id: string,
+  ttl: number,
+  segment: string,
+  method: "GET" | "POST",
+  body?: unknown,
+): Promise<{ status: number; payload: Record<string, unknown> }> {
+  let loadedStatus = 502;
+  const payload = await readThroughCloudCache({
+    store: new LocalSyncStore(getDb()),
+    scope,
+    resource,
+    id,
+    maxAgeMs: ttl,
+    load: async () => {
+      const response = await forward(segment, method, body);
+      loadedStatus = response.status;
+      if (response.payload.ok !== true) {
+        throw new Error(String(response.payload.reason ?? "brain-failed"));
+      }
+      return response.payload;
+    },
+  });
+  return { status: loadedStatus === 502 ? 200 : loadedStatus, payload };
+}
+
 const brainRoute = new Hono()
   .get("/list", async (c) => {
-    const { status, payload } = await forward("list", "GET");
-    return c.json(payload as object, status as 200);
+    const { status, payload } = await cachedRead(
+      await scopeForCache(),
+      "brain-list",
+      "all",
+      BRAIN_LIST_TTL_MS,
+      "list",
+      "GET",
+    );
+    return c.json(payload, status as 200);
   })
   .get("/graph", async (c) => {
-    const { status, payload } = await forward("graph", "GET");
-    return c.json(payload as object, status as 200);
+    const { status, payload } = await cachedRead(
+      await scopeForCache(),
+      "brain-graph",
+      "all",
+      BRAIN_LIST_TTL_MS,
+      "graph",
+      "GET",
+    );
+    return c.json(payload, status as 200);
   })
   .get("/export", async (c) => {
     const { status, payload } = await forward("export", "GET");
-    return c.json(payload as object, status as 200);
+    return c.json(payload, status as 200);
   })
   .post("/read", async (c) => {
-    const { status, payload } = await forward(
+    const body = (await c.req.json()) as { path?: unknown };
+    if (typeof body.path !== "string") {
+      return c.json({ ok: false, reason: "invalid-path" }, 400);
+    }
+    const { status, payload } = await cachedRead(
+      await scopeForCache(),
+      "brain-file",
+      body.path,
+      BRAIN_BODY_TTL_MS,
       "read",
       "POST",
-      await c.req.json(),
+      { path: body.path },
     );
-    return c.json(payload as object, status as 200);
+    return c.json(payload, status as 200);
   })
   .post("/write", async (c) => {
-    const { status, payload } = await forward(
-      "write",
-      "POST",
-      await c.req.json(),
-    );
-    return c.json(payload as object, status as 200);
+    const body = (await c.req.json()) as BrainWrite;
+    if (typeof body.path !== "string" || typeof body.text !== "string") {
+      return c.json({ ok: false, reason: "invalid-request" }, 400);
+    }
+    const scope = await scopeForCache();
+    if (!scope) {
+      const { status, payload } = await forward("write", "POST", body);
+      return c.json(payload, status as 200);
+    }
+    const store = new LocalSyncStore(getDb());
+    store.writeAndEnqueue({
+      scope,
+      resource: "brain-file",
+      entityId: body.path,
+      kind: "write",
+      value: { ok: true, text: body.text, version: body.ifMatch ?? null },
+      expectedRevision: body.ifMatch,
+    });
+    emitSyncEvent({ resource: "brain-file", entityId: body.path });
+    emitSyncEvent({ resource: "brain-list" });
+    void drainBrainOperations(scope);
+    // The canonical revision is assigned by Cloud; do not pretend the old
+    // ifMatch revision is current while this local-first operation is pending.
+    return c.json({ ok: true, pending: true });
   })
   .post("/delete", async (c) => {
-    const { status, payload } = await forward(
-      "delete",
-      "POST",
-      await c.req.json(),
-    );
-    return c.json(payload as object, status as 200);
+    const body = (await c.req.json()) as BrainDelete;
+    if (typeof body.path !== "string") {
+      return c.json({ ok: false, reason: "invalid-path" }, 400);
+    }
+    const scope = await scopeForCache();
+    if (!scope) {
+      const { status, payload } = await forward("delete", "POST", body);
+      return c.json(payload, status as 200);
+    }
+    const store = new LocalSyncStore(getDb());
+    store.deleteAndEnqueue({
+      scope,
+      resource: "brain-file",
+      entityId: body.path,
+    });
+    emitSyncEvent({ resource: "brain-file", entityId: body.path });
+    emitSyncEvent({ resource: "brain-list" });
+    void drainBrainOperations(scope);
+    return c.json({ ok: true, pending: true });
   })
   .post("/clear", async (c) => {
     const { status, payload } = await forward("clear", "POST", {});
-    return c.json(payload as object, status as 200);
+    return c.json(payload, status as 200);
   });
 
+export { drainBrainOperations };
 export default brainRoute;

--- a/apps/server/src/routes/brain.ts
+++ b/apps/server/src/routes/brain.ts
@@ -13,6 +13,7 @@ const log = createAppLogger("brain-proxy");
 const BRAIN_REQUEST_TIMEOUT_MS = 15_000;
 const BRAIN_LIST_TTL_MS = 5 * 60_000;
 const BRAIN_BODY_TTL_MS = 24 * 60 * 60_000;
+const BRAIN_DRAIN_INTERVAL_MS = 60_000;
 
 type BrainWrite = { path: string; text: string; ifMatch?: number };
 type BrainDelete = { path: string };
@@ -151,6 +152,26 @@ async function drainBrainOperations(scope: string): Promise<void> {
   );
 }
 
+let drainTimer: NodeJS.Timeout | null = null;
+
+/** Retries due Brain operations after their backoff expires, even while idle. */
+function startBrainSyncDrain(): void {
+  if (drainTimer) return;
+  const drain = async () => {
+    const scope = await scopeForCache();
+    if (scope) await drainBrainOperations(scope);
+  };
+  void drain();
+  drainTimer = setInterval(() => void drain(), BRAIN_DRAIN_INTERVAL_MS);
+  drainTimer.unref();
+}
+
+function stopBrainSyncDrain(): void {
+  if (!drainTimer) return;
+  clearInterval(drainTimer);
+  drainTimer = null;
+}
+
 async function cachedRead(
   scope: string | null,
   resource: string,
@@ -233,13 +254,15 @@ const brainRoute = new Hono()
       return c.json(payload, status as 200);
     }
     const store = new LocalSyncStore(getDb());
+    const previous = store.readCached(scope, "brain-file", body.path);
+    const expectedRevision = body.ifMatch ?? previous?.revision ?? undefined;
     store.writeAndEnqueue({
       scope,
       resource: "brain-file",
       entityId: body.path,
       kind: "write",
       value: { ok: true, text: body.text, version: body.ifMatch ?? null },
-      expectedRevision: body.ifMatch,
+      expectedRevision,
     });
     emitSyncEvent({ resource: "brain-file", entityId: body.path });
     emitSyncEvent({ resource: "brain-list" });
@@ -274,5 +297,5 @@ const brainRoute = new Hono()
     return c.json(payload, status as 200);
   });
 
-export { drainBrainOperations };
+export { drainBrainOperations, startBrainSyncDrain, stopBrainSyncDrain };
 export default brainRoute;

--- a/apps/server/src/routes/brain.ts
+++ b/apps/server/src/routes/brain.ts
@@ -23,6 +23,15 @@ type CloudFailure = {
   current?: { content: string; version: number };
 };
 
+class BrainUpstreamError extends Error {
+  constructor(
+    readonly status: number,
+    readonly payload: Record<string, unknown>,
+  ) {
+    super(String(payload.reason ?? "brain-failed"));
+  }
+}
+
 async function forward(
   segment: string,
   method: "GET" | "POST",
@@ -67,89 +76,132 @@ function scopeForCache(): Promise<string | null> {
   return cached ? Promise.resolve(cached) : resolveSyncScope();
 }
 
-async function drainBrainOperations(scope: string): Promise<void> {
-  const store = new LocalSyncStore(getDb());
-  const operations = store
-    .dueOperations(scope)
-    .filter((operation) => operation.resource === "brain-file");
-  await Promise.all(
-    operations.map(async (operation) => {
-      const body = operation.payload as { text?: unknown };
-      const request =
-        operation.kind === "write"
-          ? {
-              path: operation.entityId,
-              text: typeof body.text === "string" ? body.text : "",
-              ifMatch: operation.expectedRevision ?? undefined,
-              clientOperationId: operation.operationId,
-            }
-          : {
-              path: operation.entityId,
-              clientOperationId: operation.operationId,
-            };
-      const { status, payload } = await forward(
-        operation.kind === "write" ? "write" : "delete",
-        "POST",
-        request,
-      );
-      if (payload.ok === true) {
-        store.completeOperation(operation.operationId);
-        if (operation.kind === "write") {
-          const cached = store.readCached(
-            scope,
-            "brain-file",
-            operation.entityId,
-          );
-          if (cached) {
-            store.writeCached({
-              scope,
-              resource: "brain-file",
-              id: operation.entityId,
-              value: cached.value,
-              revision:
-                typeof payload.version === "number"
-                  ? payload.version
-                  : cached.revision,
-            });
-          }
+const activeBrainDrains = new Map<string, Promise<void>>();
+const requestedBrainDrains = new Set<string>();
+const recoveredBrainScopes = new Set<string>();
+const clearingBrainScopes = new Set<string>();
+
+async function processBrainOperation(
+  store: LocalSyncStore,
+  scope: string,
+  operation: ReturnType<LocalSyncStore["claimDueOperations"]>[number],
+): Promise<void> {
+  const body = operation.payload as { text?: unknown };
+  const request =
+    operation.kind === "write"
+      ? {
+          path: operation.entityId,
+          text: typeof body.text === "string" ? body.text : "",
+          ifMatch: operation.expectedRevision ?? undefined,
+          clientOperationId: operation.operationId,
         }
-        emitSyncEvent({ resource: "brain-file", entityId: operation.entityId });
-        emitSyncEvent({ resource: "brain-list" });
-        return;
-      }
-      const reason =
-        typeof payload.reason === "string" ? payload.reason : `http-${status}`;
-      if (reason === "conflict") {
-        const current = (payload as unknown as CloudFailure).current;
-        if (current) {
-          store.writeCached({
-            scope,
-            resource: "brain-file",
-            id: operation.entityId,
-            value: {
-              ok: true,
-              text: current.content,
-              version: current.version,
-            },
-            revision: current.version,
-          });
-        }
-        store.failOperation(operation.operationId, "conflict");
-        emitSyncEvent({ resource: "brain-file", entityId: operation.entityId });
-        return;
-      }
-      if (status >= 400 && status < 500 && status !== 409) {
-        store.failOperation(operation.operationId, reason);
-        return;
-      }
-      store.deferOperation(
-        operation.operationId,
-        operation.attempts + 1,
-        syncBackoffMs(operation.attempts + 1),
-        reason,
-      );
-    }),
+      : {
+          path: operation.entityId,
+          clientOperationId: operation.operationId,
+        };
+  const { status, payload } = await forward(
+    operation.kind === "write" ? "write" : "delete",
+    "POST",
+    request,
   );
+  if (payload.ok === true) {
+    store.completeOperation(
+      operation.operationId,
+      operation.kind === "write" && typeof payload.version === "number"
+        ? payload.version
+        : undefined,
+    );
+    emitSyncEvent({
+      resource: "brain-file",
+      entityId: operation.entityId,
+      source: "remote",
+    });
+    emitSyncEvent({ resource: "brain-list", source: "remote" });
+    return;
+  }
+  const reason =
+    typeof payload.reason === "string" ? payload.reason : `http-${status}`;
+  if (reason === "conflict") {
+    const current = (payload as unknown as CloudFailure).current;
+    // Do not overwrite a newer local edit while its predecessor reports a
+    // conflict. The failed head blocks that successor until the user retries,
+    // preserving the edit rather than replacing it with stale Cloud content.
+    if (current) {
+      if (store.hasQueuedSuccessor(operation.operationId)) {
+        store.updateCachedRevision({
+          scope,
+          resource: "brain-file",
+          id: operation.entityId,
+          revision: current.version,
+        });
+      } else {
+        store.writeCached({
+          scope,
+          resource: "brain-file",
+          id: operation.entityId,
+          value: {
+            ok: true,
+            text: current.content,
+            version: current.version,
+          },
+          revision: current.version,
+        });
+      }
+    }
+    store.failOperation(operation.operationId, "conflict");
+    emitSyncEvent({
+      resource: "brain-file",
+      entityId: operation.entityId,
+      source: "remote",
+    });
+    emitSyncEvent({ resource: "brain-list", source: "remote" });
+    return;
+  }
+  if (status >= 400 && status < 500 && status !== 409) {
+    store.failOperation(operation.operationId, reason);
+    return;
+  }
+  store.deferOperation(
+    operation.operationId,
+    operation.attempts + 1,
+    syncBackoffMs(operation.attempts + 1),
+    reason,
+  );
+}
+
+async function drainBrainOperations(scope: string): Promise<void> {
+  const active = activeBrainDrains.get(scope);
+  if (active) {
+    requestedBrainDrains.add(scope);
+    return active;
+  }
+  const drain = (async () => {
+    const store = new LocalSyncStore(getDb());
+    if (!recoveredBrainScopes.has(scope)) {
+      store.recoverSyncingOperations(scope, "brain-file");
+      recoveredBrainScopes.add(scope);
+    }
+    do {
+      requestedBrainDrains.delete(scope);
+      while (true) {
+        const operations = store.claimDueOperations(scope, "brain-file");
+        if (operations.length === 0) break;
+        await Promise.all(
+          operations.map((operation) =>
+            processBrainOperation(store, scope, operation),
+          ),
+        );
+      }
+    } while (requestedBrainDrains.has(scope));
+  })();
+  activeBrainDrains.set(scope, drain);
+  try {
+    await drain;
+  } finally {
+    if (activeBrainDrains.get(scope) === drain) {
+      activeBrainDrains.delete(scope);
+    }
+  }
 }
 
 let drainTimer: NodeJS.Timeout | null = null;
@@ -191,37 +243,53 @@ async function cachedRead(
     load: async () => {
       const response = await forward(segment, method, body);
       loadedStatus = response.status;
-      if (response.payload.ok !== true) {
-        throw new Error(String(response.payload.reason ?? "brain-failed"));
-      }
+      if (response.payload.ok !== true)
+        throw new BrainUpstreamError(response.status, response.payload);
       return response.payload;
     },
   });
   return { status: loadedStatus === 502 ? 200 : loadedStatus, payload };
 }
 
+async function respondCachedRead(
+  load: () => Promise<{ status: number; payload: Record<string, unknown> }>,
+): Promise<Response> {
+  try {
+    const { status, payload } = await load();
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (error) {
+    if (error instanceof BrainUpstreamError) {
+      return new Response(JSON.stringify(error.payload), {
+        status: error.status,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw error;
+  }
+}
+
 const brainRoute = new Hono()
-  .get("/list", async (c) => {
-    const { status, payload } = await cachedRead(
-      await scopeForCache(),
-      "brain-list",
-      "all",
-      BRAIN_LIST_TTL_MS,
-      "list",
-      "GET",
+  .get("/list", async () => {
+    const scope = await scopeForCache();
+    return respondCachedRead(() =>
+      cachedRead(scope, "brain-list", "all", BRAIN_LIST_TTL_MS, "list", "GET"),
     );
-    return c.json(payload, status as 200);
   })
-  .get("/graph", async (c) => {
-    const { status, payload } = await cachedRead(
-      await scopeForCache(),
-      "brain-graph",
-      "all",
-      BRAIN_LIST_TTL_MS,
-      "graph",
-      "GET",
+  .get("/graph", async () => {
+    const scope = await scopeForCache();
+    return respondCachedRead(() =>
+      cachedRead(
+        scope,
+        "brain-graph",
+        "all",
+        BRAIN_LIST_TTL_MS,
+        "graph",
+        "GET",
+      ),
     );
-    return c.json(payload, status as 200);
   })
   .get("/export", async (c) => {
     const { status, payload } = await forward("export", "GET");
@@ -232,16 +300,13 @@ const brainRoute = new Hono()
     if (typeof body.path !== "string") {
       return c.json({ ok: false, reason: "invalid-path" }, 400);
     }
-    const { status, payload } = await cachedRead(
-      await scopeForCache(),
-      "brain-file",
-      body.path,
-      BRAIN_BODY_TTL_MS,
-      "read",
-      "POST",
-      { path: body.path },
+    const path = body.path;
+    const scope = await scopeForCache();
+    return respondCachedRead(() =>
+      cachedRead(scope, "brain-file", path, BRAIN_BODY_TTL_MS, "read", "POST", {
+        path,
+      }),
     );
-    return c.json(payload, status as 200);
   })
   .post("/write", async (c) => {
     const body = (await c.req.json()) as BrainWrite;
@@ -252,6 +317,9 @@ const brainRoute = new Hono()
     if (!scope) {
       const { status, payload } = await forward("write", "POST", body);
       return c.json(payload, status as 200);
+    }
+    if (clearingBrainScopes.has(scope)) {
+      return c.json({ ok: false, reason: "brain-clear-in-progress" }, 409);
     }
     const store = new LocalSyncStore(getDb());
     const previous = store.readCached(scope, "brain-file", body.path);
@@ -264,9 +332,21 @@ const brainRoute = new Hono()
       value: { ok: true, text: body.text, version: body.ifMatch ?? null },
       expectedRevision,
     });
-    emitSyncEvent({ resource: "brain-file", entityId: body.path });
-    emitSyncEvent({ resource: "brain-list" });
-    void drainBrainOperations(scope);
+    store.applyBrainListMutation({
+      scope,
+      kind: "write",
+      path: body.path,
+      text: body.text,
+    });
+    emitSyncEvent({
+      resource: "brain-file",
+      entityId: body.path,
+      source: "local",
+    });
+    emitSyncEvent({ resource: "brain-list", source: "local" });
+    void drainBrainOperations(scope).catch((error) =>
+      log.error(`Brain operation drain failed: ${error}`),
+    );
     // The canonical revision is assigned by Cloud; do not pretend the old
     // ifMatch revision is current while this local-first operation is pending.
     return c.json({ ok: true, pending: true });
@@ -281,20 +361,55 @@ const brainRoute = new Hono()
       const { status, payload } = await forward("delete", "POST", body);
       return c.json(payload, status as 200);
     }
+    if (clearingBrainScopes.has(scope)) {
+      return c.json({ ok: false, reason: "brain-clear-in-progress" }, 409);
+    }
     const store = new LocalSyncStore(getDb());
     store.deleteAndEnqueue({
       scope,
       resource: "brain-file",
       entityId: body.path,
     });
-    emitSyncEvent({ resource: "brain-file", entityId: body.path });
-    emitSyncEvent({ resource: "brain-list" });
-    void drainBrainOperations(scope);
+    store.applyBrainListMutation({
+      scope,
+      kind: "delete",
+      path: body.path,
+    });
+    emitSyncEvent({
+      resource: "brain-file",
+      entityId: body.path,
+      source: "local",
+    });
+    emitSyncEvent({ resource: "brain-list", source: "local" });
+    void drainBrainOperations(scope).catch((error) =>
+      log.error(`Brain operation drain failed: ${error}`),
+    );
     return c.json({ ok: true, pending: true });
   })
   .post("/clear", async (c) => {
-    const { status, payload } = await forward("clear", "POST", {});
-    return c.json(payload, status as 200);
+    const scope = await scopeForCache();
+    if (!scope) {
+      const { status, payload } = await forward("clear", "POST", {});
+      return c.json(payload, status as 200);
+    }
+    clearingBrainScopes.add(scope);
+    try {
+      await drainBrainOperations(scope);
+      const store = new LocalSyncStore(getDb());
+      if (store.getBrainStatus(scope).pending > 0) {
+        return c.json({ ok: false, reason: "brain-sync-pending" }, 409);
+      }
+      const { status, payload } = await forward("clear", "POST", {});
+      if (payload.ok === true) {
+        store.clearBrain(scope);
+        emitSyncEvent({ resource: "brain-file", source: "remote" });
+        emitSyncEvent({ resource: "brain-list", source: "remote" });
+        emitSyncEvent({ resource: "brain-graph", source: "remote" });
+      }
+      return c.json(payload, status as 200);
+    } finally {
+      clearingBrainScopes.delete(scope);
+    }
   });
 
 export { drainBrainOperations, startBrainSyncDrain, stopBrainSyncDrain };

--- a/apps/server/src/routes/config.ts
+++ b/apps/server/src/routes/config.ts
@@ -1,6 +1,7 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
+import { cachedCloudJson } from "../lib/cloud-cache.js";
 import {
   freestyleConfigSchema,
   getConfig,
@@ -25,7 +26,12 @@ const config = new Hono()
    */
   .get("/cloud", async (c) => {
     try {
-      const cloud = await fetchCloudConfig();
+      const cloud = await cachedCloudJson({
+        resource: "config",
+        id: "cloud",
+        maxAgeMs: 24 * 60 * 60_000,
+        load: fetchCloudConfig,
+      });
       return c.json({
         suggestedLanguages: cloud.suggestedLanguages,
       });

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -39,6 +39,7 @@ import scheduledRoute from "./scheduled.js";
 import settings from "./settings.js";
 import streamRoute from "./stream.js";
 import suggestionsRoute from "./suggestions.js";
+import syncRoute from "./sync.js";
 import transcribe, { transcribePreWarmRoute } from "./transcribe.js";
 import usage from "./usage.js";
 import vocabulary from "./vocabulary.js";
@@ -90,6 +91,7 @@ const apiRouter = new Hono()
     return c.json({ ok: true });
   })
   .route("/settings", settings)
+  .route("/sync", syncRoute)
   .route("/keys", apiKeys)
   .route("/config", configRoute)
   .route("/connectors", connectorsRoute)

--- a/apps/server/src/routes/org.ts
+++ b/apps/server/src/routes/org.ts
@@ -2,6 +2,7 @@ import { createAppLogger } from "@freestyle-voice/utils";
 import { setActiveOrgSchema } from "@freestyle-voice/validations";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
+import { getDb } from "../lib/db.js";
 import { formatError } from "../lib/format-error.js";
 import {
   clearCachedOrgSlug,
@@ -12,6 +13,8 @@ import {
 import { pullCloudPreferences } from "../lib/preferences-sync.js";
 import { getSessionToken } from "../lib/sessions.js";
 import { clearOutbox } from "../lib/sync-outbox.js";
+import { cachedSyncScope, resolveSyncScope } from "../lib/sync-scope.js";
+import { LocalSyncStore } from "../lib/sync-store.js";
 
 const log = createAppLogger("org");
 
@@ -55,6 +58,7 @@ const org = new Hono()
       return c.json({ error: "Not signed in to Freestyle Cloud" }, 401);
     }
     const { organizationId } = c.req.valid("json");
+    const previousScope = cachedSyncScope();
     try {
       await setCloudActiveOrganization(token, organizationId);
       // Member preferences (cleanup tones, languages, vocabulary) are per-org,
@@ -67,6 +71,10 @@ const org = new Hono()
       //   - reload the new org's snapshot into the local settings/vocabulary
       //     tables so the app reflects the switch immediately (like sign-in).
       await pullCloudPreferences();
+      const nextScope = await resolveSyncScope();
+      if (previousScope && previousScope !== nextScope) {
+        new LocalSyncStore(getDb()).clearScope(previousScope);
+      }
       return c.json({ ok: true });
     } catch (err) {
       log.warn(`failed to set active organization: ${formatError(err)}`);

--- a/apps/server/src/routes/sync.ts
+++ b/apps/server/src/routes/sync.ts
@@ -1,0 +1,35 @@
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import { getDb } from "../lib/db.js";
+import { subscribeSyncEvents } from "../lib/sync-events.js";
+import { cachedSyncScope } from "../lib/sync-scope.js";
+import { LocalSyncStore } from "../lib/sync-store.js";
+
+const sync = new Hono()
+  .get("/status", (c) => {
+    const scope = cachedSyncScope();
+    return c.json({
+      scope,
+      ...(scope
+        ? new LocalSyncStore(getDb()).getStatus(scope)
+        : { pending: 0, failed: 0 }),
+    });
+  })
+  .get("/events", (c) =>
+    streamSSE(c, async (stream) => {
+      const unsubscribe = subscribeSyncEvents((event) => {
+        void stream.writeSSE({ event: "sync", data: JSON.stringify(event) });
+      });
+      try {
+        await new Promise<void>((resolve) => {
+          c.req.raw.signal.addEventListener("abort", () => resolve(), {
+            once: true,
+          });
+        });
+      } finally {
+        unsubscribe();
+      }
+    }),
+  );
+
+export default sync;

--- a/apps/server/src/routes/sync.ts
+++ b/apps/server/src/routes/sync.ts
@@ -18,7 +18,11 @@ const sync = new Hono()
   .get("/events", (c) =>
     streamSSE(c, async (stream) => {
       const unsubscribe = subscribeSyncEvents((event) => {
-        void stream.writeSSE({ event: "sync", data: JSON.stringify(event) });
+        // Clients can close between the Set iteration and the write. That is
+        // normal for SSE and must not surface as an unhandled rejection.
+        void stream
+          .writeSSE({ event: "sync", data: JSON.stringify(event) })
+          .catch(() => {});
       });
       try {
         await new Promise<void>((resolve) => {

--- a/apps/server/src/routes/usage.ts
+++ b/apps/server/src/routes/usage.ts
@@ -2,6 +2,7 @@ import { createAppLogger } from "@freestyle-voice/utils";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
+import { cachedCloudJson } from "../lib/cloud-cache.js";
 import { formatError } from "../lib/format-error.js";
 import { fetchCloudUsage } from "../lib/freestyle-cloud.js";
 import { registerSuperProperties, setPersonProperties } from "../lib/sentry.js";
@@ -39,7 +40,14 @@ const usage = new Hono().get(
       // Forward the caller's `?fresh=1` (set by the post-checkout poll) so the
       // cloud bypasses its plan cache and reports an upgrade immediately.
       const { fresh } = c.req.valid("query");
-      const balance = await fetchCloudUsage(token, { fresh: fresh === "1" });
+      const balance = fresh
+        ? await fetchCloudUsage(token, { fresh: true })
+        : await cachedCloudJson({
+            resource: "usage",
+            id: "current",
+            maxAgeMs: 60_000,
+            load: () => fetchCloudUsage(token),
+          });
       rememberPlan(balance.plan ?? "free");
       return c.json(balance);
     } catch (err) {

--- a/apps/server/tests/brain-proxy.test.ts
+++ b/apps/server/tests/brain-proxy.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import createApp from "../src/index.js";
+import { getDb, writeSetting } from "../src/lib/db.js";
+import { freestyleCloudUrl } from "../src/lib/freestyle-cloud.js";
+import { clearSession, setSession } from "../src/lib/sessions.js";
+
+const app = createApp();
+
+afterEach(() => {
+  clearSession();
+  vi.unstubAllGlobals();
+  getDb().exec(
+    "DELETE FROM sync_entities; DELETE FROM sync_operations; DELETE FROM sync_resource_state;",
+  );
+});
+
+function setCachedScope(): void {
+  const host = freestyleCloudUrl();
+  setSession({
+    token: "cloud-session",
+    user: { id: "brain-user", email: "brain@example.com" },
+    host,
+  });
+  writeSetting(`sync_scope:${host}:brain-user`, "cloud:brain-user:brain-org");
+}
+
+async function flushAsyncWork(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) await Promise.resolve();
+}
+
+describe("Brain cached reads", () => {
+  it.each([
+    ["/api/brain/list", { method: "GET" }],
+    ["/api/brain/graph", { method: "GET" }],
+    [
+      "/api/brain/read",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ path: "notes/example.md" }),
+      },
+    ],
+  ] as const)("preserves Cloud auth failures for %s", async (path, init) => {
+    const response = await app.request(path, init);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      reason: "cloud_auth_required",
+    });
+  });
+
+  it("sends a later write only after the in-flight write settles", async () => {
+    setCachedScope();
+    let resolveFirst!: (response: Response) => void;
+    const firstResponse = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => firstResponse)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, version: 3 }), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await app.request("/api/brain/write", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        path: "notes/ordered.md",
+        text: "first",
+        ifMatch: 1,
+      }),
+    });
+    await app.request("/api/brain/write", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: "notes/ordered.md", text: "second" }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    resolveFirst(
+      new Response(JSON.stringify({ ok: true, version: 2 }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    await flushAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string),
+    ).toMatchObject({
+      path: "notes/ordered.md",
+      text: "second",
+      ifMatch: 2,
+      clientOperationId: expect.any(String),
+    });
+  });
+
+  it("sends a deletion only after the in-flight write settles", async () => {
+    setCachedScope();
+    let resolveFirst!: (response: Response) => void;
+    const firstResponse = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => firstResponse)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await app.request("/api/brain/write", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: "notes/remove.md", text: "draft" }),
+    });
+    await app.request("/api/brain/delete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: "notes/remove.md" }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    resolveFirst(
+      new Response(JSON.stringify({ ok: true, version: 4 }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    await flushAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string),
+    ).toMatchObject({
+      path: "notes/remove.md",
+      clientOperationId: expect.any(String),
+    });
+  });
+});

--- a/apps/server/tests/courier-notification-migration.test.ts
+++ b/apps/server/tests/courier-notification-migration.test.ts
@@ -25,7 +25,7 @@ describe("Courier Inbox authority migration", () => {
     expect(tables).toEqual([]);
     expect(
       db.prepare("SELECT version FROM schema_version WHERE id = 1").get(),
-    ).toEqual({ version: 29 });
+    ).toEqual({ version: 30 });
     db.close();
   });
 });

--- a/apps/server/tests/courier-notification-migration.test.ts
+++ b/apps/server/tests/courier-notification-migration.test.ts
@@ -25,7 +25,7 @@ describe("Courier Inbox authority migration", () => {
     expect(tables).toEqual([]);
     expect(
       db.prepare("SELECT version FROM schema_version WHERE id = 1").get(),
-    ).toEqual({ version: 30 });
+    ).toEqual({ version: 31 });
     db.close();
   });
 });

--- a/apps/server/tests/sync-operations-migration.test.ts
+++ b/apps/server/tests/sync-operations-migration.test.ts
@@ -1,0 +1,58 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { initSchema } from "../src/lib/schema.js";
+
+describe("sync operation ordering migration", () => {
+  it("upgrades the v30 single-operation queue without losing its operation", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE TABLE schema_version (
+        id INTEGER PRIMARY KEY CHECK(id = 1),
+        version INTEGER NOT NULL
+      );
+      INSERT INTO schema_version (id, version) VALUES (1, 30);
+      CREATE TABLE sync_operations (
+        operation_id TEXT PRIMARY KEY,
+        scope TEXT NOT NULL,
+        resource TEXT NOT NULL,
+        entity_id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        expected_revision INTEGER,
+        state TEXT NOT NULL,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        next_attempt_at TEXT NOT NULL,
+        last_error TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE UNIQUE INDEX idx_sync_operations_entity
+        ON sync_operations (scope, resource, entity_id);
+      INSERT INTO sync_operations
+        (operation_id, scope, resource, entity_id, kind, payload, state, next_attempt_at, created_at, updated_at)
+      VALUES
+        ('operation-1', 'cloud:user:org', 'brain-file', 'notes/example.md', 'write', '{}', 'pending', datetime('now'), datetime('now'), datetime('now'));
+    `);
+
+    initSchema(db);
+
+    expect(
+      db.prepare("SELECT version FROM schema_version WHERE id = 1").get(),
+    ).toEqual({ version: 31 });
+    expect(
+      db
+        .prepare(
+          "SELECT sequence FROM sync_operations WHERE operation_id = 'operation-1'",
+        )
+        .get(),
+    ).toEqual({ sequence: 0 });
+    expect(
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_sync_operations_entity'",
+        )
+        .get(),
+    ).toBeUndefined();
+    db.close();
+  });
+});

--- a/apps/server/tests/sync-store.test.ts
+++ b/apps/server/tests/sync-store.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getDb } from "../src/lib/db.js";
+import { LocalSyncStore } from "../src/lib/sync-store.js";
+
+describe("LocalSyncStore", () => {
+  it("keeps cached records and pending operations isolated by account scope", () => {
+    const store = new LocalSyncStore(getDb());
+    store.writeCached({
+      scope: "cloud:user-a:org-a",
+      resource: "brain-file",
+      id: "notes/a.md",
+      value: { text: "A" },
+      revision: 1,
+    });
+    store.enqueue({
+      scope: "cloud:user-a:org-a",
+      resource: "brain-file",
+      entityId: "notes/a.md",
+      kind: "write",
+      payload: { text: "A" },
+      expectedRevision: 1,
+    });
+
+    expect(
+      store.readCached("cloud:user-a:org-a", "brain-file", "notes/a.md")?.value,
+    ).toEqual({ text: "A" });
+    expect(
+      store.readCached("cloud:user-b:org-b", "brain-file", "notes/a.md"),
+    ).toBeNull();
+    expect(store.getStatus("cloud:user-b:org-b").pending).toBe(0);
+  });
+});

--- a/apps/server/tests/sync-store.test.ts
+++ b/apps/server/tests/sync-store.test.ts
@@ -29,4 +29,124 @@ describe("LocalSyncStore", () => {
     ).toBeNull();
     expect(store.getStatus("cloud:user-b:org-b").pending).toBe(0);
   });
+
+  it("keeps a newly queued operation behind one that is already syncing", () => {
+    const store = new LocalSyncStore(getDb());
+    const scope = "cloud:queue-user:queue-org";
+    const firstOperation = store.enqueue({
+      scope,
+      resource: "brain-file",
+      entityId: "notes/ordered.md",
+      kind: "write",
+      payload: { text: "first" },
+      expectedRevision: 1,
+    });
+    getDb()
+      .prepare(
+        "UPDATE sync_operations SET state = 'syncing' WHERE operation_id = ?",
+      )
+      .run(firstOperation);
+
+    store.enqueue({
+      scope,
+      resource: "brain-file",
+      entityId: "notes/ordered.md",
+      kind: "delete",
+      payload: { path: "notes/ordered.md" },
+      expectedRevision: 1,
+    });
+
+    const operations = getDb()
+      .prepare(
+        "SELECT kind, state FROM sync_operations WHERE scope = ? ORDER BY created_at, rowid",
+      )
+      .all(scope);
+    expect(operations).toEqual([
+      { kind: "write", state: "syncing" },
+      { kind: "delete", state: "pending" },
+    ]);
+  });
+
+  it("requeues an operation that was syncing when the server stopped", () => {
+    const store = new LocalSyncStore(getDb());
+    const scope = "cloud:recovery-user:recovery-org";
+    const operationId = store.enqueue({
+      scope,
+      resource: "brain-file",
+      entityId: "notes/recovery.md",
+      kind: "write",
+      payload: { text: "recover me" },
+    });
+    getDb()
+      .prepare(
+        "UPDATE sync_operations SET state = 'syncing' WHERE operation_id = ?",
+      )
+      .run(operationId);
+
+    expect(
+      (
+        store as unknown as {
+          recoverSyncingOperations: (scope: string, resource: string) => void;
+        }
+      ).recoverSyncingOperations(scope, "brain-file"),
+    ).toBeUndefined();
+    expect(store.claimDueOperations(scope, "brain-file")).toMatchObject([
+      { operationId, entityId: "notes/recovery.md", kind: "write" },
+    ]);
+  });
+
+  it("applies local Brain writes and deletions to the cached file list", () => {
+    const store = new LocalSyncStore(getDb());
+    const scope = "cloud:list-user:list-org";
+    store.writeCached({
+      scope,
+      resource: "brain-list",
+      id: "all",
+      value: {
+        ok: true,
+        files: [{ path: "notes/remote.md", size: 6, modified: 1 }],
+      },
+    });
+    store.writeAndEnqueue({
+      scope,
+      resource: "brain-file",
+      entityId: "notes/local.md",
+      kind: "write",
+      value: { ok: true, text: "local" },
+    });
+    store.applyBrainListMutation({
+      scope,
+      kind: "write",
+      path: "notes/local.md",
+      text: "local",
+    });
+    store.deleteAndEnqueue({
+      scope,
+      resource: "brain-file",
+      entityId: "notes/remote.md",
+    });
+    store.applyBrainListMutation({
+      scope,
+      kind: "delete",
+      path: "notes/remote.md",
+    });
+    // A read cache entry is not a local mutation and must never make a file
+    // reappear after Cloud removed it from the authoritative list.
+    store.writeCached({
+      scope,
+      resource: "brain-file",
+      id: "notes/stale-read.md",
+      value: { ok: true, text: "stale" },
+    });
+
+    expect(store.readCached(scope, "brain-list", "all")?.value).toMatchObject({
+      ok: true,
+      files: [
+        {
+          path: "notes/local.md",
+          size: 5,
+        },
+      ],
+    });
+  });
 });

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -4,6 +4,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   resolve: {
     alias: {
+      "@freestyle-voice/sync": resolve(
+        __dirname,
+        "../../packages/sync/src/index.ts",
+      ),
       "@freestyle-voice/validations/cleanup-presets": resolve(
         __dirname,
         "../../packages/validations/src/cleanup-presets.ts",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@freestyle-voice/sync",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "build": "pkgroll --clean-dist --minify"
+  },
+  "devDependencies": {
+    "pkgroll": "^2.27.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -1,0 +1,14 @@
+export type SyncOperationKind = "write" | "delete";
+
+export interface SyncScope {
+  userId: string;
+  organizationId: string | null;
+}
+
+export function syncScopeKey(scope: SyncScope): string {
+  return `cloud:${scope.userId}:${scope.organizationId ?? "personal"}`;
+}
+
+export function syncBackoffMs(attempts: number): number {
+  return Math.min(60_000 * 2 ** Math.max(0, attempts - 1), 3_600_000);
+}

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -10,5 +10,7 @@ export function syncScopeKey(scope: SyncScope): string {
 }
 
 export function syncBackoffMs(attempts: number): number {
-  return Math.min(60_000 * 2 ** Math.max(0, attempts - 1), 3_600_000);
+  const capped = Math.min(60_000 * 2 ** Math.max(0, attempts - 1), 3_600_000);
+  // Keep retries from synchronizing across a fleet after a shared outage.
+  return Math.round(capped * (0.8 + Math.random() * 0.4));
 }

--- a/packages/sync/tsconfig.json
+++ b/packages/sync/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../utils/tsconfig.json", "include": ["./src/**/*"] }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,9 @@ importers:
       '@freestyle-voice/stt':
         specifier: workspace:*
         version: link:../../packages/stt
+      '@freestyle-voice/sync':
+        specifier: workspace:*
+        version: link:../../packages/sync
       '@freestyle-voice/validations':
         specifier: workspace:*
         version: link:../../packages/validations
@@ -509,6 +512,15 @@ importers:
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/sync:
+    devDependencies:
+      pkgroll:
+        specifier: ^2.27.0
+        version: 2.27.0(typescript@5.9.3)(vite@7.3.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   packages/utils:
     dependencies:
@@ -15307,9 +15319,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 


### PR DESCRIPTION
## Summary
- add the internal scoped SQLite sync store, cache state, durable operations, LRU body eviction, local sync status, and event stream
- cache Brain files, usage, cloud config, and attention behind the local Hono server; invalidate matching React Query families after background refresh
- make Brain writes/deletes optimistic and durable, purge scope data on sign-out/org change, and recover Cloud-wins conflicts

## Dependency
Requires https://github.com/freestyle-voice/cloud/pull/218 for idempotent Brain operation receipts before this is released.

## Verification
- pnpm exec biome check [changed files]
- pnpm turbo build --filter=@freestyle-voice/electron...
- pnpm --filter @freestyle-voice/server test -- tests/sync-store.test.ts

The server suite reports 71 passing files / 468 passing tests.