### PR TITLE
feat(remix): support independent local models

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -27,6 +27,7 @@
     "test:visual": "npm run build && playwright test tests/dashboard-visual.test.ts"
   },
   "dependencies": {
+    "@ai-sdk/react": "3.0.280",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@freestyle-voice/server": "workspace:*",

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1844,6 +1844,20 @@ app.whenReady().then(async () => {
   // showPill runs for every hotkey press.
   registerPillPositionIpc();
 
+  // Sprite travel samples `screen` on an interval. Electron exposes that API
+  // only after the ready event, and a slow E2E launch can otherwise let its
+  // first tick crash the main process before the window is created.
+  initSpriteTravel({
+    getWindow: () => companionWindow,
+    windowSize: () => SPRITES_INFO[companionFormSetting()].windowSize,
+    homePosition: () => companionPosition(),
+    theaterAvailable: () =>
+      SPRITES_INFO[companionFormSetting()].kind === "sheet",
+    travelEnabled: () => SPRITES_INFO[companionFormSetting()].travel === true,
+    sendEvent: (ev) =>
+      companionWindow?.webContents.send("companion:sprite-event", ev),
+  });
+
   void startLinuxPasteHelper();
   void recoverDuckedVolumeFromCrash();
 
@@ -3823,16 +3837,6 @@ ipcMain.on("notifications:auth-changed", (event) => {
   if (event.sender !== panelWindow?.webContents) return;
   courierNativeNotifications.clearAll();
   notificationWindow()?.webContents.send("notifications:auth-changed");
-});
-
-initSpriteTravel({
-  getWindow: () => companionWindow,
-  windowSize: () => SPRITES_INFO[companionFormSetting()].windowSize,
-  homePosition: () => companionPosition(),
-  theaterAvailable: () => SPRITES_INFO[companionFormSetting()].kind === "sheet",
-  travelEnabled: () => SPRITES_INFO[companionFormSetting()].travel === true,
-  sendEvent: (ev) =>
-    companionWindow?.webContents.send("companion:sprite-event", ev),
 });
 
 ipcMain.handle("sprite:perform-sync", (event, payload: unknown) => {

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -1362,6 +1362,7 @@ function PanelInner({
     setMessages,
   } = useRemixRecovery({
     id: thread.id,
+    type: thread.type,
     messages: thread.messages,
     onFork: onSwitchThread,
     onActionUnavailable: (actionId) =>
@@ -1369,10 +1370,14 @@ function PanelInner({
         pending.filter((item) => item.call.toolCallId !== actionId),
       ),
     onFinish: ({ messages: finished }) => {
-      queryClient.setQueryData(queryKeys.threads.detail(thread.id), {
-        id: thread.id,
-        messages: finished,
-      });
+      queryClient.setQueryData(
+        queryKeys.threads.detail(thread.id, thread.type ?? "remote"),
+        {
+          id: thread.id,
+          type: thread.type,
+          messages: finished,
+        },
+      );
       void invalidateThreads(queryClient);
       void queryClient.invalidateQueries({ queryKey: queryKeys.attention });
       void queryClient.invalidateQueries({

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -79,6 +79,7 @@ function anchoredLayerStyle(
 
 interface ThreadState {
   id: string;
+  type?: "local" | "remote";
   messages: UIMessage[];
 }
 
@@ -606,8 +607,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
       const message = messages[i];
       if (message.role !== "assistant") continue;
       const text = message.parts
-        .filter(isTextUIPart)
-        .map((part) => part.text)
+        .map((part) => (part.type === "text" ? part.text : ""))
         .join("")
         .trim();
       return text || null;

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -240,6 +240,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
     queue,
   } = useRemixRecovery({
     id: thread.id,
+    type: thread.type,
     messages: thread.messages,
     onActionUnavailable: (actionId) =>
       setApprovals((pending) =>

--- a/apps/electron/src/renderer/src/components/remix-session-context.tsx
+++ b/apps/electron/src/renderer/src/components/remix-session-context.tsx
@@ -19,6 +19,7 @@ import {
   createThread,
   deleteThread as deleteStoredThread,
   getThread,
+  renameLocalThread,
   type ThreadState,
   type ThreadSummary,
 } from "@renderer/lib/threads";
@@ -68,12 +69,21 @@ type RemixSessionContextValue = {
   completedSessionIds: ReadonlySet<string>;
   markSessionSeen: (threadId: string) => void;
   requestThreadTitleRefresh: (threadId: string) => void;
-  renameThread: (threadId: string, title: string) => Promise<void>;
-  requestDeleteThread: (threadId: string, title: string) => void;
+  renameThread: (
+    threadId: string,
+    title: string,
+    type?: "local" | "remote",
+  ) => Promise<void>;
+  requestDeleteThread: (
+    threadId: string,
+    title: string,
+    type?: "local" | "remote",
+  ) => void;
 };
 
 type ThreadDeletionVariables = {
   threadId: string;
+  type: "local" | "remote";
   selected: ThreadState | null;
   localTitles: Record<string, string>;
 };
@@ -114,6 +124,7 @@ export function RemixSessionProvider({
   const [pendingThreadDeletion, setPendingThreadDeletion] = useState<{
     threadId: string;
     title: string;
+    type: "local" | "remote";
   } | null>(null);
   const queryClient = useQueryClient();
   const { canRequestData, phase } = useCloudAuth();
@@ -279,13 +290,30 @@ export function RemixSessionProvider({
     });
   }, [canRequestData]);
 
-  const renameThread = useCallback(async (threadId: string, title: string) => {
-    const nextTitle = title.trim();
-    if (!nextTitle) return;
-    setLocalTitles((titles) => ({ ...titles, [threadId]: nextTitle }));
-    const saved = await window.api?.setRemixSessionTitle?.(threadId, nextTitle);
-    if (!saved) throw new Error("Could not save the session name.");
-  }, []);
+  const renameThread = useCallback(
+    async (threadId: string, title: string, type?: "local" | "remote") => {
+      const nextTitle = title.trim();
+      if (!nextTitle) return;
+      const resolvedType =
+        type ??
+        (thread?.id === threadId ? (thread.type ?? "remote") : "remote");
+      if (resolvedType === "local") {
+        await renameLocalThread(threadId, nextTitle);
+        setThread((current) =>
+          current?.id === threadId ? { ...current, title: nextTitle } : current,
+        );
+        await invalidateThreads(queryClient);
+        return;
+      }
+      setLocalTitles((titles) => ({ ...titles, [threadId]: nextTitle }));
+      const saved = await window.api?.setRemixSessionTitle?.(
+        threadId,
+        nextTitle,
+      );
+      if (!saved) throw new Error("Could not save the session name.");
+    },
+    [queryClient, thread?.id, thread?.type],
+  );
 
   const refreshThread = useCallback(
     async (threadId: string) => {
@@ -337,8 +365,8 @@ export function RemixSessionProvider({
     ThreadDeletionVariables,
     ThreadDeletionContext
   >({
-    mutationFn: ({ threadId }: ThreadDeletionVariables) =>
-      deleteStoredThread(threadId),
+    mutationFn: ({ threadId, type }: ThreadDeletionVariables) =>
+      deleteStoredThread(threadId, type),
     onMutate: async ({ threadId, selected, localTitles }) => {
       // A late session-list response was able to repaint the just-deleted row
       // because the old version changed cache data before cancellation had
@@ -418,10 +446,11 @@ export function RemixSessionProvider({
   });
 
   const deleteThreadNow = useCallback(
-    (threadId: string) => {
+    (threadId: string, type: "local" | "remote") => {
       const selected = thread?.id === threadId ? thread : null;
       return deleteThreadMutation.mutateAsync({
         threadId,
+        type,
         selected,
         localTitles,
       });
@@ -430,14 +459,17 @@ export function RemixSessionProvider({
   );
 
   const requestDeleteThread = useCallback(
-    (threadId: string, title: string) => {
+    (threadId: string, title: string, type?: "local" | "remote") => {
+      const resolvedType =
+        type ??
+        (thread?.id === threadId ? (thread.type ?? "remote") : "remote");
       if (shouldSkipDeletionConfirmation("session")) {
-        void deleteThreadNow(threadId).catch(() => {});
+        void deleteThreadNow(threadId, resolvedType).catch(() => {});
         return;
       }
-      setPendingThreadDeletion({ threadId, title });
+      setPendingThreadDeletion({ threadId, title, type: resolvedType });
     },
-    [deleteThreadNow],
+    [deleteThreadNow, thread?.id, thread?.type],
   );
 
   useEffect(() => {
@@ -480,9 +512,16 @@ export function RemixSessionProvider({
 
   useEffect(() => {
     if (latestQuery.isPending) return;
-    if (latestQuery.data) {
+    const latestThread = latestQuery.data;
+    if (latestThread?.id && latestThread.messages) {
       setThread(
-        (current) => current ?? { ...latestQuery.data, type: "remote" },
+        (current) =>
+          current ?? {
+            id: latestThread.id,
+            title: latestThread.title ?? null,
+            messages: latestThread.messages,
+            type: "remote",
+          },
       );
       return;
     }
@@ -568,7 +607,7 @@ export function RemixSessionProvider({
           setPendingThreadDeletion(null);
           if (!pending) return;
           if (skipConfirmation) setDeletionConfirmationSkipped("session", true);
-          void deleteThreadNow(pending.threadId).catch(() => {});
+          void deleteThreadNow(pending.threadId, pending.type).catch(() => {});
         }}
       />
     </RemixSessionContext.Provider>

--- a/apps/electron/src/renderer/src/components/remix-session-context.tsx
+++ b/apps/electron/src/renderer/src/components/remix-session-context.tsx
@@ -16,6 +16,7 @@ import {
   threadQueryOptions,
 } from "@renderer/lib/query";
 import {
+  createThread,
   deleteThread as deleteStoredThread,
   getThread,
   type ThreadState,
@@ -86,10 +87,6 @@ type ThreadDeletionContext = {
 const RemixSessionContext = createContext<RemixSessionContextValue | null>(
   null,
 );
-
-function newThread(): ThreadState {
-  return { id: crypto.randomUUID(), messages: [] };
-}
 
 /**
  * One source of truth for the selected Remix thread. The app sidebar and the
@@ -181,23 +178,28 @@ export function RemixSessionProvider({
       markSessionSeen(summary.id);
 
       const cached = queryClient.getQueryData<ThreadState>(
-        queryKeys.threads.detail(summary.id),
+        queryKeys.threads.detail(summary.id, summary.type ?? "remote"),
       );
       if (cached) {
         setLoadingThreadId(null);
         setThread(cached);
       } else {
         setLoadingThreadId(summary.id);
-        setThread({ id: summary.id, title: summary.title, messages: [] });
+        setThread({
+          id: summary.id,
+          type: summary.type ?? "remote",
+          title: summary.title,
+          messages: [],
+        });
       }
 
       void queryClient
-        .fetchQuery(threadQueryOptions(summary.id))
+        .fetchQuery(threadQueryOptions(summary.id, summary.type ?? "remote"))
         .then((loaded) => {
           if (!loaded) throw new Error("Conversation not found.");
           if (selectionRef.current !== selection) return;
           queryClient.setQueryData(
-            queryKeys.threads.detail(summary.id),
+            queryKeys.threads.detail(summary.id, summary.type ?? "remote"),
             loaded,
           );
           setThread(loaded);
@@ -221,10 +223,14 @@ export function RemixSessionProvider({
     if (summary) selectThread(summary);
   }, [selectThread]);
 
-  const startNewThread = useCallback(
-    () => switchThread(newThread()),
-    [switchThread],
-  );
+  const startNewThread = useCallback(() => {
+    setThreadLoadError(null);
+    setLoadingThreadId("creating");
+    void createThread()
+      .then((next) => switchThread(next))
+      .catch(() => setThreadLoadError("Couldn’t start a new conversation."))
+      .finally(() => setLoadingThreadId(null));
+  }, [switchThread]);
 
   useEffect(() => {
     if (phase === "signed_out") {
@@ -283,13 +289,20 @@ export function RemixSessionProvider({
 
   const refreshThread = useCallback(
     async (threadId: string) => {
-      const loaded = await queryClient.fetchQuery(threadQueryOptions(threadId));
+      const type =
+        thread?.id === threadId ? (thread.type ?? "remote") : "remote";
+      const loaded = await queryClient.fetchQuery(
+        threadQueryOptions(threadId, type),
+      );
       if (!loaded) return;
-      queryClient.setQueryData(queryKeys.threads.detail(threadId), loaded);
+      queryClient.setQueryData(
+        queryKeys.threads.detail(threadId, type),
+        loaded,
+      );
       setThread((current) => (current?.id === threadId ? loaded : current));
       await invalidateThreads(queryClient);
     },
-    [queryClient],
+    [queryClient, thread?.id, thread?.type],
   );
 
   const requestThreadTitleRefresh = useCallback(
@@ -358,7 +371,7 @@ export function RemixSessionProvider({
 
       let replacementSelection: number | null = null;
       if (selected) {
-        switchThread(newThread());
+        startNewThread();
         replacementSelection = selectionRef.current;
       }
       deletionVersionRef.current += 1;
@@ -467,8 +480,20 @@ export function RemixSessionProvider({
 
   useEffect(() => {
     if (latestQuery.isPending) return;
-    setThread((current) => current ?? latestQuery.data ?? newThread());
-  }, [latestQuery.data, latestQuery.isPending]);
+    if (latestQuery.data) {
+      setThread(
+        (current) => current ?? { ...latestQuery.data, type: "remote" },
+      );
+      return;
+    }
+    if (canRequestData && !thread) startNewThread();
+  }, [
+    canRequestData,
+    latestQuery.data,
+    latestQuery.isPending,
+    startNewThread,
+    thread,
+  ]);
 
   const value = useMemo(
     () => ({

--- a/apps/electron/src/renderer/src/components/thread-history.tsx
+++ b/apps/electron/src/renderer/src/components/thread-history.tsx
@@ -57,7 +57,7 @@ export function ThreadHistory({
   /** Electron-local title overrides; canonical thread data remains unchanged. */
   titleOverrides?: Record<string, string>;
   /** Sidebar-only actions. Search results intentionally remain selection-only. */
-  onRename?: (threadId: string, title: string) => Promise<void>;
+  onRename?: (thread: ThreadSummary, title: string) => Promise<void>;
   onDelete?: (thread: ThreadSummary) => void;
   /** Keep desktop Remix rows clean while exposing their actions on right-click. */
   sessionActions?: "dropdown" | "context";
@@ -136,7 +136,7 @@ export function ThreadHistory({
       return;
     }
     setActionError(null);
-    void onRename(thread.id, title)
+    void onRename(thread, title)
       .then(() => setRenamingId(null))
       .catch(() => setActionError("Couldn’t rename that session."));
   };

--- a/apps/electron/src/renderer/src/lib/api.test.ts
+++ b/apps/electron/src/renderer/src/lib/api.test.ts
@@ -48,4 +48,18 @@ describe("typed API client startup routing", () => {
     expect(unauthorized).toHaveBeenCalledTimes(1);
     unsubscribe();
   });
+
+  it("does not sign out for a stale Remix ownership response", async () => {
+    fetchMock.mockResolvedValue(
+      Response.json({ error: "remix_account_changed" }, { status: 401 }),
+    );
+    const { getClient, subscribeToUnauthorized } = await import("./api");
+    const unauthorized = vi.fn();
+    const unsubscribe = subscribeToUnauthorized(unauthorized);
+
+    await getClient().api.settings.$get();
+
+    expect(unauthorized).not.toHaveBeenCalled();
+    unsubscribe();
+  });
 });

--- a/apps/electron/src/renderer/src/lib/api.ts
+++ b/apps/electron/src/renderer/src/lib/api.ts
@@ -21,6 +21,20 @@ let apiBaseResolution: Promise<void> | null = null;
 let initPromise: Promise<void> | null = null;
 const unauthorizedListeners = new Set<() => void>();
 
+async function isDefinitiveUnauthorized(response: Response): Promise<boolean> {
+  if (response.status !== 401) return false;
+
+  // A durable Remix observer can outlive an account change. Its ownership
+  // boundary deliberately returns 401 to reject that stale observer, but the
+  // device may still have a valid current session. Keep that request scoped to
+  // its own recovery error instead of clearing the whole renderer into sign-in.
+  const body = await response
+    .clone()
+    .json()
+    .catch(() => null);
+  return body?.error !== "remix_account_changed";
+}
+
 /**
  * Subscribe to definitive protected-request failures observed by either API
  * transport. A 401 is the server's authoritative signal that the locally
@@ -37,7 +51,7 @@ async function observedFetch(
   init?: RequestInit,
 ): Promise<Response> {
   const response = await fetch(input, init);
-  if (response.status === 401) {
+  if (await isDefinitiveUnauthorized(response)) {
     for (const listener of unauthorizedListeners) listener();
   }
   return response;

--- a/apps/electron/src/renderer/src/lib/query.ts
+++ b/apps/electron/src/renderer/src/lib/query.ts
@@ -112,7 +112,8 @@ export const queryKeys = {
     latest: ["threads", "latest"] as const,
     lists: THREAD_LIST_QUERY_KEY,
     list: (origin: ThreadOrigin) => [...THREAD_LIST_QUERY_KEY, origin] as const,
-    detail: (id: string) => ["threads", "detail", id] as const,
+    detail: (id: string, type: "local" | "remote" = "remote") =>
+      ["threads", "detail", type, id] as const,
   },
   brain: {
     all: ["brain"] as const,
@@ -334,10 +335,13 @@ export function durableThreadRunsQueryOptions(threadId: string) {
   };
 }
 
-export function threadQueryOptions(id: string) {
+export function threadQueryOptions(
+  id: string,
+  type: "local" | "remote" = "remote",
+) {
   return {
-    queryKey: queryKeys.threads.detail(id),
-    queryFn: () => getThread(id),
+    queryKey: queryKeys.threads.detail(id, type),
+    queryFn: () => getThread(id, type),
     enabled: id.length > 0,
   };
 }

--- a/apps/electron/src/renderer/src/lib/threads.ts
+++ b/apps/electron/src/renderer/src/lib/threads.ts
@@ -161,6 +161,19 @@ export async function deleteThread(
   );
 }
 
+export async function renameLocalThread(
+  id: string,
+  title: string,
+): Promise<void> {
+  await responseJson<{ ok: true }>(
+    await apiFetch(`/api/remix/sessions/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title }),
+    }),
+  );
+}
+
 /** The ordinary thread remains D1 history; this optional envelope adds only
  * durable execution state and never contains server-side tool inputs. */
 export async function getThreadRuntime(

--- a/apps/electron/src/renderer/src/lib/threads.ts
+++ b/apps/electron/src/renderer/src/lib/threads.ts
@@ -4,6 +4,7 @@ import type { UIMessage } from "ai";
 /** The canonical title is generated and persisted by the Remix agent. */
 export type ThreadState = {
   id: string;
+  type?: "local" | "remote";
   title?: string | null;
   messages: UIMessage[];
 };
@@ -75,6 +76,7 @@ export const THREAD_ORIGIN_LABELS: Record<ThreadOrigin, string> = {
 
 export type ThreadSummary = {
   id: string;
+  type?: "local" | "remote";
   title: string;
   updatedAt: number;
   origin?: ThreadOrigin;
@@ -114,16 +116,44 @@ export async function getLatestThread(): Promise<ThreadState | null> {
   return data.thread;
 }
 
-export async function getThread(id: string): Promise<ThreadState | null> {
-  const data = await responseJson<{ thread: ThreadState | null }>(
-    await apiFetch(`/api/agent/thread/${encodeURIComponent(id)}`),
+/** Server-owned creation freezes local versus managed-Cloud ownership. */
+export async function createThread(): Promise<ThreadState> {
+  const data = await responseJson<{ thread: ThreadState }>(
+    await apiFetch("/api/remix/sessions", { method: "POST" }),
   );
   return data.thread;
 }
 
+export async function getThread(
+  id: string,
+  type: "local" | "remote" = "remote",
+): Promise<ThreadState | null> {
+  if (type === "local") {
+    const data = await responseJson<{ thread: ThreadState }>(
+      await apiFetch(`/api/remix/sessions/${encodeURIComponent(id)}`),
+    );
+    return { ...data.thread, type: "local" };
+  }
+  const data = await responseJson<{ thread: ThreadState | null }>(
+    await apiFetch(`/api/agent/thread/${encodeURIComponent(id)}`),
+  );
+  return data.thread ? { ...data.thread, type: "remote" } : null;
+}
+
 /** Remove a single server-owned thread. Display-name overrides live locally
  * in Electron and are cleaned up by the Remix session provider afterwards. */
-export async function deleteThread(id: string): Promise<void> {
+export async function deleteThread(
+  id: string,
+  type: "local" | "remote" = "remote",
+): Promise<void> {
+  if (type === "local") {
+    await responseJson<{ ok: true }>(
+      await apiFetch(`/api/remix/sessions/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      }),
+    );
+    return;
+  }
   await responseJson<{ ok: true }>(
     await apiFetch(`/api/agent/thread/${encodeURIComponent(id)}`, {
       method: "DELETE",

--- a/apps/electron/src/renderer/src/lib/use-remix-recovery.ts
+++ b/apps/electron/src/renderer/src/lib/use-remix-recovery.ts
@@ -1,5 +1,6 @@
+import { useChat } from "@ai-sdk/react";
 import { apiFetch, initApiBase } from "@renderer/lib/api";
-import type { UIMessage } from "ai";
+import { Chat, DefaultChatTransport, type UIMessage } from "ai";
 import {
   useEffect,
   useMemo,
@@ -11,6 +12,7 @@ import { RemixRecoveryController } from "./remix-recovery-controller";
 
 type Options = {
   id: string;
+  type?: "local" | "remote";
   messages: UIMessage[];
   context?: () => unknown;
   onToolCall: (event: {
@@ -66,21 +68,61 @@ export function useRemixRecovery(options: Options) {
       }),
     [options.id],
   );
+  // The chat owns streaming message state. Recreating it for every streamed
+  // token would discard that state, so only a session ID creates a new chat.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: explained above
+  const localChat = useMemo(
+    () =>
+      new Chat({
+        id: options.id,
+        messages: options.messages,
+        transport: new DefaultChatTransport({
+          api: `/api/remix/sessions/${encodeURIComponent(options.id)}/stream`,
+          fetch: async (input, init) => {
+            await initApiBase();
+            return apiFetch(input, init);
+          },
+          prepareSendMessagesRequest: ({ messages }) => ({
+            body: {
+              messages,
+              context: (ref.current.context ?? defaultContext)(),
+            },
+          }),
+        }),
+        onToolCall: ({ toolCall }) => ref.current.onToolCall({ toolCall }),
+        onFinish: async ({ messages }) => {
+          await initApiBase();
+          await apiFetch(
+            `/api/remix/sessions/${encodeURIComponent(options.id)}/messages`,
+            {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ messages }),
+            },
+          );
+          ref.current.onFinish?.({ messages });
+        },
+        onError: (error) => ref.current.onError?.(error),
+      }),
+    [options.id],
+  );
+  const local = useChat({ chat: localChat });
   const snapshot = useSyncExternalStore(
     controller.subscribe,
     controller.getSnapshot,
   );
   const [now, setNow] = useState(Date.now);
   useEffect(() => {
+    if (options.type === "local") return;
     void controller.start();
     return controller.dispose;
-  }, [controller]);
+  }, [controller, options.type]);
   useEffect(() => {
     if (snapshot.recovery.phase !== "reconnecting") return;
     const timer = setInterval(() => setNow(Date.now()), 250);
     return () => clearInterval(timer);
   }, [snapshot.recovery.phase]);
-  return useMemo(
+  const remote = useMemo(
     () => ({
       messages: snapshot.messages,
       status: snapshot.status,
@@ -161,4 +203,37 @@ export function useRemixRecovery(options: Options) {
     }),
     [controller, snapshot, now],
   );
+  if (options.type !== "local") return remote;
+  return {
+    messages: local.messages,
+    status: local.status,
+    canonical: true,
+    durableRuntime: { data: null, refetch: async () => ({ data: null }) },
+    setMessages: local.setMessages,
+    clearError: local.clearError,
+    sendMessage: local.sendMessage,
+    regenerate: local.regenerate,
+    addToolResult: local.addToolResult,
+    addToolOutput: local.addToolOutput,
+    stop: local.stop,
+    cancel: local.stop,
+    authorizeTool: async () => {},
+    resumeStream: async () => {},
+    recovery: {
+      state: { phase: "idle" as const },
+      now,
+      attempt: () => {},
+      resume: async () => {},
+      desktop: null,
+      retryDesktop: async () => {},
+    },
+    queue: {
+      items: [],
+      active: local.status === "streaming" || local.status === "submitted",
+      enqueue: async () => {},
+      update: async () => {},
+      remove: async () => {},
+      steer: async () => {},
+    },
+  };
 }

--- a/apps/electron/src/renderer/src/lib/use-remix-recovery.ts
+++ b/apps/electron/src/renderer/src/lib/use-remix-recovery.ts
@@ -1,6 +1,6 @@
-import { useChat } from "@ai-sdk/react";
+import { Chat, useChat } from "@ai-sdk/react";
 import { apiFetch, initApiBase } from "@renderer/lib/api";
-import { Chat, DefaultChatTransport, type UIMessage } from "ai";
+import { DefaultChatTransport, type UIMessage } from "ai";
 import {
   useEffect,
   useMemo,
@@ -92,7 +92,7 @@ export function useRemixRecovery(options: Options) {
         onToolCall: ({ toolCall }) => ref.current.onToolCall({ toolCall }),
         onFinish: async ({ messages }) => {
           await initApiBase();
-          await apiFetch(
+          const response = await apiFetch(
             `/api/remix/sessions/${encodeURIComponent(options.id)}/messages`,
             {
               method: "PUT",
@@ -100,6 +100,9 @@ export function useRemixRecovery(options: Options) {
               body: JSON.stringify({ messages }),
             },
           );
+          if (!response.ok) {
+            throw new Error("Could not save this local Remix session.");
+          }
           ref.current.onFinish?.({ messages });
         },
         onError: (error) => ref.current.onError?.(error),

--- a/apps/electron/src/renderer/src/pages/models/index.tsx
+++ b/apps/electron/src/renderer/src/pages/models/index.tsx
@@ -18,6 +18,7 @@ import { MlxWarmingDialog } from "./mlx-memory-section";
 import { ConfirmDialog, type ModalState, ModelModal } from "./model-modal";
 import { Eyebrow, PageShell } from "./page-chrome";
 import { PairCard } from "./pair-card";
+import { RemixModelCard } from "./remix-model-card";
 import {
   FREESTYLE_CLOUD_CLEANUP,
   FREESTYLE_CLOUD_TIER,
@@ -31,6 +32,14 @@ import { displayName } from "./utils";
  * both, depending on which sides the user routes to it.
  */
 const FREESTYLE_CLOUD_PROVIDER = "freestyle-cloud";
+
+const FREESTYLE_CLOUD_REMIX: AvailableModel = {
+  provider_id: FREESTYLE_CLOUD_PROVIDER,
+  provider_name: "Freestyle Cloud",
+  model_id: "freestyle-cloud/remix",
+  model_name: "Freestyle Cloud",
+  type: "llm",
+};
 
 export default function ModelsPage(): React.JSX.Element {
   const { t } = useTranslation();
@@ -178,6 +187,18 @@ export default function ModelsPage(): React.JSX.Element {
     setModal({ kind: "list", type: "llm", llmView: "tiers" });
   };
 
+  const openRemix = (): void => setModal({ kind: "list", type: "remix" });
+
+  const configureFreestyleRemix = async (): Promise<void> => {
+    setCloudBusy(true);
+    try {
+      if (!(await ensureCloudAuth())) return;
+      await m.configureModel(FREESTYLE_CLOUD_REMIX, "remix");
+    } finally {
+      setCloudBusy(false);
+    }
+  };
+
   const onToggleCleanup = (next: boolean): void => {
     if (freestyleVoiceActive) return;
     if (!next) {
@@ -199,9 +220,10 @@ export default function ModelsPage(): React.JSX.Element {
       return;
     }
 
-    if (freestyleVoiceActive) return;
+    if (type === "llm" && freestyleVoiceActive) return;
 
     if (
+      type === "llm" &&
       model.provider_id === FREESTYLE_CLOUD_PROVIDER &&
       model.model_id === FREESTYLE_CLOUD_CLEANUP.model_id
     ) {
@@ -266,6 +288,8 @@ export default function ModelsPage(): React.JSX.Element {
       setModal({ kind: "list", type: "voice", voiceView: "tiers" });
     } else if (modal.type === "llm") {
       setModal({ kind: "list", type: "llm", llmView: "tiers" });
+    } else if (modal.type === "remix") {
+      setModal({ kind: "list", type: "remix" });
     } else {
       closeModal();
     }
@@ -350,6 +374,13 @@ export default function ModelsPage(): React.JSX.Element {
             }
           />
 
+          <RemixModelCard
+            model={m.defaultRemix}
+            busy={cloudBusy}
+            onChooseModel={openRemix}
+            onUseCloud={() => void configureFreestyleRemix()}
+          />
+
           <KeysSection
             apiKeys={m.apiKeys}
             configured={m.configured}
@@ -430,7 +461,8 @@ export default function ModelsPage(): React.JSX.Element {
                   }}
                 />
                 {(m.defaultVoice?.provider === pendingProviderDelete ||
-                  m.defaultLlm?.provider === pendingProviderDelete) &&
+                  m.defaultLlm?.provider === pendingProviderDelete ||
+                  m.defaultRemix?.provider === pendingProviderDelete) &&
                   t("models.deleteProviderCurrentSuffix")}
                 .
               </>

--- a/apps/electron/src/renderer/src/pages/models/model-list.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-list.tsx
@@ -162,6 +162,8 @@ function buildVoiceRows(m: UseModels, h: VoiceHandlers): Row[] {
 function buildLlmRows(
   m: UseModels,
   h: { onPickCloud: (model: AvailableModel) => void; onClose: () => void },
+  selectedModel: ConfiguredModel | undefined,
+  type: "llm" | "remix",
 ): Row[] {
   const rows: Row[] = [];
 
@@ -184,8 +186,8 @@ function buildLlmRows(
         curated: model.curated === true,
         gateway: model.gateway,
         selected:
-          m.defaultLlm?.model_id === model.model_id &&
-          m.defaultLlm?.provider === model.provider_id,
+          selectedModel?.model_id === model.model_id &&
+          selectedModel?.provider === model.provider_id,
         hasKey:
           providerId === FREESTYLE_CLOUD_CLEANUP.provider_id ||
           m.keyProviders.has(providerId),
@@ -195,8 +197,8 @@ function buildLlmRows(
   }
 
   const names = new Set(m.localLlm.models);
-  if (m.defaultLlm?.provider === "local-llm") {
-    names.add(m.defaultLlm.model_id.replace(/^local-llm\//, ""));
+  if (selectedModel?.provider === "local-llm") {
+    names.add(selectedModel.model_id.replace(/^local-llm\//, ""));
   }
   for (const name of names) {
     const modelId = `local-llm/${name}`;
@@ -208,11 +210,11 @@ function buildLlmRows(
       meta: "On-device",
       curated: true,
       selected:
-        m.defaultLlm?.provider === "local-llm" &&
-        m.defaultLlm?.model_id === modelId,
+        selectedModel?.provider === "local-llm" &&
+        selectedModel?.model_id === modelId,
       status: "ready",
       onSelect: () =>
-        void m.selectLocalLlmModel(name).then((selected) => {
+        void m.selectLocalLlmModel(name, type).then((selected) => {
           if (selected) h.onClose();
         }),
     });
@@ -237,7 +239,7 @@ export function ModelList({
   onPickLocalVoice,
   onRequestDeleteLocal,
 }: {
-  type: "voice" | "llm";
+  type: "voice" | "llm" | "remix";
   voiceView?: "tiers" | "all" | "local" | "cloud";
   llmView?: "tiers" | "all" | "local" | "cloud";
   m: UseModels;
@@ -271,6 +273,7 @@ export function ModelList({
       if (voiceView === "all") return "all";
       return voiceView ?? "tiers";
     }
+    if (type === "remix") return "all";
     if (llmView === "cloud") return "cloud";
     if (llmView === "local") return "local";
     if (llmView === "all") return "all";
@@ -315,7 +318,12 @@ export function ModelList({
           onPickLocalVoice,
           onRequestDeleteLocal,
         })
-      : buildLlmRows(m, { onPickCloud, onClose });
+      : buildLlmRows(
+          m,
+          { onPickCloud, onClose },
+          type === "remix" ? m.defaultRemix : m.defaultLlm,
+          type,
+        );
 
   const q = search.toLowerCase();
   // Curated-only for LLM until expanded; searching always searches everything.
@@ -355,7 +363,7 @@ export function ModelList({
     ? filteredRows.length - filteredRows.filter((r) => r.curated).length
     : 0;
 
-  const showLocalLlmForm = type === "llm" && localOnly;
+  const showLocalLlmForm = type !== "voice" && localOnly;
   const showOpenaiSttForm = type === "voice" && cloudOnly;
 
   const scopedTitle =
@@ -365,11 +373,17 @@ export function ModelList({
         : cloudOnly
           ? "Cloud models"
           : "All voice models"
-      : localOnly
-        ? "On-device cleanup"
-        : cloudOnly
-          ? "Cloud cleanup models"
-          : "All cleanup models";
+      : type === "remix"
+        ? localOnly
+          ? "On-device Remix models"
+          : cloudOnly
+            ? "Cloud Remix models"
+            : "All Remix models"
+        : localOnly
+          ? "On-device cleanup"
+          : cloudOnly
+            ? "Cloud cleanup models"
+            : "All cleanup models";
 
   return (
     <>
@@ -401,7 +415,7 @@ export function ModelList({
             <Laptop className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
           ) : type === "voice" ? (
             <Key className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-          ) : type === "llm" && localOnly ? (
+          ) : localOnly ? (
             <Laptop className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
           ) : (
             <Key className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
@@ -716,7 +730,7 @@ function ListEmptyState({
   showLlmConnect,
   connected,
 }: {
-  type: "voice" | "llm";
+  type: "voice" | "llm" | "remix";
   localOnly: boolean;
   showLlmConnect: boolean;
   connected: boolean | null;

--- a/apps/electron/src/renderer/src/pages/models/model-modal.tsx
+++ b/apps/electron/src/renderer/src/pages/models/model-modal.tsx
@@ -35,14 +35,14 @@ import { displayName } from "./utils";
 export type ModalState =
   | {
       kind: "list";
-      type: "voice" | "llm";
+      type: "voice" | "llm" | "remix";
       voiceView?: "tiers" | "all" | "local" | "cloud";
       llmView?: "tiers" | "all" | "local" | "cloud";
     }
   | {
       kind: "key";
       /** Slot to return to on Back; null = standalone key edit. */
-      type: "voice" | "llm" | null;
+      type: "voice" | "llm" | "remix" | null;
       provider: string;
       modelName?: string;
       /** Model to configure after the key is saved (null for edits). */
@@ -132,7 +132,11 @@ export function ModelModal({
     <Backdrop
       onClose={onClose}
       label={
-        modal.type === "voice" ? "Choose a voice model" : "Pick an LLM model"
+        modal.type === "voice"
+          ? "Choose a voice model"
+          : modal.type === "remix"
+            ? "Choose a Remix model"
+            : "Pick an LLM model"
       }
     >
       <ModelList

--- a/apps/electron/src/renderer/src/pages/models/models-shared-role.test.ts
+++ b/apps/electron/src/renderer/src/pages/models/models-shared-role.test.ts
@@ -26,16 +26,21 @@ describe("Models shared assistant role", () => {
   });
 
   it("uses the compact Settings frame instead of a standalone editorial page", async () => {
-    const [page, pairCard, modal] = await Promise.all([
+    const [page, pairCard, remixCard, modal, modelList] = await Promise.all([
       readFile(resolve(modelsRoot, "index.tsx"), "utf8"),
       readFile(resolve(modelsRoot, "pair-card.tsx"), "utf8"),
+      readFile(resolve(modelsRoot, "remix-model-card.tsx"), "utf8"),
       readFile(resolve(modelsRoot, "model-modal.tsx"), "utf8"),
+      readFile(resolve(modelsRoot, "model-list.tsx"), "utf8"),
     ]);
 
     expect(page).toContain('data-testid="models-settings-page"');
     expect(page).toContain('data-testid="models-api-keys"');
     expect(pairCard).toContain('data-testid="models-configuration"');
     expect(pairCard).not.toContain("fontSize: 34");
+    expect(page).toContain("<RemixModelCard");
+    expect(remixCard).toContain('data-testid="remix-model-configuration"');
+    expect(modelList).toContain('type: "voice" | "llm" | "remix"');
     expect(modal).toContain("max-h-[calc(100dvh-2rem)]");
   });
 });

--- a/apps/electron/src/renderer/src/pages/models/remix-model-card.tsx
+++ b/apps/electron/src/renderer/src/pages/models/remix-model-card.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@renderer/components/ui/button";
+import { cn } from "@renderer/lib/utils";
+import { Cloud, Sparkles } from "lucide-react";
+import type React from "react";
+
+import { Eyebrow } from "./page-chrome";
+import type { ConfiguredModel } from "./types";
+import { displayName } from "./utils";
+
+/**
+ * Remix has its own model role: a selected personal model runs and persists
+ * locally; Freestyle Cloud leaves the existing managed session path intact.
+ */
+export function RemixModelCard({
+  model,
+  busy,
+  onChooseModel,
+  onUseCloud,
+}: {
+  model: ConfiguredModel | undefined;
+  busy?: boolean;
+  onChooseModel: () => void;
+  onUseCloud: () => void;
+}): React.JSX.Element {
+  const local = !!model && model.provider !== "freestyle-cloud";
+  return (
+    <section
+      className="border-border bg-card/55 flex flex-col gap-4 rounded-[12px] border p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5"
+      data-testid="remix-model-configuration"
+    >
+      <div className="min-w-0">
+        <Eyebrow text="Remix runtime" mono={false} />
+        <div className="mt-2 flex min-w-0 items-center gap-2">
+          {local ? (
+            <Sparkles className="text-primary h-4 w-4 shrink-0" />
+          ) : (
+            <Cloud className="text-primary h-4 w-4 shrink-0" />
+          )}
+          <p className="text-foreground truncate text-[16px] font-semibold tracking-[-0.012em]">
+            {local ? model.model_name : "Freestyle Cloud"}
+          </p>
+        </div>
+        <p className="text-muted-foreground mt-1 text-[12px] leading-[1.5]">
+          {local
+            ? `${displayName(model.provider)} · sessions stay on this device`
+            : "Cloud sessions stay synced across your devices"}
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {local && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onUseCloud}
+            disabled={busy}
+            className={cn("text-muted-foreground hover:text-foreground")}
+          >
+            Use Cloud
+          </Button>
+        )}
+        <Button variant="outline" size="sm" onClick={onChooseModel}>
+          {local ? "Change model" : "Choose a model"}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/electron/src/renderer/src/pages/models/use-models.ts
+++ b/apps/electron/src/renderer/src/pages/models/use-models.ts
@@ -99,6 +99,8 @@ export interface UseModels {
   keyProviders: Set<string>;
   defaultVoice: ConfiguredModel | undefined;
   defaultLlm: ConfiguredModel | undefined;
+  /** The explicit Remix role; absent means Freestyle Cloud manages Remix. */
+  defaultRemix: ConfiguredModel | undefined;
   voiceItems: VoiceItem[];
   llmModelsByProvider: Map<
     string,
@@ -111,7 +113,7 @@ export interface UseModels {
   // Actions — each refetches as needed
   configureModel: (
     model: AvailableModel,
-    type: "voice" | "llm",
+    type: "voice" | "llm" | "remix",
   ) => Promise<void>;
   saveKey: (provider: string, key: string) => Promise<string | null>;
   selectLocalVoice: (
@@ -123,7 +125,10 @@ export interface UseModels {
   downloadLocal: (defId: string, engine?: "whisper" | "mlx") => Promise<void>;
   cancelLocal: (defId: string, engine?: "whisper" | "mlx") => Promise<void>;
   deleteLocal: (defId: string, engine?: "whisper" | "mlx") => Promise<void>;
-  selectLocalLlmModel: (modelName: string) => Promise<boolean>;
+  selectLocalLlmModel: (
+    modelName: string,
+    type?: "llm" | "remix",
+  ) => Promise<boolean>;
   setCleanup: (next: boolean) => void;
   saveMlxKeepAliveMinutes: (minutes: number) => void;
   deleteProvider: (provider: string) => Promise<void>;
@@ -377,6 +382,10 @@ export function useModels(): UseModels {
     () => configured.find((m) => m.type === "llm" && m.is_default === 1),
     [configured],
   );
+  const defaultRemix = useMemo(
+    () => configured.find((m) => m.type === "remix" && m.is_default === 1),
+    [configured],
+  );
   const llmModelsByProvider = useMemo(
     () => groupByProvider(available, "llm"),
     [available],
@@ -395,7 +404,7 @@ export function useModels(): UseModels {
   // -------------------------------------------------------------------------
 
   const configureModel = useCallback(
-    async (model: AvailableModel, type: "voice" | "llm") => {
+    async (model: AvailableModel, type: "voice" | "llm" | "remix") => {
       const response = await getClient().api.models.configured.$post({
         json: {
           provider: model.provider_id,
@@ -610,7 +619,7 @@ export function useModels(): UseModels {
   );
 
   const selectLocalLlmModel = useCallback(
-    async (modelName: string) => {
+    async (modelName: string, type: "llm" | "remix" = "llm") => {
       setLocalActionError(null);
       try {
         const response = await getClient().api.models.configured.$post({
@@ -618,7 +627,7 @@ export function useModels(): UseModels {
             provider: "local-llm",
             model_id: `local-llm/${modelName}`,
             model_name: modelName,
-            type: "llm",
+            type,
             is_default: true,
           },
         });
@@ -737,6 +746,7 @@ export function useModels(): UseModels {
     keyProviders,
     defaultVoice,
     defaultLlm,
+    defaultRemix,
     voiceItems,
     llmModelsByProvider,
     localLlm,

--- a/apps/electron/src/renderer/src/remix-session-mutations.test.ts
+++ b/apps/electron/src/renderer/src/remix-session-mutations.test.ts
@@ -23,7 +23,7 @@ describe("Remix session deletion", () => {
     expect(source).toContain(
       "context.mutationVersion === deletionVersionRef.current",
     );
-    expect(source).toContain("switchThread(newThread())");
+    expect(source).toContain("startNewThread()");
     expect(source).toContain("onError");
     expect(source).toContain("Couldn’t delete this session.");
     expect(source).toContain("onSettled");

--- a/apps/electron/src/renderer/src/remix-session-switching.test.ts
+++ b/apps/electron/src/renderer/src/remix-session-switching.test.ts
@@ -41,7 +41,7 @@ describe("Remix session switching", () => {
     );
 
     expect(sessions).toContain("onPanelThreadUpdated");
-    expect(sessions).toContain("fetchQuery(threadQueryOptions(threadId))");
+    expect(sessions).toContain("threadQueryOptions(threadId, type)");
     expect(sessions).toContain("current?.id === threadId ? loaded : current");
   });
 

--- a/apps/electron/src/renderer/src/shell-workspace-switcher.test.ts
+++ b/apps/electron/src/renderer/src/shell-workspace-switcher.test.ts
@@ -94,9 +94,11 @@ describe("workspace switcher", () => {
     );
 
     expect(remixSidebar).toContain("titleOverrides={localTitles}");
-    expect(remixSidebar).toContain("onRename={renameThread}");
     expect(remixSidebar).toContain(
-      "onDelete={(picked) => requestDeleteThread(picked.id, picked.title)}",
+      "renameThread(picked.id, title, picked.type)",
+    );
+    expect(remixSidebar).toContain(
+      "requestDeleteThread(picked.id, picked.title, picked.type)",
     );
     expect(remixSidebar).toContain('sessionActions="context"');
     expect(remixSidebar).toContain("sessionActivity={sessionActivity}");

--- a/apps/electron/src/renderer/src/shell.tsx
+++ b/apps/electron/src/renderer/src/shell.tsx
@@ -400,8 +400,6 @@ function RemixSidebarSessions({
     };
   }, [updateMoreSessionsState]);
 
-  if (!thread) return null;
-
   return (
     <section className="remix-sidebar-sessions" aria-label="Remix chats">
       <div className="remix-sidebar-sessions-head">
@@ -433,17 +431,21 @@ function RemixSidebarSessions({
         data-has-more={hasMoreSessions || undefined}
       >
         <ThreadHistory
-          currentId={sidebarCurrentThreadId(workspaceSurface, thread.id)}
+          currentId={sidebarCurrentThreadId(workspaceSurface, thread?.id ?? "")}
           searchQuery={searchQuery}
           titleOverrides={localTitles}
-          onRename={renameThread}
-          onDelete={(picked) => requestDeleteThread(picked.id, picked.title)}
+          onRename={(picked, title) =>
+            renameThread(picked.id, title, picked.type)
+          }
+          onDelete={(picked) =>
+            requestDeleteThread(picked.id, picked.title, picked.type)
+          }
           sessionActions="context"
           sessionActivity={sessionActivity}
           completedSessionIds={completedSessionIds}
           onSessionSeen={markSessionSeen}
           onPick={(picked) => {
-            if (picked.id !== thread.id) selectThread(picked);
+            if (picked.id !== thread?.id) selectThread(picked);
           }}
         />
       </div>

--- a/apps/electron/tests/remix-recovery.test.ts
+++ b/apps/electron/tests/remix-recovery.test.ts
@@ -129,6 +129,15 @@ async function installFixtures(page: Page) {
         return json({ onboarding: JSON.stringify({ v: 2, done: true }) });
       if (path === "/api/health")
         return json({ name: "freestyle", status: "ok" });
+      if (path === "/api/remix/sessions" && init?.method === "POST")
+        return json({
+          thread: {
+            id: crypto.randomUUID(),
+            type: "remote",
+            title: null,
+            messages: [],
+          },
+        });
       if (path === "/api/remix/turns") {
         if (clientRequestId !== body!.clientRequestId) {
           f.status = "running";

--- a/apps/server/src/lib/providers.ts
+++ b/apps/server/src/lib/providers.ts
@@ -30,6 +30,7 @@ function getChatModelId(providerId: string, modelId: string): string {
 interface DefaultModels {
   voice: { provider: string; model_id: string; model_name: string } | null;
   llm: { provider: string; model_id: string; model_name: string } | null;
+  remix: { provider: string; model_id: string; model_name: string } | null;
 }
 
 export function getDefaultModels(): DefaultModels {
@@ -49,10 +50,18 @@ export function getDefaultModels(): DefaultModels {
     .get() as
     | { provider: string; model_id: string; model_name: string }
     | undefined;
+  const remix = db
+    .prepare(
+      "SELECT provider, model_id, model_name FROM model_configs WHERE type = 'remix' AND is_default = 1 LIMIT 1",
+    )
+    .get() as
+    | { provider: string; model_id: string; model_name: string }
+    | undefined;
 
   return {
     voice: voice ?? null,
     llm: llm ?? null,
+    remix: remix ?? null,
   };
 }
 

--- a/apps/server/src/lib/remix-runtime.ts
+++ b/apps/server/src/lib/remix-runtime.ts
@@ -1,0 +1,17 @@
+import { FREESTYLE_CLOUD_PROVIDER_ID } from "./freestyle-cloud.js";
+import { getDefaultModels } from "./providers.js";
+
+export type RemixRuntime =
+  | { kind: "managed" }
+  | {
+      kind: "local";
+      model: { provider: string; model_id: string; model_name: string };
+    };
+
+/** Remix is Cloud-managed unless the user explicitly selects their own model. */
+export function getRemixRuntime(): RemixRuntime {
+  const model = getDefaultModels().remix;
+  if (!model || model.provider === FREESTYLE_CLOUD_PROVIDER_ID)
+    return { kind: "managed" };
+  return { kind: "local", model };
+}

--- a/apps/server/src/lib/remix-store.ts
+++ b/apps/server/src/lib/remix-store.ts
@@ -79,7 +79,7 @@ function isFresh(thread: RemixThread): boolean {
 }
 
 /** The latest thread while still fresh, else null. Never creates one — GET
- * must not mutate; thread creation belongs to startNewThread. */
+ * must not mutate; thread creation is explicit. */
 export function getActiveThread(type: RemixSessionType): RemixThread | null {
   const latest = latestThread(type);
   return latest && isFresh(latest) ? latest : null;
@@ -115,8 +115,6 @@ export function createRemixThread(
   if (!row) throw new Error("Failed to create remix thread");
   return rowToThread(row);
 }
-
-export const startNewThread = createRemixThread;
 
 export function getRemixThread(threadId: string): RemixThread | null {
   const row = getDb()

--- a/apps/server/src/lib/remix-store.ts
+++ b/apps/server/src/lib/remix-store.ts
@@ -10,8 +10,20 @@ export const REMIX_THREAD_IDLE_MS = 15 * 60 * 1000;
 /** Thread payloads are capped so a long-lived thread can't grow unbounded. */
 export const MAX_THREAD_MESSAGES = 40;
 
+export type RemixSessionType = "local" | "remote";
+
+export interface LocalRemixModel {
+  provider: string;
+  modelId: string;
+  modelName: string;
+}
+
 export interface RemixThread {
-  id: number;
+  id: string;
+  type: RemixSessionType;
+  title: string | null;
+  remoteScope: string | null;
+  model: LocalRemixModel | null;
   createdAt: string;
   lastActiveAt: string;
 }
@@ -22,7 +34,13 @@ export interface StoredUiMessage {
 }
 
 interface ThreadRow {
-  id: number;
+  id: string;
+  type: RemixSessionType;
+  title: string | null;
+  remote_scope: string | null;
+  model_provider: string | null;
+  model_id: string | null;
+  model_name: string | null;
   created_at: string;
   last_active_at: string;
 }
@@ -30,15 +48,28 @@ interface ThreadRow {
 function rowToThread(row: ThreadRow): RemixThread {
   return {
     id: row.id,
+    type: row.type,
+    title: row.title,
+    remoteScope: row.remote_scope,
+    model:
+      row.model_provider && row.model_id && row.model_name
+        ? {
+            provider: row.model_provider,
+            modelId: row.model_id,
+            modelName: row.model_name,
+          }
+        : null,
     createdAt: row.created_at,
     lastActiveAt: row.last_active_at,
   };
 }
 
-function latestThread(): RemixThread | null {
+function latestThread(type: RemixSessionType): RemixThread | null {
   const row = getDb()
-    .prepare("SELECT * FROM remix_threads ORDER BY id DESC LIMIT 1")
-    .get() as ThreadRow | undefined;
+    .prepare(
+      "SELECT * FROM remix_threads WHERE type = ? ORDER BY last_active_at DESC LIMIT 1",
+    )
+    .get(type) as ThreadRow | undefined;
   return row ? rowToThread(row) : null;
 }
 
@@ -49,17 +80,34 @@ function isFresh(thread: RemixThread): boolean {
 
 /** The latest thread while still fresh, else null. Never creates one — GET
  * must not mutate; thread creation belongs to startNewThread. */
-export function getActiveThread(): RemixThread | null {
-  const latest = latestThread();
+export function getActiveThread(type: RemixSessionType): RemixThread | null {
+  const latest = latestThread(type);
   return latest && isFresh(latest) ? latest : null;
 }
 
 /** Force a new thread (the card's explicit "new thread" affordance). */
-export function startNewThread(): RemixThread {
+export function createRemixThread(
+  type: RemixSessionType,
+  model: LocalRemixModel | null = null,
+  remoteScope: string | null = null,
+): RemixThread {
+  if (type === "local" && !model)
+    throw new Error("Local Remix sessions require a resolved model");
+  if (type === "remote" && !remoteScope)
+    throw new Error("Remote Remix sessions require an account scope");
   const db = getDb();
-  const id = Number(
-    db.prepare("INSERT INTO remix_threads DEFAULT VALUES").run()
-      .lastInsertRowid,
+  const id = crypto.randomUUID();
+  db.prepare(
+    `INSERT INTO remix_threads
+      (id, type, remote_scope, model_provider, model_id, model_name)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    type,
+    remoteScope,
+    model?.provider ?? null,
+    model?.modelId ?? null,
+    model?.modelName ?? null,
   );
   const row = db.prepare("SELECT * FROM remix_threads WHERE id = ?").get(id) as
     | ThreadRow
@@ -68,7 +116,75 @@ export function startNewThread(): RemixThread {
   return rowToThread(row);
 }
 
-export function getThreadMessages(threadId: number): StoredUiMessage[] {
+export const startNewThread = createRemixThread;
+
+export function getRemixThread(threadId: string): RemixThread | null {
+  const row = getDb()
+    .prepare("SELECT * FROM remix_threads WHERE id = ?")
+    .get(threadId) as ThreadRow | undefined;
+  return row ? rowToThread(row) : null;
+}
+
+/** Local sessions are the only complete transcripts owned by this database. */
+export function listLocalRemixThreads(limit = 24): RemixThread[] {
+  return getDb()
+    .prepare(
+      `SELECT * FROM remix_threads
+       WHERE type = 'local'
+       ORDER BY last_active_at DESC
+       LIMIT ?`,
+    )
+    .all(limit)
+    .map((row) => rowToThread(row as unknown as ThreadRow));
+}
+
+export function updateRemixThreadTitle(
+  threadId: string,
+  title: string | null,
+): boolean {
+  const result = getDb()
+    .prepare(
+      `UPDATE remix_threads
+       SET title = ?, last_active_at = datetime('now')
+       WHERE id = ? AND type = 'local'`,
+    )
+    .run(title, threadId);
+  return result.changes > 0;
+}
+
+export function deleteLocalRemixThread(threadId: string): boolean {
+  const result = getDb()
+    .prepare("DELETE FROM remix_threads WHERE id = ? AND type = 'local'")
+    .run(threadId);
+  return result.changes > 0;
+}
+
+/** A remote row is sidebar cache metadata only: never a transcript snapshot. */
+export function upsertRemoteRemixThread(input: {
+  id: string;
+  title: string | null;
+  remoteScope: string;
+  updatedAt?: number;
+}): void {
+  getDb()
+    .prepare(
+      `INSERT INTO remix_threads (id, type, title, remote_scope, last_active_at)
+       VALUES (?, 'remote', ?, ?, datetime(? / 1000, 'unixepoch'))
+       ON CONFLICT(id) DO UPDATE SET
+         title = excluded.title,
+         remote_scope = excluded.remote_scope,
+         last_active_at = excluded.last_active_at
+       WHERE remix_threads.type = 'remote'`,
+    )
+    .run(
+      input.id,
+      input.title,
+      input.remoteScope,
+      input.updatedAt ?? Date.now(),
+    );
+}
+
+export function getThreadMessages(threadId: string): StoredUiMessage[] {
   const rows = getDb()
     .prepare(
       "SELECT ui_message FROM remix_messages WHERE thread_id = ? ORDER BY id DESC LIMIT ?",
@@ -94,12 +210,12 @@ export function getThreadMessages(threadId: number): StoredUiMessage[] {
  * not exist, so the route can 404 instead of hitting the FK.
  */
 export function saveThreadMessages(
-  threadId: number,
+  threadId: string,
   messages: StoredUiMessage[],
 ): boolean {
   const db = getDb();
   const exists = db
-    .prepare("SELECT id FROM remix_threads WHERE id = ?")
+    .prepare("SELECT id FROM remix_threads WHERE id = ? AND type = 'local'")
     .get(threadId);
   if (!exists) return false;
 
@@ -140,7 +256,7 @@ export function saveThreadMessages(
 }
 
 export interface RemixRunInput {
-  threadId?: number | null;
+  threadId?: string | null;
   lane: "transform" | "agent";
   instruction: string;
   beforeText?: string | null;
@@ -179,7 +295,7 @@ export function recordRemixRun(run: RemixRunInput): number {
 
 export interface RemixRunRow {
   id: number;
-  thread_id: number | null;
+  thread_id: string | null;
   lane: string;
   instruction: string;
   before_text: string | null;
@@ -216,7 +332,7 @@ export function purgeExpiredRemixData(retentionDays: number): number {
   const runs = db
     .prepare("DELETE FROM remix_runs WHERE created_at < datetime('now', ?)")
     .run(cutoff);
-  const activeThreadId = getActiveThread()?.id ?? -1;
+  const activeThreadId = getActiveThread("local")?.id ?? "";
   const threads = db
     .prepare(
       "DELETE FROM remix_threads WHERE last_active_at < datetime('now', ?) AND id != ?",

--- a/apps/server/src/lib/schema.ts
+++ b/apps/server/src/lib/schema.ts
@@ -7,7 +7,7 @@ import { countFixes } from "./fixes.js";
 // and would otherwise perturb test module-mock ordering.
 const DEFAULT_CLOUD_URL = "https://service.freestylevoice.com";
 
-const SCHEMA_VERSION = 29;
+const SCHEMA_VERSION = 31;
 
 // Legacy default format-rule patterns (used only by pre-v12 migrations below):
 // domain/phrase entries match as substrings of url+title+app; bare words match
@@ -770,6 +770,160 @@ function applyMigrations(db: DatabaseSync, currentVersion: number): void {
         PRIMARY KEY(connection_id, original_name)
       );
     `);
+  }
+
+  // Remix owns an independent model role. SQLite cannot alter the CHECK
+  // constraint in place, so rebuild this small configuration table while
+  // retaining the existing stable model IDs.
+  if (currentVersion < 30 && tableExists(db, "model_configs")) {
+    db.exec(`
+      ALTER TABLE model_configs RENAME TO model_configs_legacy;
+      CREATE TABLE model_configs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        provider TEXT NOT NULL,
+        model_id TEXT NOT NULL,
+        model_name TEXT NOT NULL,
+        type TEXT NOT NULL CHECK(type IN ('voice', 'llm', 'remix')),
+        is_default INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(provider, model_id, type)
+      );
+      INSERT INTO model_configs (id, provider, model_id, model_name, type, is_default, created_at)
+        SELECT id, provider, model_id, model_name, type, is_default, created_at
+        FROM model_configs_legacy;
+      DROP TABLE model_configs_legacy;
+      CREATE INDEX IF NOT EXISTS idx_model_configs_type_default
+        ON model_configs(type, is_default);
+    `);
+  }
+
+  if (currentVersion < 31 && tableExists(db, "remix_threads")) {
+    db.exec(`
+        ALTER TABLE remix_messages RENAME TO remix_messages_legacy;
+        ALTER TABLE remix_runs RENAME TO remix_runs_legacy;
+        ALTER TABLE remix_threads RENAME TO remix_threads_legacy;
+        CREATE TABLE remix_threads (
+          id TEXT PRIMARY KEY,
+          type TEXT NOT NULL CHECK(type IN ('local', 'remote')),
+          title TEXT,
+          remote_scope TEXT,
+          model_provider TEXT,
+          model_id TEXT,
+          model_name TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          last_active_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE TABLE remix_messages (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          thread_id TEXT NOT NULL REFERENCES remix_threads(id) ON DELETE CASCADE,
+          message_id TEXT NOT NULL,
+          ui_message TEXT NOT NULL,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          UNIQUE(thread_id, message_id)
+        );
+        CREATE TABLE remix_runs (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          thread_id TEXT REFERENCES remix_threads(id) ON DELETE SET NULL,
+          lane TEXT NOT NULL CHECK(lane IN ('transform','agent')),
+          instruction TEXT NOT NULL,
+          before_text TEXT,
+          after_text TEXT NOT NULL,
+          app_name TEXT,
+          llm_provider TEXT,
+          llm_model TEXT,
+          input_tokens INTEGER NOT NULL DEFAULT 0,
+          output_tokens INTEGER NOT NULL DEFAULT 0,
+          cost_usd REAL NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+    const rows = db
+      .prepare(
+        "SELECT id, created_at, last_active_at FROM remix_threads_legacy",
+      )
+      .all() as Array<{
+      id: number;
+      created_at: string;
+      last_active_at: string;
+    }>;
+    const threadIds = new Map<number, string>();
+    const insertThread = db.prepare(
+      "INSERT INTO remix_threads (id, type, created_at, last_active_at) VALUES (?, 'local', ?, ?)",
+    );
+    for (const row of rows) {
+      const id = crypto.randomUUID();
+      threadIds.set(row.id, id);
+      insertThread.run(id, row.created_at, row.last_active_at);
+    }
+    const messageRows = db
+      .prepare(
+        "SELECT thread_id, message_id, ui_message, created_at FROM remix_messages_legacy",
+      )
+      .all() as Array<{
+      thread_id: number;
+      message_id: string;
+      ui_message: string;
+      created_at: string;
+    }>;
+    const insertMessage = db.prepare(
+      "INSERT INTO remix_messages (thread_id, message_id, ui_message, created_at) VALUES (?, ?, ?, ?)",
+    );
+    for (const row of messageRows) {
+      const threadId = threadIds.get(row.thread_id);
+      if (threadId)
+        insertMessage.run(
+          threadId,
+          row.message_id,
+          row.ui_message,
+          row.created_at,
+        );
+    }
+    const runRows = db
+      .prepare("SELECT * FROM remix_runs_legacy")
+      .all() as Array<{
+      id: number;
+      thread_id: number | null;
+      lane: string;
+      instruction: string;
+      before_text: string | null;
+      after_text: string;
+      app_name: string | null;
+      llm_provider: string | null;
+      llm_model: string | null;
+      input_tokens: number;
+      output_tokens: number;
+      cost_usd: number;
+      created_at: string;
+    }>;
+    const insertRun = db.prepare(
+      `INSERT INTO remix_runs (id, thread_id, lane, instruction, before_text, after_text, app_name,
+          llm_provider, llm_model, input_tokens, output_tokens, cost_usd, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const row of runRows) {
+      insertRun.run(
+        row.id,
+        row.thread_id === null ? null : (threadIds.get(row.thread_id) ?? null),
+        row.lane,
+        row.instruction,
+        row.before_text,
+        row.after_text,
+        row.app_name,
+        row.llm_provider,
+        row.llm_model,
+        row.input_tokens,
+        row.output_tokens,
+        row.cost_usd,
+        row.created_at,
+      );
+    }
+    db.exec(`
+        DROP TABLE remix_messages_legacy;
+        DROP TABLE remix_runs_legacy;
+        DROP TABLE remix_threads_legacy;
+        CREATE INDEX IF NOT EXISTS idx_remix_threads_type_activity
+          ON remix_threads(type, last_active_at DESC);
+      `);
   }
 
   // Upsert schema version

--- a/apps/server/src/routes/agent-threads.ts
+++ b/apps/server/src/routes/agent-threads.ts
@@ -3,7 +3,15 @@ import { Hono } from "hono";
 import { trustedDesktopAgentFields } from "../lib/agent-request.js";
 import { agentStreamStore } from "../lib/agent-stream-store.js";
 import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
-import { getSessionToken, invalidateSession } from "../lib/sessions.js";
+import {
+  listLocalRemixThreads,
+  upsertRemoteRemixThread,
+} from "../lib/remix-store.js";
+import {
+  getSession,
+  getSessionToken,
+  invalidateSession,
+} from "../lib/sessions.js";
 
 const log = createAppLogger("agent-threads");
 
@@ -108,7 +116,39 @@ const agentThreadsRoute = new Hono()
     }
     const query = params.size > 0 ? `?${params.toString()}` : "";
     const { status, payload } = await forward(query);
-    return c.json(payload as object, status as 200);
+    if (status !== 200 || !payload || typeof payload !== "object")
+      return c.json(payload as object, status as 200);
+    const envelope = payload as {
+      threads?: Array<{ id?: unknown; title?: unknown; updatedAt?: unknown }>;
+    };
+    const session = getSession();
+    const scope = session ? `${session.host}:${session.user.id}` : null;
+    const threads = (envelope.threads ?? []).map((thread) => {
+      if (scope && typeof thread.id === "string") {
+        upsertRemoteRemixThread({
+          id: thread.id,
+          title: typeof thread.title === "string" ? thread.title : null,
+          remoteScope: scope,
+          updatedAt:
+            typeof thread.updatedAt === "number" ? thread.updatedAt : undefined,
+        });
+      }
+      return { ...thread, type: "remote" as const };
+    });
+    // Local conversations never cross this boundary beyond their sidebar
+    // metadata. Keep pagination Cloud-owned so a local row cannot distort a
+    // Cloud cursor.
+    const includeLocal = !c.req.query("cursor") && origin !== "scheduled";
+    const localThreads = includeLocal
+      ? listLocalRemixThreads().map((thread) => ({
+          id: thread.id,
+          title: thread.title?.trim() || "New chat",
+          updatedAt: Date.parse(`${thread.lastActiveAt.replace(" ", "T")}Z`),
+          origin: "user" as const,
+          type: "local" as const,
+        }))
+      : [];
+    return c.json({ ...envelope, threads: [...localThreads, ...threads] }, 200);
   })
   .get("/latest", async (c) => {
     const { status, payload } = await forward("/latest");

--- a/apps/server/src/routes/remix-sessions.ts
+++ b/apps/server/src/routes/remix-sessions.ts
@@ -1,0 +1,177 @@
+import {
+  MCP_TOOLS_MAX,
+  REMIX_CLIENT_TOOLS,
+  remixAgentRequestSchema,
+} from "@freestyle-voice/validations";
+import { zValidator } from "@hono/zod-validator";
+import {
+  convertToModelMessages,
+  type FlexibleSchema,
+  stepCountIs,
+  streamText,
+  tool,
+  type UIMessage,
+} from "ai";
+import { Hono } from "hono";
+import { z } from "zod";
+import { buildRemixAgentSystem } from "../lib/editor/remix-prompts.js";
+import { createMcpStore } from "../lib/mcp/store.js";
+import { createCleanupModel } from "../lib/providers.js";
+import { getRemixRuntime } from "../lib/remix-runtime.js";
+import {
+  createRemixThread,
+  deleteLocalRemixThread,
+  getRemixThread,
+  getThreadMessages,
+  listLocalRemixThreads,
+  saveThreadMessages,
+  updateRemixThreadTitle,
+} from "../lib/remix-store.js";
+import { getSession } from "../lib/sessions.js";
+
+const threadIdSchema = z.string().uuid();
+const storedMessageSchema = z.object({ id: z.string().min(1) }).passthrough();
+const MAX_LOCAL_REMIX_STEPS = 16;
+
+function createLocalRemixTools() {
+  const clientTools = Object.fromEntries(
+    Object.entries(REMIX_CLIENT_TOOLS).map(([name, definition]) => [
+      name,
+      tool({
+        description: definition.description,
+        inputSchema: definition.inputSchema as FlexibleSchema<
+          Record<string, unknown>
+        >,
+      }),
+    ]),
+  );
+  const mcpTools = Object.fromEntries(
+    createMcpStore()
+      .listEnabledTools()
+      .slice(0, MCP_TOOLS_MAX)
+      .filter(({ tool: definition }) => !(definition.wireName in clientTools))
+      .map(({ tool: definition }) => [
+        definition.wireName,
+        tool({
+          description: definition.description,
+          inputSchema: definition.inputSchema as FlexibleSchema<
+            Record<string, unknown>
+          >,
+        }),
+      ]),
+  );
+  return { ...clientTools, ...mcpTools };
+}
+
+function localThreadPayload(threadId: string) {
+  const thread = getRemixThread(threadId);
+  if (!thread || thread.type !== "local") return null;
+  return { ...thread, messages: getThreadMessages(thread.id) };
+}
+
+/**
+ * The renderer gets session ownership from this boundary rather than deriving
+ * it from a selected model. This keeps model changes from reclassifying an
+ * existing conversation and ensures only local sessions can read SQLite bodies.
+ */
+const remixSessionsRoute = new Hono()
+  .post("/", (c) => {
+    const runtime = getRemixRuntime();
+    const session = runtime.kind === "managed" ? getSession() : null;
+    if (runtime.kind === "managed" && !session)
+      return c.json({ error: "cloud_auth_required" }, 401);
+    const thread = createRemixThread(
+      runtime.kind === "local" ? "local" : "remote",
+      runtime.kind === "local"
+        ? {
+            provider: runtime.model.provider,
+            modelId: runtime.model.model_id,
+            modelName: runtime.model.model_name,
+          }
+        : null,
+      session ? `${session.host}:${session.user.id}` : null,
+    );
+    return c.json({ thread: { ...thread, messages: [] } }, 201);
+  })
+  .get("/local", (c) => c.json({ threads: listLocalRemixThreads() }))
+  .post(
+    "/:id/stream",
+    zValidator("param", z.object({ id: threadIdSchema })),
+    zValidator("json", remixAgentRequestSchema),
+    async (c) => {
+      const thread = getRemixThread(c.req.valid("param").id);
+      if (!thread || thread.type !== "local" || !thread.model)
+        return c.json({ error: "local_thread_not_found" }, 404);
+      try {
+        const model = await createCleanupModel(
+          thread.model.provider,
+          thread.model.modelId,
+        );
+        const request = c.req.valid("json");
+        const result = streamText({
+          model,
+          system: buildRemixAgentSystem(request.context, {
+            hasWebSearch: false,
+          }),
+          messages: await convertToModelMessages(
+            request.messages as UIMessage[],
+          ),
+          tools: createLocalRemixTools(),
+          stopWhen: stepCountIs(MAX_LOCAL_REMIX_STEPS),
+          maxRetries: 0,
+          abortSignal: c.req.raw.signal,
+        });
+        return result.toUIMessageStreamResponse({
+          originalMessages: request.messages as UIMessage[],
+          generateMessageId: () => crypto.randomUUID(),
+          onError: () => "Remix could not complete this request.",
+        });
+      } catch {
+        return c.json({ error: "remix_unavailable" }, 502);
+      }
+    },
+  )
+  .get("/:id", zValidator("param", z.object({ id: threadIdSchema })), (c) => {
+    const thread = localThreadPayload(c.req.valid("param").id);
+    if (!thread) return c.json({ error: "thread_not_found" }, 404);
+    return c.json({ thread });
+  })
+  .put(
+    "/:id/messages",
+    zValidator("param", z.object({ id: threadIdSchema })),
+    zValidator(
+      "json",
+      z.object({ messages: z.array(storedMessageSchema).max(40) }),
+    ),
+    (c) => {
+      const { id } = c.req.valid("param");
+      if (!saveThreadMessages(id, c.req.valid("json").messages))
+        return c.json({ error: "thread_not_found" }, 404);
+      return c.json({ ok: true });
+    },
+  )
+  .patch(
+    "/:id",
+    zValidator("param", z.object({ id: threadIdSchema })),
+    zValidator(
+      "json",
+      z.object({ title: z.string().trim().max(200).nullable() }),
+    ),
+    (c) => {
+      const { id } = c.req.valid("param");
+      if (!updateRemixThreadTitle(id, c.req.valid("json").title))
+        return c.json({ error: "thread_not_found" }, 404);
+      return c.json({ ok: true });
+    },
+  )
+  .delete(
+    "/:id",
+    zValidator("param", z.object({ id: threadIdSchema })),
+    (c) => {
+      if (!deleteLocalRemixThread(c.req.valid("param").id))
+        return c.json({ error: "thread_not_found" }, 404);
+      return c.json({ ok: true });
+    },
+  );
+
+export default remixSessionsRoute;

--- a/apps/server/src/routes/remix-sessions.ts
+++ b/apps/server/src/routes/remix-sessions.ts
@@ -141,7 +141,11 @@ const remixSessionsRoute = new Hono()
     zValidator("param", z.object({ id: threadIdSchema })),
     zValidator(
       "json",
-      z.object({ messages: z.array(storedMessageSchema).max(40) }),
+      // The local store retains only the newest 40 messages, but the renderer
+      // sends the full active conversation (the same 400-message cap used by
+      // Remix requests). Rejecting it at 41 would silently stop persistence
+      // for otherwise valid longer local conversations.
+      z.object({ messages: z.array(storedMessageSchema).max(400) }),
     ),
     (c) => {
       const { id } = c.req.valid("param");

--- a/apps/server/src/routes/remix.ts
+++ b/apps/server/src/routes/remix.ts
@@ -11,6 +11,7 @@ import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
 import { createMcpStore } from "../lib/mcp/store.js";
 import { getSessionToken, invalidateSession } from "../lib/sessions.js";
 import { remixDurableRoute } from "./remix-durable.js";
+import remixSessionsRoute from "./remix-sessions.js";
 
 const log = createAppLogger("remix");
 
@@ -20,6 +21,7 @@ const log = createAppLogger("remix");
  * stream for the pill renderer.
  */
 const remixRoute = new Hono()
+  .route("/sessions", remixSessionsRoute)
   .route("/", remixDurableRoute)
   .post("/", zValidator("json", remixAgentRequestSchema), async (c) => {
     const token = getSessionToken();

--- a/apps/server/tests/agent-threads-proxy.test.ts
+++ b/apps/server/tests/agent-threads-proxy.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/lib/sessions.js", () => ({
   getSessionToken: () => "token",
+  getSession: () => null,
   invalidateSession: vi.fn(),
 }));
 

--- a/apps/server/tests/courier-notification-migration.test.ts
+++ b/apps/server/tests/courier-notification-migration.test.ts
@@ -25,7 +25,7 @@ describe("Courier Inbox authority migration", () => {
     expect(tables).toEqual([]);
     expect(
       db.prepare("SELECT version FROM schema_version WHERE id = 1").get(),
-    ).toEqual({ version: 29 });
+    ).toEqual({ version: 31 });
     db.close();
   });
 });

--- a/apps/server/tests/remix-runtime.test.ts
+++ b/apps/server/tests/remix-runtime.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "../src/lib/db.js";
+import { getRemixRuntime } from "../src/lib/remix-runtime.js";
+
+beforeEach(() => {
+  getDb().prepare("DELETE FROM model_configs WHERE type = 'remix'").run();
+});
+
+describe("getRemixRuntime", () => {
+  it("uses managed Cloud when no Remix model is configured", () => {
+    expect(getRemixRuntime()).toEqual({ kind: "managed" });
+  });
+
+  it("uses managed Cloud when Freestyle Cloud is selected", () => {
+    getDb()
+      .prepare(
+        `INSERT INTO model_configs
+          (provider, model_id, model_name, type, is_default)
+         VALUES ('freestyle-cloud', 'freestyle-cloud/remix', 'Freestyle Cloud', 'remix', 1)`,
+      )
+      .run();
+
+    expect(getRemixRuntime()).toEqual({ kind: "managed" });
+  });
+
+  it("selects a local runtime only for an explicitly configured non-Cloud model", () => {
+    getDb()
+      .prepare(
+        `INSERT INTO model_configs
+          (provider, model_id, model_name, type, is_default)
+         VALUES ('local-llm', 'local-llm/qwen', 'Qwen', 'remix', 1)`,
+      )
+      .run();
+
+    expect(getRemixRuntime()).toEqual({
+      kind: "local",
+      model: {
+        provider: "local-llm",
+        model_id: "local-llm/qwen",
+        model_name: "Qwen",
+      },
+    });
+  });
+});

--- a/apps/server/tests/remix-sessions.test.ts
+++ b/apps/server/tests/remix-sessions.test.ts
@@ -104,4 +104,76 @@ describe("Remix local session boundary", () => {
         .get(remote.thread.id),
     ).toEqual({ type: "remote" });
   });
+
+  it("persists local titles and removes only local sessions", async () => {
+    getDb()
+      .prepare(
+        `INSERT INTO model_configs
+          (provider, model_id, model_name, type, is_default)
+         VALUES ('local-llm', 'local-llm/qwen', 'Qwen', 'remix', 1)`,
+      )
+      .run();
+    const created = (await (
+      await remixRoute.request("/sessions", { method: "POST" })
+    ).json()) as { thread: { id: string } };
+
+    const renamed = await remixRoute.request(`/sessions/${created.thread.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "Local draft" }),
+    });
+    expect(renamed.status).toBe(200);
+    await expect(
+      remixRoute.request(`/sessions/${created.thread.id}`),
+    ).resolves.toHaveProperty("status", 200);
+    expect(
+      getDb()
+        .prepare("SELECT title FROM remix_threads WHERE id = ?")
+        .get(created.thread.id),
+    ).toEqual({ title: "Local draft" });
+
+    const deleted = await remixRoute.request(`/sessions/${created.thread.id}`, {
+      method: "DELETE",
+    });
+    expect(deleted.status).toBe(200);
+    expect(
+      getDb()
+        .prepare("SELECT COUNT(*) AS n FROM remix_threads WHERE id = ?")
+        .get(created.thread.id),
+    ).toEqual({ n: 0 });
+  });
+
+  it("accepts a full active conversation and retains the newest local snapshot", async () => {
+    getDb()
+      .prepare(
+        `INSERT INTO model_configs
+          (provider, model_id, model_name, type, is_default)
+         VALUES ('local-llm', 'local-llm/qwen', 'Qwen', 'remix', 1)`,
+      )
+      .run();
+    const created = (await (
+      await remixRoute.request("/sessions", { method: "POST" })
+    ).json()) as { thread: { id: string } };
+    const messages = Array.from({ length: 41 }, (_, index) => ({
+      id: `message-${index}`,
+      role: "user",
+      parts: [],
+    }));
+
+    const saved = await remixRoute.request(
+      `/sessions/${created.thread.id}/messages`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ messages }),
+      },
+    );
+
+    expect(saved.status).toBe(200);
+    expect(
+      getDb()
+        .prepare("SELECT COUNT(*) AS n FROM remix_messages WHERE thread_id = ?")
+        .get(created.thread.id),
+    ).toEqual({ n: 40 });
+  });
 });

--- a/apps/server/tests/remix-sessions.test.ts
+++ b/apps/server/tests/remix-sessions.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "../src/lib/db.js";
+import { freestyleCloudUrl } from "../src/lib/freestyle-cloud.js";
+import { clearSession, setSession } from "../src/lib/sessions.js";
+import remixRoute from "../src/routes/remix.js";
+
+beforeEach(() => {
+  clearSession();
+  getDb().prepare("DELETE FROM remix_messages").run();
+  getDb().prepare("DELETE FROM remix_runs").run();
+  getDb().prepare("DELETE FROM remix_threads").run();
+  getDb().prepare("DELETE FROM model_configs WHERE type = 'remix'").run();
+});
+
+describe("Remix local session boundary", () => {
+  it("requires an account before recording managed-session metadata", async () => {
+    const response = await remixRoute.request("/sessions", { method: "POST" });
+    expect(response.status).toBe(401);
+  });
+
+  it("creates an explicit local session for a non-Cloud Remix model", async () => {
+    getDb()
+      .prepare(
+        `INSERT INTO model_configs
+          (provider, model_id, model_name, type, is_default)
+         VALUES ('local-llm', 'local-llm/qwen', 'Qwen', 'remix', 1)`,
+      )
+      .run();
+
+    const response = await remixRoute.request("/sessions", { method: "POST" });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      thread: { type: "local", messages: [] },
+    });
+  });
+
+  it("creates a remote session for managed Cloud and never permits its messages in SQLite", async () => {
+    setSession({
+      token: "session-token",
+      user: { id: "user-1", email: "user@example.com" },
+      host: freestyleCloudUrl(),
+    });
+    const response = await remixRoute.request("/sessions", { method: "POST" });
+    const { thread } = (await response.json()) as {
+      thread: { id: string; type: string };
+    };
+
+    expect(thread.type).toBe("remote");
+    const save = await remixRoute.request(`/sessions/${thread.id}/messages`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [{ id: "message-1", role: "user" }] }),
+    });
+    expect(save.status).toBe(404);
+    expect(
+      getDb().prepare("SELECT COUNT(*) AS n FROM remix_messages").get(),
+    ).toEqual({ n: 0 });
+    const stream = await remixRoute.request(`/sessions/${thread.id}/stream`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        messages: [{ id: "message-1", role: "user", parts: [] }],
+        context: {
+          selection: null,
+          appName: null,
+          windowTitle: null,
+          capturedAt: 1,
+        },
+      }),
+    });
+    expect(stream.status).toBe(404);
+  });
+
+  it("freezes ownership at creation when the selected model later changes", async () => {
+    setSession({
+      token: "session-token",
+      user: { id: "user-1", email: "user@example.com" },
+      host: freestyleCloudUrl(),
+    });
+    const remote = (await (
+      await remixRoute.request("/sessions", { method: "POST" })
+    ).json()) as {
+      thread: { id: string; type: string };
+    };
+    getDb()
+      .prepare(
+        `INSERT INTO model_configs
+          (provider, model_id, model_name, type, is_default)
+         VALUES ('local-llm', 'local-llm/qwen', 'Qwen', 'remix', 1)`,
+      )
+      .run();
+    const local = (await (
+      await remixRoute.request("/sessions", { method: "POST" })
+    ).json()) as {
+      thread: { id: string; type: string };
+    };
+
+    expect(remote.thread.type).toBe("remote");
+    expect(local.thread.type).toBe("local");
+    expect(
+      getDb()
+        .prepare("SELECT type FROM remix_threads WHERE id = ?")
+        .get(remote.thread.id),
+    ).toEqual({ type: "remote" });
+  });
+});

--- a/apps/server/tests/remix-store.test.ts
+++ b/apps/server/tests/remix-store.test.ts
@@ -1,20 +1,27 @@
+import { DatabaseSync } from "node:sqlite";
 import { beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "../src/lib/db.js";
 import {
+  createRemixThread,
   getActiveThread,
   getThreadMessages,
   MAX_THREAD_MESSAGES,
   purgeExpiredRemixData,
   recordRemixRun,
   saveThreadMessages,
-  startNewThread,
 } from "../src/lib/remix-store.js";
+
+const localModel = {
+  provider: "local-llm",
+  modelId: "local-llm/qwen",
+  modelName: "Qwen",
+};
 
 function message(id: string) {
   return { id, role: "user", parts: [{ type: "text", text: id }] };
 }
 
-function ageThread(threadId: number, days: number): void {
+function ageThread(threadId: string, days: number): void {
   getDb()
     .prepare(
       "UPDATE remix_threads SET last_active_at = datetime('now', ?) WHERE id = ?",
@@ -31,7 +38,7 @@ beforeEach(() => {
 
 describe("getActiveThread", () => {
   it("returns null instead of creating a thread", () => {
-    expect(getActiveThread()).toBeNull();
+    expect(getActiveThread("local")).toBeNull();
     const count = getDb()
       .prepare("SELECT COUNT(*) AS n FROM remix_threads")
       .get() as { n: number };
@@ -39,11 +46,85 @@ describe("getActiveThread", () => {
   });
 
   it("returns a fresh thread and ignores an idle one", () => {
-    const thread = startNewThread();
-    expect(getActiveThread()?.id).toBe(thread.id);
+    const thread = createRemixThread("local", localModel);
+    expect(getActiveThread("local")?.id).toBe(thread.id);
 
     ageThread(thread.id, 1);
-    expect(getActiveThread()).toBeNull();
+    expect(getActiveThread("local")).toBeNull();
+  });
+});
+
+describe("Remix thread identity", () => {
+  it("requires an explicit session type and uses UUID thread IDs", () => {
+    const thread = createRemixThread("local", localModel);
+
+    expect(thread).toMatchObject({ type: "local" });
+    expect(thread.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(
+      getDb().prepare("PRAGMA table_info(remix_threads)").all(),
+    ).toContainEqual(
+      expect.objectContaining({ name: "type", notnull: 1, dflt_value: null }),
+    );
+  });
+
+  it("migrates integer local history to UUID local sessions without losing rows", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE TABLE schema_version (id INTEGER PRIMARY KEY CHECK(id = 1), version INTEGER NOT NULL);
+      INSERT INTO schema_version (id, version) VALUES (1, 29);
+      CREATE TABLE remix_threads (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        created_at TEXT NOT NULL,
+        last_active_at TEXT NOT NULL
+      );
+      CREATE TABLE remix_messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        thread_id INTEGER NOT NULL,
+        message_id TEXT NOT NULL,
+        ui_message TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE(thread_id, message_id)
+      );
+      CREATE TABLE remix_runs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        thread_id INTEGER,
+        lane TEXT NOT NULL,
+        instruction TEXT NOT NULL,
+        before_text TEXT,
+        after_text TEXT NOT NULL,
+        app_name TEXT,
+        llm_provider TEXT,
+        llm_model TEXT,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_usd REAL NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL
+      );
+      INSERT INTO remix_threads (id, created_at, last_active_at) VALUES (7, '2026-01-01', '2026-01-02');
+      INSERT INTO remix_messages (thread_id, message_id, ui_message, created_at) VALUES (7, 'message-1', '{"id":"message-1"}', '2026-01-01');
+      INSERT INTO remix_runs (thread_id, lane, instruction, after_text, created_at) VALUES (7, 'agent', 'help', 'done', '2026-01-01');
+    `);
+
+    // The production schema migration is imported lazily so this fixture does
+    // not share the test process's application database.
+    return import("../src/lib/schema.js").then(({ initSchema }) => {
+      initSchema(db);
+      const thread = db.prepare("SELECT id, type FROM remix_threads").get() as {
+        id: string;
+        type: string;
+      };
+      expect(thread.type).toBe("local");
+      expect(thread.id).toMatch(/^[0-9a-f-]{36}$/i);
+      expect(db.prepare("SELECT thread_id FROM remix_messages").get()).toEqual({
+        thread_id: thread.id,
+      });
+      expect(db.prepare("SELECT thread_id FROM remix_runs").get()).toEqual({
+        thread_id: thread.id,
+      });
+      db.close();
+    });
   });
 });
 
@@ -53,7 +134,7 @@ describe("saveThreadMessages", () => {
   });
 
   it("is a true snapshot: rows absent from the sync are deleted", () => {
-    const thread = startNewThread();
+    const thread = createRemixThread("local", localModel);
     expect(
       saveThreadMessages(thread.id, [message("a"), message("b"), message("c")]),
     ).toBe(true);
@@ -68,7 +149,7 @@ describe("saveThreadMessages", () => {
   });
 
   it("keeps only the newest MAX_THREAD_MESSAGES rows", () => {
-    const thread = startNewThread();
+    const thread = createRemixThread("local", localModel);
     const batch = Array.from({ length: MAX_THREAD_MESSAGES + 10 }, (_, i) =>
       message(`m${i}`),
     );
@@ -97,11 +178,11 @@ describe("recordRemixRun", () => {
 
 describe("purgeExpiredRemixData", () => {
   it("deletes runs and idle threads older than the window, cascading messages", () => {
-    const oldThread = startNewThread();
+    const oldThread = createRemixThread("local", localModel);
     saveThreadMessages(oldThread.id, [message("old")]);
     ageThread(oldThread.id, 40);
 
-    const freshThread = startNewThread();
+    const freshThread = createRemixThread("local", localModel);
     saveThreadMessages(freshThread.id, [message("fresh")]);
 
     const oldRun = recordRemixRun({
@@ -146,7 +227,7 @@ describe("purgeExpiredRemixData", () => {
   });
 
   it("never deletes the active thread", () => {
-    const thread = startNewThread();
+    const thread = createRemixThread("local", localModel);
     expect(purgeExpiredRemixData(30)).toBe(0);
     expect(
       getDb()

--- a/packages/validations/src/models.ts
+++ b/packages/validations/src/models.ts
@@ -4,7 +4,7 @@ export const configureModelSchema = z.object({
   provider: z.string().min(1, "Provider is required"),
   model_id: z.string().min(1, "Model ID is required"),
   model_name: z.string().min(1, "Model name is required"),
-  type: z.enum(["voice", "llm"]),
+  type: z.enum(["voice", "llm", "remix"]),
   is_default: z.boolean().optional(),
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
 
   apps/electron:
     dependencies:
+      '@ai-sdk/react':
+        specifier: 3.0.280
+        version: 3.0.280(react@19.2.6)(zod@4.5.4)
       '@electron-toolkit/preload':
         specifier: ^3.0.2
         version: 3.0.2(electron@39.8.10)
@@ -658,6 +661,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@3.0.189':
+    resolution: {integrity: sha512-roPKojHenQm7U77kNNE0w586jP2vnjxaNx/+KFSQkJRLLAxrg7yUwZQfyOEizoTxdaltu+ZIlLRTw09X3XbGvQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/google@3.0.118':
     resolution: {integrity: sha512-Pa6OPnbFIFbR5llVYFUa0ua5PSNdZ6H/U+SEO6wH1aD6hNK7LTcgNxRaylHV7Ny4tr3g7LVjceYDYJNhIY9jnQ==}
     engines: {node: '>=18'}
@@ -700,6 +709,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.50':
+    resolution: {integrity: sha512-YAcB+7M1JhAYsHorTrWyldCyZihjCKr/QRXH2vFrara/+lwqNE7q5KzoucKLZ7ktFiUonhnhFhRoiymsq/2K2Q==}
+    engines: {node: '>=18.17'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
@@ -711,6 +726,12 @@ packages:
   '@ai-sdk/provider@3.0.15':
     resolution: {integrity: sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/react@3.0.280':
+    resolution: {integrity: sha512-A00dgsOo3Xq4b8je0DM8dBFHZX/8iTIKupOhWcvXcYdKo9nxOKwC+fh9SFGbFbvQhDn8awEPiTm5a25GD8aCsA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@alcalzone/ansi-tokenize@0.2.5':
     resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
@@ -5292,6 +5313,12 @@ packages:
 
   ai@6.0.240:
     resolution: {integrity: sha512-nVytcmJmHAR+1UU3KlRQJ8Un8gePSAcbTfvShNGfbG9hYnQWKdyFRZWa4QBlKH5yiNLNqSS4Y9u0T0KcbY6FkA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@6.0.277:
+    resolution: {integrity: sha512-fYlPj2QsisCH66SsEfWM8gV0ZR+6NLuRYSnVw3GKUKlvP+iIAUQR1bUJn1Y6lcAKeoEWQeZaann2ahXZY2HXtQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -10362,6 +10389,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.5.1:
+    resolution: {integrity: sha512-BRw55e8r0B7SpDN20CAzoQAHl7y1yP7/Zt7oqUjMv0vSt2u2Xnkm88Ws+VypbV9BXHQVuSuyVq7zMjO16wSExw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   systeminformation@5.33.4:
     resolution: {integrity: sha512-poXpX8M9NBll1NDMW1ho6qRFkjrlttfm8E/YtPmn5x0TQ1z8LoJUHg9kwr/sRDmCjktqfnFRxqsoUNpaRakeMQ==}
     engines: {node: '>=10.0.0'}
@@ -10438,6 +10470,10 @@ packages:
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -11190,6 +11226,13 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.5.4
 
+  '@ai-sdk/gateway@3.0.189(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.15
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.5.4)
+      '@vercel/oidc': 3.2.0
+      zod: 4.5.4
+
   '@ai-sdk/google@3.0.118(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.15
@@ -11237,6 +11280,14 @@ snapshots:
       undici: 6.28.0
       zod: 4.5.4
 
+  '@ai-sdk/provider-utils@4.0.50(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.15
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      undici: 6.28.0
+      zod: 4.5.4
+
   '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
@@ -11248,6 +11299,16 @@ snapshots:
   '@ai-sdk/provider@3.0.15':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/react@3.0.280(react@19.2.6)(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.5.4)
+      ai: 6.0.277(zod@4.5.4)
+      react: 19.2.6
+      swr: 2.5.1(react@19.2.6)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
 
   '@alcalzone/ansi-tokenize@0.2.5':
     dependencies:
@@ -16409,6 +16470,14 @@ snapshots:
       '@ai-sdk/gateway': 3.0.162(zod@4.5.4)
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.41(zod@4.5.4)
+      '@opentelemetry/api': 1.9.1
+      zod: 4.5.4
+
+  ai@6.0.277(zod@4.5.4):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.189(zod@4.5.4)
+      '@ai-sdk/provider': 3.0.15
+      '@ai-sdk/provider-utils': 4.0.50(zod@4.5.4)
       '@opentelemetry/api': 1.9.1
       zod: 4.5.4
 
@@ -22880,6 +22949,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.5.1(react@19.2.6):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
+
   systeminformation@5.33.4: {}
 
   tagged-tag@1.0.0: {}
@@ -23011,6 +23086,8 @@ snapshots:
       any-promise: 1.3.0
 
   throat@5.0.0: {}
+
+  throttleit@2.1.0: {}
 
   through@2.3.8: {}
 


### PR DESCRIPTION
## Summary
- move desktop Remix traffic to the canonical /api/remix route while keeping the Cloud legacy agent endpoint untouched
- add an independent persisted Remix model role and Models-page block; cleanup model selection no longer affects Remix
- run non-Freestyle Remix models locally with document, local, and MCP tools; retain the managed Cloud path for Freestyle Remix
- migrate existing local model configuration safely and cover the route, runtime, model-role migration, and renderer contracts

## Verification
- pnpm --filter @freestyle-voice/server test
- pnpm --filter @freestyle-voice/electron test
- pnpm --filter @freestyle-voice/server build
- pnpm --filter @freestyle-voice/electron typecheck
- pnpm exec biome check (changed files)