### PR TITLE
fix(models): Recover from local Whisper setup failures

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -844,6 +844,19 @@ function openPanelSettings(): void {
   });
 }
 
+function openPanelModels(): void {
+  openPanel({ trigger: "other" });
+  const win = panelWindow;
+  if (win && !win.isDestroyed()) {
+    win.show();
+    win.focus();
+  }
+  panelRendererMessages.send({
+    channel: "dashboard:navigate",
+    payload: "/settings/models",
+  });
+}
+
 /**
  * Resolves once a freshly-created pill window has finished loading and is
  * visible.  `null` when no deferred show is in progress.
@@ -2047,8 +2060,26 @@ app.whenReady().then(async () => {
       cancelId: 1,
     });
     if (response !== 0) return false;
-    openPanel({ focusComposer: true });
+    openPanelModels();
     return true;
+  });
+
+  ipcMain.handle("local-whisper:prompt-recovery", async () => {
+    const { response } = await dialog.showMessageBox({
+      type: "warning",
+      message: "Local Whisper needs setup",
+      detail:
+        "CMake is required to finish setting up Local Whisper. Use Freestyle Cloud instead, or choose another model in Settings > Models.",
+      buttons: ["Use Freestyle Cloud", "Choose another model", "Not now"],
+      defaultId: 0,
+      cancelId: 2,
+    });
+    if (response === 0) return "cloud";
+    if (response === 1) {
+      openPanelModels();
+      return "models";
+    }
+    return "dismissed";
   });
 
   // Shown when Freestyle Cloud reports the free-tier usage limit is exhausted.

--- a/apps/electron/src/main/panel-renderer-message-queue.ts
+++ b/apps/electron/src/main/panel-renderer-message-queue.ts
@@ -8,7 +8,10 @@ export type PanelRendererMessage =
   | { channel: "panel:dictation"; payload: PanelDictationEvent }
   | { channel: "panel:open-thread"; payload: string }
   | { channel: "panel:thread-updated"; payload: string }
-  | { channel: "dashboard:navigate"; payload: "/settings" | "/remix" };
+  | {
+      channel: "dashboard:navigate";
+      payload: "/settings" | "/settings/models" | "/remix";
+    };
 
 /**
  * Holds panel messages until React has registered its IPC listeners. Electron's

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -48,6 +48,9 @@ declare global {
       onServerChanged: (callback: () => void) => () => void;
       openLogsFolder: () => Promise<boolean>;
       openExternal: (url: string) => Promise<boolean>;
+      localWhisperPromptRecovery: () => Promise<
+        "cloud" | "models" | "dismissed"
+      >;
       onHotkeyDown: (callback: () => void) => () => void;
       onHotkeyUp: (callback: () => void) => () => void;
       onDictationCancel: (callback: () => void) => () => void;
@@ -113,7 +116,7 @@ declare global {
       panelPointerEntered: () => void;
       onPanelFocusComposer: (callback: () => void) => () => void;
       onDashboardNavigate: (
-        callback: (route: "/settings" | "/remix") => void,
+        callback: (route: "/settings" | "/settings/models" | "/remix") => void,
       ) => () => void;
       notificationPresent: (payload: {
         messageId: string;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -61,6 +61,8 @@ const api = {
     ipcRenderer.invoke("cloud:prompt-sign-in"),
   cloudPromptUpgrade: (): Promise<boolean> =>
     ipcRenderer.invoke("cloud:prompt-upgrade"),
+  localWhisperPromptRecovery: (): Promise<"cloud" | "models" | "dismissed"> =>
+    ipcRenderer.invoke("local-whisper:prompt-recovery"),
   pasteRemixResult: (text: string): Promise<boolean> =>
     ipcRenderer.invoke("remix:paste", text),
   onRemixDown: (callback: () => void): (() => void) => {
@@ -286,9 +288,13 @@ const api = {
     ipcRenderer.on("panel:focus-composer", handler);
     return () => ipcRenderer.removeListener("panel:focus-composer", handler);
   },
-  onDashboardNavigate: (callback: (route: "/settings" | "/remix") => void) => {
-    const handler = (_e: unknown, route: "/settings" | "/remix"): void =>
-      callback(route);
+  onDashboardNavigate: (
+    callback: (route: "/settings" | "/settings/models" | "/remix") => void,
+  ) => {
+    const handler = (
+      _e: unknown,
+      route: "/settings" | "/settings/models" | "/remix",
+    ): void => callback(route);
     ipcRenderer.on("dashboard:navigate", handler);
     return () => ipcRenderer.removeListener("dashboard:navigate", handler);
   },

--- a/apps/electron/src/renderer/src/lib/local-whisper-recovery.test.ts
+++ b/apps/electron/src/renderer/src/lib/local-whisper-recovery.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { recoverFromLocalWhisperSetup } from "./local-whisper-recovery";
+
+describe("Local Whisper setup recovery", () => {
+  it("switches to Freestyle Cloud only after the user chooses it", async () => {
+    const calls: string[] = [];
+
+    const recovered = await recoverFromLocalWhisperSetup({
+      prompt: async () => "cloud",
+      activateCloud: async () => {
+        calls.push("activate-cloud");
+        return true;
+      },
+      resume: () => calls.push("resume"),
+    });
+
+    expect(recovered).toBe(true);
+    expect(calls).toEqual(["activate-cloud", "resume"]);
+  });
+
+  it("leaves the selected model unchanged when the user opens model setup", async () => {
+    const calls: string[] = [];
+
+    const recovered = await recoverFromLocalWhisperSetup({
+      prompt: async () => "models",
+      activateCloud: async () => {
+        calls.push("activate-cloud");
+        return true;
+      },
+      resume: () => calls.push("resume"),
+    });
+
+    expect(recovered).toBe(false);
+    expect(calls).toEqual([]);
+  });
+});

--- a/apps/electron/src/renderer/src/lib/local-whisper-recovery.ts
+++ b/apps/electron/src/renderer/src/lib/local-whisper-recovery.ts
@@ -1,0 +1,16 @@
+export type LocalWhisperRecoveryChoice = "cloud" | "models" | "dismissed";
+
+export async function recoverFromLocalWhisperSetup({
+  prompt,
+  activateCloud,
+  resume,
+}: {
+  prompt: () => Promise<LocalWhisperRecoveryChoice>;
+  activateCloud: () => Promise<boolean>;
+  resume: () => void;
+}): Promise<boolean> {
+  if ((await prompt()) !== "cloud") return false;
+  if (!(await activateCloud())) return false;
+  resume();
+  return true;
+}

--- a/apps/electron/src/renderer/src/pages/app.tsx
+++ b/apps/electron/src/renderer/src/pages/app.tsx
@@ -19,6 +19,7 @@ import {
   getNeedsAppContextForCleanup,
   refreshNeedsAppContextForCleanup,
 } from "@renderer/lib/cleanup-app-context";
+import { recoverFromLocalWhisperSetup } from "@renderer/lib/local-whisper-recovery";
 import { Recorder, RecorderSupersededError } from "@renderer/lib/recorder";
 import { Streamer, type StreamerConnectionState } from "@renderer/lib/streamer";
 import {
@@ -383,6 +384,7 @@ interface TranscribeResult {
   error?: string;
   cloudAuthRequired?: boolean;
   usageExceeded?: boolean;
+  localWhisperSetupRequired?: boolean;
   providerCategory?: string;
   /**
    * Terminal pipeline disposition from the server. A plugin that called
@@ -820,6 +822,32 @@ export default function AppPage(): React.JSX.Element {
           void window.api.cloudPromptUpgrade();
           return;
         }
+        if (results.some((r) => r.localWhisperSetupRequired)) {
+          const errMsg =
+            results.find((r) => r.localWhisperSetupRequired)?.error ??
+            "Local Whisper needs setup";
+          failedTranscriptionErrorRef.current = errMsg;
+          setCanRetry(streamerRef.current?.hasCapturedAudio() ?? false);
+          setPillNotice("unavailable");
+          setPillState("error");
+          const recovered = await recoverFromLocalWhisperSetup({
+            prompt: () => window.api.localWhisperPromptRecovery(),
+            activateCloud: async () => {
+              const response = await apiFetch(
+                "/api/models/defaults/freestyle-cloud",
+                { method: "POST" },
+              );
+              if (response.status === 401) {
+                void window.api.cloudPromptSignIn();
+                return false;
+              }
+              return response.ok;
+            },
+            resume: retryFailedTranscription,
+          });
+          if (!recovered) hidePill();
+          return;
+        }
         const errMsg = results.find((r) => r.error)?.error;
         if (errMsg) {
           failedTranscriptionErrorRef.current = errMsg;
@@ -864,6 +892,7 @@ export default function AppPage(): React.JSX.Element {
           } else if (res.status === 401) {
             const body = (await res.json().catch(() => null)) as {
               error?: string;
+              detail?: string;
             } | null;
             if (body?.error === "cloud_auth_required") {
               hidePill();
@@ -1019,6 +1048,7 @@ export default function AppPage(): React.JSX.Element {
           if (!res.ok) {
             const body = (await res.json().catch(() => null)) as {
               error?: string;
+              detail?: string;
             } | null;
             if (res.status === 401 && body?.error === "cloud_auth_required") {
               return {
@@ -1034,6 +1064,17 @@ export default function AppPage(): React.JSX.Element {
                 cleaned: "",
                 error: USAGE_LIMIT_DIALOG_MESSAGE,
                 usageExceeded: true,
+              };
+            }
+            if (
+              res.status === 422 &&
+              body?.error === "local_whisper_setup_failed"
+            ) {
+              return {
+                raw: "",
+                cleaned: "",
+                error: body.detail ?? "Local Whisper needs setup",
+                localWhisperSetupRequired: true,
               };
             }
             return { raw: "", cleaned: "", error: errorMsg };
@@ -1984,6 +2025,17 @@ export default function AppPage(): React.JSX.Element {
               cleaned: "",
               error: USAGE_LIMIT_DIALOG_MESSAGE,
               usageExceeded: true,
+            };
+          }
+          if (
+            res.status === 422 &&
+            body?.error === "local_whisper_setup_failed"
+          ) {
+            return {
+              raw: "",
+              cleaned: "",
+              error: body.detail ?? "Local Whisper needs setup",
+              localWhisperSetupRequired: true,
             };
           }
           const msg =

--- a/apps/server/src/lib/freestyle-cloud-defaults.ts
+++ b/apps/server/src/lib/freestyle-cloud-defaults.ts
@@ -4,6 +4,7 @@ import {
   FREESTYLE_CLOUD_PROVIDER_ID,
   FREESTYLE_CLOUD_TRANSCRIBE_MODEL_ID,
 } from "./freestyle-cloud.js";
+import { captureModelSelection } from "./sentry.js";
 
 export function applyFreestyleCloudDefaults(): void {
   const db = getDb();
@@ -38,6 +39,22 @@ export function applyFreestyleCloudDefaults(): void {
     `INSERT INTO settings (key, value, updated_at) VALUES ('llm_cleanup', 'true', datetime('now'))
      ON CONFLICT(key) DO UPDATE SET value = 'true', updated_at = datetime('now')`,
   ).run();
+}
+
+/** Keep telemetry aligned with the paired defaults applied above. */
+export function recordFreestyleCloudDefaultSelection(): void {
+  captureModelSelection({
+    provider: FREESTYLE_CLOUD_PROVIDER_ID,
+    modelId: FREESTYLE_CLOUD_TRANSCRIBE_MODEL_ID,
+    type: "voice",
+    action: "selected",
+  });
+  captureModelSelection({
+    provider: FREESTYLE_CLOUD_PROVIDER_ID,
+    modelId: FREESTYLE_CLOUD_CLEANUP_MODEL_ID,
+    type: "llm",
+    action: "selected",
+  });
 }
 
 export function revertFreestyleCloudDefaults(): void {

--- a/apps/server/src/lib/sentry.ts
+++ b/apps/server/src/lib/sentry.ts
@@ -191,6 +191,33 @@ export function capture(
   }
 }
 
