### PR TITLE
fix(electron): serialize macOS hotkey startup

### DIFF
--- a/apps/electron/src/main/hotkey-startup.test.ts
+++ b/apps/electron/src/main/hotkey-startup.test.ts
@@ -1,0 +1,78 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  shouldRetryMacNativeListener,
+  shouldScheduleRemixRegistration,
+} from "./hotkey-startup";
+
+const mainPath = resolve(dirname(fileURLToPath(import.meta.url)), "index.ts");
+
+function sourceForFunction(source: string, name: string): string {
+  const start = source.search(new RegExp(`(?:async )?function ${name}\\(`));
+  const nextFunction = source.slice(start + 1).search(/\n(?:async )?function /);
+  const end = nextFunction === -1 ? -1 : start + 1 + nextFunction;
+  return source.slice(start, end === -1 ? undefined : end);
+}
+
+describe("hotkey startup registration", () => {
+  it("does not queue equal default Remix settings during initial registration", () => {
+    expect(shouldScheduleRemixRegistration(false, false, true)).toBe(false);
+    expect(shouldScheduleRemixRegistration(true, false, true)).toBe(true);
+    expect(shouldScheduleRemixRegistration(false, false, false)).toBe(true);
+  });
+
+  it("retries only transient native startup failures", () => {
+    expect(shouldRetryMacNativeListener(true, "")).toBe(true);
+    expect(shouldRetryMacNativeListener(false, "")).toBe(true);
+    expect(
+      shouldRetryMacNativeListener(
+        false,
+        "Native key listener binary not found: macos-key-listener",
+      ),
+    ).toBe(false);
+    expect(
+      shouldRetryMacNativeListener(false, "accessibility-not-granted"),
+    ).toBe(false);
+  });
+
+  it("serializes listener teardown, startup retries, and shutdown", async () => {
+    const source = await readFile(mainPath, "utf8");
+    const startup = source.slice(
+      source.indexOf(
+        "// Remix uses its default even when the server is unavailable",
+      ),
+      source.indexOf("// Listen for hotkey changes from the settings UI"),
+    );
+    const configuredRegistration = sourceForFunction(
+      source,
+      "registerConfiguredHotkeys",
+    );
+    const applyRemix = sourceForFunction(source, "applyRemixSettings");
+    const scheduleListeners = sourceForFunction(
+      source,
+      "scheduleListenerRegistration",
+    );
+    const registerHotkey = sourceForFunction(source, "registerHotkey");
+    const cleanup = sourceForFunction(source, "cleanupBeforeQuit");
+
+    expect(startup).not.toContain(
+      "scheduleRemixHotkeyRegistration(getDefaultRemixHotkey());",
+    );
+    expect(startup).toContain("remixInitialized = true;");
+    expect(configuredRegistration).toContain(
+      "await stopNativeHotkeyListeners();",
+    );
+    expect(configuredRegistration).toContain("NATIVE_LISTENER_RETRY_DELAYS_MS");
+    expect(configuredRegistration).toContain("registerHotkey(hotkey, false)");
+    expect(configuredRegistration).toContain("await registerRemixHotkey();");
+    expect(applyRemix).toContain("scheduleRemixHotkeyRegistration()");
+    expect(applyRemix).toContain("configured !== remixHotkeyPreference");
+    expect(applyRemix).toContain("listenerRegistration.isActive");
+    expect(registerHotkey).toContain("shouldRetryMacNativeListener");
+    expect(scheduleListeners).toContain("if (isQuitting || !remixInitialized)");
+    expect(cleanup).toContain("remixInitialized = false;");
+    expect(cleanup).toContain("listenerRegistration.shutdown();");
+  });
+});

--- a/apps/electron/src/main/hotkey-startup.ts
+++ b/apps/electron/src/main/hotkey-startup.ts
@@ -1,0 +1,19 @@
+/** Whether a Remix settings update needs a separate listener lifecycle. */
+export function shouldScheduleRemixRegistration(
+  preferenceChanged: boolean,
+  hasListener: boolean,
+  registrationInProgress: boolean,
+): boolean {
+  return preferenceChanged || (!hasListener && !registrationInProgress);
+}
+
+/**
+ * The cold-start failure has no error output (or reaches the READY deadline).
+ * Permission, binary, and spawn errors are permanent until their cause changes.
+ */
+export function shouldRetryMacNativeListener(
+  didTimeOut: boolean,
+  nativeError: string,
+): boolean {
+  return didTimeOut || nativeError.length === 0;
+}

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -134,6 +134,10 @@ import { AudioPlaybackController } from "./audio-control/controller";
 import { recoverDuckedVolumeFromCrash } from "./audio-control/volume-ducker";
 import { CourierNativeNotificationPresenter } from "./courier-native-notifications";
 import { HotkeyRecorder } from "./hotkey-recorder";
