### PR TITLE
chore(mobile): Bump app version to 0.0.3

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Freestyle",
     "slug": "freestyle",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "freestyle",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freestyle-voice/mobile",
   "main": "expo-router/entry",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "dependencies": {
     "@better-auth/expo": "^1.6.23",
     "@better-auth/stripe": "^1.6.23",


### PR DESCRIPTION
## Summary
- update the Expo application version to 0.0.3
- keep the mobile package metadata aligned with the app manifest

## Validation
- verify both version fields resolve to 0.0.3
- git diff --check