+/** Record an explicit model configuration or default-selection change. */
+export function captureModelSelection({
+  provider,
+  modelId,
+  type,
+  action,
+}: {
+  provider: string;
+  modelId: string;
+  type: string;
+  action: "configured" | "selected";
+}): void {
+  if (!isTelemetryEnabled()) return;
+  try {
+    Sentry.metrics.count("freestyle.model_selection", 1, {
+      attributes: {
+        provider,
+        model_id: modelId,
+        type,
+        action,
+      },
+    });
+  } catch {
+    // Metrics must never alter model selection behavior.
+  }
+}
+
 export function captureException(
   error: unknown,
   additionalProperties?: Record<string, unknown>,

--- a/apps/server/src/lib/streaming/providers/whisper-local.ts
+++ b/apps/server/src/lib/streaming/providers/whisper-local.ts
@@ -17,6 +17,32 @@ import { stripProviderPrefix } from "../types.js";
 
 const log = createAppLogger("whisper");
 
+export function getLocalWhisperSetupFailure(error: unknown): {
+  error: "local_whisper_setup_failed";
+  reason: "cmake_missing" | "setup_failed";
+  detail: string;
+} | null {
+  const message = error instanceof Error ? error.message : String(error);
+  if (
+    !message.startsWith(
+      "whisper-server binary not found and automatic setup failed:",
+    )
+  ) {
+    return null;
+  }
+
+  const cmakeMissing =
+    /spawn cmake ENOENT/.test(message) ||
+    message.includes("CMake is required to build Local Whisper");
+  return {
+    error: "local_whisper_setup_failed",
+    reason: cmakeMissing ? "cmake_missing" : "setup_failed",
+    detail: cmakeMissing
+      ? "Local Whisper needs CMake to finish setup. Choose Freestyle Cloud or another model in Settings > Models."
+      : "Local Whisper could not finish setup. Choose Freestyle Cloud or another model in Settings > Models.",
+  };
+}
+
 export class WhisperLocalTranscriptionProvider
   implements TranscriptionProvider
 {

--- a/apps/server/src/lib/whisper/models.ts
+++ b/apps/server/src/lib/whisper/models.ts
@@ -394,6 +394,24 @@ async function buildFromSource(): Promise<void> {
   const binDir = getBinDir();
   if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true });
 
+  // Check the one required build tool before downloading and unpacking source.
+  // This lets the caller offer an actionable fallback without leaving a partial
+  // source tree behind on machines that do not have CMake installed.
+  try {
+    await execFile("cmake", ["--version"], { timeout: 10_000 });
+  } catch (err) {
+    const code =
+      err && typeof err === "object" && "code" in err
+        ? (err as { code?: unknown }).code
+        : undefined;
+    if (code === "ENOENT") {
+      throw new Error(
+        "CMake is required to build Local Whisper. Install CMake and try again.",
+      );
+    }
+    throw err;
+  }
+
   const srcDir = join(binDir, "whisper.cpp-src");
   const buildDir = join(srcDir, "build");
 

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -23,7 +23,10 @@ import {
   updateCloudProfile,
   updateCloudUserName,
 } from "../lib/freestyle-cloud.js";
-import { applyFreestyleCloudDefaults } from "../lib/freestyle-cloud-defaults.js";
+import {
+  applyFreestyleCloudDefaults,
+  recordFreestyleCloudDefaultSelection,
+} from "../lib/freestyle-cloud-defaults.js";
 import {
   pullCloudPreferences,
   pullCloudPreferencesWithRetry,
@@ -84,6 +87,7 @@ const auth = new Hono()
         host: freestyleCloudUrl(),
       });
       applyFreestyleCloudDefaults();