+import {
+  shouldRetryMacNativeListener,
+  shouldScheduleRemixRegistration,
+} from "./hotkey-startup";
 import { normalizeAccelerator } from "./hotkey-utils";
 import { NativeKeyListener } from "./key-listener";
 import * as linuxAutostart from "./linux-autostart";
@@ -172,6 +176,7 @@ import {
 import { initPluginUiHost, invalidatePluginViews } from "./plugins/ui-host";
 import { isRemixTargetAllowed } from "./remix-target";
 import { rendererUrl } from "./renderer-url";
+import { SerializedRegistration } from "./serialized-registration";
 import {
   initSpriteTravel,
   performSyncAction,
@@ -527,13 +532,16 @@ let remixEscapeActive = false;
 let currentHotkeyAccel: string | null = null;
 let hotkeyActivationMode: "hold" | "toggle" = "hold";
 let hotkeyRecorder: HotkeyRecorder | null = null;
+// The latest desired dictation accelerator. The coordinator below coalesces
+// settings updates and starts listeners only after the prior pair has stopped.
+let requestedHotkey: string | undefined;
 /** Own listener process — native binaries only take one accelerator each. */
 let remixKeyListener: NativeKeyListener | null = null;
 let remixPressed = false;
 /** User-configured accel (may differ from what's listening while parked/off). */
 let remixHotkeyPreference: string | undefined;
 let currentRemixAccel: string | null = null;
-/** False until server settings are read once (don't spawn on defaults). */
+/** True once Remix may register, initially with its default accelerator. */
 let remixInitialized = false;
 /** Onboarding practice: allow Remix to target Freestyle's own window. */
 const remixPracticeTarget = false;
@@ -2602,10 +2610,10 @@ app.whenReady().then(async () => {
   // server. Once the server answers, re-register with the configured
   // accelerator + activation mode (only if they differ, to avoid a needless
   // native-listener rebuild).
+  // Remix uses its default even when the server is unavailable, but its native
+  // helper is started only after this dictation registration has settled.
+  remixInitialized = true;
   scheduleHotkeyRegistration(DEFAULT_HOTKEY);
-  // Register the unobtrusive Remix hold control at startup too. Settings may
-  // refine it later, but a cold server must never leave this path inert.
-  scheduleRemixHotkeyRegistration(getDefaultRemixHotkey());
   void waitForServerReady().then(async () => {
     // One request for both keys, instead of a read per key. Skip if the server
     // never answered — the default registered above stands.
@@ -4361,10 +4369,19 @@ export function setCompanionState(state: CompanionState): void {
 
 function applyRemixSettings(settings: Record<string, string>): void {
   remixInitialized = true;
-  const configured = settings[SETTINGS_KEYS.remixHotkey];
-  scheduleRemixHotkeyRegistration(
-    configured && isValidAccelerator(configured) ? configured : undefined,
-  );
+  const stored = settings[SETTINGS_KEYS.remixHotkey];
+  const configured = stored && isValidAccelerator(stored) ? stored : undefined;
+  const changed = configured !== remixHotkeyPreference;
+  remixHotkeyPreference = configured;
+  if (
+    shouldScheduleRemixRegistration(
+      changed,
+      remixKeyListener !== null,
+      listenerRegistration.isActive,
+    )
+  ) {
+    scheduleRemixHotkeyRegistration();
+  }
 }
 
 const DEFAULT_HOTKEY = getDefaultHotkey();
@@ -4564,11 +4581,8 @@ function setRemixRouteKeys(open: boolean): void {
 }
 
 function scheduleRemixHotkeyRegistration(hotkey?: string): void {
-  void registerRemixHotkey(hotkey).catch((err) => {
-    hotkeyLog.error(
-      `Remix hotkey registration failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  });
+  if (hotkey !== undefined) remixHotkeyPreference = hotkey;
+  scheduleListenerRegistration();
 }
 
 /** False if the Remix chord includes C — injected Copy would collide with it. */
@@ -4649,10 +4663,12 @@ function handleRemixHotkeyUp(): void {
 
 /** Start the Remix native listener. No globalShortcut fallback (needs hold/tap). */
 async function registerRemixHotkey(hotkey?: string): Promise<void> {
+  if (isQuitting) return;
   if (remixKeyListener) {
-    remixKeyListener.stop();
+    await remixKeyListener.stop();
     remixKeyListener = null;
   }
+  if (isQuitting) return;
 
   remixHotkeyPreference = hotkey ?? remixHotkeyPreference;
   const configured = hotkey ?? remixHotkeyPreference;
@@ -4853,12 +4869,66 @@ function registerGlobalShortcutToggle(accel: string): string | null {
   return null;
 }
 
-function scheduleHotkeyRegistration(hotkey?: string): void {
-  void registerHotkey(hotkey).catch((err) => {
+const NATIVE_LISTENER_RETRY_DELAYS_MS = [500, 1_000] as const;
+
+const listenerRegistration = new SerializedRegistration(
+  registerConfiguredHotkeys,
+  (error) => {
     hotkeyLog.error(
-      `Hotkey registration failed: ${err instanceof Error ? err.message : String(err)}`,
+      `Hotkey registration failed: ${error instanceof Error ? error.message : String(error)}`,
     );
-  });
+  },
+);
+
+function scheduleListenerRegistration(): void {
+  if (isQuitting || !remixInitialized) return;
+  listenerRegistration.schedule();
+}
+
+function scheduleHotkeyRegistration(hotkey?: string): void {
+  requestedHotkey ??= currentHotkeyAccel ?? DEFAULT_HOTKEY;
+  if (hotkey !== undefined) requestedHotkey = hotkey;
+  scheduleListenerRegistration();
+}
+
+/** Stop both event-tap helpers before the next native listener is spawned. */
+async function stopNativeHotkeyListeners(): Promise<void> {
+  const listeners = [keyListener, remixKeyListener].filter(
+    (listener): listener is NativeKeyListener => listener !== null,
+  );
+  keyListener = null;
+  remixKeyListener = null;
+  currentRemixAccel = null;
+  await Promise.all(listeners.map((listener) => listener.stop()));
+}
+
+/** Register dictation and Remix in order, retrying a cold-start native timeout. */
+async function registerConfiguredHotkeys(): Promise<void> {
+  if (isQuitting) return;
+  await stopNativeHotkeyListeners();
+  if (isQuitting) return;
+
+  const hotkey = requestedHotkey ?? currentHotkeyAccel ?? DEFAULT_HOTKEY;
+  let result = await registerHotkey(hotkey, false);
+  for (const [attempt, delay] of NATIVE_LISTENER_RETRY_DELAYS_MS.entries()) {
+    if (result !== "retryable-startup-failure" || isQuitting) break;
+    hotkeyLog.warn(
+      `Native key listener timed out during startup; retrying (${attempt + 1}/${NATIVE_LISTENER_RETRY_DELAYS_MS.length}).`,
+    );
+    await wait(delay);
+    if (isQuitting) return;
+    result = await registerHotkey(hotkey, false);
+  }
+
+  if (isQuitting) return;
+  if (result === "retryable-startup-failure") {
+    result = await registerHotkey(hotkey, true);
+  }
+  if (result === "retryable-startup-failure") {
+    hotkeyLog.error("Native key listener timed out after all startup retries.");
+  }
+  if (isQuitting) return;
+  await registerRemixHotkey();
 }
 
 let accessibilityWatch: NodeJS.Timeout | null = null;
@@ -4872,16 +4942,19 @@ function watchForAccessibilityGrant(): void {
     accessibilityWatch = null;
     hotkeyLog.info("Accessibility granted; re-registering hotkeys.");
     scheduleHotkeyRegistration(currentHotkeyAccel ?? undefined);
-    if (remixInitialized) scheduleRemixHotkeyRegistration();
   }, ACCESSIBILITY_WATCH_MS);
   accessibilityWatch.unref();
 }
 
-async function registerHotkey(hotkey?: string): Promise<void> {
+async function registerHotkey(
+  hotkey?: string,
+  allowTimeoutFallback = true,
+): Promise<"started" | "retryable-startup-failure" | "fallback"> {
   try {
+    if (isQuitting) return "fallback";
     // Tear down previous listener
     if (keyListener) {
-      keyListener.stop();
+      await keyListener.stop();
       keyListener = null;
     }
     hotkeyPressed = false;
@@ -4956,21 +5029,27 @@ async function registerHotkey(hotkey?: string): Promise<void> {
     // Another registerHotkey call may have replaced keyListener while we
     // were awaiting — if so, abandon this attempt.
     if (keyListener !== listener) {
-      listener.stop();
-      return;
+      await listener.stop();
+      return "fallback";
     }
 
     if (started) {
       accessibilityConfirmed = true;
       hotkeyDegradedNotified = false;
-      // Dictation hotkey moved — re-resolve remix (may free or steal a chord).
-      if (remixInitialized) scheduleRemixHotkeyRegistration();
+      return "started";
     } else {
+      const timedOut = listener.didStartTimeOut;
+      await listener.stop();
+      keyListener = null;
+      const retryableStartupFailure =
+        process.platform === "darwin" &&
+        shouldRetryMacNativeListener(timedOut, nativeError);
+      if (retryableStartupFailure && !allowTimeoutFallback) {
+        return "retryable-startup-failure";
+      }
       hotkeyLog.warn(
         "Native key listener unavailable, falling back to Electron globalShortcut (toggle mode).",
       );
-      listener.stop();
-      keyListener = null;
       if (nativeError.includes("accessibility-not-granted")) {
         watchForAccessibilityGrant();
       }
@@ -4997,11 +5076,13 @@ async function registerHotkey(hotkey?: string): Promise<void> {
         }
         reportHotkeyError(message);
       }
+      return "fallback";
     }
   } catch (err) {
     hotkeyLog.error(
       `registerHotkey failed: ${err instanceof Error ? err.message : String(err)}`,
     );
+    return "fallback";
   }
 }
 
@@ -5034,6 +5115,8 @@ let updateAvailableVersion: string | null = null;
 function cleanupBeforeQuit(): void {
   // No app-host plugin registry to dispose anymore — every hook (including
   // `dispose`) runs server-side, and the server has its own shutdown path.
+  remixInitialized = false;
+  listenerRegistration.shutdown();
   void disposeServerPlugins().catch(() => {});
   audioPlaybackController.restoreSync();
   stopLinuxPasteHelper();

--- a/apps/electron/src/main/key-listener-startup.test.ts
+++ b/apps/electron/src/main/key-listener-startup.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { child, emit, resetListeners, spawnMock } = vi.hoisted(() => {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  const addListener = (
+    event: string,
+    listener: (...args: unknown[]) => void,
+  ) => {
+    const registered = listeners.get(event) ?? [];
+    registered.push(listener);
+    listeners.set(event, registered);
+  };
+  const childProcess = {
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(addListener),
+    once: vi.fn(addListener),
+    kill: vi.fn(),
+  };
+  return {
+    child: childProcess,
+    emit: (event: string, ...args: unknown[]) => {
+      for (const listener of listeners.get(event) ?? []) listener(...args);
+    },
+    resetListeners: () => listeners.clear(),
+    spawnMock: vi.fn(() => childProcess),
+  };
+});
+
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
+vi.mock("./native-binary", () => ({
+  getNativeBinaryPath: () => "/tmp/macos-key-listener",
+}));
+
+import { NativeKeyListener } from "./key-listener";
+
+afterEach(() => {
+  vi.useRealTimers();
+  child.kill.mockClear();
+  child.on.mockClear();
+  child.once.mockClear();
+  resetListeners();
+  spawnMock.mockClear();
+});
+
+describe("NativeKeyListener startup", () => {
+  it("stops and reports a listener that never becomes ready", async () => {
+    vi.useFakeTimers();
+    const errors: string[] = [];
+    const listener = new NativeKeyListener({
+      hotkey: "Fn",
+      onKeyDown: () => {},
+      onKeyUp: () => {},
+      onError: (error) => errors.push(error),
+    });
+
+    const started = listener.start();
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    await expect(started).resolves.toBe(false);
+    expect(errors).toContain("Key listener timed out waiting for READY.");
+  });
+
+  it("waits for the child to exit before allowing a replacement listener", async () => {
+    const listener = new NativeKeyListener({
+      hotkey: "Fn",
+      onKeyDown: () => {},
+      onKeyUp: () => {},
+    });
+    void listener.start();
+
+    let stopped = false;
+    const stopping = listener.stop().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+
+    emit("close", 0);
+    await stopping;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+});

--- a/apps/electron/src/main/key-listener.ts
+++ b/apps/electron/src/main/key-listener.ts
@@ -35,6 +35,8 @@ const BINARY_NAMES: Record<string, string> = {
 };
 
 const MAC_SOLO_FN_CHORD_GRACE_MS = 50;
+const KEY_LISTENER_READY_TIMEOUT_MS = 5_000;
+const KEY_LISTENER_STOP_TIMEOUT_MS = 1_000;
 
 /**
  * Convert an Electron accelerator to the format expected by the native binary.
@@ -131,6 +133,8 @@ export class NativeKeyListener {
   private process: ChildProcess | null = null;
   private options: KeyListenerOptions;
   private destroyed = false;
+  private termination: Promise<void> | null = null;
+  private startTimedOut = false;
   private restartTimer: ReturnType<typeof setTimeout> | null = null;
   private restartAttempts = 0;
   private static readonly MAX_RESTART_ATTEMPTS = 5;
@@ -149,11 +153,12 @@ export class NativeKeyListener {
 
   /**
    * Start the native key listener binary.
-   * Resolves true once the binary emits READY, false if it exits or
-   * fails before that.
+   * Resolves true once the binary emits READY, false if it exits, fails, or
+   * does not become ready in time.
    */
   start(): Promise<boolean> {
     if (this.destroyed) return Promise.resolve(false);
+    this.startTimedOut = false;
 
     const binaryName = BINARY_NAMES[process.platform];
     if (!binaryName) {
@@ -183,10 +188,12 @@ export class NativeKeyListener {
       args.push(formatHotkeyForBinary(this.options.hotkey));
     }
 
+    let child: ChildProcess;
     try {
-      this.process = spawn(binaryPath, args, {
+      child = spawn(binaryPath, args, {
         stdio: ["pipe", "pipe", "pipe"],
       });
+      this.process = child;
     } catch (err) {
       this.options.onError?.(
         `Failed to spawn key listener: ${err instanceof Error ? err.message : String(err)}`,
@@ -198,8 +205,29 @@ export class NativeKeyListener {
       let settled = false;
       let stderrOutput = "";
       let lineBuffer = "";
+      let readyTimeout: ReturnType<typeof setTimeout> | null = null;
 
-      this.process!.stdout?.on("data", (data: Buffer) => {
+      const settle = (started: boolean): void => {
+        if (settled) return;
+        settled = true;
+        if (readyTimeout) {
+          clearTimeout(readyTimeout);
+          readyTimeout = null;
+        }
+        resolve(started);
+      };
+
+      readyTimeout = setTimeout(() => {
+        if (settled) return;
+        const message = "Key listener timed out waiting for READY.";
+        log.warn(message);
+        this.options.onError?.(message);
+        this.startTimedOut = true;
+        void this.stop();
+        settle(false);
+      }, KEY_LISTENER_READY_TIMEOUT_MS);
+
+      child.stdout?.on("data", (data: Buffer) => {
         lineBuffer += data.toString();
         const lines = lineBuffer.split("\n");
         lineBuffer = lines.pop() ?? "";
@@ -207,42 +235,39 @@ export class NativeKeyListener {
         for (const line of lines) {
           const trimmed = line.trim();
           if (!settled && trimmed === "READY") {
-            settled = true;
-            resolve(true);
+            settle(true);
           }
           this.handleLine(trimmed);
         }
       });
 
-      this.process!.stderr?.on("data", (data: Buffer) => {
+      child.stderr?.on("data", (data: Buffer) => {
         const text = data.toString().trim();
         stderrOutput += `${text}\n`;
         log.debug(text);
       });
 
-      this.process!.on("close", (code) => {
-        this.process = null;
+      child.on("close", (code) => {
+        if (this.process === child) this.process = null;
         if (!settled) {
-          settled = true;
           log.warn(
             `Key listener exited before READY (code ${code})${stderrOutput.trim() ? `: ${stderrOutput.trim()}` : ""}`,
           );
           if (stderrOutput.trim()) {
             this.options.onError?.(stderrOutput.trim());
           }
-          resolve(false);
+          settle(false);
         }
         if (!this.destroyed && code !== 0) {
           this.scheduleRestart();
         }
       });
 
-      this.process!.on("error", (err) => {
+      child.on("error", (err) => {
         this.options.onError?.(`Key listener process error: ${err.message}`);
-        this.process = null;
+        if (this.process === child) this.process = null;
         if (!settled) {
-          settled = true;
-          resolve(false);
+          settle(false);
         }
         if (!this.destroyed) {
           this.scheduleRestart();
@@ -528,7 +553,7 @@ export class NativeKeyListener {
   /**
    * Stop the key listener and clean up.
    */
-  stop(): void {
+  stop(): Promise<void> {
     this.destroyed = true;
     this.cancelMacSoloFnDown();
 
@@ -537,18 +562,43 @@ export class NativeKeyListener {
       this.restartTimer = null;
     }
 
-    if (this.process) {
-      try {
-        // Send SIGTERM for graceful shutdown
-        this.process.kill("SIGTERM");
-      } catch {
-        // Process may already be dead
-      }
-      this.process = null;
+    const child = this.process;
+    if (!child) return this.termination ?? Promise.resolve();
+    this.process = null;
+
+    let finishTermination: (() => void) | undefined;
+    const termination = new Promise<void>((resolve) => {
+      let finished = false;
+      const finish = (): void => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeout);
+        resolve();
+      };
+      finishTermination = finish;
+      child.once("close", finish);
+      child.once("error", finish);
+      const timeout = setTimeout(finish, KEY_LISTENER_STOP_TIMEOUT_MS);
+      timeout.unref();
+    });
+    this.termination = termination;
+
+    try {
+      // Send SIGTERM for graceful shutdown.
+      child.kill("SIGTERM");
+    } catch {
+      // Process may already be dead.
+      finishTermination?.();
     }
+
+    return termination;
   }
 
   get isRunning(): boolean {
     return this.process !== null;
+  }
+
+  get didStartTimeOut(): boolean {
+    return this.startTimedOut;
   }
 }

--- a/apps/electron/src/main/serialized-registration.test.ts
+++ b/apps/electron/src/main/serialized-registration.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { SerializedRegistration } from "./serialized-registration";
+
+describe("SerializedRegistration", () => {
+  it("waits for teardown before running the latest requested registration", async () => {
+    let finishFirst: (() => void) | undefined;
+    const firstRun = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const run = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => firstRun)
+      .mockResolvedValue(undefined);
+    const coordinator = new SerializedRegistration(run, vi.fn());
+
+    coordinator.schedule();
+    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(1));
+    expect(coordinator.isActive).toBe(true);
+    coordinator.schedule();
+    coordinator.schedule();
+
+    expect(run).toHaveBeenCalledTimes(1);
+    finishFirst?.();
+    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(coordinator.isActive).toBe(false));
+  });
+
+  it("does not run queued work after shutdown", async () => {
+    let finishFirst: (() => void) | undefined;
+    const firstRun = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const run = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => firstRun)
+      .mockResolvedValue(undefined);
+    const coordinator = new SerializedRegistration(run, vi.fn());
+
+    coordinator.schedule();
+    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(1));
+    coordinator.schedule();
+    coordinator.shutdown();
+    finishFirst?.();
+
+    await Promise.resolve();
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/electron/src/main/serialized-registration.ts
+++ b/apps/electron/src/main/serialized-registration.ts
@@ -1,0 +1,46 @@
+/**
+ * Runs listener registration work one lifecycle at a time.
+ *
+ * A setting change can arrive while a native helper is still stopping or
+ * starting. Coalescing those requests prevents two event-tap helpers from
+ * racing each other, while preserving one final pass for the latest settings.
+ */
+export class SerializedRegistration {
+  private running = false;
+  private rerunRequested = false;
+  private stopped = false;
+
+  constructor(
+    private readonly run: () => Promise<void>,
+    private readonly onError: (error: unknown) => void,
+  ) {}
+
+  schedule(): void {
+    if (this.stopped) return;
+    this.rerunRequested = true;
+    if (this.running) return;
+    this.running = true;
+    void this.drain();
+  }
+
+  shutdown(): void {
+    this.stopped = true;
+    this.rerunRequested = false;
+  }
+
+  get isActive(): boolean {
+    return this.running || this.rerunRequested;
+  }
+
+  private async drain(): Promise<void> {
+    while (!this.stopped && this.rerunRequested) {
+      this.rerunRequested = false;
+      try {
+        await this.run();
+      } catch (error) {
+        this.onError(error);
+      }
+    }
+    this.running = false;
+  }
+}


### PR DESCRIPTION
## Summary
- serialize native dictation and Remix listener startup so the event-tap helpers do not race
- time out stalled native helpers, await their termination, and retry transient macOS cold-start failures before fallback
- prevent duplicate default-setting restarts and listener registration during quit

## Verification
- pnpm --filter @freestyle-voice/electron test (82 files, 330 tests)
- pnpm exec biome check on changed files
- pnpm turbo build --filter=@freestyle-voice/electron...
- independent re-review: no remaining actionable blockers