### PR TITLE
feat(electron): surface Remix run activity

### DIFF
--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -1206,9 +1206,15 @@ function DurableRunHistory({
   );
 }
 
-function ApprovalDetails({ call }: { call: AgentToolCall }): React.JSX.Element {
-  const approval = describeAgentApproval(call);
-
+function ApprovalDetails({
+  approval,
+  commandReviewed,
+  onCommandReviewChange,
+}: {
+  approval: ReturnType<typeof describeAgentApproval>;
+  commandReviewed: boolean;
+  onCommandReviewChange: (reviewed: boolean) => void;
+}): React.JSX.Element {
   return (
     <>
       <span className="tavern-approve-title">{approval.title}</span>
@@ -1217,10 +1223,23 @@ function ApprovalDetails({ call }: { call: AgentToolCall }): React.JSX.Element {
         <span>{approval.summary}</span>
       </div>
       <p className="tavern-approve-scope">{approval.scope}</p>
-      <details className="tavern-approve-technical">
+      <details
+        className="tavern-approve-technical"
+        open={approval.requiresCommandReview}
+      >
         <summary>Technical details</summary>
         <pre>{approval.technical}</pre>
       </details>
+      {approval.requiresCommandReview ? (
+        <label className="tavern-approve-review">
+          <input
+            type="checkbox"
+            checked={commandReviewed}
+            onChange={(event) => onCommandReviewChange(event.target.checked)}
+          />
+          I reviewed the complete command above.
+        </label>
+      ) : null}
     </>
   );
 }
@@ -1319,6 +1338,9 @@ function PanelInner({
       durable?: { turnId: string; actionId: string };
     }>
   >([]);
+  const [reviewedCommands, setReviewedCommands] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
@@ -1442,6 +1464,7 @@ function PanelInner({
     setDraft("");
     setNotice(null);
     setApprovals([]);
+    setReviewedCommands(new Set());
     setCopiedMessageId(null);
     setEditingMessageId(null);
     setEditDraft("");
@@ -2215,30 +2238,52 @@ function PanelInner({
                     threadId={thread.id}
                     activeTurnId={durableRuntime.data?.activeTurn?.id}
                   />
-                  {approvals.map((approval) => (
-                    <div
-                      key={approval.call.toolCallId}
-                      className="tavern-approve"
-                    >
-                      <ApprovalDetails call={approval.call} />
-                      <div className="tavern-approve-actions">
-                        <button
-                          type="button"
-                          className="tavern-approve-btn tavern-approve-allow"
-                          onClick={() => resolveApproval(approval, true)}
-                        >
-                          Allow
-                        </button>
-                        <button
-                          type="button"
-                          className="tavern-approve-btn"
-                          onClick={() => resolveApproval(approval, false)}
-                        >
-                          Don't allow
-                        </button>
+                  {approvals.map((approval) => {
+                    const details = describeAgentApproval(approval.call);
+                    const commandReviewed = reviewedCommands.has(
+                      approval.call.toolCallId,
+                    );
+                    const setCommandReviewed = (reviewed: boolean): void => {
+                      setReviewedCommands((current) => {
+                        const next = new Set(current);
+                        if (reviewed) next.add(approval.call.toolCallId);
+                        else next.delete(approval.call.toolCallId);
+                        return next;
+                      });
+                    };
+
+                    return (
+                      <div
+                        key={approval.call.toolCallId}
+                        className="tavern-approve"
+                      >
+                        <ApprovalDetails
+                          approval={details}
+                          commandReviewed={commandReviewed}
+                          onCommandReviewChange={setCommandReviewed}
+                        />
+                        <div className="tavern-approve-actions">
+                          <button
+                            type="button"
+                            className="tavern-approve-btn tavern-approve-allow"
+                            disabled={
+                              details.requiresCommandReview && !commandReviewed
+                            }
+                            onClick={() => resolveApproval(approval, true)}
+                          >
+                            Allow
+                          </button>
+                          <button
+                            type="button"
+                            className="tavern-approve-btn"
+                            onClick={() => resolveApproval(approval, false)}
+                          >
+                            Don't allow
+                          </button>
+                        </div>
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                   {durableRuntime.data?.pendingAction?.kind === "connector" &&
                   durableRuntime.data.pendingAction.status === "pending" ? (
                     <div className="tavern-approve">

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -42,7 +42,7 @@ import {
   type AgentToolCall,
   agentToolTier,
   DECLINED_OUTPUT,
-  describeAgentAction,
+  describeAgentApproval,
   executeAgentTool,
   reportAgentToolResult,
   requestAgentFileSaveGrant,
@@ -61,6 +61,7 @@ import {
   prependThreadToHistory,
   queryKeys,
 } from "@renderer/lib/query";
+import { describeRemixRun } from "@renderer/lib/remix-run-state";
 import { executeRemixTool } from "@renderer/lib/remix-tool-executor";
 import { useSpriteEmitter } from "@renderer/lib/sprite-emitter";
 import {
@@ -84,7 +85,6 @@ import { compactActivitySummary } from "@renderer/lib/workspace-navigation";
 import { SpriteBadge } from "@renderer/sprites/badge";
 import { type CompanionForm, DEFAULT_COMPANION_FORM } from "@shared/companion";
 import { PANEL_MAX_WIDTH, PANEL_MIN_WIDTH } from "@shared/panel";
-import { SPRITES_INFO } from "@shared/sprites";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   DefaultChatTransport,
@@ -1206,6 +1206,25 @@ function DurableRunHistory({
   );
 }
 
+function ApprovalDetails({ call }: { call: AgentToolCall }): React.JSX.Element {
+  const approval = describeAgentApproval(call);
+
+  return (
+    <>
+      <span className="tavern-approve-title">{approval.title}</span>
+      <div className="tavern-approve-summary">
+        <strong>{approval.target}</strong>
+        <span>{approval.summary}</span>
+      </div>
+      <p className="tavern-approve-scope">{approval.scope}</p>
+      <details className="tavern-approve-technical">
+        <summary>Technical details</summary>
+        <pre>{approval.technical}</pre>
+      </details>
+    </>
+  );
+}
+
 function PanelInner({
   thread,
   onSwitchThread,
@@ -1875,6 +1894,10 @@ function PanelInner({
     desktop &&
     desktopSurface === "chat" &&
     (narrowRemix ? narrowContextOpen : contextRailOpen);
+  const remixRun = describeRemixRun(
+    durableRuntime.data ?? null,
+    approvals.length > 0,
+  );
   const toggleContextRail = (): void => {
     if (narrowRemix) setNarrowContextOpen((open) => !open);
     else setContextRailOpen(!contextRailOpen);
@@ -2197,13 +2220,7 @@ function PanelInner({
                       key={approval.call.toolCallId}
                       className="tavern-approve"
                     >
-                      <span className="tavern-approve-title">
-                        {SPRITES_INFO[spriteForm].label.toLowerCase()} wants to
-                        act
-                      </span>
-                      <div className="tavern-approve-text">
-                        {describeAgentAction(approval.call)}
-                      </div>
+                      <ApprovalDetails call={approval.call} />
                       <div className="tavern-approve-actions">
                         <button
                           type="button"
@@ -2402,11 +2419,12 @@ function PanelInner({
             <RemixContextRail
               attention={contextAttention}
               open={contextRailVisible}
+              run={remixRun}
               onOpenInspector={openInspector}
             />
           ) : null}
           {desktop && inspectorTarget ? (
-            <RemixInspector target={inspectorTarget} />
+            <RemixInspector target={inspectorTarget} run={remixRun} />
           ) : null}
         </div>
       </div>

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -11,7 +11,7 @@ import {
   type AgentToolCall,
   agentToolTier,
   DECLINED_OUTPUT,
-  describeAgentAction,
+  describeAgentApproval,
   executeAgentTool,
   reportAgentToolResult,
   requestAgentFileSaveGrant,
@@ -1257,7 +1257,7 @@ function RemixApprovalCard({
   resolving: boolean;
   onResolve: (approval: PendingApproval, allowed: boolean) => void;
 }): React.JSX.Element {
-  const description = describeAgentAction(approval.call);
+  const details = describeAgentApproval(approval.call);
 
   return (
     <section className="remix-chat-approval" aria-live="polite">
@@ -1265,7 +1265,17 @@ function RemixApprovalCard({
       <div className="remix-chat-approval-title">
         Remix wants to act locally
       </div>
-      <pre className="remix-chat-approval-detail">{description}</pre>
+      <div className="remix-chat-approval-summary">
+        <strong>
+          {details.title} · {details.target}
+        </strong>
+        <span>{details.summary}</span>
+      </div>
+      <p className="remix-chat-approval-scope">{details.scope}</p>
+      <details className="remix-chat-approval-technical">
+        <summary>Technical details</summary>
+        <pre>{details.technical}</pre>
+      </details>
       <div className="remix-chat-approval-actions">
         <button
           type="button"
@@ -1984,10 +1994,29 @@ const REMIX_CHAT_CSS = `
     font-size: 12.5px;
     font-weight: 650;
   }
-  .remix-chat-approval-detail {
+  .remix-chat-approval-summary {
+    display: grid;
+    gap: 2px;
+    color: ${INK_DIM};
+    font-size: 11px;
+    line-height: 1.4;
+  }
+  .remix-chat-approval-summary strong { color: ${INK}; }
+  .remix-chat-approval-scope {
+    margin: 0;
+    color: ${INK_FAINT};
+    font-size: 10px;
+    line-height: 1.35;
+  }
+  .remix-chat-approval-technical {
+    color: ${INK_FAINT};
+    font-size: 10px;
+  }
+  .remix-chat-approval-technical summary { cursor: pointer; }
+  .remix-chat-approval-technical pre {
     max-height: 98px;
     overflow: auto;
-    margin: 0;
+    margin: 7px 0 0;
     padding: 7px 8px;
     border: 1px solid rgba(245, 241, 228, 0.09);
     border-radius: 8px;

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -1258,6 +1258,9 @@ function RemixApprovalCard({
   onResolve: (approval: PendingApproval, allowed: boolean) => void;
 }): React.JSX.Element {
   const details = describeAgentApproval(approval.call);
+  const [commandReviewed, setCommandReviewed] = useState(
+    !details.requiresCommandReview,
+  );
 
   return (
     <section className="remix-chat-approval" aria-live="polite">
@@ -1272,15 +1275,28 @@ function RemixApprovalCard({
         <span>{details.summary}</span>
       </div>
       <p className="remix-chat-approval-scope">{details.scope}</p>
-      <details className="remix-chat-approval-technical">
+      <details
+        className="remix-chat-approval-technical"
+        open={details.requiresCommandReview}
+      >
         <summary>Technical details</summary>
         <pre>{details.technical}</pre>
       </details>
+      {details.requiresCommandReview ? (
+        <label className="remix-chat-approval-review">
+          <input
+            type="checkbox"
+            checked={commandReviewed}
+            onChange={(event) => setCommandReviewed(event.target.checked)}
+          />
+          I reviewed the complete command above.
+        </label>
+      ) : null}
       <div className="remix-chat-approval-actions">
         <button
           type="button"
           className="remix-chat-approval-allow"
-          disabled={resolving}
+          disabled={resolving || !commandReviewed}
           onClick={() => onResolve(approval, true)}
         >
           {resolving ? "Working…" : "Allow"}
@@ -2028,6 +2044,15 @@ const REMIX_CHAT_CSS = `
     white-space: pre-wrap;
     word-break: break-word;
   }
+  .remix-chat-approval-review {
+    display: flex;
+    gap: 7px;
+    align-items: flex-start;
+    color: ${INK_DIM};
+    font-size: 10px;
+    line-height: 1.35;
+  }
+  .remix-chat-approval-review input { margin: 1px 0 0; }
   .remix-chat-approval-actions {
     display: flex;
     align-items: center;

--- a/apps/electron/src/renderer/src/components/remix-context-rail.test.ts
+++ b/apps/electron/src/renderer/src/components/remix-context-rail.test.ts
@@ -22,6 +22,8 @@ describe("Remix context rail", () => {
     expect(rail).toContain("onOpenInspector={onOpenInspector}");
     expect(rail).toContain('onOpenInspector({ kind: "tasks" })');
     expect(rail).toContain('onOpenInspector({ kind: "notes" })');
+    expect(rail).toContain("RemixRunCard");
+    expect(rail).toContain('onOpenInspector({ kind: "run", run })');
     expect(rail).toContain('kind: "file"');
     expect(rail).toContain("View all");
     expect(rail).not.toContain("remix-context-preview");
@@ -32,6 +34,9 @@ describe("Remix context rail", () => {
     expect(rail).toContain("aria-hidden={!open}");
     expect(rail).toContain("inert={!open}");
     expect(panel).toContain("const contextRailVisible =");
+    expect(panel).toContain("const remixRun = describeRemixRun(");
+    expect(panel).toContain("approvals.length > 0");
+    expect(panel).toContain("run={remixRun}");
     expect(panel).toContain(
       "narrowRemix ? narrowContextOpen : contextRailOpen",
     );
@@ -67,6 +72,7 @@ describe("Remix context rail", () => {
     expect(styles).toContain("padding: 12px 12px 14px;");
     expect(styles).not.toContain("--remix-chat-header-height");
     expect(styles).toContain(".remix-context-card-icon");
+    expect(styles).toContain(".remix-context-run-state");
     const railStyles = styles.slice(
       styles.indexOf(".remix-context-rail"),
       styles.indexOf(".remix-context-card {"),

--- a/apps/electron/src/renderer/src/components/remix-context-rail.tsx
+++ b/apps/electron/src/renderer/src/components/remix-context-rail.tsx
@@ -7,6 +7,7 @@ import {
   writeBrainFile,
 } from "@renderer/lib/brain-fs";
 import { notesQueryOptions, queryKeys } from "@renderer/lib/query";
+import type { RemixRunState } from "@renderer/lib/remix-run-state";
 import {
   appendRemixTodo,
   parseRemixTodos,
@@ -14,11 +15,18 @@ import {
   toggleRemixTodo,
 } from "@renderer/lib/remix-tasks";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Brain, ChevronDown, FileText, ListTodo, Plus } from "lucide-react";
+import {
+  Activity,
+  Brain,
+  ChevronDown,
+  FileText,
+  ListTodo,
+  Plus,
+} from "lucide-react";
 import type React from "react";
 import { useMemo, useState } from "react";
 
-export type RemixContextKind = "tasks" | "notes" | "brain";
+export type RemixContextKind = "tasks" | "notes" | "brain" | "run";
 
 const PREVIEW_LIMIT = 3;
 
@@ -64,7 +72,13 @@ function ContextCard({
   children: React.ReactNode;
 }): React.JSX.Element {
   const Icon =
-    kind === "tasks" ? ListTodo : kind === "notes" ? FileText : Brain;
+    kind === "tasks"
+      ? ListTodo
+      : kind === "notes"
+        ? FileText
+        : kind === "brain"
+          ? Brain
+          : Activity;
 
   return (
     <section
@@ -349,13 +363,46 @@ function ContextBrain({
   );
 }
 
+function RemixRunCard({
+  run,
+  onOpenInspector,
+}: {
+  run: RemixRunState;
+  onOpenInspector?: (target: RemixInspectorTarget) => void;
+}): React.JSX.Element {
+  const needsAttention =
+    run.state === "approval" ||
+    run.state === "desktop" ||
+    run.state === "attention";
+
+  return (
+    <ContextCard
+      kind="run"
+      title="Run"
+      attention={needsAttention}
+      onOpen={
+        onOpenInspector
+          ? () => onOpenInspector({ kind: "run", run })
+          : undefined
+      }
+    >
+      <div className="remix-context-run-state" data-state={run.state}>
+        <strong>{run.title}</strong>
+        <span>{run.detail}</span>
+      </div>
+    </ContextCard>
+  );
+}
+
 export function RemixContextRail({
   attention,
   open,
+  run,
   onOpenInspector,
 }: {
   attention: RemixContextKind | null;
   open: boolean;
+  run: RemixRunState;
   onOpenInspector?: (target: RemixInspectorTarget) => void;
 }): React.JSX.Element {
   return (
@@ -365,6 +412,7 @@ export function RemixContextRail({
       aria-label="Conversation context"
       inert={!open}
     >
+      <RemixRunCard run={run} onOpenInspector={onOpenInspector} />
       <ContextTasks
         attention={attention === "tasks"}
         onOpenInspector={onOpenInspector}

--- a/apps/electron/src/renderer/src/components/remix-inspector.test.ts
+++ b/apps/electron/src/renderer/src/components/remix-inspector.test.ts
@@ -16,6 +16,10 @@ describe("Remix inspector", () => {
     expect(inspector).toContain('role="separator"');
     expect(inspector).toContain('aria-label="Resize inspector"');
     expect(inspector).toContain("onOpenFile");
+    expect(inspector).toContain('kind: "run"');
+    expect(inspector).toContain("InspectorRun");
+    expect(inspector).toContain("run: RemixRunState");
+    expect(inspector).toContain("<InspectorRun run={run} />");
     expect(inspector).toContain("data-remix-inspector-tab");
     expect(inspector).toContain('className="remix-inspector-editor"');
     expect(inspector).toContain("BreadcrumbPage");

--- a/apps/electron/src/renderer/src/components/remix-inspector.tsx
+++ b/apps/electron/src/renderer/src/components/remix-inspector.tsx
@@ -10,9 +10,11 @@ import { usePersistentState } from "@renderer/hooks/use-persistent-state";
 import { listBrainFiles, writeBrainFile } from "@renderer/lib/brain-fs";
 import {
   brainFileQueryOptions,
+  durableTurnTimelineQueryOptions,
   notesQueryOptions,
   queryKeys,
 } from "@renderer/lib/query";
+import type { RemixRunState } from "@renderer/lib/remix-run-state";
 import {
   appendRemixTodo,
   parseRemixTodos,
@@ -39,6 +41,7 @@ export type RemixInspectorTarget =
   | { kind: "tasks" }
   | { kind: "notes" }
   | { kind: "brain" }
+  | { kind: "run"; run: RemixRunState }
   | { kind: "file"; path: string; title?: string };
 
 type InspectorTab = RemixInspectorTarget & { id: string; title: string };
@@ -54,6 +57,7 @@ function tabFor(target: RemixInspectorTarget): InspectorTab {
     return { ...target, id: "notes", title: "Notes" };
   if (target.kind === "brain")
     return { ...target, id: "brain", title: "Brain" };
+  if (target.kind === "run") return { ...target, id: "run", title: "Run" };
   return {
     ...target,
     id: `file:${target.path}`,
@@ -368,23 +372,60 @@ function InspectorCollection({
   );
 }
 
+function InspectorRun({ run }: { run: RemixRunState }): React.JSX.Element {
+  const timeline = useQuery({
+    ...durableTurnTimelineQueryOptions(run.turnId ?? ""),
+    enabled: Boolean(run.turnId),
+  });
+
+  return (
+    <section className="remix-inspector-run" aria-label="Run activity">
+      <span className="remix-inspector-run-state" data-state={run.state}>
+        {run.title}
+      </span>
+      <p>{run.detail}</p>
+      {timeline.isLoading ? (
+        <DataSkeleton label="Loading run activity" rows={2} />
+      ) : timeline.data?.length ? (
+        <ol>
+          {timeline.data.map((event) => (
+            <li key={event.id} data-status={event.status}>
+              <strong>{event.status.replace(/_/g, " ")}</strong>
+              {event.summary ? <span>{event.summary}</span> : null}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="remix-inspector-run-empty">
+          Activity will appear here as Remix works.
+        </p>
+      )}
+    </section>
+  );
+}
+
 function InspectorContent({
   tab,
+  run,
   onOpenFile,
 }: {
   tab: InspectorTab;
+  run: RemixRunState;
   onOpenFile: (target: RemixInspectorTarget) => void;
 }): React.JSX.Element {
   if (tab.kind === "file") return <InspectorFile path={tab.path} />;
   if (tab.kind === "tasks") return <InspectorTasks />;
+  if (tab.kind === "run") return <InspectorRun run={run} />;
 
   return <InspectorCollection kind={tab.kind} onOpenFile={onOpenFile} />;
 }
 
 export function RemixInspector({
   target,
+  run,
 }: {
   target: RemixInspectorTarget | null;
+  run: RemixRunState;
 }): React.JSX.Element | null {
   const [widthRaw, setWidthRaw] = usePersistentState<string>(
     "remix.inspectorWidth",
@@ -403,7 +444,9 @@ export function RemixInspector({
     const tab = tabFor(next);
     setTabs((current) =>
       current.some((candidate) => candidate.id === tab.id)
-        ? current
+        ? current.map((candidate) =>
+            candidate.id === tab.id ? tab : candidate,
+          )
         : [...current, tab],
     );
     setActiveId(tab.id);
@@ -486,7 +529,7 @@ export function RemixInspector({
       <div className="remix-inspector-body" role="tabpanel">
         {tabs.map((tab) => (
           <div key={tab.id} hidden={tab.id !== active.id}>
-            <InspectorContent tab={tab} onOpenFile={openTab} />
+            <InspectorContent tab={tab} run={run} onOpenFile={openTab} />
           </div>
         ))}
       </div>

--- a/apps/electron/src/renderer/src/lib/agent-tools.test.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.test.ts
@@ -92,6 +92,7 @@ describe("agent approval details", () => {
       summary: `${"x".repeat(120)}…`,
       scope: "Only this action is approved.",
       technical: `Run in your shell:\n$ ${command}`,
+      requiresCommandReview: true,
     });
   });
 });

--- a/apps/electron/src/renderer/src/lib/agent-tools.test.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.test.ts
@@ -7,6 +7,7 @@ vi.mock("@shared/sprite-events", () => ({
 import {
   agentToolResultTelemetry,
   agentToolTier,
+  describeAgentApproval,
   executeAgentTool,
   requestAgentFileSaveGrant,
 } from "./agent-tools";
@@ -40,6 +41,58 @@ describe("agent tool approval tiers", () => {
     await expect(
       agentToolTier(call("connector__gmail__474d41494c5f53454")),
     ).resolves.toBeNull();
+  });
+});
+
+describe("agent approval details", () => {
+  it("names the affected file and preserves one-action scope for a local write", () => {
+    expect(
+      describeAgentApproval({
+        toolName: "Write",
+        toolCallId: "call-1",
+        input: { path: "/tmp/plan.md", text: "# Today\n\nShip it" },
+      }),
+    ).toEqual({
+      title: "Write a file",
+      target: "/tmp/plan.md",
+      summary: "Write 16 characters",
+      scope: "Only this action is approved.",
+      technical: "Write 16 characters to /tmp/plan.md",
+    });
+  });
+
+  it("keeps a command readable without granting a broader shell session", () => {
+    expect(
+      describeAgentApproval({
+        toolName: "Bash",
+        toolCallId: "call-1",
+        input: { command: "pnpm test" },
+      }),
+    ).toEqual({
+      title: "Run a command",
+      target: "This desktop",
+      summary: "pnpm test",
+      scope: "Only this action is approved.",
+      technical: "Run in your shell:\n$ pnpm test",
+    });
+  });
+
+  it("bounds a long command in the summary while retaining it in technical details", () => {
+    const command = "x".repeat(200);
+
+    expect(
+      describeAgentApproval({
+        toolName: "Bash",
+        toolCallId: "call-1",
+        input: { command },
+      }),
+    ).toEqual({
+      title: "Run a command",
+      target: "This desktop",
+      summary: `${"x".repeat(120)}…`,
+      scope: "Only this action is approved.",
+      technical: `Run in your shell:\n$ ${command}`,
+    });
   });
 });
 

--- a/apps/electron/src/renderer/src/lib/agent-tools.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.ts
@@ -104,6 +104,8 @@ export type AgentApprovalDetails = {
   summary: string;
   scope: string;
   technical: string;
+  /** A truncated shell preview needs an explicit user acknowledgement. */
+  requiresCommandReview?: true;
 };
 
 /** A small, user-facing summary of the exact local action being approved. */
@@ -123,6 +125,7 @@ export function describeAgentApproval(
         summary: commandPreview(command),
         scope: oneAction,
         technical: `Run in your shell:\n$ ${command}`,
+        ...(command.length > 120 ? { requiresCommandReview: true } : {}),
       };
     }
     case "Read":

--- a/apps/electron/src/renderer/src/lib/agent-tools.ts
+++ b/apps/electron/src/renderer/src/lib/agent-tools.ts
@@ -39,6 +39,10 @@ const SAFE_RESULT_CATEGORIES = new Set([
 const str = (input: Record<string, unknown>, key: string): string =>
   typeof input[key] === "string" ? (input[key] as string) : "";
 
+function commandPreview(command: string): string {
+  return command.length > 120 ? `${command.slice(0, 120)}…` : command;
+}
+
 export async function agentToolTier(
   call: AgentToolCall,
 ): Promise<AgentToolTier | null> {
@@ -91,6 +95,94 @@ export function describeAgentAction(call: AgentToolCall): string {
       return `Save ${str(input, "filename")} to your Downloads folder`;
     default:
       return `Run ${call.toolName.replace(/_/g, " ")}.`;
+  }
+}
+
+export type AgentApprovalDetails = {
+  title: string;
+  target: string;
+  summary: string;
+  scope: string;
+  technical: string;
+};
+
+/** A small, user-facing summary of the exact local action being approved. */
+export function describeAgentApproval(
+  call: AgentToolCall,
+): AgentApprovalDetails {
+  const input = (call.input ?? {}) as Record<string, unknown>;
+  const oneAction = "Only this action is approved.";
+  const path = str(input, "path") || "This desktop";
+
+  switch (call.toolName) {
+    case "Bash": {
+      const command = str(input, "command") || "Run a command";
+      return {
+        title: "Run a command",
+        target: "This desktop",
+        summary: commandPreview(command),
+        scope: oneAction,
+        technical: `Run in your shell:\n$ ${command}`,
+      };
+    }
+    case "Read":
+      return {
+        title: "Read a file",
+        target: path,
+        summary: "Read its contents",
+        scope: oneAction,
+        technical: describeAgentAction(call),
+      };
+    case "Write": {
+      const text = str(input, "text");
+      return {
+        title: "Write a file",
+        target: path,
+        summary: `Write ${text.length} characters`,
+        scope: oneAction,
+        technical: describeAgentAction(call),
+      };
+    }
+    case "Edit":
+      return {
+        title: "Edit a file",
+        target: path,
+        summary: "Apply the requested edit",
+        scope: oneAction,
+        technical: describeAgentAction(call),
+      };
+    case "Glob":
+      return {
+        title: "List files",
+        target: path,
+        summary: str(input, "pattern") || "List matching files",
+        scope: oneAction,
+        technical: describeAgentAction(call),
+      };
+    case "Grep":
+      return {
+        title: "Search files",
+        target: path,
+        summary: str(input, "query") || "Search file contents",
+        scope: oneAction,
+        technical: describeAgentAction(call),
+      };
+    case "save_file":
+      return {
+        title: "Save a download",
+        target: "Downloads",
+        summary: str(input, "filename") || "Save a file",
+        scope: oneAction,
+        technical: describeAgentAction(call),
+      };
+    default:
+      return {
+        title: "Run a local action",
+        target: "This desktop",
+        summary: call.toolName.replace(/_/g, " "),
+        scope: oneAction,
+        technical: describeAgentAction(call),
+      };
   }
 }
 

--- a/apps/electron/src/renderer/src/lib/remix-run-state.test.ts
+++ b/apps/electron/src/renderer/src/lib/remix-run-state.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { describeRemixRun } from "./remix-run-state";
+
+describe("Remix run status", () => {
+  it("prioritizes a connected-app approval over a running turn", () => {
+    expect(
+      describeRemixRun({
+        activeTurn: { id: "turn-1", status: "running", error: null },
+        pendingAction: {
+          id: "action-1",
+          turnId: "turn-1",
+          kind: "connector",
+          status: "pending",
+          toolName: "connector__gmail__send",
+          display: "Send a draft through Gmail",
+          capability: "gmail.send",
+          expiresAt: "2026-09-08T12:00:00.000Z",
+        },
+      }),
+    ).toEqual({
+      state: "approval",
+      title: "Approval needed",
+      detail: "Review the connected-app action before Remix can continue.",
+      turnId: "turn-1",
+    });
+  });
+
+  it("makes a claimed desktop action visible instead of describing it as generic work", () => {
+    expect(
+      describeRemixRun({
+        activeTurn: { id: "turn-2", status: "waiting_desktop", error: null },
+        pendingAction: {
+          id: "action-2",
+          turnId: "turn-2",
+          kind: "desktop",
+          status: "pending",
+          toolName: "Write",
+          display: "Save the outline to notes.md",
+          capability: "files.write",
+          expiresAt: "2026-09-08T12:00:00.000Z",
+        },
+      }),
+    ).toEqual({
+      state: "desktop",
+      title: "Action ready on this desktop",
+      detail: "Open it here to let Remix continue.",
+      turnId: "turn-2",
+    });
+  });
+
+  it("keeps an active turn legible when no action needs the user", () => {
+    expect(
+      describeRemixRun({
+        activeTurn: { id: "turn-3", status: "running", error: null },
+        pendingAction: null,
+      }),
+    ).toEqual({
+      state: "working",
+      title: "Remix is working",
+      detail: "Follow its progress or send a follow-up.",
+      turnId: "turn-3",
+    });
+  });
+
+  it("keeps a claimed action in progress instead of asking for approval again", () => {
+    expect(
+      describeRemixRun({
+        activeTurn: {
+          id: "turn-claimed",
+          status: "waiting_approval",
+          error: null,
+        },
+        pendingAction: {
+          id: "action-claimed",
+          turnId: "turn-claimed",
+          kind: "connector",
+          status: "claimed",
+          toolName: "connector__gmail__send",
+          display: "Send a draft through Gmail",
+          capability: "gmail.send",
+          expiresAt: "2026-09-08T12:00:00.000Z",
+        },
+      }),
+    ).toEqual({
+      state: "working",
+      title: "Remix is completing an approved action",
+      detail: "Follow its progress while Remix finishes this step.",
+      turnId: "turn-claimed",
+    });
+  });
+
+  it("keeps an expired desktop action recoverable instead of calling it working", () => {
+    expect(
+      describeRemixRun({
+        activeTurn: {
+          id: "turn-desktop",
+          status: "needs_desktop",
+          error: "The desktop action expired.",
+        },
+        pendingAction: null,
+      }),
+    ).toEqual({
+      state: "desktop",
+      title: "A desktop is needed",
+      detail:
+        "The desktop action expired. Reconnect an available Freestyle desktop to continue.",
+      turnId: "turn-desktop",
+    });
+  });
+
+  it("shows an in-flight local approval in the rail before durable state catches up", () => {
+    expect(
+      describeRemixRun(
+        {
+          activeTurn: { id: "turn-4", status: "running", error: null },
+          pendingAction: null,
+        },
+        true,
+      ),
+    ).toEqual({
+      state: "approval",
+      title: "Approval needed",
+      detail: "Review the local action before Remix can continue.",
+      turnId: "turn-4",
+    });
+  });
+});

--- a/apps/electron/src/renderer/src/lib/remix-run-state.ts
+++ b/apps/electron/src/renderer/src/lib/remix-run-state.ts
@@ -1,0 +1,125 @@
+import type { DurableThreadRuntime } from "./threads";
+
+export type RemixRunState = {
+  state: "approval" | "desktop" | "working" | "queued" | "attention" | "idle";
+  title: string;
+  detail: string;
+  turnId?: string;
+};
+
+/**
+ * The context rail needs one calm, actionable summary rather than the raw
+ * durable runtime envelope. Pending actions take precedence because they are
+ * the only states in which the user can unblock a turn.
+ */
+export function describeRemixRun(
+  runtime: Pick<DurableThreadRuntime, "activeTurn" | "pendingAction"> | null,
+  hasLocalApproval = false,
+): RemixRunState {
+  const turnId = runtime?.pendingAction?.turnId ?? runtime?.activeTurn?.id;
+  const pendingAction = runtime?.pendingAction;
+
+  if (hasLocalApproval) {
+    return {
+      state: "approval",
+      title: "Approval needed",
+      detail: "Review the local action before Remix can continue.",
+      ...(turnId ? { turnId } : {}),
+    };
+  }
+
+  if (pendingAction?.status === "pending") {
+    if (pendingAction.kind === "connector") {
+      return {
+        state: "approval",
+        title: "Approval needed",
+        detail: "Review the connected-app action before Remix can continue.",
+        ...(turnId ? { turnId } : {}),
+      };
+    }
+    return {
+      state: "desktop",
+      title: "Action ready on this desktop",
+      detail: "Open it here to let Remix continue.",
+      ...(turnId ? { turnId } : {}),
+    };
+  }
+
+  const activeTurn = runtime?.activeTurn;
+  if (activeTurn) {
+    switch (activeTurn.status) {
+      case "queued":
+        return {
+          state: "queued",
+          title: "Remix is queued",
+          detail: "It will start as soon as the current work finishes.",
+          turnId: activeTurn.id,
+        };
+      case "running":
+        return {
+          state: "working",
+          title: "Remix is working",
+          detail: "Follow its progress or send a follow-up.",
+          turnId: activeTurn.id,
+        };
+      case "waiting_approval":
+        if (pendingAction?.status === "claimed") {
+          return {
+            state: "working",
+            title: "Remix is completing an approved action",
+            detail: "Follow its progress while Remix finishes this step.",
+            turnId: activeTurn.id,
+          };
+        }
+        return {
+          state: "approval",
+          title: "Approval needs attention",
+          detail: "Review the action so Remix can continue.",
+          turnId: activeTurn.id,
+        };
+      case "waiting_desktop":
+        return {
+          state: "desktop",
+          title: "Waiting for this desktop",
+          detail: "Open Freestyle here to let Remix continue.",
+          turnId: activeTurn.id,
+        };
+      case "needs_desktop":
+        return {
+          state: "desktop",
+          title: "A desktop is needed",
+          detail: `${activeTurn.error ?? "This step needs an available Freestyle desktop."} Reconnect an available Freestyle desktop to continue.`,
+          turnId: activeTurn.id,
+        };
+      case "failed":
+        return {
+          state: "attention",
+          title: "Run needs attention",
+          detail: activeTurn.error ?? "Remix couldn't finish this run.",
+          turnId: activeTurn.id,
+        };
+      case "completed":
+      case "canceled":
+        return {
+          state: "idle",
+          title: "No active run",
+          detail:
+            "The latest run is finished. Start a conversation to continue.",
+          turnId: activeTurn.id,
+        };
+      default:
+        return {
+          state: "working",
+          title: "Remix is working",
+          detail: "Follow its progress or send a follow-up.",
+          turnId: activeTurn.id,
+        };
+    }
+  }
+
+  return {
+    state: "idle",
+    title: "No active run",
+    detail: "Start a conversation to give Remix something to do.",
+  };
+}

--- a/apps/electron/src/renderer/src/remix-workspace.css
+++ b/apps/electron/src/renderer/src/remix-workspace.css
@@ -985,6 +985,30 @@
   margin: 0 10px 8px;
 }
 
+.remix-context-run-state {
+  display: grid;
+  gap: 3px;
+  padding: 0 10px 10px;
+}
+
+.remix-context-run-state strong {
+  color: var(--foreground);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.remix-context-run-state span {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.remix-context-run-state[data-state="approval"] strong,
+.remix-context-run-state[data-state="desktop"] strong,
+.remix-context-run-state[data-state="attention"] strong {
+  color: var(--remix-context-accent);
+}
+
 /* The overview remains scannable. Detailed work lives beside the conversation,
    so it reads as a real workspace instead of a temporary overlay. */
 .remix-inspector {
@@ -1406,6 +1430,64 @@
   color: var(--foreground);
   font: inherit;
   font-size: 11px;
+}
+
+.remix-inspector-run {
+  display: grid;
+  gap: 10px;
+}
+
+.remix-inspector-run-state {
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.remix-inspector-run-state[data-state="approval"],
+.remix-inspector-run-state[data-state="desktop"],
+.remix-inspector-run-state[data-state="attention"] {
+  color: var(--remix-context-accent);
+}
+
+.remix-inspector-run p {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.remix-inspector-run ol {
+  display: grid;
+  gap: 8px;
+  margin: 2px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.remix-inspector-run li {
+  display: grid;
+  gap: 2px;
+  border-left: 2px solid var(--border);
+  padding-left: 9px;
+}
+
+.remix-inspector-run li[data-status="running"],
+.remix-inspector-run li[data-status="pending"] {
+  border-left-color: var(--remix-context-accent);
+}
+
+.remix-inspector-run li strong {
+  color: var(--foreground);
+  font-size: 11px;
+  font-weight: 620;
+  text-transform: capitalize;
+}
+
+.remix-inspector-run li span,
+.remix-inspector-run-empty {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.4;
 }
 
 @media (max-width: 1080px) {

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1427,6 +1427,19 @@
   font: 10px/1.45 var(--tavern-mono);
 }
 
+.tavern-approve-review {
+  display: flex;
+  gap: 7px;
+  align-items: flex-start;
+  color: var(--tavern-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.tavern-approve-review input {
+  margin: 1px 0 0;
+}
+
 .tavern-approve-actions {
   display: flex;
   gap: 8px;

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1390,6 +1390,43 @@
   overflow-wrap: anywhere;
 }
 
+.tavern-approve-summary {
+  display: grid;
+  gap: 2px;
+}
+
+.tavern-approve-summary strong {
+  color: var(--tavern-ink);
+  font-size: 12px;
+}
+
+.tavern-approve-summary span,
+.tavern-approve-scope {
+  margin: 0;
+  color: var(--tavern-muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.tavern-approve-technical {
+  color: var(--tavern-muted);
+  font-size: 11px;
+}
+
+.tavern-approve-technical summary {
+  cursor: pointer;
+}
+
+.tavern-approve-technical pre {
+  max-height: 98px;
+  overflow: auto;
+  margin: 7px 0 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--tavern-ink);
+  font: 10px/1.45 var(--tavern-mono);
+}
+
 .tavern-approve-actions {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Summary
- add a Remix Run context card that reflects work, queueing, approvals, desktop handoffs, recovery, and failures
- keep the persistent Run inspector synchronized with the current run and its durable event timeline
- make local action approvals name the exact target and one-action scope, with bounded shell previews and expandable technical detail

## Verification
- pnpm --filter @freestyle-voice/electron test (84 files, 340 tests)
- pnpm --filter @freestyle-voice/electron typecheck
- pnpm --filter @freestyle-voice/electron test:visual (passed before final review fixes; final UI logic is unit-covered)