+      recordFreestyleCloudDefaultSelection();
       identifyCloudUser(user);
       // If a DIFFERENT account previously synced on this device, scrub its
       // synced preferences + vocabulary first so this account seeds cleanly and

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -7,6 +7,7 @@ import {
   FREESTYLE_CLOUD_PROVIDER_ID,
   FREESTYLE_CLOUD_TRANSCRIBE_MODEL_ID,
 } from "../lib/freestyle-cloud.js";
+import { applyFreestyleCloudDefaults } from "../lib/freestyle-cloud-defaults.js";
 import {
   LEGACY_MLX_ASR_MODELS,
   MLX_ASR_MODELS,
@@ -16,7 +17,8 @@ import {
 import { getMlxModelStatus } from "../lib/mlx-asr/models.js";
 import { reconcileUnsupportedMlxVoiceDefault } from "../lib/mlx-asr/reconcile.js";
 import { canRunMlxAsr } from "../lib/mlx-asr/server.js";
-import { capture } from "../lib/sentry.js";
+import { capture, captureModelSelection } from "../lib/sentry.js";
+import { getSessionToken } from "../lib/sessions.js";
 import {
   LEGACY_WHISPER_MODELS,
   WHISPER_MODELS,
@@ -491,6 +493,27 @@ const models = new Hono()
     }[];
     return c.json(rows);
   })
