### PR TITLE
fix(dictation): Send live language selections

### DIFF
--- a/apps/server/src/lib/freestyle-cloud.ts
+++ b/apps/server/src/lib/freestyle-cloud.ts
@@ -352,9 +352,9 @@ export async function transcribeWithFreestyleCloud(opts: {
   token: string;
   audio: Uint8Array;
   /**
-   * Per-request language override (ISO codes). Only sent when a
-   * `beforeTranscribe` plugin overrode the language for this dictation;
-   * otherwise omitted so the cloud uses the user's synced language list.
+   * Live language selection (ISO codes). Sent for every new desktop request so
+   * this dictation does not wait for preference sync; an empty array explicitly
+   * requests auto-detect.
    */
   languages?: string[];
   appContext?: string | null;
@@ -370,18 +370,15 @@ export async function transcribeWithFreestyleCloud(opts: {
 }): Promise<CloudTranscribeResult> {
   const audio = opts.audio as Uint8Array<ArrayBuffer>;
 
-  // The cloud reads the user's synced cleanup preferences (intensity, custom
-  // prompt, tones, app assignments, languages, vocabulary) from the
-  // member_preferences row, so this payload no longer carries those saved
-  // defaults. We forward only request-scoped values: the audio, per-request
-  // language / vocabulary overrides, `appContext`, plugin `systemFragments`,
-  // and `skipPostProcess` for the raw ("skip cleanup") mode.
+  // The cloud reads cleanup defaults from member_preferences. Languages are an
+  // exception because they affect this dictation's recognizer immediately.
   const form = new FormData();
   form.append("audio", new Blob([audio], { type: "audio/wav" }), "audio.wav");
   // The multipart transcribe endpoint expects `languages` as a JSON-encoded
-  // string array (form fields are strings). Omit it entirely to defer to the
-  // cloud's synced language list.
-  if (opts.languages?.length) {
+  // string array (form fields are strings). Preserve [] so the Cloud can
+  // distinguish an explicit auto-detect request from an older client omitting
+  // the field entirely.
+  if (opts.languages !== undefined) {
     form.append("languages", JSON.stringify(opts.languages));
   }
   if (opts.appContext) form.append("appContext", opts.appContext);

--- a/apps/server/src/lib/mlx-asr/language.ts
+++ b/apps/server/src/lib/mlx-asr/language.ts
@@ -1,5 +1,5 @@
 import { ISO_LANGUAGE_NAMES } from "../language.js";
-import { getMlxAsrModel } from "./constants.js";
+import { getMlxAsrModel, MLX_ASR_PROVIDER_ID } from "./constants.js";
 
 const QWEN3_LANGUAGE_NAMES = new Set([
   "Chinese",
@@ -34,12 +34,37 @@ const QWEN3_LANGUAGE_NAMES = new Set([
   "Macedonian",
 ]);
 
+function getLocalModelId(modelId: string): string {
+  const prefix = `${MLX_ASR_PROVIDER_ID}/`;
+  return modelId.startsWith(prefix) ? modelId.slice(prefix.length) : modelId;
+}
+
 export function resolveMlxLanguage(
   modelId: string,
   language: string | undefined,
 ): string | undefined {
   if (!language || language === "auto") return undefined;
-  if (getMlxAsrModel(modelId)?.family !== "qwen3-asr") return language;
+  if (getMlxAsrModel(getLocalModelId(modelId))?.family !== "qwen3-asr") {
+    return language;
+  }
   const name = ISO_LANGUAGE_NAMES[language];
   return name && QWEN3_LANGUAGE_NAMES.has(name) ? name : undefined;
+}
+
+/**
+ * Qwen3-ASR accepts one language bias per request, not a list. Keep the bias
+ * for a deliberate single-language selection; let Qwen identify the language
+ * when the user selected auto-detect or multiple languages.
+ */
+export function resolveMlxLanguageSelection(
+  modelId: string,
+  languages: string[] | undefined,
+): string | undefined {
+  if (
+    getMlxAsrModel(getLocalModelId(modelId))?.family === "qwen3-asr" &&
+    languages?.length !== 1
+  ) {
+    return undefined;
+  }
+  return resolveMlxLanguage(modelId, languages?.[0]);
 }

--- a/apps/server/src/lib/streaming/providers/freestyle-cloud.ts
+++ b/apps/server/src/lib/streaming/providers/freestyle-cloud.ts
@@ -55,13 +55,17 @@ export class FreestyleCloudTranscriptionProvider
     if (!opts.apiKey) throw new FreestyleCloudAuthError();
 
     // The cloud reads the user's synced vocabulary from the member_preferences
-    // row, so we no longer send the saved bias here. `opts.language` is
-    // forwarded as-is: it carries a per-request plugin language override when
-    // present, and is otherwise redundant with the synced language list.
+    // row, so we no longer send the saved bias here. Prefer the complete live
+    // selection, including `[]` for auto-detect; retain the singular language
+    // fallback for older internal callers.
     const data = await transcribeWithFreestyleCloud({
       token: opts.apiKey,
       audio: opts.audio,
-      ...(opts.language ? { languages: [opts.language] } : {}),
+      ...(opts.languages !== undefined
+        ? { languages: opts.languages }
+        : opts.language
+          ? { languages: [opts.language] }
+          : {}),
       mode: "raw",
     });
     return {
@@ -77,7 +81,15 @@ export class FreestyleCloudTranscriptionProvider
   }
 
   openStreamingSession(opts: StreamingSessionOptions): StreamSession {
-    const { apiKey, model, translate, cleanup, callbacks, appContext } = opts;
+    const {
+      apiKey,
+      model,
+      languages,
+      translate,
+      cleanup,
+      callbacks,
+      appContext,
+    } = opts;
 
     if (!apiKey) {
       throw new FreestyleCloudAuthError();
@@ -90,19 +102,13 @@ export class FreestyleCloudTranscriptionProvider
       },
     });
 
-    // The cloud DO reads the user's synced preferences (languages, vocabulary,
-    // intensity, custom prompt, tones, app assignments) from the
-    // member_preferences row at handshake time and applies them to both the
-    // Soniox recognizer and the cleanup prompt. So the `start` message no
-    // longer carries those saved defaults — it sends only request-scoped
-    // control values: `translate` (a local setting, not synced), the
-    // per-session `skipPostProcess` flag, plugin `systemFragments` (never
-    // synced), and the live `appContext`. `translate` is guarded server-side
-    // against the resolved (synced) language list, so it's safe to send
-    // whenever the local translate setting is on even though we omit
-    // `languages` here.
+    // Languages are a live dictation control: including the local selection
+    // makes the next session correct even while cross-device preference sync or
+    // a region-local Cloud cache is catching up. Other cleanup defaults remain
+    // server-side; only request-scoped values travel here.
     const buildStartMessage = () => ({
       type: "start" as const,
+      languages: languages ?? [],
       ...(translate ? { translate: true } : {}),
       skipPostProcess: cleanup?.skipPostProcess ?? false,
       ...(currentContext ? { context: currentContext } : {}),

--- a/apps/server/src/lib/streaming/providers/mlx-local.ts
+++ b/apps/server/src/lib/streaming/providers/mlx-local.ts
@@ -1,7 +1,10 @@
 import { collapseAsrLineBreaks } from "@freestyle-voice/stt";
 import { createAppLogger } from "@freestyle-voice/utils";
 import { MLX_ASR_PROVIDER_ID } from "../../mlx-asr/constants.js";
-import { resolveMlxLanguage } from "../../mlx-asr/language.js";
+import {
+  resolveMlxLanguage,
+  resolveMlxLanguageSelection,
+} from "../../mlx-asr/language.js";
 import { getMlxModelStatus } from "../../mlx-asr/models.js";
 import { describeMlxSetupBlocker } from "../../mlx-asr/python.js";
 import {
@@ -44,7 +47,10 @@ export class MlxLocalTranscriptionProvider implements TranscriptionProvider {
     const text = await transcribeWithMlxAsr({
       modelId,
       audio: opts.audio,
-      language: resolveMlxLanguage(modelId, opts.language),
+      language:
+        opts.languages !== undefined
+          ? resolveMlxLanguageSelection(modelId, opts.languages)
+          : resolveMlxLanguage(modelId, opts.language),
       context: opts.bias?.kind === "prompt" ? opts.bias.text : undefined,
     });
 
@@ -65,8 +71,7 @@ export class MlxLocalTranscriptionProvider implements TranscriptionProvider {
     const modelId = stripProviderPrefix(opts.model);
     return new MlxLocalSessionTransport({
       modelId,
-      // MLX takes a single language code — use the primary.
-      language: resolveMlxLanguage(modelId, opts.languages?.[0]),
+      language: resolveMlxLanguageSelection(modelId, opts.languages),
       context: opts.bias?.kind === "prompt" ? opts.bias.text : undefined,
       callbacks: opts.callbacks,
     });

--- a/apps/server/src/lib/streaming/types.ts
+++ b/apps/server/src/lib/streaming/types.ts
@@ -32,6 +32,8 @@ export interface TranscribeOptions {
   apiKey: string;
   /** ISO-639-1 language hint; omitted lets the model auto-detect. */
   language?: string;
+  /** Live language selection for providers that accept multiple languages. */
+  languages?: string[];
   /** ASR-only vocabulary bias for the first recognition pass. */
   bias?: AsrVocabularyBias | null;
   appContext?: string | null;

--- a/apps/server/src/routes/transcribe.ts
+++ b/apps/server/src/routes/transcribe.ts
@@ -14,6 +14,7 @@ import {
 } from "../lib/freestyle-cloud.js";
 import { saveProcessedHistory, saveRawHistory } from "../lib/history-store.js";
 import { getLanguagesSetting } from "../lib/language.js";
+import { MLX_ASR_PROVIDER_ID } from "../lib/mlx-asr/constants.js";
 import {
   FreestyleEventType,
   PipelineStage,
@@ -257,20 +258,9 @@ const transcribeRoute = new Hono().post("/", async (c) => {
     }
 
     try {
-      // The cloud reads the user's synced cleanup preferences (intensity,
-      // custom prompt, tones, app assignments, languages, vocabulary) from the
-      // member_preferences row — kept in step via preferences-sync. So we no
-      // longer forward those saved defaults here; the cloud resolves them
-      // server-side (`payload ?? stored ?? default`). We only forward values
-      // that are per-request and therefore never synced:
-      //   - `languages` when a `beforeTranscribe` plugin overrode it for this
-      //     one dictation (else omit → cloud uses the synced language list),
-      //   - `vocabulary` when a `beforeTranscribe` plugin overrode the ASR bias
-      //     for this one dictation (else omit → cloud uses the synced terms),
-      //   - `appContext` and `systemFragments`, which are request-scoped.
-      const languageOverrideForCloud = languageOverride
-        ? [languageOverride]
-        : undefined;
+      // Languages are sent for every Cloud request so the live local selection
+      // wins even before the asynchronous preference sync reaches Cloud.
+      const languagesForCloud = effectiveLanguages;
       const vocabularyOverride = beforeTranscribeOutput.bias
         ? { terms: beforeTranscribeOutput.bias }
         : undefined;
@@ -279,9 +269,7 @@ const transcribeRoute = new Hono().post("/", async (c) => {
         audio: audioData,
         appContext,
         mode: useCombined ? "combined" : "raw",
-        ...(languageOverrideForCloud
-          ? { languages: languageOverrideForCloud }
-          : {}),
+        languages: languagesForCloud,
         ...(vocabularyOverride ? { vocabulary: vocabularyOverride } : {}),
         ...(useCombined && systemFragments.length > 0
           ? { systemFragments }
@@ -411,13 +399,19 @@ const transcribeRoute = new Hono().post("/", async (c) => {
             beforeTranscribeOutput.bias,
           )
         : resolveAsrVocabularyBias(voiceProvider, voiceModel);
+      const providerLanguage =
+        voiceProvider === MLX_ASR_PROVIDER_ID ? undefined : primaryLanguage;
       log.debug(`bias=${JSON.stringify(bias)}`);
       const t0 = Date.now();
       const result = await provider.transcribe({
         audio: audioData,
         model: voiceModel,
         apiKey,
-        ...(primaryLanguage ? { language: primaryLanguage } : {}),
+        ...(voiceProvider === FREESTYLE_CLOUD_PROVIDER_ID ||
+        voiceProvider === MLX_ASR_PROVIDER_ID
+          ? { languages: effectiveLanguages }
+          : {}),
+        ...(providerLanguage ? { language: providerLanguage } : {}),
         bias,
         appContext,
       });

--- a/apps/server/tests/cloud-provider-languages.test.ts
+++ b/apps/server/tests/cloud-provider-languages.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const transcribeSpy = vi.fn().mockResolvedValue({ raw: "done" });
+
+vi.mock("../src/lib/freestyle-cloud.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/lib/freestyle-cloud.js")>();
+  return { ...actual, transcribeWithFreestyleCloud: transcribeSpy };
+});
+
+const { FreestyleCloudTranscriptionProvider } = await import(
+  "../src/lib/streaming/providers/freestyle-cloud.js"
+);
+
+describe("FreestyleCloudTranscriptionProvider", () => {
+  afterEach(() => {
+    transcribeSpy.mockClear();
+  });
+
+  it("forwards the full live language selection for raw dictation", async () => {
+    await new FreestyleCloudTranscriptionProvider().transcribe({
+      audio: new Uint8Array([1]),
+      model: "freestyle-cloud/stt",
+      apiKey: "t",
+      language: "en",
+      languages: ["en", "hi"],
+    });
+
+    expect(transcribeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ languages: ["en", "hi"], mode: "raw" }),
+    );
+  });
+
+  it("forwards an explicit empty selection for Cloud auto-detect", async () => {
+    await new FreestyleCloudTranscriptionProvider().transcribe({
+      audio: new Uint8Array([1]),
+      model: "freestyle-cloud/stt",
+      apiKey: "t",
+      languages: [],
+    });
+
+    expect(transcribeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ languages: [], mode: "raw" }),
+    );
+  });
+});

--- a/apps/server/tests/cloud-transcribe-payload.test.ts
+++ b/apps/server/tests/cloud-transcribe-payload.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { transcribeWithFreestyleCloud } from "../src/lib/freestyle-cloud.js";
+
+describe("transcribeWithFreestyleCloud payload", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ raw: "done" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("sends an explicit empty language list to request Cloud auto-detect", async () => {
+    await transcribeWithFreestyleCloud({
+      token: "t",
+      audio: new Uint8Array([1]),
+      languages: [],
+      mode: "raw",
+    });
+
+    const body = fetchMock.mock.calls[0][1]?.body as FormData;
+    expect(body.get("languages")).toBe("[]");
+  });
+});

--- a/apps/server/tests/mlx-language.test.ts
+++ b/apps/server/tests/mlx-language.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { resolveMlxLanguageSelection } from "../src/lib/mlx-asr/language.js";
+
+describe("resolveMlxLanguageSelection", () => {
+  it("biases Qwen when exactly one language is selected", () => {
+    expect(resolveMlxLanguageSelection("qwen3-0.6b-8bit", ["hi"])).toBe(
+      "Hindi",
+    );
+  });
+
+  it("uses auto-detect for multiple selected languages", () => {
+    expect(
+      resolveMlxLanguageSelection("qwen3-0.6b-8bit", ["en", "hi"]),
+    ).toBeUndefined();
+  });
+
+  it("uses auto-detect when the configured Qwen model includes its provider", () => {
+    expect(
+      resolveMlxLanguageSelection("local-mlx/qwen3-0.6b-8bit", ["en", "hi"]),
+    ).toBeUndefined();
+  });
+
+  it("uses auto-detect when no language is selected", () => {
+    expect(resolveMlxLanguageSelection("qwen3-0.6b-8bit", [])).toBeUndefined();
+  });
+});

--- a/apps/server/tests/mlx-local-provider-languages.test.ts
+++ b/apps/server/tests/mlx-local-provider-languages.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+const transcribeSpy = vi.fn().mockResolvedValue("namaste");
+
+vi.mock("../src/lib/mlx-asr/models.js", () => ({
+  getMlxModelStatus: () => ({ status: "ready" }),
+}));
+
+vi.mock("../src/lib/mlx-asr/python.js", () => ({
+  describeMlxSetupBlocker: () => undefined,
+}));
+
+vi.mock("../src/lib/mlx-asr/server.js", () => ({
+  applyMlxAsrRetentionPolicy: () => undefined,
+  canRunMlxAsr: () => true,
+  ensureMlxServerRunning: async () => undefined,
+  transcribePcmWithMlxAsr: async () => "",
+  transcribeWithMlxAsr: transcribeSpy,
+}));
+
+const { MlxLocalTranscriptionProvider } = await import(
+  "../src/lib/streaming/providers/mlx-local.js"
+);
+
+describe("MlxLocalTranscriptionProvider", () => {
+  it("converts a single Qwen language selection exactly once for batch dictation", async () => {
+    await new MlxLocalTranscriptionProvider().transcribe({
+      audio: new Uint8Array([1]),
+      model: "local-mlx/qwen3-0.6b-8bit",
+      apiKey: "unused",
+      languages: ["hi"],
+    });
+
+    expect(transcribeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ language: "Hindi" }),
+    );
+  });
+});

--- a/apps/server/tests/short-dictation.test.ts
+++ b/apps/server/tests/short-dictation.test.ts
@@ -144,4 +144,19 @@ describe("a dictation that ends before its session is live", () => {
     ]);
     session.cancel();
   });
+
+  it("sends the live language list when opening a Cloud session", async () => {
+    const { session, socket } = await openSession("freestyle-cloud");
+
+    socket.open();
+
+    expect(socket.control.map((message) => JSON.parse(message))).toContainEqual(
+      {
+        type: "start",
+        languages: ["en"],
+        skipPostProcess: false,
+      },
+    );
+    session.cancel();
+  });
 });

--- a/apps/server/tests/transcribe-cloud-combined-fragments.test.ts
+++ b/apps/server/tests/transcribe-cloud-combined-fragments.test.ts
@@ -125,6 +125,7 @@ describe("POST /api/transcribe — combined cloud + beforeCleanup", () => {
   });
 
   it("keeps combined mode and forwards system fragments", async () => {
+    writeSetting("languages", JSON.stringify(["en", "hi"]));
     registry.current = new PluginRegistry([
       {
         name: "fragment",
@@ -139,13 +140,13 @@ describe("POST /api/transcribe — combined cloud + beforeCleanup", () => {
     const opts = lastCallOpts();
     expect(opts.mode).toBe("combined");
     expect(opts.systemFragments).toEqual(["Add emoji."]);
-    // The cloud reads the user's synced cleanup preferences (tones, intensity,
-    // app assignments, languages, vocabulary) from member_preferences, so the
-    // combined request must NOT carry those saved defaults.
+    // Cleanup preferences remain cloud defaults, but the live language choice
+    // must travel with this request so a stale preference cache cannot change
+    // the recognizer or cleanup language constraint.
     expect(opts.intensity).toBeUndefined();
     expect(opts.personalTone).toBeUndefined();
     expect(opts.appAssignments).toBeUndefined();
-    expect(opts.languages).toBeUndefined();
+    expect(opts.languages).toEqual(["en", "hi"]);
     expect(opts.vocabulary).toBeUndefined();
     // Combined mode does its cleanup remotely — never touches local postProcess.
     expect(postProcessSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary\n- send the local language selection with every Freestyle Cloud streaming and batch dictation\n- preserve explicit empty selections as Cloud auto-detect\n- let local Qwen auto-detect when multiple languages are selected instead of forcing the first language\n\n## Verification\n- pnpm --filter @freestyle-voice/server test\n- pnpm --filter @freestyle-voice/server... build\n- pnpm exec biome check (changed files)