### PR TITLE
fix(electron): persist companion close

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -3636,12 +3636,16 @@ ipcMain.handle("companion:status", () => companionStatus);
 
 ipcMain.handle("pet:enabled", () => petEnabled());
 
+function setPetEnabled(enabled: boolean): void {
+  writeSettings({ petEnabled: enabled });
+  panelWindow?.webContents.send("pet:enabled", enabled);
+  if (enabled) createCompanionWindow();
+  else destroyCompanionWindow();
+}
+
 ipcMain.on("pet:set-enabled", (event, enabled: unknown) => {
   if (event.sender !== panelWindow?.webContents) return;
-  const next = enabled === true;
-  writeSettings({ petEnabled: next });
-  if (next) createCompanionWindow();
-  else destroyCompanionWindow();
+  setPetEnabled(enabled === true);
 });
 
 ipcMain.on("companion:wake", (event) => {
@@ -3715,7 +3719,7 @@ ipcMain.on("companion:context-menu", (event) => {
       label: "Close companion",
       click: () => {
         hideNotifications();
-        destroyCompanionWindow();
+        setPetEnabled(false);
       },
     },
   ]).popup({ window: win });

--- a/apps/electron/src/main/preload-contract.test.ts
+++ b/apps/electron/src/main/preload-contract.test.ts
@@ -371,6 +371,20 @@ describe("preload contract", () => {
 
     expect(main).toContain('webContents.send("pet:enabled", enabled)');
     expect(preload).toContain('ipcRenderer.on("pet:enabled"');
-    expect(settings).toContain("window.api.onPetEnabled(setPetEnabled)");
+    expect(settings).toContain(
+      "window.api.onPetEnabled(petEnabledSync.onChanged)",
+    );
+  });
+
+  it("subscribes before reading companion availability so a close event wins", async () => {
+    const settings = await readFile(
+      join(rendererRoot, "pages/settings.tsx"),
+      "utf8",
+    );
+
+    expect(settings.indexOf("window.api.onPetEnabled")).toBeLessThan(
+      settings.indexOf(".petEnabled()"),
+    );
+    expect(settings).toContain("createPetEnabledStateSync");
   });
 });

--- a/apps/electron/src/main/preload-contract.test.ts
+++ b/apps/electron/src/main/preload-contract.test.ts
@@ -348,7 +348,29 @@ describe("preload contract", () => {
     expect(formHandler).toContain("panelWindow?.webContents");
     expect(formHandler).not.toContain("settingsWindow?.webContents");
     expect(menuHandler.indexOf("hideNotifications()")).toBeLessThan(
-      menuHandler.indexOf("destroyCompanionWindow()"),
+      menuHandler.indexOf("setPetEnabled(false)"),
     );
+  });
+
+  it("disables the companion when its menu closes it so it stays closed after restart", async () => {
+    const main = await readFile(mainPath, "utf8");
+    const menuHandler = main.slice(
+      main.indexOf('ipcMain.on("companion:context-menu"'),
+      main.indexOf('ipcMain.on("sprite:event"'),
+    );
+
+    expect(menuHandler).toContain("setPetEnabled(false)");
+  });
+
+  it("updates an open Settings page when companion availability changes", async () => {
+    const [main, preload, settings] = await Promise.all([
+      readFile(mainPath, "utf8"),
+      readFile(preloadPath, "utf8"),
+      readFile(join(rendererRoot, "pages/settings.tsx"), "utf8"),
+    ]);
+
+    expect(main).toContain('webContents.send("pet:enabled", enabled)');
+    expect(preload).toContain('ipcRenderer.on("pet:enabled"');
+    expect(settings).toContain("window.api.onPetEnabled(setPetEnabled)");
   });
 });

--- a/apps/electron/src/main/preload-contract.test.ts
+++ b/apps/electron/src/main/preload-contract.test.ts
@@ -387,4 +387,13 @@ describe("preload contract", () => {
     );
     expect(settings).toContain("createPetEnabledStateSync");
   });
+
+  it("cancels an unmounted Settings page's initial companion read", async () => {
+    const settings = await readFile(
+      join(rendererRoot, "pages/settings.tsx"),
+      "utf8",
+    );
+
+    expect(settings).toContain("petEnabledSync.dispose()");
+  });
 });

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -77,6 +77,7 @@ declare global {
       companionStatus: () => Promise<CompanionStatus | null>;
       petEnabled: () => Promise<boolean>;
       setPetEnabled: (enabled: boolean) => void;
+      onPetEnabled: (callback: (enabled: boolean) => void) => () => void;
       wakeCompanion: () => void;
       openCompanionWorkspace: () => void;
       beginCompanionPositionDrag: () => void;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -221,6 +221,12 @@ const api = {
   petEnabled: (): Promise<boolean> => ipcRenderer.invoke("pet:enabled"),
   setPetEnabled: (enabled: boolean): void =>
     ipcRenderer.send("pet:set-enabled", enabled),
+  onPetEnabled: (callback: (enabled: boolean) => void): (() => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, enabled: unknown) =>
+      callback(enabled === true);
+    ipcRenderer.on("pet:enabled", listener);
+    return () => ipcRenderer.removeListener("pet:enabled", listener);
+  },
   wakeCompanion: (): void => ipcRenderer.send("companion:wake"),
   openCompanionWorkspace: (): void =>
     ipcRenderer.send("companion:open-workspace"),

--- a/apps/electron/src/renderer/src/lib/pet-enabled.test.ts
+++ b/apps/electron/src/renderer/src/lib/pet-enabled.test.ts
@@ -21,4 +21,18 @@ describe("pet-enabled state synchronization", () => {
 
     expect(values).toEqual([true, false]);
   });
+
+  it("ignores a cleaned-up Settings page's pending initial read", () => {
+    const values: boolean[] = [];
+    const stale = createPetEnabledStateSync((enabled) => values.push(enabled));
+    const current = createPetEnabledStateSync((enabled) =>
+      values.push(enabled),
+    );
+
+    stale.dispose();
+    current.onChanged(false);
+    stale.onInitial(true);
+
+    expect(values).toEqual([false]);
+  });
 });