+  .post("/defaults/freestyle-cloud", (c) => {
+    if (!getSessionToken()) {
+      return c.json({ error: "cloud_auth_required" }, 401);
+    }
+
+    applyFreestyleCloudDefaults();
+    captureModelSelection({
+      provider: FREESTYLE_CLOUD_PROVIDER_ID,
+      modelId: FREESTYLE_CLOUD_TRANSCRIBE_MODEL_ID,
+      type: "voice",
+      action: "selected",
+    });
+    captureModelSelection({
+      provider: FREESTYLE_CLOUD_PROVIDER_ID,
+      modelId: FREESTYLE_CLOUD_CLEANUP_MODEL_ID,
+      type: "llm",
+      action: "selected",
+    });
+
+    return c.json({ ok: true });
+  })
   .post("/configured", zValidator("json", configureModelSchema), (c) => {
     const db = getDb();
     const body = c.req.valid("json");
@@ -525,6 +548,14 @@ const models = new Hono()
       type: body.type,
       is_default: body.is_default ?? false,
     });
+    if (body.is_default) {
+      captureModelSelection({
+        provider: body.provider,
+        modelId: body.model_id,
+        type: body.type,
+        action: "selected",
+      });
+    }
 
     return c.json({ id: result.lastInsertRowid, ...body }, 201);
   })
