### PR TITLE
feat(electron): Allow hiding the desktop sidebar

### DIFF
--- a/apps/electron/src/renderer/src/lib/sidebar-visibility.test.ts
+++ b/apps/electron/src/renderer/src/lib/sidebar-visibility.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   isSidebarVisibility,
-  nextSidebarVisibility,
   SIDEBAR_VISIBILITY_STORAGE_KEY,
 } from "./sidebar-visibility";
 
@@ -13,10 +12,5 @@ describe("sidebar visibility preference", () => {
     expect(isSidebarVisibility("hidden")).toBe(true);
     expect(isSidebarVisibility("")).toBe(false);
     expect(isSidebarVisibility("collapsed")).toBe(false);
-  });
-
-  it("switches between the two supported sidebar states", () => {
-    expect(nextSidebarVisibility("visible")).toBe("hidden");
-    expect(nextSidebarVisibility("hidden")).toBe("visible");
   });
 });

--- a/apps/electron/src/renderer/src/lib/sidebar-visibility.test.ts
+++ b/apps/electron/src/renderer/src/lib/sidebar-visibility.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isSidebarVisibility,
+  nextSidebarVisibility,
+  SIDEBAR_VISIBILITY_STORAGE_KEY,
+} from "./sidebar-visibility";
+
+describe("sidebar visibility preference", () => {
+  it("only restores a saved visible or hidden preference", () => {
+    expect(SIDEBAR_VISIBILITY_STORAGE_KEY).toBe("shell.sidebarVisibility");
+    expect(isSidebarVisibility("visible")).toBe(true);
+    expect(isSidebarVisibility("hidden")).toBe(true);
+    expect(isSidebarVisibility("")).toBe(false);
+    expect(isSidebarVisibility("collapsed")).toBe(false);
+  });
+
+  it("switches between the two supported sidebar states", () => {
+    expect(nextSidebarVisibility("visible")).toBe("hidden");
+    expect(nextSidebarVisibility("hidden")).toBe("visible");
+  });
+});

--- a/apps/electron/src/renderer/src/lib/sidebar-visibility.ts
+++ b/apps/electron/src/renderer/src/lib/sidebar-visibility.ts
@@ -5,9 +5,3 @@ export type SidebarVisibility = "visible" | "hidden";
 export function isSidebarVisibility(value: string): value is SidebarVisibility {
   return value === "visible" || value === "hidden";
 }
-
-export function nextSidebarVisibility(
-  visibility: SidebarVisibility,
-): SidebarVisibility {
-  return visibility === "visible" ? "hidden" : "visible";
-}

--- a/apps/electron/src/renderer/src/lib/sidebar-visibility.ts
+++ b/apps/electron/src/renderer/src/lib/sidebar-visibility.ts
@@ -1,0 +1,13 @@
+export const SIDEBAR_VISIBILITY_STORAGE_KEY = "shell.sidebarVisibility";
+
+export type SidebarVisibility = "visible" | "hidden";
+
+export function isSidebarVisibility(value: string): value is SidebarVisibility {
+  return value === "visible" || value === "hidden";
+}
+
+export function nextSidebarVisibility(
+  visibility: SidebarVisibility,
+): SidebarVisibility {
+  return visibility === "visible" ? "hidden" : "visible";
+}

--- a/apps/electron/src/renderer/src/shell.css
+++ b/apps/electron/src/renderer/src/shell.css
@@ -107,3 +107,54 @@
   height: 20px;
   stroke-width: 1.8;
 }
+
+/* The sidebar can leave the window entirely; both controls retain a compact,
+ * predictable target without making the app chrome feel like a toolbar. */
+.sidebar-visibility-toggle,
+.sidebar-reveal-trigger {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 0;
+  border-radius: 7px;
+  padding: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.sidebar-visibility-toggle {
+  margin-left: auto;
+}
+
+.sidebar-visibility-toggle:hover,
+.sidebar-reveal-trigger:hover {
+  background: var(--secondary);
+  color: var(--foreground);
+}
+
+.sidebar-visibility-toggle:focus-visible,
+.sidebar-reveal-trigger:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.sidebar-visibility-toggle svg,
+.sidebar-reveal-trigger svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 1.8;
+}
+
+.sidebar-reveal-trigger {
+  position: absolute;
+  z-index: 11;
+  top: 12px;
+  left: 12px;
+}
+
+/* The dashboard's custom titlebar puts macOS traffic lights at x=20. */
+html.glass .sidebar-reveal-trigger {
+  left: 86px;
+}