--- a/apps/electron/src/renderer/src/lib/pet-enabled.test.ts
+++ b/apps/electron/src/renderer/src/lib/pet-enabled.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { createPetEnabledStateSync } from "./pet-enabled";
+
+describe("pet-enabled state synchronization", () => {
+  it("keeps a newer companion-close event over a stale initial read", () => {
+    const values: boolean[] = [];
+    const sync = createPetEnabledStateSync((enabled) => values.push(enabled));
+
+    sync.onChanged(false);
+    sync.onInitial(true);
+
+    expect(values).toEqual([false]);
+  });
+
+  it("uses the initial value until a live companion update arrives", () => {
+    const values: boolean[] = [];
+    const sync = createPetEnabledStateSync((enabled) => values.push(enabled));
+
+    sync.onInitial(true);
+    sync.onChanged(false);
+
+    expect(values).toEqual([true, false]);
+  });
+});

--- a/apps/electron/src/renderer/src/lib/pet-enabled.ts
+++ b/apps/electron/src/renderer/src/lib/pet-enabled.ts
@@ -1,0 +1,18 @@
+export function createPetEnabledStateSync(
+  setEnabled: (enabled: boolean) => void,
+): {
+  onInitial: (enabled: boolean) => void;
+  onChanged: (enabled: boolean) => void;
+} {
+  let receivedUpdate = false;
+
+  return {
+    onInitial: (enabled) => {
+      if (!receivedUpdate) setEnabled(enabled);
+    },
+    onChanged: (enabled) => {
+      receivedUpdate = true;
+      setEnabled(enabled);
+    },
+  };
+}

--- a/apps/electron/src/renderer/src/lib/pet-enabled.ts
+++ b/apps/electron/src/renderer/src/lib/pet-enabled.ts
@@ -3,16 +3,22 @@ export function createPetEnabledStateSync(
 ): {
   onInitial: (enabled: boolean) => void;
   onChanged: (enabled: boolean) => void;
+  dispose: () => void;
 } {
   let receivedUpdate = false;
+  let disposed = false;
 
   return {
     onInitial: (enabled) => {
-      if (!receivedUpdate) setEnabled(enabled);
+      if (!disposed && !receivedUpdate) setEnabled(enabled);
     },
     onChanged: (enabled) => {
+      if (disposed) return;
       receivedUpdate = true;
       setEnabled(enabled);
+    },
+    dispose: () => {
+      disposed = true;
     },
   };
 }

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -556,7 +556,12 @@ export default function SettingsPage(): React.JSX.Element {
       .petEnabled()
       .then(setPetEnabled)
       .catch(() => {});
-    return window.api.onCompanionForm(setCompanionForm);
+    const offForm = window.api.onCompanionForm(setCompanionForm);
+    const offPetEnabled = window.api.onPetEnabled(setPetEnabled);
+    return () => {
+      offForm();
+      offPetEnabled();
+    };
   }, []);
 
   const handleDeviceChange = useCallback((deviceId: string) => {

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -561,6 +561,7 @@ export default function SettingsPage(): React.JSX.Element {
       .catch(() => {});
     const offForm = window.api.onCompanionForm(setCompanionForm);
     return () => {
+      petEnabledSync.dispose();
       offForm();
       offPetEnabled();
     };

--- a/apps/electron/src/renderer/src/pages/settings.tsx
+++ b/apps/electron/src/renderer/src/pages/settings.tsx
@@ -64,6 +64,7 @@ import {
 } from "@renderer/lib/deletion-confirmation";
 import { formatNumber } from "@renderer/lib/format";
 import { requestMicAccess, resolveMicStatus } from "@renderer/lib/permissions";
+import { createPetEnabledStateSync } from "@renderer/lib/pet-enabled";
 import { IS_LINUX, IS_MAC, IS_WINDOWS } from "@renderer/lib/platform";
 import {
   invalidateThreads,
@@ -548,16 +549,17 @@ export default function SettingsPage(): React.JSX.Element {
   }, [checkPermissions]);
 
   useEffect(() => {
+    const petEnabledSync = createPetEnabledStateSync(setPetEnabled);
+    const offPetEnabled = window.api.onPetEnabled(petEnabledSync.onChanged);
     void window.api
       .companionForm()
       .then(setCompanionForm)
       .catch(() => {});
     void window.api
       .petEnabled()
-      .then(setPetEnabled)
+      .then(petEnabledSync.onInitial)
       .catch(() => {});
     const offForm = window.api.onCompanionForm(setCompanionForm);
-    const offPetEnabled = window.api.onPetEnabled(setPetEnabled);
     return () => {
       offForm();
       offPetEnabled();


### PR DESCRIPTION
## Summary

- Persist the companion as disabled when its context menu closes it, preventing recreation on restart.
- Keep an already-open Settings page synchronized with companion enablement changes.
- Cover both close persistence and Settings synchronization in the Electron IPC contract test.

## Verification

- `pnpm test`
- `pnpm biome check .`
- `pnpm --filter @freestyle-voice/electron typecheck`
- Independent code review: no remaining findings.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
- [x] Ran `pnpm biome check .` (lint + formatting)
- [x] Ran `pnpm --filter @freestyle-voice/electron typecheck:web` (if touching the app)