@@ -553,6 +584,12 @@ const models = new Hono()
       type: row.type,
       provider: row.provider,
       model_id: row.model_id,
+    });
+    captureModelSelection({
+      provider: row.provider,
+      modelId: row.model_id,
+      type: row.type,
+      action: "selected",
     });
 
     return c.json({ ok: true });

--- a/apps/server/src/routes/models.ts
+++ b/apps/server/src/routes/models.ts
@@ -7,7 +7,10 @@ import {
   FREESTYLE_CLOUD_PROVIDER_ID,
   FREESTYLE_CLOUD_TRANSCRIBE_MODEL_ID,
 } from "../lib/freestyle-cloud.js";
-import { applyFreestyleCloudDefaults } from "../lib/freestyle-cloud-defaults.js";
+import {
+  applyFreestyleCloudDefaults,
+  recordFreestyleCloudDefaultSelection,
+} from "../lib/freestyle-cloud-defaults.js";
 import {
   LEGACY_MLX_ASR_MODELS,
   MLX_ASR_MODELS,
@@ -499,18 +502,7 @@ const models = new Hono()
     }
 
     applyFreestyleCloudDefaults();
-    captureModelSelection({
-      provider: FREESTYLE_CLOUD_PROVIDER_ID,
-      modelId: FREESTYLE_CLOUD_TRANSCRIBE_MODEL_ID,
-      type: "voice",
-      action: "selected",
-    });
-    captureModelSelection({
-      provider: FREESTYLE_CLOUD_PROVIDER_ID,
-      modelId: FREESTYLE_CLOUD_CLEANUP_MODEL_ID,
-      type: "llm",
-      action: "selected",
-    });
+    recordFreestyleCloudDefaultSelection();
 
     return c.json({ ok: true });
   })

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -35,6 +35,7 @@ import { getDefaultModels } from "../lib/providers.js";
 import { capture, captureException } from "../lib/sentry.js";
 import { invalidateSession } from "../lib/sessions.js";
 import { CloudAuthError } from "../lib/streaming/providers/freestyle-cloud.js";