--- a/apps/electron/src/renderer/src/shell.tsx
+++ b/apps/electron/src/renderer/src/shell.tsx
@@ -23,6 +23,12 @@ import { useCloudAuth } from "@renderer/lib/auth-context";
 import { MOD_LABEL } from "@renderer/lib/platform";
 import { listPlugins } from "@renderer/lib/plugins-api";
 import { queryKeys } from "@renderer/lib/query";
+import {
+  isSidebarVisibility,
+  nextSidebarVisibility,
+  SIDEBAR_VISIBILITY_STORAGE_KEY,
+  type SidebarVisibility,
+} from "@renderer/lib/sidebar-visibility";
 import { cn } from "@renderer/lib/utils";
 import {
   DEFAULT_WORKSPACE,
@@ -54,6 +60,8 @@ import {
   Mic,
   Network,
   Paintbrush,
+  PanelLeftClose,
+  PanelLeftOpen,
   PawPrint,
   PlugZap,
   Plus,
@@ -225,9 +233,11 @@ function NavList({ items }: { items: NavItem[] }): React.JSX.Element {
 function SettingsSidebar({
   workspace,
   onBack,
+  onHideSidebar,
 }: {
   workspace: Workspace;
   onBack: () => void;
+  onHideSidebar: () => void;
 }): React.JSX.Element {
   const [query, setQuery] = useState("");
   const normalizedQuery = query.trim().toLowerCase();
@@ -246,14 +256,17 @@ function SettingsSidebar({
         className="px-4 pt-2 pb-3"
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
-        <button
-          type="button"
-          onClick={onBack}
-          className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-md px-1 py-1 text-[11px] transition-colors"
-        >
-          <ArrowLeft className="size-3.5" aria-hidden="true" />
-          Back to app
-        </button>
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onBack}
+            className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-md px-1 py-1 text-[11px] transition-colors"
+          >
+            <ArrowLeft className="size-3.5" aria-hidden="true" />
+            Back to app
+          </button>
+          <SidebarVisibilityToggle onClick={onHideSidebar} />
+        </div>
         <p className="text-foreground mt-3 px-1 text-[17px] font-semibold tracking-[-0.02em]">
           Settings
         </p>
@@ -311,6 +324,24 @@ function SettingsSidebar({
         ) : null}
       </nav>
     </div>
+  );
+}
+
+function SidebarVisibilityToggle({
+  onClick,
+}: {
+  onClick: () => void;
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      className="sidebar-visibility-toggle"
+      aria-label="Hide sidebar"
+      title="Hide sidebar"
+      onClick={onClick}
+    >
+      <PanelLeftClose aria-hidden="true" />
+    </button>
   );
 }
 
@@ -656,6 +687,16 @@ export default function AppShell(): React.JSX.Element {
     (width: number) => setSidebarWidthRaw(String(clampSidebarWidth(width))),
     [setSidebarWidthRaw],
   );
+  const [sidebarVisibility, setSidebarVisibility] =
+    usePersistentState<SidebarVisibility>(
+      SIDEBAR_VISIBILITY_STORAGE_KEY,
+      "visible",
+      isSidebarVisibility,
+    );
+  const isSidebarHidden = sidebarVisibility === "hidden";
+  const toggleSidebarVisibility = useCallback(() => {
+    setSidebarVisibility(nextSidebarVisibility(sidebarVisibility));
+  }, [setSidebarVisibility, sidebarVisibility]);
 
   const changeWorkspace = useCallback(
     (workspace: Workspace) => {
@@ -751,96 +792,102 @@ export default function AppShell(): React.JSX.Element {
 
   return (
     <div className="glass-window-shell flex h-screen min-h-0">
-      <aside
-        className="glass-sidebar flex min-h-0 shrink-0 flex-col border-r"
-        style={
-          {
-            WebkitAppRegion: "drag",
-            flexBasis: sidebarWidth,
-            width: sidebarWidth,
-          } as React.CSSProperties
-        }
-      >
-        <div
-          className={cn(
-            "shrink-0 transition-[height] duration-150",
-            isFullscreen ? "h-0" : "h-8",
-          )}
-        />
-        {isSettingsRoute ? (
-          <SettingsSidebar
-            workspace={sidebarWorkspace}
-            onBack={() => navigate(workspaceHomeRoute(sidebarWorkspace))}
-          />
-        ) : (
-          <>
+      {!isSidebarHidden ? (
+        <>
+          <aside
+            className="glass-sidebar flex min-h-0 shrink-0 flex-col border-r"
+            style={
+              {
+                WebkitAppRegion: "drag",
+                flexBasis: sidebarWidth,
+                width: sidebarWidth,
+              } as React.CSSProperties
+            }
+          >
             <div
-              className="remix-sidebar-titlebar"
-              style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
-            >
-              <WorkspaceSwitcher
-                workspace={activeWorkspace}
-                onWorkspaceChange={changeWorkspace}
+              className={cn(
+                "shrink-0 transition-[height] duration-150",
+                isFullscreen ? "h-0" : "h-8",
+              )}
+            />
+            {isSettingsRoute ? (
+              <SettingsSidebar
+                workspace={sidebarWorkspace}
+                onBack={() => navigate(workspaceHomeRoute(sidebarWorkspace))}
+                onHideSidebar={toggleSidebarVisibility}
               />
-              {import.meta.env.DEV && (
-                <span className="remix-dev-badge" title="Development build">
-                  DEV
-                </span>
-              )}
-              {isRemixSidebar && canRequestData ? (
-                <button
-                  type="button"
-                  aria-label="Search sessions"
-                  title="Search sessions"
-                  onClick={() => handleSessionSearchOpenChange(true)}
-                  className="remix-session-search-trigger"
-                >
-                  <Search aria-hidden="true" />
-                </button>
-              ) : null}
-            </div>
-
-            <div
-              className="no-scrollbar min-h-0 flex-1 overflow-y-auto"
-              style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
-            >
-              {isRemixSidebar && canRequestData ? (
-                <RemixSidebarSessions searchQuery="" />
-              ) : (
-                <>
-                  <NavList items={mainNav} />
-                  {pluginNav.length > 0 ? (
-                    <>
-                      <div className="border-sidebar-border mx-3 my-1.5 border-t" />
-                      <NavList items={pluginNav} />
-                    </>
-                  ) : null}
-                </>
-              )}
-            </div>
-            {!isRemixSidebar && !user ? (
+            ) : (
               <>
-                {pluginNav.length > 0 ? (
-                  <div className="border-sidebar-border mx-3 my-1.5 border-t" />
+                <div
+                  className="remix-sidebar-titlebar"
+                  style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+                >
+                  <WorkspaceSwitcher
+                    workspace={activeWorkspace}
+                    onWorkspaceChange={changeWorkspace}
+                  />
+                  {import.meta.env.DEV && (
+                    <span className="remix-dev-badge" title="Development build">
+                      DEV
+                    </span>
+                  )}
+                  {isRemixSidebar && canRequestData ? (
+                    <button
+                      type="button"
+                      aria-label="Search sessions"
+                      title="Search sessions"
+                      onClick={() => handleSessionSearchOpenChange(true)}
+                      className="remix-session-search-trigger"
+                    >
+                      <Search aria-hidden="true" />
+                    </button>
+                  ) : null}
+                  <SidebarVisibilityToggle onClick={toggleSidebarVisibility} />
+                </div>
+
+                <div
+                  className="no-scrollbar min-h-0 flex-1 overflow-y-auto"
+                  style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+                >
+                  {isRemixSidebar && canRequestData ? (
+                    <RemixSidebarSessions searchQuery="" />
+                  ) : (
+                    <>
+                      <NavList items={mainNav} />
+                      {pluginNav.length > 0 ? (
+                        <>
+                          <div className="border-sidebar-border mx-3 my-1.5 border-t" />
+                          <NavList items={pluginNav} />
+                        </>
+                      ) : null}
+                    </>
+                  )}
+                </div>
+                {!isRemixSidebar && !user ? (
+                  <>
+                    {pluginNav.length > 0 ? (
+                      <div className="border-sidebar-border mx-3 my-1.5 border-t" />
+                    ) : null}
+                    <NavList items={footerNav} />
+                  </>
                 ) : null}
-                <NavList items={footerNav} />
+                <UpgradeCtaCard />
+                <div
+                  className="border-sidebar-border mx-3 mt-2 border-t pt-2"
+                  style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+                >
+                  <CloudProfileButton />
+                </div>
+                <div className="h-3" />
               </>
-            ) : null}
-            <UpgradeCtaCard />
-            <div
-              className="border-sidebar-border mx-3 mt-2 border-t pt-2"
-              style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
-            >
-              <CloudProfileButton />
-            </div>
-            <div className="h-3" />
-          </>
-        )}
-      </aside>
-      <SidebarResizeHandle
-        width={sidebarWidth}
-        onWidthChange={setSidebarWidth}
-      />
+            )}
+          </aside>
+          <SidebarResizeHandle
+            width={sidebarWidth}
+            onWidthChange={setSidebarWidth}
+          />
+        </>
+      ) : null}
 
       {isRemixSidebar && canRequestData ? (
         <SessionSearchDialog
@@ -853,7 +900,10 @@ export default function AppShell(): React.JSX.Element {
       ) : null}
 
       <div className="glass-content relative z-0 flex min-h-0 min-w-0 flex-1 flex-col">
-        <ContentTitlebar />
+        <ContentTitlebar
+          sidebarHidden={isSidebarHidden}
+          onShowSidebar={toggleSidebarVisibility}
+        />
         <UpdateBanner className="relative z-50 mt-4 w-[calc(100%-3rem)] max-w-2xl self-center" />
 
         <main
@@ -893,12 +943,32 @@ function SignedOutShell(): React.JSX.Element {
  * sibling of every route gives Remix and ordinary pages one reliable place to
  * drag the window, without putting a drag region over buttons inside a page.
  */
-function ContentTitlebar(): React.JSX.Element {
+function ContentTitlebar({
+  sidebarHidden = false,
+  onShowSidebar,
+}: {
+  sidebarHidden?: boolean;
+  onShowSidebar?: () => void;
+}): React.JSX.Element {
   return (
-    <div
-      className="glass-content-titlebar"
-      aria-hidden="true"
-      style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
-    />
+    <>
+      <div
+        className="glass-content-titlebar"
+        aria-hidden="true"
+        style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+      />
+      {sidebarHidden && onShowSidebar ? (
+        <button
+          type="button"
+          className="sidebar-reveal-trigger"
+          aria-label="Show sidebar"
+          title="Show sidebar"
+          onClick={onShowSidebar}
+          style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+        >
+          <PanelLeftOpen aria-hidden="true" />
+        </button>
+      ) : null}
+    </>
   );
 }

--- a/apps/electron/src/renderer/src/shell.tsx
+++ b/apps/electron/src/renderer/src/shell.tsx
@@ -25,7 +25,6 @@ import { listPlugins } from "@renderer/lib/plugins-api";
 import { queryKeys } from "@renderer/lib/query";
 import {
   isSidebarVisibility,
-  nextSidebarVisibility,
   SIDEBAR_VISIBILITY_STORAGE_KEY,
   type SidebarVisibility,
 } from "@renderer/lib/sidebar-visibility";
@@ -677,6 +676,7 @@ export default function AppShell(): React.JSX.Element {
   const [isSessionSearchOpen, setIsSessionSearchOpen] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const sessionSearchRef = useRef<HTMLInputElement>(null);
+  const sidebarRevealRef = useRef<HTMLButtonElement>(null);
   const [sidebarWidthRaw, setSidebarWidthRaw] = usePersistentState<string>(
     "shell.sidebarWidth",
     "220",
@@ -694,9 +694,13 @@ export default function AppShell(): React.JSX.Element {
       isSidebarVisibility,
     );
   const isSidebarHidden = sidebarVisibility === "hidden";
-  const toggleSidebarVisibility = useCallback(() => {
-    setSidebarVisibility(nextSidebarVisibility(sidebarVisibility));
-  }, [setSidebarVisibility, sidebarVisibility]);
+  const hideSidebar = useCallback(() => {
+    setSidebarVisibility("hidden");
+    requestAnimationFrame(() => sidebarRevealRef.current?.focus());
+  }, [setSidebarVisibility]);
+  const showSidebar = useCallback(() => {
+    setSidebarVisibility("visible");
+  }, [setSidebarVisibility]);
 
   const changeWorkspace = useCallback(
     (workspace: Workspace) => {
@@ -814,7 +818,7 @@ export default function AppShell(): React.JSX.Element {
               <SettingsSidebar
                 workspace={sidebarWorkspace}
                 onBack={() => navigate(workspaceHomeRoute(sidebarWorkspace))}
-                onHideSidebar={toggleSidebarVisibility}
+                onHideSidebar={hideSidebar}
               />
             ) : (
               <>
@@ -842,7 +846,7 @@ export default function AppShell(): React.JSX.Element {
                       <Search aria-hidden="true" />
                     </button>
                   ) : null}
-                  <SidebarVisibilityToggle onClick={toggleSidebarVisibility} />
+                  <SidebarVisibilityToggle onClick={hideSidebar} />
                 </div>
 
                 <div
@@ -902,7 +906,8 @@ export default function AppShell(): React.JSX.Element {
       <div className="glass-content relative z-0 flex min-h-0 min-w-0 flex-1 flex-col">
         <ContentTitlebar
           sidebarHidden={isSidebarHidden}
-          onShowSidebar={toggleSidebarVisibility}
+          onShowSidebar={showSidebar}
+          sidebarRevealRef={sidebarRevealRef}
         />
         <UpdateBanner className="relative z-50 mt-4 w-[calc(100%-3rem)] max-w-2xl self-center" />
 
@@ -946,9 +951,11 @@ function SignedOutShell(): React.JSX.Element {
 function ContentTitlebar({
   sidebarHidden = false,
   onShowSidebar,
+  sidebarRevealRef,
 }: {
   sidebarHidden?: boolean;
   onShowSidebar?: () => void;
+  sidebarRevealRef?: React.RefObject<HTMLButtonElement | null>;
 }): React.JSX.Element {
   return (
     <>
@@ -961,6 +968,7 @@ function ContentTitlebar({
         <button
           type="button"
           className="sidebar-reveal-trigger"
+          ref={sidebarRevealRef}
           aria-label="Show sidebar"
           title="Show sidebar"
           onClick={onShowSidebar}

--- a/apps/electron/tests/dashboard-visual.test.ts
+++ b/apps/electron/tests/dashboard-visual.test.ts
@@ -351,6 +351,43 @@ test("captures every main dashboard page while loading and after data resolves",
   }
 });
 
+test("captures the desktop sidebar hidden and restored", async ({
+  browserName,
+}, testInfo) => {
+  void browserName;
+  await dashboard.goto(`${DASHBOARD_URL}?visual=sidebar-toggle#/today`);
+  await dashboard
+    .locator("html")
+    .evaluate((html) => html.classList.add("dark"));
+  await expect(dashboard.getByRole("status")).toHaveCount(0, {
+    timeout: 5_000,
+  });
+
+  const hideSidebar = dashboard.getByRole("button", { name: "Hide sidebar" });
+  await expect(hideSidebar).toBeVisible();
+  await hideSidebar.click();
+
+  await expect(dashboard.locator(".glass-sidebar")).toHaveCount(0);
+  const showSidebar = dashboard.getByRole("button", { name: "Show sidebar" });
+  await expect(showSidebar).toBeFocused();
+  const hidden = testInfo.outputPath("sidebar-hidden.png");
+  await dashboard.screenshot({ path: hidden });
+  await testInfo.attach("sidebar-hidden", {
+    path: hidden,
+    contentType: "image/png",
+  });
+
+  await showSidebar.click();
+  await expect(dashboard.locator(".glass-sidebar")).toBeVisible();
+  await expect(hideSidebar).toBeVisible();
+  const restored = testInfo.outputPath("sidebar-restored.png");
+  await dashboard.screenshot({ path: restored });
+  await testInfo.attach("sidebar-restored", {
+    path: restored,
+    contentType: "image/png",
+  });
+});
+
 test("shows full-window sign-in after a protected request returns 401", async () => {
   await dashboard.goto(`${DASHBOARD_URL}?visual=protected-401#/today`);
 


### PR DESCRIPTION
The desktop sidebar can now be hidden and restored without resetting its configured width. A keyboard-accessible restore control appears in the content pane and clears the custom macOS traffic lights; Dictate, Remix, and Settings share the saved preference.
