### PR TITLE
perf(electron): render shell during auth reconciliation

### DIFF
--- a/apps/electron/src/renderer/src/components/attention-home.tsx
+++ b/apps/electron/src/renderer/src/components/attention-home.tsx
@@ -43,7 +43,7 @@ export function AttentionHome({
   const auth = useCloudAuth();
   const query = useQuery({
     ...attentionQueryOptions(),
-    enabled: !auth.loading && Boolean(auth.user),
+    enabled: auth.canRequestData,
   });
 
   if (auth.loading || !auth.user) return null;

--- a/apps/electron/src/renderer/src/components/cloud-profile.tsx
+++ b/apps/electron/src/renderer/src/components/cloud-profile.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@renderer/components/ui/dropdown-menu";
 import { Progress } from "@renderer/components/ui/progress";
+import { Skeleton } from "@renderer/components/ui/skeleton";
 import { useUpgradeModal } from "@renderer/components/upgrade-modal";
 import { useCloudAuth } from "@renderer/lib/auth-context";
 import { formatNumber } from "@renderer/lib/format";
@@ -110,7 +111,7 @@ export function UpgradeCtaCard(): React.JSX.Element | null {
 }
 
 export function CloudProfileButton(): React.JSX.Element {
-  const { user, loading, signingIn, signIn, signOut } = useCloudAuth();
+  const { user, phase, signingIn, signIn, signOut } = useCloudAuth();
   const { isPro, openBillingPortal } = useCloudUsage(!!user);
   const { data: activeOrg } = useActiveOrganization(!!user);
   const { data: orgs } = useListOrganizations(!!user);
@@ -119,11 +120,15 @@ export function CloudProfileButton(): React.JSX.Element {
 
   const hasMultipleOrgs = orgs && orgs.length > 1;
 
-  if (loading) {
+  if (phase === "checking") {
     return (
-      <div className={cn(ROW, "text-muted-foreground/50")}>
-        <Loader2 className="size-3.5 shrink-0 animate-spin" />
-        <span className="flex-1 text-left">…</span>
+      <div
+        className={cn(ROW, "pointer-events-none")}
+        role="status"
+        aria-label="Loading profile"
+      >
+        <Skeleton className="size-6 shrink-0 rounded-full" />
+        <Skeleton className="h-3.5 w-24 rounded-full" />
       </div>
     );
   }

--- a/apps/electron/src/renderer/src/components/login-gate.tsx
+++ b/apps/electron/src/renderer/src/components/login-gate.tsx
@@ -6,23 +6,9 @@ export function LoginGate({
 }: {
   children: React.ReactNode;
 }): React.JSX.Element | null {
-  const { user, loading } = useCloudAuth();
-  // AppShell supplies a neutral, full-window signed-out frame while this
-  // check runs. Keep protected content empty until we know whether the app or
-  // sign-in screen belongs there; this avoids exposing user data during an
-  // auth transition without briefly rendering the app sidebar.
-  if (loading) return <StartupContentPlaceholder />;
-  if (!user) return <LoginPage />;
+  const { phase } = useCloudAuth();
+  if (phase === "signed_out") return <LoginPage />;
   return <>{children}</>;
-}
-
-/**
- * The surrounding signed-out shell is already visible during auth
- * verification. This intentionally leaves it empty rather than rendering a
- * fake skeleton before the sign-in page or authenticated route mounts.
- */
-function StartupContentPlaceholder(): React.JSX.Element {
-  return <div className="min-h-0 flex-1" aria-busy="true" />;
 }
 
 /** The same page as onboarding's sign-in step, minus the step machinery. */

--- a/apps/electron/src/renderer/src/components/page-loading-skeleton.tsx
+++ b/apps/electron/src/renderer/src/components/page-loading-skeleton.tsx
@@ -1,49 +1,29 @@
-import { DragSpacer } from "@renderer/components/drag-spacer";
 import { Skeleton } from "@renderer/components/ui/skeleton";
 
 /**
- * First-load frame for the Dictionary and Vocabulary pages. It reserves the
- * same title, toolbar, and entry-list geometry as the populated page so data
- * arrival does not replace a centered status message with a different layout.
+ * First-load rows for Dictionary and Vocabulary. The surrounding pages render
+ * their static title and controls immediately; only user-created entries wait
+ * for their own query.
  */
-export function DictionaryLikePageSkeleton(): React.JSX.Element {
+export function DictionaryLikeEntriesSkeleton(): React.JSX.Element {
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <DragSpacer />
-      <div
-        aria-busy="true"
-        aria-label="Loading entries"
-        className="responsive-page-scroll flex-1 overflow-auto"
-        role="status"
-      >
-        <div className="mb-7 space-y-3">
-          <Skeleton className="h-11 w-52 max-w-full" />
-          <Skeleton className="h-4 w-[min(34rem,80%)] max-w-full" />
+    <div
+      aria-busy="true"
+      aria-label="Loading entries"
+      className="border-border bg-card overflow-hidden rounded-[12px] border"
+      role="status"
+    >
+      {["first", "second", "third", "fourth"].map((row) => (
+        <div
+          key={row}
+          className="border-border/60 grid min-h-[57px] items-center gap-3.5 border-b px-5 py-3.5 last:border-b-0 [grid-template-columns:minmax(7rem,0.7fr)_minmax(0,2fr)_4rem_2rem] max-[900px]:grid-cols-1"
+        >
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-10 justify-self-end max-[900px]:justify-self-start" />
+          <Skeleton className="size-7 justify-self-end max-[900px]:hidden" />
         </div>
-
-        <div className="mb-5 flex flex-col gap-2.5 min-[1080px]:flex-row">
-          <Skeleton className="h-10 min-w-0 flex-1 rounded-lg" />
-          <div className="flex gap-2.5">
-            <Skeleton className="h-9 w-20" />
-            <Skeleton className="h-9 w-20" />
-            <Skeleton className="h-9 w-28" />
-          </div>
-        </div>
-
-        <div className="border-border bg-card overflow-hidden rounded-[12px] border">
-          {["first", "second", "third", "fourth"].map((row) => (
-            <div
-              key={row}
-              className="border-border/60 grid min-h-[57px] items-center gap-3.5 border-b px-5 py-3.5 last:border-b-0 [grid-template-columns:minmax(7rem,0.7fr)_minmax(0,2fr)_4rem_2rem] max-[900px]:grid-cols-1"
-            >
-              <Skeleton className="h-6 w-24" />
-              <Skeleton className="h-3 w-full" />
-              <Skeleton className="h-3 w-10 justify-self-end max-[900px]:justify-self-start" />
-              <Skeleton className="size-7 justify-self-end max-[900px]:hidden" />
-            </div>
-          ))}
-        </div>
-      </div>
+      ))}
     </div>
   );
 }

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -824,6 +824,7 @@ function SignInGate(): React.JSX.Element {
  * implementation.
  */
 export function RemixWorkspace(): React.JSX.Element {
+  const { phase } = useCloudAuth();
   const {
     thread,
     switchThread,
@@ -840,7 +841,13 @@ export function RemixWorkspace(): React.JSX.Element {
     openChat,
   } = useRemixSession();
 
-  if (!thread) return <div className="remix-workspace" />;
+  if (!thread) {
+    return phase === "checking" ? (
+      <RemixWorkspaceLoadingSkeleton />
+    ) : (
+      <div className="remix-workspace" />
+    );
+  }
 
   return (
     <div className="remix-workspace">
@@ -860,6 +867,14 @@ export function RemixWorkspace(): React.JSX.Element {
         onOpenChat={openChat}
         desktop
       />
+    </div>
+  );
+}
+
+function RemixWorkspaceLoadingSkeleton(): React.JSX.Element {
+  return (
+    <div className="remix-workspace">
+      <ConversationSkeleton />
     </div>
   );
 }
@@ -1057,9 +1072,9 @@ function ConversationSkeleton(): React.JSX.Element {
       aria-live="polite"
       aria-label="Loading conversation"
     >
-      <span className="remix-conversation-skeleton-line is-user" />
-      <span className="remix-conversation-skeleton-line is-assistant" />
-      <span className="remix-conversation-skeleton-line is-assistant-short" />
+      <span className="remix-conversation-skeleton-line is-user block h-12 w-[min(57%,390px)] self-end rounded-xl border border-border bg-card" />
+      <span className="remix-conversation-skeleton-line is-assistant block h-[54px] w-[min(74%,520px)] rounded-xl border border-border bg-card" />
+      <span className="remix-conversation-skeleton-line is-assistant-short block h-[18px] w-[min(46%,310px)] rounded-xl border border-border bg-card" />
       <span className="sr-only">Loading conversation</span>
     </div>
   );
@@ -1892,13 +1907,19 @@ function PanelInner({
   };
 
   // Signed out, the gate is the entire panel — no head, no tabs, no way to
-  // reach the agent. While auth status resolves, show nothing rather than
-  // flashing the gate at signed-in users.
+  // reach the agent. While auth status resolves, keep the conversation's
+  // layout visible but withhold its sensitive controls and content.
   if (!auth.user) {
     return (
       <div className={desktop ? "remix-agent" : "tavern-shell"}>
-        <div className="tavern tavern-panel">
-          {auth.loading ? null : <SignInGate />}
+        <div
+          className={`tavern tavern-panel${desktop ? " remix-agent-panel" : ""}`}
+        >
+          {auth.phase === "checking" ? (
+            <ConversationSkeleton />
+          ) : (
+            <SignInGate />
+          )}
         </div>
         {!desktop ? <PanelTail /> : null}
         {!desktop ? <PanelResizeHandle /> : null}

--- a/apps/electron/src/renderer/src/components/remix-session-context.tsx
+++ b/apps/electron/src/renderer/src/components/remix-session-context.tsx
@@ -119,10 +119,10 @@ export function RemixSessionProvider({
     title: string;
   } | null>(null);
   const queryClient = useQueryClient();
-  const { user, loading } = useCloudAuth();
+  const { canRequestData, phase } = useCloudAuth();
   const latestQuery = useQuery({
     ...latestThreadQueryOptions(),
-    enabled: !loading && !!user,
+    enabled: canRequestData,
   });
   const selectionRef = useRef(0);
   const deletionVersionRef = useRef(0);
@@ -227,7 +227,7 @@ export function RemixSessionProvider({
   );
 
   useEffect(() => {
-    if (loading || !user) {
+    if (phase === "signed_out") {
       setThread(null);
       setWorkspaceSurface("chat");
       setLoadingThreadId(null);
@@ -244,10 +244,10 @@ export function RemixSessionProvider({
       ?.getRemixSessionTitles?.()
       .then((titles) => setLocalTitles(titles))
       .catch(() => {});
-  }, [loading, user]);
+  }, [phase]);
 
   useEffect(() => {
-    if (loading || !user) return;
+    if (!canRequestData) return;
     return subscribeToAgentThreadActivity(({ threads: entries }) => {
       const next = Object.fromEntries(
         entries.map((entry) => [entry.threadId, entry]),
@@ -271,7 +271,7 @@ export function RemixSessionProvider({
         });
       }
     });
-  }, [loading, user]);
+  }, [canRequestData]);
 
   const renameThread = useCallback(async (threadId: string, title: string) => {
     const nextTitle = title.trim();
@@ -434,7 +434,7 @@ export function RemixSessionProvider({
   }, [deleteNotice]);
 
   useEffect(() => {
-    if (loading || !user) return;
+    if (!canRequestData) return;
     const off = window.api.onPanelOpenThread((threadId) => {
       openChat();
       const selection = ++selectionRef.current;
@@ -451,10 +451,10 @@ export function RemixSessionProvider({
         });
     });
     return () => off?.();
-  }, [loading, markSessionSeen, openChat, queryClient, user]);
+  }, [canRequestData, markSessionSeen, openChat, queryClient]);
 
   useEffect(() => {
-    if (loading || !user) return;
+    if (!canRequestData) return;
     const off = window.api?.onPanelThreadUpdated?.((threadId) => {
       // This is an observation update, not a navigation command. If someone
       // opened the pill in the workspace and then selected another session,
@@ -463,7 +463,7 @@ export function RemixSessionProvider({
       requestThreadTitleRefresh(threadId);
     });
     return () => off?.();
-  }, [loading, refreshThread, requestThreadTitleRefresh, user]);
+  }, [canRequestData, refreshThread, requestThreadTitleRefresh]);
 
   useEffect(() => {
     if (latestQuery.isPending) return;

--- a/apps/electron/src/renderer/src/dashboard.tsx
+++ b/apps/electron/src/renderer/src/dashboard.tsx
@@ -31,7 +31,14 @@ import { ThemeProvider, useTheme } from "next-themes";
 import { lazy, StrictMode, Suspense, useEffect, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import { I18nextProvider } from "react-i18next";
-import { HashRouter, Navigate, Outlet, Route, Routes } from "react-router";
+import {
+  HashRouter,
+  Navigate,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+} from "react-router";
 
 // Route-level code splitting: the landing route (Today), the app shell, and the
 // tiny not-found page load eagerly; every other page is lazy so the initial
@@ -81,7 +88,73 @@ function ThemePreferenceBridge(): React.JSX.Element | null {
 // Keep the workspace shell and its geometry present while a lazy page chunk
 // arrives. The page's own loading state replaces this next; this only covers
 // the short gap before that component can mount.
+type RouteFallbackCopy = {
+  eyebrow?: string;
+  title: string;
+  subtitle?: string;
+};
+
+const PAGE_FALLBACKS: Record<string, RouteFallbackCopy> = {
+  "/remix": { title: "Remix" },
+  "/dictionary": {
+    title: "Shortcuts",
+    subtitle: "Shortcuts that expand as you speak. Say the key, get the value.",
+  },
+  "/vocabulary": { title: "Vocabulary" },
+  "/tone": {
+    title: "Tone",
+    subtitle: "How much Freestyle cleans up — and how it sounds in each app.",
+  },
+  "/settings/models": { title: "Models" },
+  "/help": { title: "Help" },
+  "/profile": {
+    title: "Profile",
+    subtitle: "Manage your account details.",
+  },
+  "/plugins": {
+    title: "Plugins",
+    subtitle:
+      "Install plugins to add features. Each runs in the dictation pipeline and can ship its own page.",
+  },
+};
+
+const SETTINGS_FALLBACKS: Record<string, RouteFallbackCopy> = {
+  application: { eyebrow: "Settings", title: "Application" },
+  companion: { eyebrow: "Settings", title: "Companion" },
+  recording: { eyebrow: "Settings", title: "Dictation" },
+  remix: { eyebrow: "Settings", title: "Remix" },
+  mcp: { eyebrow: "Settings", title: "MCP connections" },
+  display: { eyebrow: "Settings", title: "Appearance" },
+  permissions: { eyebrow: "Settings", title: "Permissions" },
+  data: { eyebrow: "Settings", title: "Data" },
+  notifications: { eyebrow: "Settings", title: "Notifications" },
+  connectedApps: { eyebrow: "Settings", title: "Connected apps" },
+  billing: { eyebrow: "Settings", title: "Usage & billing" },
+  network: { eyebrow: "Settings", title: "Network" },
+};
+
+function fallbackCopyForPath(pathname: string): RouteFallbackCopy {
+  const pageFallback = PAGE_FALLBACKS[pathname];
+  if (pageFallback) return pageFallback;
+
+  if (pathname.startsWith("/settings/")) {
+    const section = pathname.slice("/settings/".length);
+    return SETTINGS_FALLBACKS[section] ?? SETTINGS_FALLBACKS.recording;
+  }
+
+  if (pathname.startsWith("/plugins/")) return { title: "Plugin" };
+
+  return { title: "Freestyle" };
+}
+
+// This copy intentionally stays local and synchronous. Locale files load after
+// mount, so waiting for translated strings here would recreate the blank/skeleton
+// gap that this fallback is meant to avoid. The lazy page replaces it as soon as
+// its chunk (and its translated content) is available.
 function RouteFallback(): React.JSX.Element {
+  const { pathname } = useLocation();
+  const { eyebrow, title, subtitle } = fallbackCopyForPath(pathname);
+
   return (
     <div
       aria-busy="true"
@@ -89,9 +162,21 @@ function RouteFallback(): React.JSX.Element {
       className="dashboard-route-skeleton flex min-h-0 flex-1 flex-col gap-7 px-6 pb-8 pt-12 sm:px-10"
       role="status"
     >
-      <div className="max-w-xl space-y-3">
-        <div className="dashboard-route-skeleton-line h-9 w-56 animate-pulse rounded-md bg-muted/65" />
-        <div className="dashboard-route-skeleton-line h-3 w-80 max-w-full animate-pulse rounded-full bg-muted/55" />
+      <div className="max-w-xl">
+        {eyebrow ? (
+          <p className="text-muted-foreground mono mb-2 text-[10px] font-semibold tracking-[0.16em] uppercase">
+            {eyebrow}
+          </p>
+        ) : null}
+        <h1 className="serif text-foreground m-0 text-[48px] font-normal leading-[0.95] tracking-[-0.025em]">
+          <span className="serif-italic text-primary">{title}</span>
+          <span>.</span>
+        </h1>
+        {subtitle ? (
+          <p className="text-muted-foreground mt-2.5 max-w-[580px] text-[14px] leading-[1.5]">
+            {subtitle}
+          </p>
+        ) : null}
       </div>
       <div className="grid max-w-5xl gap-4 md:grid-cols-2">
         {["first", "second"].map((card) => (

--- a/apps/electron/src/renderer/src/lib/api.test.ts
+++ b/apps/electron/src/renderer/src/lib/api.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+
+describe("typed API client startup routing", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("window", {
+      api: {
+        getServerUrl: vi.fn(async () => "https://desktop.example.test"),
+        getServerToken: vi.fn(async () => "configured-server-token"),
+        getServerPort: vi.fn(async () => 4649),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves the configured target and bearer token at request dispatch", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const { getClient } = await import("./api");
+
+    await getClient().api.settings.$get();
+
+    const request = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(request.url).toBe("https://desktop.example.test/api/settings");
+    expect(request.headers.get("authorization")).toBe(
+      "Bearer configured-server-token",
+    );
+  });
+
+  it("reports a typed protected 401 to the shared observer", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 401 }));
+    const { getClient, subscribeToUnauthorized } = await import("./api");
+    const unauthorized = vi.fn();
+    const unsubscribe = subscribeToUnauthorized(unauthorized);
+
+    await getClient().api.settings.$get();
+
+    expect(unauthorized).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+});

--- a/apps/electron/src/renderer/src/lib/api.ts
+++ b/apps/electron/src/renderer/src/lib/api.ts
@@ -43,6 +43,31 @@ async function observedFetch(
   return response;
 }
 
+/**
+ * Hono constructs a request URL when `getClient()` is called. During startup
+ * that can precede the asynchronous IPC read of the configured server target.
+ * Resolve and rebuild the request at dispatch time so a cached typed client
+ * never sends its first request to the default loopback port or omits a
+ * newly-read bearer token.
+ */
+async function resolvedClientFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  await resolveApiBase();
+
+  const original = new Request(input, init);
+  const url = new URL(original.url);
+  const target = `${getApiBase()}${url.pathname}${url.search}${url.hash}`;
+  const headers = new Headers(original.headers);
+  for (const [key, value] of Object.entries(bearerAuthHeaders(serverToken))) {
+    if (!headers.has(key)) headers.set(key, value);
+  }
+
+  const routedRequest = new Request(target, original);
+  return observedFetch(new Request(routedRequest, { headers }));
+}
+
 /** Base URL of the locally-run server (used when no server URL is configured). */
 export function getLocalApiBase(): string {
   return `http://127.0.0.1:${resolvedPort}`;
@@ -199,7 +224,7 @@ export function getClient() {
   if (!_client || _clientBase !== base || _clientToken !== serverToken) {
     _client = hc<AppType>(base, {
       headers: bearerAuthHeaders(serverToken),
-      fetch: observedFetch,
+      fetch: resolvedClientFetch,
     });
     _clientBase = base;
     _clientToken = serverToken;

--- a/apps/electron/src/renderer/src/lib/api.ts
+++ b/apps/electron/src/renderer/src/lib/api.ts
@@ -19,6 +19,29 @@ let apiBaseResolution: Promise<void> | null = null;
 // The in-flight health probe, shared so concurrent callers do not each run a
 // redundant server check during the same startup tick.
 let initPromise: Promise<void> | null = null;
+const unauthorizedListeners = new Set<() => void>();
+
+/**
+ * Subscribe to definitive protected-request failures observed by either API
+ * transport. A 401 is the server's authoritative signal that the locally
+ * stored session can no longer be used; transport failures are deliberately
+ * not reported here.
+ */
+export function subscribeToUnauthorized(listener: () => void): () => void {
+  unauthorizedListeners.add(listener);
+  return () => unauthorizedListeners.delete(listener);
+}
+
+async function observedFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const response = await fetch(input, init);
+  if (response.status === 401) {
+    for (const listener of unauthorizedListeners) listener();
+  }
+  return response;
+}
 
 /** Base URL of the locally-run server (used when no server URL is configured). */
 export function getLocalApiBase(): string {
@@ -59,7 +82,7 @@ export function apiFetch(
     for (const [key, value] of Object.entries(bearerAuthHeaders(serverToken))) {
       if (!headers.has(key)) headers.set(key, value);
     }
-    return fetch(`${getApiBase()}${path}`, { ...init, headers });
+    return observedFetch(`${getApiBase()}${path}`, { ...init, headers });
   });
 }
 
@@ -174,7 +197,10 @@ export function getClient() {
   // client is otherwise stable, so this avoids allocating a fresh one — and
   // re-parsing headers — on every query/mutation call site.
   if (!_client || _clientBase !== base || _clientToken !== serverToken) {
-    _client = hc<AppType>(base, { headers: bearerAuthHeaders(serverToken) });
+    _client = hc<AppType>(base, {
+      headers: bearerAuthHeaders(serverToken),
+      fetch: observedFetch,
+    });
     _clientBase = base;
     _clientToken = serverToken;
   }

--- a/apps/electron/src/renderer/src/lib/auth-context.tsx
+++ b/apps/electron/src/renderer/src/lib/auth-context.tsx
@@ -1,4 +1,8 @@
-import { type QueryClient, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   createContext,
   useCallback,
@@ -8,7 +12,7 @@ import {
   useState,
 } from "react";
 import type { CloudUser } from "../../../shared/cloud-user";
-import { getClient, resolveApiBase } from "./api";
+import { getClient, resolveApiBase, subscribeToUnauthorized } from "./api";
 import { resetBrainCache } from "./brain-fs";
 import { queryKeys } from "./query";
 
@@ -19,6 +23,10 @@ function resetAccountCaches(queryClient: QueryClient): void {
 
 export interface UseCloudAuth {
   user: CloudUser | null;
+  /** Whether the server has not yet definitively accepted or rejected the session. */
+  phase: "checking" | "authenticated" | "signed_out";
+  /** Read-only requests may use the stored bearer while the profile reconciles. */
+  canRequestData: boolean;
   loading: boolean;
   signingIn: boolean;
   /** Device user code, surfaced while a sign-in is pending. */
@@ -37,86 +45,78 @@ const CloudAuthContext = createContext<UseCloudAuth | null>(null);
 /** Renderer-side state for Freestyle Cloud sign-in (drives the OAuth device flow in main). */
 function useCloudAuthState(): UseCloudAuth {
   const queryClient = useQueryClient();
-  const [user, setUser] = useState<CloudUser | null>(null);
-  const [loading, setLoading] = useState(true);
   const [signingIn, setSigningIn] = useState(false);
   const [userCode, setUserCode] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [sessionExpired, setSessionExpired] = useState(false);
+  const [forcedSignedOut, setForcedSignedOut] = useState(false);
   const wasSignedInRef = useRef(false);
   const cancelledRef = useRef(false);
   const signInPromiseRef = useRef<Promise<CloudUser | null> | null>(null);
   const signInAttemptRef = useRef(0);
-  // Collapses concurrent status checks into one in-flight request. On a fresh
-  // window the mount retry-loop and the `focus` listener (fired the moment the
-  // just-shown window focuses) both call refreshInternal within the same tick —
-  // without this they'd hit /api/auth/status twice back-to-back.
-  const refreshInFlightRef = useRef<Promise<{
-    user: CloudUser | null;
-    reached: boolean;
-  }> | null>(null);
-
-  const refreshInternal = useCallback(async (): Promise<{
-    user: CloudUser | null;
-    reached: boolean;
-  }> => {
-    if (refreshInFlightRef.current) return refreshInFlightRef.current;
-    const run = (async () => {
-      let reached = false;
+  const authStatusQuery = useQuery({
+    queryKey: queryKeys.cloud.authStatus,
+    queryFn: async (): Promise<{
+      user: CloudUser | null;
+      reached: boolean;
+    }> => {
       await resolveApiBase();
-      const user = await getClient()
-        .api.auth.status.$get()
-        .then(async (res) => {
-          if (!res.ok) return null;
-          reached = true;
-          const data = await res.json();
-          return data.user ?? null;
-        })
-        .catch(() => null);
-      if (reached) {
-        if (!user && wasSignedInRef.current) {
-          setSessionExpired(true);
-          queryClient.removeQueries({
-            queryKey: queryKeys.connectors.all,
-          });
-        }
-        if (user) setSessionExpired(false);
-        wasSignedInRef.current = !!user;
-        setUser(user);
-      }
-      return { user, reached };
-    })();
-    refreshInFlightRef.current = run;
-    try {
-      return await run;
-    } finally {
-      refreshInFlightRef.current = null;
+      const response = await getClient().api.auth.status.$get();
+      // Only a successfully decoded status response can declare the visitor
+      // signed out. A timeout, offline error, or 5xx leaves the shell usable
+      // and lets each requested resource report its own state.
+      if (!response.ok) return { user: null, reached: false };
+      const data = await response.json();
+      return { user: data.user ?? null, reached: true };
+    },
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const status = authStatusQuery.data;
+  const { refetch: refetchAuthStatus } = authStatusQuery;
+  const phase = forcedSignedOut
+    ? "signed_out"
+    : status?.reached
+      ? status.user
+        ? "authenticated"
+        : "signed_out"
+      : "checking";
+  const user = phase === "authenticated" ? (status?.user ?? null) : null;
+  const loading = phase === "checking";
+  const canRequestData = phase !== "signed_out";
+
+  useEffect(() => {
+    if (!status?.reached) return;
+    if (!status.user && wasSignedInRef.current) {
+      setSessionExpired(true);
+      queryClient.removeQueries({ queryKey: queryKeys.connectors.all });
     }
-  }, [queryClient]);
+    if (status.user) setSessionExpired(false);
+    wasSignedInRef.current = !!status.user;
+  }, [queryClient, status]);
+
+  useEffect(
+    () =>
+      subscribeToUnauthorized(() => {
+        const wasSignedIn = wasSignedInRef.current;
+        wasSignedInRef.current = false;
+        setSessionExpired(wasSignedIn);
+        setForcedSignedOut(true);
+        resetAccountCaches(queryClient);
+      }),
+    [queryClient],
+  );
 
   const refresh = useCallback(
-    async (): Promise<CloudUser | null> => (await refreshInternal()).user,
-    [refreshInternal],
+    async (): Promise<CloudUser | null> =>
+      (await refetchAuthStatus()).data?.user ?? null,
+    [refetchAuthStatus],
   );
 
   useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      for (let attempt = 0; attempt < 15 && !cancelled; attempt++) {
-        const { reached } = await refreshInternal();
-        if (reached) break;
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-      }
-      if (!cancelled) setLoading(false);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [refreshInternal]);
-
-  useEffect(() => {
     const revalidate = (): void => {
-      void refreshInternal();
+      void refetchAuthStatus();
     };
     window.addEventListener("focus", revalidate);
     const timer = setInterval(revalidate, 5 * 60 * 1000);
@@ -124,7 +124,7 @@ function useCloudAuthState(): UseCloudAuth {
       window.removeEventListener("focus", revalidate);
       clearInterval(timer);
     };
-  }, [refreshInternal]);
+  }, [refetchAuthStatus]);
 
   const signIn = useCallback(async (): Promise<CloudUser | null> => {
     if (signInPromiseRef.current) return signInPromiseRef.current;
@@ -170,7 +170,11 @@ function useCloudAuthState(): UseCloudAuth {
         resetAccountCaches(queryClient);
         wasSignedInRef.current = true;
         setSessionExpired(false);
-        setUser(data.user);
+        setForcedSignedOut(false);
+        queryClient.setQueryData(queryKeys.cloud.authStatus, {
+          user: data.user,
+          reached: true,
+        });
         return data.user;
       }
       throw new Error("Sign-in timed out. Please try again.");
@@ -208,12 +212,14 @@ function useCloudAuthState(): UseCloudAuth {
       .catch(() => {});
     wasSignedInRef.current = false;
     setSessionExpired(false);
-    setUser(null);
+    setForcedSignedOut(true);
     resetAccountCaches(queryClient);
   }, [queryClient]);
 
   return {
     user,
+    phase,
+    canRequestData,
     loading,
     signingIn,
     userCode,

--- a/apps/electron/src/renderer/src/lib/auth-context.tsx
+++ b/apps/electron/src/renderer/src/lib/auth-context.tsx
@@ -69,8 +69,13 @@ function useCloudAuthState(): UseCloudAuth {
       const data = await response.json();
       return { user: data.user ?? null, reached: true };
     },
+    enabled: !forcedSignedOut,
     retry: false,
     refetchOnWindowFocus: false,
+    // A transient startup outage must not switch the window to sign-in, but
+    // it should still reconcile promptly once the local server or network is
+    // available again. Stop this cadence as soon as status is authoritative.
+    refetchInterval: (query) => (query.state.data?.reached ? false : 5_000),
   });
 
   const status = authStatusQuery.data;

--- a/apps/electron/src/renderer/src/lib/query.ts
+++ b/apps/electron/src/renderer/src/lib/query.ts
@@ -140,6 +140,7 @@ export const queryKeys = {
   attention: ["attention"] as const,
 
   cloud: {
+    authStatus: ["cloud-auth-status"] as const,
     usage: ["cloud-usage"] as const,
     orgs: ["cloud-orgs"] as const,
     activeOrg: ["cloud-active-org"] as const,

--- a/apps/electron/src/renderer/src/pages/dictionary.tsx
+++ b/apps/electron/src/renderer/src/pages/dictionary.tsx
@@ -4,7 +4,7 @@ import {
 } from "@freestyle-voice/validations";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { DragSpacer } from "@renderer/components/drag-spacer";
-import { DictionaryLikePageSkeleton } from "@renderer/components/page-loading-skeleton";
+import { DictionaryLikeEntriesSkeleton } from "@renderer/components/page-loading-skeleton";
 import { Button } from "@renderer/components/ui/button";
 import { Input } from "@renderer/components/ui/input";
 import { Textarea } from "@renderer/components/ui/textarea";
@@ -142,7 +142,8 @@ export default function DictionaryPage(): React.JSX.Element {
 
   const importRef = useRef<HTMLInputElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const searchShortcutEnabled = !(total === 0 && !search && !showForm);
+  const searchShortcutEnabled =
+    loading || !(total === 0 && !search && !showForm);
 
   useEffect(() => {
     if (!searchShortcutEnabled) return;
@@ -198,11 +199,7 @@ export default function DictionaryPage(): React.JSX.Element {
     [invalidate],
   );
 
-  if (loading) {
-    return <DictionaryLikePageSkeleton />;
-  }
-
-  const isEmpty = total === 0 && !search;
+  const isEmpty = !loading && total === 0 && !search;
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -340,7 +337,9 @@ export default function DictionaryPage(): React.JSX.Element {
             )}
 
             {/* Entries list */}
-            {entries.length === 0 ? (
+            {loading ? (
+              <DictionaryLikeEntriesSkeleton />
+            ) : entries.length === 0 ? (
               <NoSearchResults search={search} />
             ) : (
               <div className="border-border bg-card overflow-hidden rounded-[12px] border">

--- a/apps/electron/src/renderer/src/pages/history.tsx
+++ b/apps/electron/src/renderer/src/pages/history.tsx
@@ -546,31 +546,6 @@ export default function HistoryPage(): React.JSX.Element {
     return out;
   }, [dailyData, hasDevSeedEntry]);
 
-  if (loading) {
-    // Keep the real page frame (DragSpacer + scroll column) and show placeholder
-    // rows instead of a blank centered spinner, so the panel shows structure
-    // immediately while the first /api/history fetch resolves. Matches the main
-    // return's wrapper so there's no layout shift when content arrives.
-    return (
-      <div className="flex h-full min-h-0 flex-col">
-        <DragSpacer />
-        <div
-          className="responsive-page-scroll flex-1 overflow-auto pt-5"
-          style={{ scrollbarWidth: "none" } as React.CSSProperties}
-        >
-          <div className="animate-pulse space-y-3" aria-hidden="true">
-            {["s1", "s2", "s3", "s4", "s5", "s6"].map((k) => (
-              <div
-                key={k}
-                className="border-border/50 bg-card/60 h-16 rounded-lg border"
-              />
-            ))}
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   const isGenuineEmpty = stats?.unfiltered_total_sessions === 0;
 
   const hero = heroReady && !heroDismissed && !isGenuineEmpty && (
@@ -722,6 +697,37 @@ export default function HistoryPage(): React.JSX.Element {
       </div>
     </div>
   );
+
+  if (loading) {
+    // Keep navigation affordances available while the initial history request
+    // resolves. Only the sensitive rows are placeholders, so the first paint
+    // already reads as the usable Dictate history surface.
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <DragSpacer />
+        <div
+          className="responsive-page-scroll flex-1 overflow-auto pt-5"
+          style={{ scrollbarWidth: "none" } as React.CSSProperties}
+        >
+          {searchRow}
+          <div
+            className="animate-pulse space-y-3"
+            aria-busy="true"
+            aria-label="Loading transcription history"
+            role="status"
+          >
+            {["s1", "s2", "s3", "s4", "s5", "s6"].map((k) => (
+              <div
+                key={k}
+                className="border-border/50 bg-card/60 h-16 rounded-lg border"
+                aria-hidden="true"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const filtersModal = (
     <FiltersModal

--- a/apps/electron/src/renderer/src/pages/profile.tsx
+++ b/apps/electron/src/renderer/src/pages/profile.tsx
@@ -62,7 +62,9 @@ function initialsFor(user: {
 }
 
 export default function ProfilePage(): React.JSX.Element {
-  const { user } = useCloudAuth();
+  const { user, phase } = useCloudAuth();
+
+  if (phase === "checking") return <ProfilePageSkeleton />;
 
   if (!user) {
     return (
@@ -111,6 +113,36 @@ export default function ProfilePage(): React.JSX.Element {
 
         {/* Connected accounts */}
         <ConnectedAccountsCard enabled={!!user} />
+      </div>
+    </PageShell>
+  );
+}
+
+function ProfilePageSkeleton(): React.JSX.Element {
+  return (
+    <PageShell>
+      <PageHeader title="Profile" subtitle="Manage your account details." />
+      <div className="mx-auto max-w-2xl space-y-6" aria-busy="true">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-4">
+              <Skeleton className="size-16 rounded-full" />
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-32" />
+                <Skeleton className="h-4 w-48" />
+              </div>
+            </div>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-4 w-64" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-9 w-full max-w-sm" />
+          </CardContent>
+        </Card>
       </div>
     </PageShell>
   );

--- a/apps/electron/src/renderer/src/pages/tone.tsx
+++ b/apps/electron/src/renderer/src/pages/tone.tsx
@@ -516,7 +516,14 @@ export default function TonePage(): React.JSX.Element {
   const cleanupMode: CleanupCardValue = cleanupIntensity;
 
   if (loading) {
-    return <TonePageLoadingSkeleton />;
+    return (
+      <PageShell>
+        <div className="mx-auto w-full max-w-[1060px]">
+          <PageHeader title={t("tone.title")} subtitle={t("tone.subtitle")} />
+          <TonePageLoadingSkeleton />
+        </div>
+      </PageShell>
+    );
   }
 
   return (
@@ -648,33 +655,22 @@ export default function TonePage(): React.JSX.Element {
 
 function TonePageLoadingSkeleton(): React.JSX.Element {
   return (
-    <PageShell>
-      <div
-        aria-busy="true"
-        aria-label="Loading tone settings"
-        className="mx-auto w-full max-w-[1060px]"
-        role="status"
-      >
-        <div className="mb-7 space-y-3">
-          <Skeleton className="h-11 w-48 max-w-full" />
-          <Skeleton className="h-4 w-[min(34rem,80%)] max-w-full" />
-        </div>
-        <Skeleton className="h-11 w-96 max-w-full rounded-full" />
-        <div className="mt-7 grid gap-4 md:grid-cols-3">
-          {["first", "second", "third"].map((card) => (
-            <div
-              key={card}
-              className="border-border bg-card rounded-[14px] border p-5"
-            >
-              <Skeleton className="h-4 w-28" />
-              <Skeleton className="mt-4 h-3 w-full" />
-              <Skeleton className="mt-2 h-3 w-4/5" />
-              <Skeleton className="mt-7 h-9 w-24" />
-            </div>
-          ))}
-        </div>
+    <div aria-busy="true" aria-label="Loading tone settings" role="status">
+      <Skeleton className="h-11 w-96 max-w-full rounded-full" />
+      <div className="mt-7 grid gap-4 md:grid-cols-3">
+        {["first", "second", "third"].map((card) => (
+          <div
+            key={card}
+            className="border-border bg-card rounded-[14px] border p-5"
+          >
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="mt-4 h-3 w-full" />
+            <Skeleton className="mt-2 h-3 w-4/5" />
+            <Skeleton className="mt-7 h-9 w-24" />
+          </div>
+        ))}
       </div>
-    </PageShell>
+    </div>
   );
 }
 

--- a/apps/electron/src/renderer/src/pages/vocabulary.tsx
+++ b/apps/electron/src/renderer/src/pages/vocabulary.tsx
@@ -4,7 +4,7 @@ import {
 } from "@freestyle-voice/validations";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { DragSpacer } from "@renderer/components/drag-spacer";
-import { DictionaryLikePageSkeleton } from "@renderer/components/page-loading-skeleton";
+import { DictionaryLikeEntriesSkeleton } from "@renderer/components/page-loading-skeleton";
 import { Button } from "@renderer/components/ui/button";
 import { Input } from "@renderer/components/ui/input";
 import { getClient } from "@renderer/lib/api";
@@ -225,7 +225,8 @@ export default function VocabularyPage(): React.JSX.Element {
 
   const importRef = useRef<HTMLInputElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const searchShortcutEnabled = !(total === 0 && !search && !showForm);
+  const searchShortcutEnabled =
+    loading || !(total === 0 && !search && !showForm);
 
   useEffect(() => {
     if (!searchShortcutEnabled) return;
@@ -291,11 +292,7 @@ export default function VocabularyPage(): React.JSX.Element {
     [invalidate, t],
   );
 
-  if (loading) {
-    return <DictionaryLikePageSkeleton />;
-  }
-
-  const isEmpty = total === 0 && !search;
+  const isEmpty = !loading && total === 0 && !search;
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -452,7 +449,9 @@ export default function VocabularyPage(): React.JSX.Element {
               </form>
             )}
 
-            {entries.length === 0 ? (
+            {loading ? (
+              <DictionaryLikeEntriesSkeleton />
+            ) : entries.length === 0 ? (
               <NoSearchResults search={search} />
             ) : (
               <>

--- a/apps/electron/src/renderer/src/shell.tsx
+++ b/apps/electron/src/renderer/src/shell.tsx
@@ -332,6 +332,7 @@ function RemixSidebarSessions({
     completedSessionIds,
     markSessionSeen,
   } = useRemixSession();
+  const { phase } = useCloudAuth();
   const listRef = useRef<HTMLDivElement>(null);
   const [hasMoreSessions, setHasMoreSessions] = useState(false);
 
@@ -378,6 +379,7 @@ function RemixSidebarSessions({
           type="button"
           className="remix-sidebar-new"
           onClick={startNewThread}
+          disabled={phase === "checking"}
         >
           <Plus aria-hidden="true" />
           New chat
@@ -389,6 +391,7 @@ function RemixSidebarSessions({
           }`}
           aria-current={workspaceSurface === "scheduled" ? "page" : undefined}
           onClick={openScheduledTasks}
+          disabled={phase === "checking"}
         >
           <CalendarClock aria-hidden="true" />
           Schedules
@@ -623,7 +626,7 @@ export default function AppShell(): React.JSX.Element {
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
-  const { user, loading: authLoading } = useCloudAuth();
+  const { user, phase, canRequestData } = useCloudAuth();
   const isRemixRoute = location.pathname === "/remix";
   const isSettingsRoute =
     location.pathname === "/settings" ||
@@ -703,7 +706,7 @@ export default function AppShell(): React.JSX.Element {
   const { data: plugins = [] } = useQuery({
     queryKey: queryKeys.plugins,
     queryFn: () => listPlugins(),
-    enabled: !authLoading && !!user,
+    enabled: canRequestData,
   });
 
   const pluginNav = usePluginNavItems(plugins);
@@ -744,7 +747,7 @@ export default function AppShell(): React.JSX.Element {
   // established a user, the sign-in route owns the entire window; rendering
   // the app sidebar beside it makes the login experience look like a broken
   // half-loaded workspace and can briefly expose stale navigation state.
-  if (!user) return <SignedOutShell />;
+  if (phase === "signed_out") return <SignedOutShell />;
 
   return (
     <div className="glass-window-shell flex h-screen min-h-0">
@@ -784,7 +787,7 @@ export default function AppShell(): React.JSX.Element {
                   DEV
                 </span>
               )}
-              {isRemixSidebar && !authLoading && user ? (
+              {isRemixSidebar && canRequestData ? (
                 <button
                   type="button"
                   aria-label="Search sessions"
@@ -801,7 +804,7 @@ export default function AppShell(): React.JSX.Element {
               className="no-scrollbar min-h-0 flex-1 overflow-y-auto"
               style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
             >
-              {isRemixSidebar && !authLoading && user ? (
+              {isRemixSidebar && canRequestData ? (
                 <RemixSidebarSessions searchQuery="" />
               ) : (
                 <>
@@ -839,7 +842,7 @@ export default function AppShell(): React.JSX.Element {
         onWidthChange={setSidebarWidth}
       />
 
-      {isRemixSidebar && !authLoading && user ? (
+      {isRemixSidebar && canRequestData ? (
         <SessionSearchDialog
           open={isSessionSearchOpen}
           onOpenChange={handleSessionSearchOpenChange}

--- a/apps/electron/src/renderer/src/startup-rendering.test.ts
+++ b/apps/electron/src/renderer/src/startup-rendering.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 const rendererRoot = dirname(fileURLToPath(import.meta.url));
 
 describe("dashboard startup rendering", () => {
-  it("uses a full-window signed-out shell while authentication verifies", async () => {
+  it("keeps the application shell and page data mounted while authentication verifies", async () => {
     const [dashboard, gate, shell] = await Promise.all([
       readFile(resolve(rendererRoot, "dashboard.tsx"), "utf8"),
       readFile(resolve(rendererRoot, "components/login-gate.tsx"), "utf8"),
@@ -15,10 +15,12 @@ describe("dashboard startup rendering", () => {
 
     expect(dashboard).toContain("<Route element={<AppShell />}>");
     expect(dashboard).toContain("<ProtectedOutlet />");
-    expect(gate).toContain("function StartupContentPlaceholder");
-    expect(gate).not.toContain("function AuthLoadingFrame");
+    expect(gate).not.toContain("StartupContentPlaceholder");
+    expect(gate).toContain('if (phase === "signed_out") return <LoginPage />;');
     expect(shell).toContain("function SignedOutShell");
-    expect(shell).toContain("if (!user) return <SignedOutShell />;");
+    expect(shell).toContain(
+      'if (phase === "signed_out") return <SignedOutShell />;',
+    );
     expect(shell).toContain(
       'className="glass-content relative flex min-h-0 min-w-0 flex-1 flex-col"',
     );
@@ -68,18 +70,34 @@ describe("dashboard startup rendering", () => {
     expect(tone).not.toContain('t("tone.loading")');
   });
 
-  it("does not start account-only data queries until authentication resolves", async () => {
-    const [sessions, shell, upgrade] = await Promise.all([
-      readFile(
-        resolve(rendererRoot, "components/remix-session-context.tsx"),
-        "utf8",
-      ),
-      readFile(resolve(rendererRoot, "shell.tsx"), "utf8"),
-      readFile(resolve(rendererRoot, "components/upgrade-modal.tsx"), "utf8"),
-    ]);
+  it("starts read-only data queries while authentication is still checking", async () => {
+    const [api, auth, history, panel, sessions, shell, upgrade] =
+      await Promise.all([
+        readFile(resolve(rendererRoot, "lib/api.ts"), "utf8"),
+        readFile(resolve(rendererRoot, "lib/auth-context.tsx"), "utf8"),
+        readFile(resolve(rendererRoot, "pages/history.tsx"), "utf8"),
+        readFile(resolve(rendererRoot, "components/panel.tsx"), "utf8"),
+        readFile(
+          resolve(rendererRoot, "components/remix-session-context.tsx"),
+          "utf8",
+        ),
+        readFile(resolve(rendererRoot, "shell.tsx"), "utf8"),
+        readFile(resolve(rendererRoot, "components/upgrade-modal.tsx"), "utf8"),
+      ]);
 
-    expect(sessions).toContain("enabled: !loading && !!user");
-    expect(shell).toContain("enabled: !authLoading && !!user");
+    expect(api).toContain("export function subscribeToUnauthorized");
+    expect(api).toContain("fetch: observedFetch");
+    expect(auth).toContain("subscribeToUnauthorized");
+    expect(auth).toContain("resetAccountCaches(queryClient)");
+    expect(sessions).toContain("enabled: canRequestData");
+    expect(shell).toContain("enabled: canRequestData");
+    expect(sessions).toContain(
+      "const { canRequestData, phase } = useCloudAuth();",
+    );
+    expect(history).toContain('aria-label="Loading transcription history"');
+    expect(history).toContain("{searchRow}");
+    expect(panel).toContain("RemixWorkspaceLoadingSkeleton");
+    expect(panel).toContain('aria-label="Loading conversation"');
     expect(upgrade).toContain("useCheckoutState");
     expect(upgrade).toContain('open || checkoutStatus === "pending"');
   });

--- a/apps/electron/src/renderer/src/startup-rendering.test.ts
+++ b/apps/electron/src/renderer/src/startup-rendering.test.ts
@@ -49,6 +49,11 @@ describe("dashboard startup rendering", () => {
     expect(dashboard).toContain('aria-label="Loading page"');
     expect(dashboard).toContain("dashboard-route-skeleton");
     expect(dashboard).toContain("dashboard-route-skeleton-line");
+    expect(dashboard).toContain("const SETTINGS_FALLBACKS");
+    expect(dashboard).toContain('title: "Shortcuts"');
+    expect(dashboard).toContain('title: "Vocabulary"');
+    expect(dashboard).toContain('title: "Plugins"');
+    expect(dashboard).toContain('title: "Profile"');
     expect(dashboard).not.toContain(
       'return <div className="min-h-0 flex-1" />;',
     );
@@ -62,7 +67,11 @@ describe("dashboard startup rendering", () => {
     );
 
     for (const page of [dictionary, vocabulary]) {
-      expect(page).toContain("DictionaryLikePageSkeleton");
+      expect(page).toContain("DictionaryLikeEntriesSkeleton");
+      expect(page).toContain(
+        "loading || !(total === 0 && !search && !showForm)",
+      );
+      expect(page).not.toContain("return <DictionaryLike");
       expect(page).not.toMatch(/t\("(?:dictionary|vocabulary)\.loading"\)/);
     }
 
@@ -86,7 +95,7 @@ describe("dashboard startup rendering", () => {
       ]);
 
     expect(api).toContain("export function subscribeToUnauthorized");
-    expect(api).toContain("fetch: observedFetch");
+    expect(api).toContain("fetch: resolvedClientFetch");
     expect(auth).toContain("subscribeToUnauthorized");
     expect(auth).toContain("resetAccountCaches(queryClient)");
     expect(auth).toContain("refetchInterval");

--- a/apps/electron/src/renderer/src/startup-rendering.test.ts
+++ b/apps/electron/src/renderer/src/startup-rendering.test.ts
@@ -89,6 +89,8 @@ describe("dashboard startup rendering", () => {
     expect(api).toContain("fetch: observedFetch");
     expect(auth).toContain("subscribeToUnauthorized");
     expect(auth).toContain("resetAccountCaches(queryClient)");
+    expect(auth).toContain("refetchInterval");
+    expect(auth).toContain("enabled: !forcedSignedOut");
     expect(sessions).toContain("enabled: canRequestData");
     expect(shell).toContain("enabled: canRequestData");
     expect(sessions).toContain(

--- a/apps/electron/tests/dashboard-visual.test.ts
+++ b/apps/electron/tests/dashboard-visual.test.ts
@@ -24,7 +24,8 @@ const DASHBOARD_SCENARIOS = [
 ] as const;
 
 const DASHBOARD_URL = "app://renderer/index.html";
-const FIXTURE_DELAY_MS = 650;
+const PAGE_DATA_DELAY_MS = 650;
+const AUTH_STATUS_DELAY_MS = 1_800;
 
 let app: ElectronApplication | undefined;
 let pill: Page;
@@ -32,11 +33,13 @@ let dashboard: Page;
 
 async function installDashboardFixtures(page: Page): Promise<void> {
   await page.addInitScript(
-    ({ delayMs }) => {
+    ({ authStatusDelayMs, pageDataDelayMs }) => {
       const visualReviewWindow = window as typeof window & {
         __visualReviewErrors?: string[];
+        __visualReviewRequests?: string[];
       };
       visualReviewWindow.__visualReviewErrors = [];
+      visualReviewWindow.__visualReviewRequests = [];
       const originalFetch = window.fetch.bind(window);
       window.fetch = async (input, init) => {
         const url = new URL(
@@ -48,12 +51,23 @@ async function installDashboardFixtures(page: Page): Promise<void> {
         );
         if (!url.pathname.startsWith("/api/"))
           return originalFetch(input, init);
+        visualReviewWindow.__visualReviewRequests?.push(url.pathname);
 
         if (url.pathname === "/api/client-error") {
           visualReviewWindow.__visualReviewErrors?.push(
             typeof init?.body === "string" ? init.body : "Unknown client error",
           );
           return new Response(JSON.stringify({ ok: true }), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+
+        const protected401 =
+          new URLSearchParams(window.location.search).get("visual") ===
+            "protected-401" && url.pathname === "/api/history";
+        if (protected401) {
+          return new Response(JSON.stringify({ error: "Unauthorized" }), {
+            status: 401,
             headers: { "content-type": "application/json" },
           });
         }
@@ -147,15 +161,23 @@ async function installDashboardFixtures(page: Page): Promise<void> {
           return {};
         })();
 
-        if (url.pathname !== "/api/auth/status") {
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
-        }
+        await new Promise((resolve) =>
+          setTimeout(
+            resolve,
+            url.pathname === "/api/auth/status"
+              ? authStatusDelayMs
+              : pageDataDelayMs,
+          ),
+        );
         return new Response(JSON.stringify(body), {
           headers: { "content-type": "application/json" },
         });
       };
     },
-    { delayMs: FIXTURE_DELAY_MS },
+    {
+      authStatusDelayMs: AUTH_STATUS_DELAY_MS,
+      pageDataDelayMs: PAGE_DATA_DELAY_MS,
+    },
   );
 }
 
@@ -229,6 +251,22 @@ test("captures every main dashboard page while loading and after data resolves",
       dashboard.getByRole("button", { name: "Sign in via browser" }),
     ).toBeHidden();
 
+    if (scenario.id === "today") {
+      await expect(dashboard.getByLabel("Loading profile")).toBeVisible();
+      await expect(
+        dashboard.getByLabel("Loading transcription history"),
+      ).toBeVisible();
+      await expect(dashboard.getByPlaceholder(/Search/)).toBeVisible();
+    }
+    if (scenario.id === "remix") {
+      await expect(dashboard.getByLabel("Loading profile")).toBeVisible();
+      await expect(dashboard.getByLabel("Loading sessions")).toBeVisible();
+      await expect(dashboard.getByLabel("Loading conversation")).toBeVisible();
+      await expect(
+        dashboard.getByRole("button", { name: "Switch workspace" }),
+      ).toBeVisible();
+    }
+
     const loading = testInfo.outputPath(`${scenario.id}.loading.png`);
     await dashboard.screenshot({ path: loading });
     await testInfo.attach(`${scenario.id}-loading`, {
@@ -236,7 +274,9 @@ test("captures every main dashboard page while loading and after data resolves",
       contentType: "image/png",
     });
 
-    await dashboard.waitForTimeout(FIXTURE_DELAY_MS + 150);
+    await dashboard.waitForTimeout(
+      AUTH_STATUS_DELAY_MS + PAGE_DATA_DELAY_MS + 150,
+    );
     // A fixed delay is not sufficient when the lazy route itself loads before
     // it starts its data query. Wait for the semantic loading state to clear
     // so the second capture is genuinely the settled UI rather than another
@@ -251,6 +291,20 @@ test("captures every main dashboard page while loading and after data resolves",
       return visualReviewWindow.__visualReviewErrors ?? [];
     });
     expect(reportedErrors).toEqual([]);
+    const requestedEndpoints = await dashboard.evaluate(() => {
+      const visualReviewWindow = window as typeof window & {
+        __visualReviewRequests?: string[];
+      };
+      return visualReviewWindow.__visualReviewRequests ?? [];
+    });
+    if (scenario.id === "today") {
+      expect(requestedEndpoints).toContain("/api/auth/status");
+      expect(requestedEndpoints).toContain("/api/history");
+    }
+    if (scenario.id === "remix") {
+      expect(requestedEndpoints).toContain("/api/auth/status");
+      expect(requestedEndpoints).toContain("/api/agent/thread/latest");
+    }
     await expect(
       dashboard.getByRole("heading", {
         name: "Freestyle hit an unexpected error.",
@@ -265,4 +319,21 @@ test("captures every main dashboard page while loading and after data resolves",
       contentType: "image/png",
     });
   }
+});
+
+test("shows full-window sign-in after a protected request returns 401", async () => {
+  await dashboard.goto(`${DASHBOARD_URL}?visual=protected-401#/today`);
+
+  await expect(
+    dashboard.getByRole("button", { name: "Sign in via browser" }),
+  ).toBeVisible();
+  await expect(dashboard.locator(".glass-sidebar")).toHaveCount(0);
+
+  const requestedEndpoints = await dashboard.evaluate(() => {
+    const visualReviewWindow = window as typeof window & {
+      __visualReviewRequests?: string[];
+    };
+    return visualReviewWindow.__visualReviewRequests ?? [];
+  });
+  expect(requestedEndpoints).toContain("/api/history");
 });

--- a/apps/electron/tests/dashboard-visual.test.ts
+++ b/apps/electron/tests/dashboard-visual.test.ts
@@ -27,6 +27,19 @@ const DASHBOARD_URL = "app://renderer/index.html";
 const PAGE_DATA_DELAY_MS = 650;
 const AUTH_STATUS_DELAY_MS = 1_800;
 
+const STATIC_LOADING_HEADINGS: Partial<
+  Record<(typeof DASHBOARD_SCENARIOS)[number]["id"], RegExp>
+> = {
+  "settings-transcription": /Dictation/,
+  "settings-models": /Models/,
+  "settings-application": /Application/,
+  dictionary: /Shortcuts/,
+  vocabulary: /Vocabulary/,
+  tone: /Tone/,
+  profile: /Profile/,
+  plugins: /Plugins/,
+};
+
 let app: ElectronApplication | undefined;
 let pill: Page;
 let dashboard: Page;
@@ -264,6 +277,23 @@ test("captures every main dashboard page while loading and after data resolves",
       await expect(dashboard.getByLabel("Loading conversation")).toBeVisible();
       await expect(
         dashboard.getByRole("button", { name: "Switch workspace" }),
+      ).toBeVisible();
+    }
+    const staticHeading = STATIC_LOADING_HEADINGS[scenario.id];
+    if (staticHeading) {
+      await expect(
+        dashboard.getByRole("heading", { level: 1, name: staticHeading }),
+      ).toBeVisible();
+    }
+    if (
+      scenario.id === "dictionary" ||
+      scenario.id === "vocabulary" ||
+      scenario.id === "tone"
+    ) {
+      await expect(
+        dashboard.getByLabel(
+          scenario.id === "tone" ? "Loading tone settings" : "Loading entries",
+        ),
       ).toBeVisible();
     }
 


### PR DESCRIPTION
## Summary
- render the desktop shell and page skeletons while the shared React Query auth status request reconciles in the background
- start read-only Dictate, Remix, plugin, and attention queries during auth checking; reserve full-window sign-in for definitive no-user responses or protected 401s
- route Hono and raw fetch calls through one 401 observer that clears account caches, and keep account/mutating surfaces unavailable during checking
- extend real-Electron visual coverage for delayed auth, endpoint requests, loading and settled /today and /remix states, and protected-401 sign-in

## Verification
- pnpm --filter @freestyle-voice/electron test -- src/renderer/src/startup-rendering.test.ts (76 files, 312 tests passed)
- pnpm --filter @freestyle-voice/electron typecheck
- pnpm --filter @freestyle-voice/electron test:visual (real Electron; passed)

## Visual artifacts
The dashboard visual run attaches these to its Playwright result: `today.loading.png`, `today.loaded.png`, `remix.loading.png`, and `remix.loaded.png`. The loading captures verify visible sidebar/filter or workspace chrome, a profile skeleton, and data/conversation skeletons before `/api/auth/status` resolves.