+import { getLocalWhisperSetupFailure } from "../lib/streaming/providers/whisper-local.js";
 import { getProvider } from "../lib/streaming/registry.js";
 import {
   getApiKeyForProvider,
@@ -449,6 +450,10 @@ const transcribeRoute = new Hono().post("/", async (c) => {
       log.error(
         `transcribe failed (${voiceProvider}/${voiceModel}): ${formatError(err)}`,
       );
+      const localWhisperSetupFailure = getLocalWhisperSetupFailure(err);
+      if (localWhisperSetupFailure) {
+        return c.json(localWhisperSetupFailure, 422);
+      }
       if (!isTransientCloudError(err)) {
         captureException(err, { provider: voiceProvider, model: voiceModel });
       }

--- a/apps/server/tests/cloud-auth.test.ts
+++ b/apps/server/tests/cloud-auth.test.ts
@@ -4,6 +4,15 @@ import { getDb, readSetting } from "../src/lib/db.js";
 import { getDefaultModels } from "../src/lib/providers.js";
 import { clearSession, getSession, setSession } from "../src/lib/sessions.js";
 
+const telemetry = vi.hoisted(() => ({
+  captureModelSelection: vi.fn(),
+}));
+
+vi.mock("../src/lib/sentry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/lib/sentry.js")>();
+  return { ...actual, captureModelSelection: telemetry.captureModelSelection };
+});
+
 const app = createApp();
 
 vi.mock("../src/lib/freestyle-cloud.js", async (importOriginal) => {
@@ -215,6 +224,37 @@ describe("Freestyle Transcribe default on sign-in", () => {
     expect(res.status).toBe(201);
 
     expect(getDefaultModels().voice?.provider).toBe("openai");
+  });
+
+  it("records a user-selected default model for the metrics dashboard", async () => {
+    const res = await app.request("/api/models/configured", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "openai",
+        model_id: "openai/whisper-1",
+        model_name: "OpenAI Whisper",
+        type: "voice",
+        is_default: true,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(telemetry.captureModelSelection).toHaveBeenCalledWith({
+      provider: "openai",
+      modelId: "openai/whisper-1",
+      type: "voice",
+      action: "selected",
+    });
+  });
+
+  it("requires sign-in before switching the defaults back to Freestyle Cloud", async () => {
+    const res = await app.request("/api/models/defaults/freestyle-cloud", {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "cloud_auth_required" });
   });
 
   it("keeps the Freestyle voice default and disables cleanup on sign-out", async () => {

--- a/apps/server/tests/cloud-auth.test.ts
+++ b/apps/server/tests/cloud-auth.test.ts
@@ -191,6 +191,24 @@ describe("Freestyle Transcribe default on sign-in", () => {
     expect(readSetting("llm_cleanup")).toBe("true");
   });
 
+  it("records the defaults selected when sign-in applies Freestyle Cloud", async () => {
+    const res = await signIn();
+
+    expect(res.status).toBe(200);
+    expect(telemetry.captureModelSelection).toHaveBeenNthCalledWith(1, {
+      provider: "freestyle-cloud",
+      modelId: "freestyle-cloud/stt",
+      type: "voice",
+      action: "selected",
+    });
+    expect(telemetry.captureModelSelection).toHaveBeenNthCalledWith(2, {
+      provider: "freestyle-cloud",
+      modelId: "freestyle-cloud/post-process",
+      type: "llm",
+      action: "selected",
+    });
+  });
+
   it("overrides an existing non-cloud voice default and turns cleanup on", async () => {
     insertNonCloudVoiceDefault();
     getDb()
@@ -255,6 +273,20 @@ describe("Freestyle Transcribe default on sign-in", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: "cloud_auth_required" });
+  });
+
+  it("re-applies the Freestyle defaults after an authenticated recovery choice", async () => {
+    await signIn();
+    insertNonCloudVoiceDefault();
+
+    const res = await app.request("/api/models/defaults/freestyle-cloud", {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(200);
+    expect(getDefaultModels().voice?.provider).toBe("freestyle-cloud");
+    expect(getDefaultModels().llm?.provider).toBe("freestyle-cloud");
+    expect(readSetting("llm_cleanup")).toBe("true");
   });
 
   it("keeps the Freestyle voice default and disables cleanup on sign-out", async () => {

--- a/apps/server/tests/sentry.test.ts
+++ b/apps/server/tests/sentry.test.ts
@@ -29,6 +29,7 @@ vi.mock("../src/lib/db.js", () => ({
 import {
   capture,
   captureException,
+  captureModelSelection,
   identifyCloudUser,
   invalidateTelemetrySetting,
   registerSuperProperties,
@@ -76,6 +77,28 @@ describe("Sentry telemetry adapter", () => {
       {
         unit: "millisecond",
         attributes: { "event.name": "transcription completed" },
+      },
+    );
+  });
+
+  it("records the selected model as a queryable metric", () => {
+    captureModelSelection({
+      provider: "freestyle-cloud",
+      modelId: "freestyle-cloud/stt",
+      type: "voice",
+      action: "selected",
+    });
+
+    expect(sentry.metrics.count).toHaveBeenCalledWith(
+      "freestyle.model_selection",
+      1,
+      {
+        attributes: {
+          provider: "freestyle-cloud",
+          model_id: "freestyle-cloud/stt",
+          type: "voice",
+          action: "selected",
+        },
       },
     );
   });

--- a/apps/server/tests/whisper-setup-error.test.ts
+++ b/apps/server/tests/whisper-setup-error.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import * as whisperLocal from "../src/lib/streaming/providers/whisper-local.js";
+
+describe("Local Whisper setup errors", () => {
+  it("turns a missing CMake prerequisite into a recoverable setup failure", () => {
+    const error = new Error(
+      "whisper-server binary not found and automatic setup failed: spawn cmake ENOENT",
+    );
+
+    expect(whisperLocal.getLocalWhisperSetupFailure(error)).toEqual({
+      error: "local_whisper_setup_failed",
+      reason: "cmake_missing",
+      detail:
+        "Local Whisper needs CMake to finish setup. Choose Freestyle Cloud or another model in Settings > Models.",
+    });
+  });
+
+  it("recognizes the CMake preflight before a source build starts", () => {
+    const error = new Error(
+      "whisper-server binary not found and automatic setup failed: CMake is required to build Local Whisper. Install CMake and try again.",
+    );
+
+    expect(whisperLocal.getLocalWhisperSetupFailure(error)?.reason).toBe(
+      "cmake_missing",
+    );
+  });
+});


### PR DESCRIPTION
Model-default changes now emit bounded Sentry metrics, including the defaults applied after Cloud sign-in. The Product Health dashboard breaks those selections down by provider and model ID so similarly named models do not collapse into one bucket.

When Local Whisper cannot finish setup because CMake is unavailable, the server detects that prerequisite before downloading source and returns a recoverable response instead of reporting an exception. Desktop presents an explicit choice to switch the captured dictation to Freestyle Cloud and retry, or to open Models and select another provider.
