### PR TITLE
fix(electron): align sidebar reveal control

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -3925,6 +3925,14 @@ ipcMain.on("panel:commit-width", (event) => {
   if (event.sender !== panelWindow?.webContents) return;
 });
 
+ipcMain.on("panel:set-sidebar-hidden", (event, hidden: unknown) => {
+  if (event.sender !== panelWindow?.webContents) return;
+  if (typeof hidden !== "boolean") return;
+  const win = panelWindow;
+  if (!win || win.isDestroyed()) return;
+  setPanelTrafficLightPosition(win, hidden);
+});
+
 // Hover auto-dismiss belonged to the former corner companion. The restored
 // desktop workspace remains open, but accepting these channels preserves a
 // safe preload contract for any renderer still sending them.
@@ -4043,6 +4051,22 @@ const DASHBOARD_DEFAULT_WIDTH = 1080;
 const DASHBOARD_DEFAULT_HEIGHT = 760;
 const DASHBOARD_MIN_WIDTH = 760;
 const DASHBOARD_MIN_HEIGHT = 680;
+const DASHBOARD_TRAFFIC_LIGHT_POSITION = {
+  default: { x: 20, y: 16 },
+  sidebarHidden: { x: 62, y: 16 },
+};
+
+function setPanelTrafficLightPosition(
+  win: BrowserWindow,
+  sidebarHidden: boolean,
+): void {
+  if (process.platform !== "darwin") return;
+  win.setWindowButtonPosition(
+    sidebarHidden
+      ? DASHBOARD_TRAFFIC_LIGHT_POSITION.sidebarHidden
+      : DASHBOARD_TRAFFIC_LIGHT_POSITION.default,
+  );
+}
 
 function panelPosition(display: Display): {
   x: number;
@@ -4128,7 +4152,9 @@ function createPanelWindow(): void {
     title: "Freestyle",
     titleBarStyle: process.platform === "darwin" ? "hidden" : "default",
     trafficLightPosition:
-      process.platform === "darwin" ? { x: 20, y: 16 } : undefined,
+      process.platform === "darwin"
+        ? DASHBOARD_TRAFFIC_LIGHT_POSITION.default
+        : undefined,
     transparent: false,
     resizable: true,
     minWidth: DASHBOARD_MIN_WIDTH,

--- a/apps/electron/src/main/native-window-controls.test.ts
+++ b/apps/electron/src/main/native-window-controls.test.ts
@@ -44,6 +44,21 @@ describe("native desktop window controls", () => {
     expect(shell).not.toContain("window.api?.windowControl");
   });
 
+  it("moves native traffic lights clear of a hidden-sidebar restore control", async () => {
+    const [source, shell] = await Promise.all([
+      readFile(mainPath, "utf8"),
+      readFile(shellPath, "utf8"),
+    ]);
+
+    expect(source).toContain('ipcMain.on("panel:set-sidebar-hidden"');
+    expect(source).toContain("setPanelTrafficLightPosition");
+    expect(source).toContain("win.setWindowButtonPosition(");
+    expect(source).toContain("DASHBOARD_TRAFFIC_LIGHT_POSITION.sidebarHidden");
+    expect(shell).toContain(
+      "window.api.setPanelSidebarHidden(isSidebarHidden)",
+    );
+  });
+
   it("publishes native fullscreen changes for the sidebar layout", async () => {
     const source = await readFile(mainPath, "utf8");
 

--- a/apps/electron/src/main/native-window-controls.test.ts
+++ b/apps/electron/src/main/native-window-controls.test.ts
@@ -44,21 +44,6 @@ describe("native desktop window controls", () => {
     expect(shell).not.toContain("window.api?.windowControl");
   });
 
-  it("moves native traffic lights clear of a hidden-sidebar restore control", async () => {
-    const [source, shell] = await Promise.all([
-      readFile(mainPath, "utf8"),
-      readFile(shellPath, "utf8"),
-    ]);
-
-    expect(source).toContain('ipcMain.on("panel:set-sidebar-hidden"');
-    expect(source).toContain("setPanelTrafficLightPosition");
-    expect(source).toContain("win.setWindowButtonPosition(");
-    expect(source).toContain("DASHBOARD_TRAFFIC_LIGHT_POSITION.sidebarHidden");
-    expect(shell).toContain(
-      "window.api.setPanelSidebarHidden(isSidebarHidden)",
-    );
-  });
-
   it("publishes native fullscreen changes for the sidebar layout", async () => {
     const source = await readFile(mainPath, "utf8");
 

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -108,6 +108,7 @@ declare global {
       panelClose: () => void;
       panelResizeWidth: (width: number) => void;
       panelCommitWidth: () => void;
+      setPanelSidebarHidden: (hidden: boolean) => void;
       openSettings: () => void;
       settingsClose: () => void;
       panelSetBusy: (busy: boolean) => void;

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -280,6 +280,8 @@ const api = {
   panelResizeWidth: (width: number): void =>
     ipcRenderer.send("panel:resize-width", width),
   panelCommitWidth: (): void => ipcRenderer.send("panel:commit-width"),
+  setPanelSidebarHidden: (hidden: boolean): void =>
+    ipcRenderer.send("panel:set-sidebar-hidden", hidden),
   openSettings: (): void => ipcRenderer.send("settings:open"),
   settingsClose: (): void => ipcRenderer.send("settings:close"),
   panelSetBusy: (busy: boolean): void =>

--- a/apps/electron/src/renderer/src/shell.css
+++ b/apps/electron/src/renderer/src/shell.css
@@ -153,8 +153,3 @@
   top: 12px;
   left: 12px;
 }
-
-/* The dashboard's custom titlebar puts macOS traffic lights at x=20. */
-html.glass .sidebar-reveal-trigger {
-  left: 86px;
-}

--- a/apps/electron/src/renderer/src/shell.tsx
+++ b/apps/electron/src/renderer/src/shell.tsx
@@ -703,8 +703,8 @@ export default function AppShell(): React.JSX.Element {
   }, [setSidebarVisibility]);
 
   useEffect(() => {
-    window.api.setPanelSidebarHidden(isSidebarHidden);
-  }, [isSidebarHidden]);
+    window.api.setPanelSidebarHidden(phase !== "signed_out" && isSidebarHidden);
+  }, [isSidebarHidden, phase]);
 
   const changeWorkspace = useCallback(
     (workspace: Workspace) => {

--- a/apps/electron/src/renderer/src/shell.tsx
+++ b/apps/electron/src/renderer/src/shell.tsx
@@ -702,6 +702,10 @@ export default function AppShell(): React.JSX.Element {
     setSidebarVisibility("visible");
   }, [setSidebarVisibility]);
 
+  useEffect(() => {
+    window.api.setPanelSidebarHidden(isSidebarHidden);
+  }, [isSidebarHidden]);
+
   const changeWorkspace = useCallback(
     (workspace: Workspace) => {
       setSidebarWorkspace(workspace);

--- a/apps/electron/tests/dashboard-visual.test.ts
+++ b/apps/electron/tests/dashboard-visual.test.ts
@@ -44,6 +44,26 @@ let app: ElectronApplication | undefined;
 let pill: Page;
 let dashboard: Page;
 
+async function dashboardWindowButtonPosition(): Promise<{
+  x: number;
+  y: number;
+} | null> {
+  return app!.evaluate(({ BrowserWindow }) => {
+    const panel = BrowserWindow.getAllWindows().find((window) =>
+      window.webContents.getURL().includes("index.html"),
+    );
+    return panel?.getWindowButtonPosition() ?? null;
+  });
+}
+
+async function expectDashboardWindowButtonPosition(position: {
+  x: number;
+  y: number;
+}): Promise<void> {
+  if (process.platform !== "darwin") return;
+  await expect.poll(dashboardWindowButtonPosition).toEqual(position);
+}
+
 async function installDashboardFixtures(page: Page): Promise<void> {
   await page.addInitScript(
     ({ authStatusDelayMs, pageDataDelayMs }) => {
@@ -370,6 +390,7 @@ test("captures the desktop sidebar hidden and restored", async ({
   await expect(dashboard.locator(".glass-sidebar")).toHaveCount(0);
   const showSidebar = dashboard.getByRole("button", { name: "Show sidebar" });
   await expect(showSidebar).toBeFocused();
+  await expectDashboardWindowButtonPosition({ x: 62, y: 16 });
   const revealBounds = await showSidebar.boundingBox();
   expect(revealBounds).not.toBeNull();
   expect(revealBounds?.x).toBeLessThanOrEqual(16);
@@ -383,6 +404,7 @@ test("captures the desktop sidebar hidden and restored", async ({
   await showSidebar.click();
   await expect(dashboard.locator(".glass-sidebar")).toBeVisible();
   await expect(hideSidebar).toBeVisible();
+  await expectDashboardWindowButtonPosition({ x: 20, y: 16 });
   const restored = testInfo.outputPath("sidebar-restored.png");
   await dashboard.screenshot({ path: restored });
   await testInfo.attach("sidebar-restored", {
@@ -392,12 +414,16 @@ test("captures the desktop sidebar hidden and restored", async ({
 });
 
 test("shows full-window sign-in after a protected request returns 401", async () => {
+  await dashboard.evaluate(() => {
+    localStorage.setItem("shell.sidebarVisibility", "hidden");
+  });
   await dashboard.goto(`${DASHBOARD_URL}?visual=protected-401#/today`);
 
   await expect(
     dashboard.getByRole("button", { name: "Sign in via browser" }),
   ).toBeVisible();
   await expect(dashboard.locator(".glass-sidebar")).toHaveCount(0);
+  await expectDashboardWindowButtonPosition({ x: 20, y: 16 });
 
   const requestedEndpoints = await dashboard.evaluate(() => {
     const visualReviewWindow = window as typeof window & {

--- a/apps/electron/tests/dashboard-visual.test.ts
+++ b/apps/electron/tests/dashboard-visual.test.ts
@@ -370,6 +370,9 @@ test("captures the desktop sidebar hidden and restored", async ({
   await expect(dashboard.locator(".glass-sidebar")).toHaveCount(0);
   const showSidebar = dashboard.getByRole("button", { name: "Show sidebar" });
   await expect(showSidebar).toBeFocused();
+  const revealBounds = await showSidebar.boundingBox();
+  expect(revealBounds).not.toBeNull();
+  expect(revealBounds?.x).toBeLessThanOrEqual(16);
   const hidden = testInfo.outputPath("sidebar-hidden.png");
   await dashboard.screenshot({ path: hidden });
   await testInfo.attach("sidebar-hidden", {


### PR DESCRIPTION
## Summary

Align the sidebar restore control with the left edge when the desktop sidebar is hidden.

## Validation

- `pnpm --filter electron exec playwright test tests/dashboard-visual.test.ts`
- `pnpm --filter electron test:e2e` (45 passed)

The visual regression test now asserts that the focused restore control remains at x <= 16.
