### PR TITLE
feat(remix): Recover durable chats across disconnects

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -27,7 +27,6 @@
     "test:visual": "npm run build && playwright test tests/dashboard-visual.test.ts"
   },
   "dependencies": {
-    "@ai-sdk/react": "^3.0.44",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@freestyle-voice/server": "workspace:*",

--- a/apps/electron/src/renderer/src/components/panel-stop.test.ts
+++ b/apps/electron/src/renderer/src/components/panel-stop.test.ts
@@ -4,10 +4,9 @@ import { describe, expect, it } from "vitest";
 const panel = readFileSync(new URL("./panel.tsx", import.meta.url), "utf8");
 
 describe("desktop stop generation", () => {
-  it("cancels the durable turn as well as the local stream", () => {
-    expect(panel).toMatch(
-      /const stopGeneration[\s\S]*?stop\(\);[\s\S]*?cancelDurableTurn\(turnId\)/,
-    );
-    expect(panel).toContain("durableRuntime.refetch()");
+  it("uses the shared durable cancel controller independently of Send", () => {
+    expect(panel).toMatch(/const stopGeneration[\s\S]*?void cancel\(\)/);
+    expect(panel).toContain('aria-label="Stop generating"');
+    expect(panel).toContain('aria-label="Send"');
   });
 });

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -56,8 +56,8 @@ import {
   prependThreadToHistory,
   queryKeys,
 } from "@renderer/lib/query";
-import { describeRemixRun } from "@renderer/lib/remix-run-state";
 import { remixReconnectLabel } from "@renderer/lib/remix-recovery";
+import { describeRemixRun } from "@renderer/lib/remix-run-state";
 import {
   executeApprovedRemixTool,
   executeRemixTool,

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -1,7 +1,6 @@
 import "../overlay.css";
 import "../tavern.css";
 
-import { useChat } from "@ai-sdk/react";
 import { AgentMessageQueueControls } from "@renderer/components/agent-message-queue";
 import { RotatingThinkingLabel } from "@renderer/components/agents/loading-states/rotating-thinking-label";
 import { AttentionHome } from "@renderer/components/attention-home";
@@ -37,7 +36,6 @@ import {
   toolActivityParts,
 } from "@renderer/lib/agent-activity";
 import { readAgentBrief } from "@renderer/lib/agent-brief";
-import { useAgentMessageQueue } from "@renderer/lib/agent-message-queue";
 import {
   type AgentToolCall,
   agentToolTier,
@@ -48,10 +46,8 @@ import {
   requestAgentFileSaveGrant,
 } from "@renderer/lib/agent-tools";
 import { capture } from "@renderer/lib/analytics";
-import { apiFetch } from "@renderer/lib/api";
 import { useCloudAuth } from "@renderer/lib/auth-context";
 import { resetBrainCache } from "@renderer/lib/brain-fs";
-import { composerAction } from "@renderer/lib/composer-action";
 import { seedMessageFor } from "@renderer/lib/onboarding-core";
 import {
   connectorConnectionsQueryOptions,
@@ -62,15 +58,13 @@ import {
   queryKeys,
 } from "@renderer/lib/query";
 import { describeRemixRun } from "@renderer/lib/remix-run-state";
+import { remixReconnectLabel } from "@renderer/lib/remix-recovery";
 import { executeRemixTool } from "@renderer/lib/remix-tool-executor";
 import { useSpriteEmitter } from "@renderer/lib/sprite-emitter";
 import {
-  cancelDurableTurn,
   type DurableThreadAction,
   type DurableThreadRun,
   displayThreadTitle,
-  getThread,
-  getThreadRuntime,
   sendDurableTurnCommand,
   type ThreadState,
   type ThreadSummary,
@@ -81,16 +75,13 @@ import {
   type ToolPhase,
   toolPresentation,
 } from "@renderer/lib/tool-presentation";
+import { useRemixRecovery } from "@renderer/lib/use-remix-recovery";
 import { compactActivitySummary } from "@renderer/lib/workspace-navigation";
 import { SpriteBadge } from "@renderer/sprites/badge";
 import { type CompanionForm, DEFAULT_COMPANION_FORM } from "@shared/companion";
 import { PANEL_MAX_WIDTH, PANEL_MIN_WIDTH } from "@shared/panel";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  DefaultChatTransport,
-  lastAssistantMessageIsCompleteWithToolCalls,
-  type UIMessage,
-} from "ai";
+import type { UIMessage } from "ai";
 import {
   Check,
   Copy,
@@ -102,7 +93,7 @@ import {
   X,
 } from "lucide-react";
 import type React from "react";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 type WorkspaceView = "chat" | "history";
 
@@ -1350,46 +1341,22 @@ function PanelInner({
   // Whether the current draft arrived by voice, so message_sent can say so.
   const dictatedRef = useRef(false);
 
-  const durableRuntime = useQuery({
-    queryKey: ["durable-thread-runtime", thread.id],
-    queryFn: () => getThreadRuntime(thread.id),
-    enabled: !isSessionLoading,
-    retry: false,
-    refetchInterval: (query) =>
-      query.state.data?.activeTurn || query.state.data?.pendingAction
-        ? 1_000
-        : false,
-  });
-
-  const transport = useMemo(
-    () =>
-      new DefaultChatTransport({
-        api: "/api/agent",
-        body: { threadId: thread.id },
-        fetch: ((input: string | URL | Request, init?: RequestInit) =>
-          apiFetch(
-            typeof input === "string" ? input : "/api/agent",
-            init ?? {},
-          )) as typeof fetch,
-      }),
-    [thread.id],
-  );
-
   const {
     messages,
     sendMessage,
     regenerate,
-    stop,
+    cancel,
+    authorizeTool,
+    recovery,
+    queue,
+    canonical,
+    durableRuntime,
     status,
     addToolOutput,
     setMessages,
-    resumeStream,
-  } = useChat({
+  } = useRemixRecovery({
     id: thread.id,
     messages: thread.messages,
-    transport,
-    resume: true,
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     onFinish: ({ messages: finished }) => {
       queryClient.setQueryData(queryKeys.threads.detail(thread.id), {
         id: thread.id,
@@ -1537,59 +1504,10 @@ function PanelInner({
     });
   }, [messages.length, queryClient, thread.id]);
 
-  const busy = status === "submitted" || status === "streaming";
-  const queue = useAgentMessageQueue(thread.id);
-  const queueWasActiveRef = useRef(false);
-  const queueInitializedRef = useRef(false);
-  const queueHadItemsRef = useRef(false);
-  const queueNeedsRefreshRef = useRef(false);
-  const queueThreadRef = useRef(thread.id);
-  useEffect(() => {
-    if (queueThreadRef.current === thread.id) return;
-    queueThreadRef.current = thread.id;
-    queueWasActiveRef.current = false;
-    queueInitializedRef.current = false;
-    queueHadItemsRef.current = false;
-    queueNeedsRefreshRef.current = false;
-  }, [thread.id]);
-  useEffect(() => {
-    // Initial `resume: true` already attaches a newly opened workspace to a
-    // pill-owned stream. Resume only when the local queue later starts its
-    // next server-owned turn.
-    if (!queueInitializedRef.current) {
-      queueInitializedRef.current = true;
-      queueWasActiveRef.current = queue.active;
-      return;
-    }
-    if (!queue.active) {
-      queueWasActiveRef.current = false;
-      return;
-    }
-    if (busy || queueWasActiveRef.current) return;
-    queueWasActiveRef.current = true;
-    void getThread(thread.id)
-      .then((next) => {
-        if (next) setMessages(next.messages);
-        return resumeStream();
-      })
-      .catch(() => setNotice("Couldn’t resume the queued message."));
-  }, [busy, queue.active, resumeStream, setMessages, thread.id]);
-  useEffect(() => {
-    const hasItems = queue.items.length > 0;
-    if (queueHadItemsRef.current && !hasItems)
-      queueNeedsRefreshRef.current = true;
-    queueHadItemsRef.current = hasItems;
-    // If the local server completed a short follow-up between queue polls,
-    // there is no live stream to resume. Reload the durable thread once.
-    if (!queueNeedsRefreshRef.current || queue.active || busy) return;
-    queueNeedsRefreshRef.current = false;
-    void getThread(thread.id)
-      .then((next) => {
-        if (next) setMessages(next.messages);
-      })
-      .catch(() => {});
-  }, [busy, queue.active, queue.items.length, setMessages, thread.id]);
-  const action = composerAction(status);
+  const busy =
+    status === "submitted" ||
+    status === "streaming" ||
+    recovery.state.phase !== "idle";
   // The spark loader holds the floor until the first response text streams in;
   // once text is flowing, the growing message itself is the indicator.
   const lastMessage = messages[messages.length - 1];
@@ -1614,9 +1532,10 @@ function PanelInner({
     setNotice(null);
     setDraft("");
     if (busy) {
-      void queue
-        .enqueue(text)
-        .catch(() => setNotice("Couldn’t queue that message."));
+      void queue.enqueue(text).catch(() => {
+        setDraft(text);
+        setNotice("Couldn’t queue that message.");
+      });
       capture("remix_message_queued", { source: "typed", chars: text.length });
       return;
     }
@@ -1626,34 +1545,8 @@ function PanelInner({
 
   const stopGeneration = (): void => {
     if (!busy) return;
-    stop();
-    const cancel = (turnId: string) =>
-      void cancelDurableTurn(turnId)
-        .then(async () => {
-          await durableRuntime.refetch();
-          await queryClient.invalidateQueries({
-            queryKey: queryKeys.durableThreadRuns(thread.id),
-          });
-        })
-        .catch(() =>
-          setNotice(
-            "Stopped locally, but couldn't cancel the server turn. Check this conversation when you're back online.",
-          ),
-        );
-    const activeTurnId = durableRuntime.data?.activeTurn?.id;
-    if (activeTurnId) {
-      cancel(activeTurnId);
-      return;
-    }
-    // The first runtime poll can trail the streamed response by a moment. A
-    // one-off refetch closes that race so Stop remains server-authoritative.
-    void durableRuntime
-      .refetch()
-      .then(({ data }) => {
-        const turnId = data?.activeTurn?.id;
-        if (turnId) cancel(turnId);
-      })
-      .catch(() => {});
+    setApprovals([]);
+    void cancel();
   };
 
   const copyMessage = (message: UIMessage): void => {
@@ -1721,6 +1614,17 @@ function PanelInner({
     );
     void (async () => {
       const startedAt = Date.now();
+      try {
+        if (!approval.durable) await authorizeTool(call.toolCallId);
+      } catch (error) {
+        setApprovals((pending) => [...pending, approval]);
+        setNotice(
+          error instanceof Error
+            ? error.message
+            : "Couldn't confirm this action.",
+        );
+        return;
+      }
       const grant =
         allowed && call.toolName === "save_file"
           ? await requestAgentFileSaveGrant(call)
@@ -2321,7 +2225,8 @@ function PanelInner({
                       </div>
                     </div>
                   ) : null}
-                  {durableRuntime.data?.pendingAction?.kind === "desktop" &&
+                  {!canonical &&
+                  durableRuntime.data?.pendingAction?.kind === "desktop" &&
                   durableRuntime.data.pendingAction.status === "pending" ? (
                     <div className="tavern-approve">
                       <span className="tavern-approve-title">
@@ -2383,7 +2288,23 @@ function PanelInner({
                   />
                 </>
               ) : null}
-              {notice ? <p className="tavern-notice">{notice}</p> : null}
+              {recovery.state.phase !== "idle" ? (
+                <button
+                  type="button"
+                  className="tavern-notice"
+                  onClick={
+                    recovery.state.phase === "reconnecting"
+                      ? recovery.attempt
+                      : recovery.state.phase === "paused"
+                        ? recovery.resume
+                        : undefined
+                  }
+                >
+                  {remixReconnectLabel(recovery.state, recovery.now)}
+                </button>
+              ) : notice ? (
+                <p className="tavern-notice">{notice}</p>
+              ) : null}
             </div>
 
             {chatActive ? (
@@ -2424,37 +2345,30 @@ function PanelInner({
                       }
                     }}
                   />
+                  {busy ? (
+                    <button
+                      type="button"
+                      className="tavern-btn tavern-btn-send is-stop"
+                      aria-label="Stop generating"
+                      title="Stop generating"
+                      onClick={stopGeneration}
+                    >
+                      <WorkspaceIcon name="stop" />
+                    </button>
+                  ) : null}
                   <button
                     type="button"
-                    className={`tavern-btn tavern-btn-send${action === "stop" && !draft.trim() ? " is-stop" : ""}`}
-                    aria-label={
-                      action === "stop" && !draft.trim()
-                        ? "Stop generating"
-                        : busy
-                          ? "Queue message"
-                          : "Send"
-                    }
-                    title={
-                      action === "stop" && !draft.trim()
-                        ? "Stop generating"
-                        : busy
-                          ? "Queue message"
-                          : "Send"
-                    }
+                    className="tavern-btn tavern-btn-send"
+                    aria-label="Send"
+                    title={busy ? "Queue message" : "Send"}
                     disabled={
                       isSessionLoading ||
                       Boolean(sessionLoadError) ||
-                      (action !== "stop" && !draft.trim())
+                      !draft.trim()
                     }
-                    onClick={
-                      action === "stop" && !draft.trim() ? stopGeneration : send
-                    }
+                    onClick={send}
                   >
-                    <WorkspaceIcon
-                      name={
-                        action === "stop" && !draft.trim() ? "stop" : "send"
-                      }
-                    />
+                    <WorkspaceIcon name="send" />
                   </button>
                 </div>
               </>

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -2291,7 +2291,7 @@ function PanelInner({
               {recovery.desktop ? (
                 <button
                   type="button"
-                  className="tavern-notice"
+                  className="tavern-notice tavern-recovery-notice"
                   onClick={() =>
                     void recovery
                       .retryDesktop()
@@ -2305,7 +2305,7 @@ function PanelInner({
               ) : recovery.state.phase !== "idle" ? (
                 <button
                   type="button"
-                  className="tavern-notice"
+                  className="tavern-notice tavern-recovery-notice"
                   onClick={
                     recovery.state.phase === "reconnecting"
                       ? recovery.attempt

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -445,8 +445,8 @@ function MessageActions({
           className="tavern-msg-action"
           disabled={disabled}
           onClick={onEdit}
-          aria-label="Edit and resend message"
-          title="Edit and resend"
+          aria-label="Edit in new chat"
+          title="Edit in new chat (keeps this conversation)"
         >
           <Pencil aria-hidden="true" />
         </button>
@@ -457,8 +457,8 @@ function MessageActions({
           className="tavern-msg-action"
           disabled={disabled}
           onClick={onRegenerate}
-          aria-label="Regenerate response"
-          title="Regenerate response"
+          aria-label="Regenerate in new chat"
+          title="Regenerate in new chat (keeps this conversation)"
         >
           <RotateCcw aria-hidden="true" />
         </button>
@@ -508,6 +508,10 @@ function ChatMessage({
       <div className="tavern-msg tavern-msg-user-wrap">
         {editing ? (
           <div className="tavern-msg-edit">
+            <p>
+              Continue this edit in a new chat. This conversation stays
+              unchanged.
+            </p>
             <textarea
               className="tavern-msg-edit-input"
               value={editDraft}
@@ -537,7 +541,7 @@ function ChatMessage({
                 disabled={!editDraft.trim() || disabled}
                 onClick={onResendEdit}
               >
-                Send again
+                Send in new chat
               </button>
             </div>
           </div>
@@ -1357,6 +1361,11 @@ function PanelInner({
   } = useRemixRecovery({
     id: thread.id,
     messages: thread.messages,
+    onFork: onSwitchThread,
+    onActionUnavailable: (actionId) =>
+      setApprovals((pending) =>
+        pending.filter((item) => item.call.toolCallId !== actionId),
+      ),
     onFinish: ({ messages: finished }) => {
       queryClient.setQueryData(queryKeys.threads.detail(thread.id), {
         id: thread.id,
@@ -1394,7 +1403,7 @@ function PanelInner({
         input: toolCall.input,
       };
       const tier = await agentToolTier(call);
-      if (tier === "confirmed") {
+      if (tier === "confirmed" || toolCall.requiresConfirmation) {
         setApprovals((prev) => [...prev, { call }]);
         return;
       }
@@ -2288,7 +2297,21 @@ function PanelInner({
                   />
                 </>
               ) : null}
-              {recovery.state.phase !== "idle" ? (
+              {recovery.desktop ? (
+                <button
+                  type="button"
+                  className="tavern-notice"
+                  onClick={() =>
+                    void recovery
+                      .retryDesktop()
+                      .catch(() =>
+                        setNotice("This desktop action is not ready to retry."),
+                      )
+                  }
+                >
+                  Desktop action interrupted — Review before retrying
+                </button>
+              ) : recovery.state.phase !== "idle" ? (
                 <button
                   type="button"
                   className="tavern-notice"

--- a/apps/electron/src/renderer/src/components/panel.tsx
+++ b/apps/electron/src/renderer/src/components/panel.tsx
@@ -43,7 +43,6 @@ import {
   describeAgentApproval,
   executeAgentTool,
   reportAgentToolResult,
-  requestAgentFileSaveGrant,
 } from "@renderer/lib/agent-tools";
 import { capture } from "@renderer/lib/analytics";
 import { useCloudAuth } from "@renderer/lib/auth-context";
@@ -59,7 +58,10 @@ import {
 } from "@renderer/lib/query";
 import { describeRemixRun } from "@renderer/lib/remix-run-state";
 import { remixReconnectLabel } from "@renderer/lib/remix-recovery";
-import { executeRemixTool } from "@renderer/lib/remix-tool-executor";
+import {
+  executeApprovedRemixTool,
+  executeRemixTool,
+} from "@renderer/lib/remix-tool-executor";
 import { useSpriteEmitter } from "@renderer/lib/sprite-emitter";
 import {
   type DurableThreadAction,
@@ -1634,20 +1636,9 @@ function PanelInner({
         );
         return;
       }
-      const grant =
-        allowed && call.toolName === "save_file"
-          ? await requestAgentFileSaveGrant(call)
-          : null;
       const output = !allowed
         ? DECLINED_OUTPUT
-        : grant && grant.ok !== true
-          ? grant
-          : await executeAgentTool(call, {
-              saveFileGrant:
-                grant && typeof grant.grant === "string"
-                  ? grant.grant
-                  : undefined,
-            });
+        : await executeApprovedRemixTool(call);
       reportAgentToolResult(call, output, startedAt);
       if (approval.durable) {
         await sendDurableTurnCommand(approval.durable.turnId, {

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -12,12 +12,14 @@ import {
   describeAgentApproval,
   executeAgentTool,
   reportAgentToolResult,
-  requestAgentFileSaveGrant,
 } from "@renderer/lib/agent-tools";
 import { capture } from "@renderer/lib/analytics";
 import { apiFetch } from "@renderer/lib/api";
 import { remixReconnectLabel } from "@renderer/lib/remix-recovery";
-import { executeRemixTool } from "@renderer/lib/remix-tool-executor";
+import {
+  executeApprovedRemixTool,
+  executeRemixTool,
+} from "@renderer/lib/remix-tool-executor";
 import { useRemixRecovery } from "@renderer/lib/use-remix-recovery";
 import {
   type DynamicToolUIPart,
@@ -322,20 +324,14 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
         }
         let output: Record<string, unknown>;
         try {
-          const grant =
-            allowed && call.toolName === "save_file"
-              ? await requestAgentFileSaveGrant(call)
-              : null;
           output = !allowed
             ? DECLINED_OUTPUT
-            : grant && grant.ok !== true
-              ? grant
-              : await executeAgentTool(call, {
-                  saveFileGrant:
-                    grant && typeof grant.grant === "string"
-                      ? grant.grant
-                      : undefined,
-                });
+            : await executeApprovedRemixTool(call, {
+                onContext: (context) => {
+                  contextRef.current = context;
+                  setLiveContext(context);
+                },
+              });
         } catch (error) {
           output = {
             ok: false,

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -1,4 +1,3 @@
-import { useChat } from "@ai-sdk/react";
 import { REMIX_PRESETS, type RemixPreset } from "@freestyle-voice/validations";
 import { AgentMessageQueueControls } from "@renderer/components/agent-message-queue";
 import { AgentActivity } from "@renderer/components/agents/agent-activity";
@@ -6,7 +5,6 @@ import type { AgentActivityItem } from "@renderer/components/agents/agent-activi
 import { AgentDisclosure } from "@renderer/components/agents/agent-disclosure";
 import { RotatingThinkingLabel } from "@renderer/components/agents/loading-states/rotating-thinking-label";
 import { MessageScroller } from "@renderer/components/agents/message-scroller";
-import { useAgentMessageQueue } from "@renderer/lib/agent-message-queue";
 import {
   type AgentToolCall,
   agentToolTier,
@@ -17,20 +15,15 @@ import {
   requestAgentFileSaveGrant,
 } from "@renderer/lib/agent-tools";
 import { capture } from "@renderer/lib/analytics";
-import { apiFetch, initApiBase } from "@renderer/lib/api";
+import { apiFetch } from "@renderer/lib/api";
+import { remixReconnectLabel } from "@renderer/lib/remix-recovery";
 import { executeRemixTool } from "@renderer/lib/remix-tool-executor";
+import { useRemixRecovery } from "@renderer/lib/use-remix-recovery";
 import {
-  cancelDurableTurn,
-  getThread,
-  getThreadRuntime,
-} from "@renderer/lib/threads";
-import {
-  DefaultChatTransport,
   type DynamicToolUIPart,
   getToolOrDynamicToolName,
   isTextUIPart,
   isToolOrDynamicToolUIPart,
-  lastAssistantMessageIsCompleteWithToolCalls,
   type ToolUIPart,
   type UIMessage,
 } from "ai";
@@ -232,51 +225,6 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
-  const transport = useMemo(
-    () =>
-      new DefaultChatTransport<UIMessage>({
-        api: "/api/agent",
-
-        fetch: (async (_input: unknown, init?: RequestInit) => {
-          // The pill is often the first renderer to contact the server after
-          // launch. Resolve the configured target before its first agent turn.
-          await initApiBase();
-          const res = await apiFetch("/api/agent", init ?? {});
-          if (res.status === 401) {
-            void window.api?.cloudPromptSignIn?.();
-            throw new Error("Sign in to Freestyle Cloud to use Remix.");
-          }
-          if (res.status === 429) {
-            void window.api?.cloudPromptUpgrade?.();
-            throw new Error("You've hit this week's free limit.");
-          }
-          if (!res.ok) {
-            const body = (await res.json().catch(() => null)) as {
-              detail?: string;
-            } | null;
-            throw new Error(body?.detail || `Remix failed (${res.status}).`);
-          }
-          return res;
-        }) as typeof fetch,
-        prepareSendMessagesRequest: ({ messages }) => ({
-          body: {
-            messages,
-            threadId: thread.id,
-            ...(messages.length <= 1 ? { firstTurn: true } : {}),
-            context: {
-              selection: contextRef.current.text,
-              appName: contextRef.current.appName,
-              windowTitle: contextRef.current.windowTitle,
-              clipboard: contextRef.current.clipboard ?? null,
-              clipboardLength: contextRef.current.clipboardLength ?? 0,
-              capturedAt: contextRef.current.capturedAt,
-            },
-          },
-        }),
-      }),
-    [thread.id],
-  );
-
   const {
     messages,
     sendMessage,
@@ -284,14 +232,21 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
     status,
     stop,
     clearError,
-    setMessages,
-    resumeStream,
-  } = useChat<UIMessage>({
+    cancel,
+    authorizeTool,
+    recovery,
+    queue,
+  } = useRemixRecovery({
     id: thread.id,
     messages: thread.messages,
-    transport,
-    resume: true,
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    context: () => ({
+      selection: contextRef.current.text,
+      appName: contextRef.current.appName,
+      windowTitle: contextRef.current.windowTitle,
+      clipboard: contextRef.current.clipboard ?? null,
+      clipboardLength: contextRef.current.clipboardLength ?? 0,
+      capturedAt: contextRef.current.capturedAt,
+    }),
     onToolCall: async ({ toolCall }) => {
       const call: AgentToolCall = {
         toolName: toolCall.toolName,
@@ -320,7 +275,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
             });
       if (tier !== null) reportAgentToolResult(call, output, startedAt);
       void addToolResult({
-        tool: getToolOrDynamicToolName(toolCall as never) as never,
+        tool: toolCall.toolName,
         toolCallId: (toolCall as { toolCallId: string }).toolCallId,
         output,
       });
@@ -333,6 +288,9 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
       window.api?.remixThreadUpdated?.(thread.id);
     },
     onError: (err) => {
+      const status = (err as Error & { status?: number }).status;
+      if (status === 401) void window.api?.cloudPromptSignIn?.();
+      if (status === 429) void window.api?.cloudPromptUpgrade?.();
       setNotice(err.message || "Remix failed.");
     },
   });
@@ -346,6 +304,18 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
       setResolvingApprovalId(call.toolCallId);
       void (async () => {
         const startedAt = Date.now();
+        try {
+          await authorizeTool(call.toolCallId);
+        } catch (error) {
+          setNotice(
+            error instanceof Error
+              ? error.message
+              : "Couldn't confirm this action.",
+          );
+          resolvingApprovalRef.current = null;
+          setResolvingApprovalId(null);
+          return;
+        }
         let output: Record<string, unknown>;
         try {
           const grant =
@@ -382,62 +352,13 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
         });
       })();
     },
-    [addToolResult],
+    [addToolResult, authorizeTool],
   );
 
-  const busy = status === "submitted" || status === "streaming";
-  const queue = useAgentMessageQueue(thread.id);
-  const queueWasActiveRef = useRef(false);
-  const queueInitializedRef = useRef(false);
-  const queueHadItemsRef = useRef(false);
-  const queueNeedsRefreshRef = useRef(false);
-  const queueThreadRef = useRef(thread.id);
-  useEffect(() => {
-    if (queueThreadRef.current === thread.id) return;
-    queueThreadRef.current = thread.id;
-    queueWasActiveRef.current = false;
-    queueInitializedRef.current = false;
-    queueHadItemsRef.current = false;
-    queueNeedsRefreshRef.current = false;
-  }, [thread.id]);
-  useEffect(() => {
-    // The first observation is commonly the same stream that `resume: true`
-    // already attached to during a pill/workspace handoff. Only a later idle
-    // → active change belongs to a server-drained queued message.
-    if (!queueInitializedRef.current) {
-      queueInitializedRef.current = true;
-      queueWasActiveRef.current = queue.active;
-      return;
-    }
-    if (!queue.active) {
-      queueWasActiveRef.current = false;
-      return;
-    }
-    if (busy || queueWasActiveRef.current) return;
-    queueWasActiveRef.current = true;
-    void getThread(thread.id)
-      .then((next) => {
-        if (next) setMessages(next.messages);
-        return resumeStream();
-      })
-      .catch(() => setNotice("Couldn’t resume the queued message."));
-  }, [busy, queue.active, resumeStream, setMessages, thread.id]);
-  useEffect(() => {
-    const hasItems = queue.items.length > 0;
-    if (queueHadItemsRef.current && !hasItems)
-      queueNeedsRefreshRef.current = true;
-    queueHadItemsRef.current = hasItems;
-    // A very short server-owned follow-up may finish between queue polls, so
-    // there is no active stream for `resumeStream()` to attach to. Refresh the
-    // canonical thread once the entry leaves the queue in that case.
-    if (!queueNeedsRefreshRef.current || queue.active || busy) return;
-    queueNeedsRefreshRef.current = false;
-    void getThread(thread.id)
-      .then((next) => {
-        if (next) setMessages(next.messages);
-      })
-      .catch(() => {});
-  }, [busy, queue.active, queue.items.length, setMessages, thread.id]);
+  const busy =
+    status === "submitted" ||
+    status === "streaming" ||
+    recovery.state.phase !== "idle";
   const dispatchInFlightRef = useRef(false);
   const cancellationRequestedRef = useRef(false);
   const sawBusySinceDispatchRef = useRef(false);
@@ -465,6 +386,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
 
   useEffect(() => {
     if (busy) {
+      cancellationRequestedRef.current = false;
       sawBusySinceDispatchRef.current = true;
       return;
     }
@@ -561,18 +483,9 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
   const cancelActiveTurn = useCallback(() => {
     if (cancellationRequestedRef.current) return;
     cancellationRequestedRef.current = true;
-    void stop();
-    // Stream abort is immediate. If this request has a durable Cloud turn,
-    // cancel it too so it cannot keep invoking tools after the pill closes.
-    void getThreadRuntime(thread.id)
-      .then((runtime) => {
-        if (runtime?.activeTurn) {
-          return cancelDurableTurn(runtime.activeTurn.id);
-        }
-        return undefined;
-      })
-      .catch(() => {});
-  }, [stop, thread.id]);
+    setApprovals([]);
+    void cancel();
+  }, [cancel]);
   useEffect(() => {
     props.onCancelActive(cancelActiveTurn);
     return () => props.onCancelActive(null);
@@ -708,7 +621,8 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
       : props.voiceStatus === "transcribing"
         ? "Transcribing…"
         : null;
-  const displayNotice = notice ?? props.voiceNotice;
+  const reconnectNotice = remixReconnectLabel(recovery.state, recovery.now);
+  const displayNotice = reconnectNotice ?? notice ?? props.voiceNotice;
   const miniProgress =
     voiceLabel ??
     (waitingForApproval ? "Approval needed" : null) ??
@@ -795,7 +709,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
 
   const submit = useCallback(() => {
     const text = input.trim();
-    if (!text || dispatchInFlightRef.current) return;
+    if (!text || (dispatchInFlightRef.current && !busy)) return;
     setInput("");
     const el = inputRef.current;
     if (el) el.style.height = "auto";
@@ -810,7 +724,10 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
           clipboardLength: context.clipboardLength ?? 0,
           capturedAt: context.capturedAt,
         })
-        .catch(() => setNotice("Couldn’t queue that message."));
+        .catch(() => {
+          setInput(text);
+          setNotice("Couldn’t queue that message.");
+        });
       capture("remix_message_queued", { source: "typed" });
       return;
     }
@@ -1126,11 +1043,26 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
             ) : null}
           </MessageScroller>
 
-          {displayNotice && (
-            <div className="remix-chat-notice" role="alert">
-              {displayNotice}
-            </div>
-          )}
+          {displayNotice &&
+            (reconnectNotice ? (
+              <button
+                type="button"
+                className="remix-chat-notice"
+                onClick={
+                  recovery.state.phase === "reconnecting"
+                    ? recovery.attempt
+                    : recovery.state.phase === "paused"
+                      ? recovery.resume
+                      : undefined
+                }
+              >
+                {displayNotice}
+              </button>
+            ) : (
+              <div className="remix-chat-notice" role="alert">
+                {displayNotice}
+              </div>
+            ))}
 
           {!busy &&
           props.voiceStatus === null &&
@@ -1171,14 +1103,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
                   rows={1}
                   value={input}
                   aria-label="Message Remix"
-                  placeholder={
-                    waitingForApproval
-                      ? "Resolve the approval above…"
-                      : busy
-                        ? "Add a follow-up…"
-                        : "Message Remix…"
-                  }
-                  disabled={waitingForApproval || resolvingApprovalId !== null}
+                  placeholder={busy ? "Add a follow-up…" : "Message Remix…"}
                   onChange={(e) => {
                     setInput(e.target.value);
                     const el = e.currentTarget;
@@ -1196,7 +1121,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
                   <button
                     type="button"
                     className="remix-chat-send"
-                    onClick={() => stop()}
+                    onClick={cancelActiveTurn}
                     aria-label="Stop"
                     title="Stop"
                   >
@@ -1209,36 +1134,31 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
                       <rect x="1.5" y="1.5" width="9" height="9" rx="2" />
                     </svg>
                   </button>
-                ) : (
-                  <button
-                    type="button"
-                    className="remix-chat-send"
-                    disabled={
-                      !input.trim() ||
-                      waitingForApproval ||
-                      resolvingApprovalId !== null
-                    }
-                    onClick={submit}
-                    aria-label="Send"
-                    title="Send"
+                ) : null}
+                <button
+                  type="button"
+                  className="remix-chat-send"
+                  disabled={!input.trim()}
+                  onClick={submit}
+                  aria-label="Send"
+                  title="Send"
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 16 16"
+                    aria-hidden="true"
                   >
-                    <svg
-                      width="14"
-                      height="14"
-                      viewBox="0 0 16 16"
-                      aria-hidden="true"
-                    >
-                      <path
-                        d="M8 12.8V3.6M4.1 7.4 8 3.5l3.9 3.9"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="1.8"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      />
-                    </svg>
-                  </button>
-                )}
+                    <path
+                      d="M8 12.8V3.6M4.1 7.4 8 3.5l3.9 3.9"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
               </div>
             </>
           )}
@@ -1979,12 +1899,18 @@ const REMIX_CHAT_CSS = `
     color: ${INK_FAINT};
   }
   .remix-chat-action[data-failed="true"] { color: rgba(224, 128, 95, 0.9); }
-  .remix-chat-notice {
-    font-size: 11px;
-    color: rgba(224, 128, 95, 0.95);
-    padding: 6px 18px 0;
-    line-height: 1.35;
-  }
+   .remix-chat-notice {
+     display: block;
+     width: 100%;
+     border: 0;
+     background: transparent;
+     font-size: 11px;
+     color: rgba(224, 128, 95, 0.95);
+     padding: 6px 18px 0;
+     line-height: 1.35;
+     text-align: left;
+     cursor: pointer;
+   }
 
   .remix-chat-approval {
     display: flex;

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -239,6 +239,10 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
   } = useRemixRecovery({
     id: thread.id,
     messages: thread.messages,
+    onActionUnavailable: (actionId) =>
+      setApprovals((pending) =>
+        pending.filter((item) => item.call.toolCallId !== actionId),
+      ),
     context: () => ({
       selection: contextRef.current.text,
       appName: contextRef.current.appName,
@@ -255,7 +259,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
       };
       const startedAt = Date.now();
       const tier = await agentToolTier(call);
-      if (tier === "confirmed") {
+      if (tier === "confirmed" || toolCall.requiresConfirmation) {
         props.onExpand();
         setApprovals((pending) =>
           pending.some((item) => item.call.toolCallId === call.toolCallId)
@@ -1043,7 +1047,22 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
             ) : null}
           </MessageScroller>
 
-          {displayNotice &&
+          {recovery.desktop ? (
+            <button
+              type="button"
+              className="remix-chat-notice"
+              onClick={() =>
+                void recovery
+                  .retryDesktop()
+                  .catch(() =>
+                    setNotice("This desktop action is not ready to retry."),
+                  )
+              }
+            >
+              Desktop action interrupted — Review before retrying
+            </button>
+          ) : (
+            displayNotice &&
             (reconnectNotice ? (
               <button
                 type="button"
@@ -1062,7 +1081,8 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
               <div className="remix-chat-notice" role="alert">
                 {displayNotice}
               </div>
-            ))}
+            ))
+          )}
 
           {!busy &&
           props.voiceStatus === null &&

--- a/apps/electron/src/renderer/src/components/remix-chat.tsx
+++ b/apps/electron/src/renderer/src/components/remix-chat.tsx
@@ -1046,7 +1046,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
           {recovery.desktop ? (
             <button
               type="button"
-              className="remix-chat-notice"
+              className="remix-chat-notice remix-chat-recovery-notice"
               onClick={() =>
                 void recovery
                   .retryDesktop()
@@ -1062,7 +1062,7 @@ function RemixThread(props: RemixThreadProps): React.JSX.Element {
             (reconnectNotice ? (
               <button
                 type="button"
-                className="remix-chat-notice"
+                className="remix-chat-notice remix-chat-recovery-notice"
                 onClick={
                   recovery.state.phase === "reconnecting"
                     ? recovery.attempt
@@ -1927,6 +1927,30 @@ const REMIX_CHAT_CSS = `
      text-align: left;
      cursor: pointer;
    }
+  .remix-chat-recovery-notice {
+    display: inline-flex;
+    width: fit-content;
+    align-items: center;
+    min-height: 28px;
+    margin: 6px 18px 0;
+    padding: 5px 10px;
+    border: 1px solid rgba(224, 128, 95, 0.42);
+    border-radius: 999px;
+    background: rgba(224, 128, 95, 0.10);
+    box-shadow: inset 0 1px 0 rgba(245, 241, 228, 0.06);
+    color: rgba(246, 180, 148, 0.98);
+    font-weight: 600;
+    transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+  }
+  .remix-chat-recovery-notice:hover {
+    border-color: rgba(246, 180, 148, 0.76);
+    background: rgba(224, 128, 95, 0.18);
+    color: ${INK};
+  }
+  .remix-chat-recovery-notice:focus-visible {
+    outline: 2px solid rgba(246, 180, 148, 0.88);
+    outline-offset: 2px;
+  }
 
   .remix-chat-approval {
     display: flex;

--- a/apps/electron/src/renderer/src/lib/remix-recovery-controller.test.ts
+++ b/apps/electron/src/renderer/src/lib/remix-recovery-controller.test.ts
@@ -1,0 +1,312 @@
+import type { UIMessage } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  REMIX_CONTINUATION,
+  RemixRecoveryController,
+} from "./remix-recovery-controller";
+
+const context = {
+  selection: null,
+  appName: null,
+  windowTitle: null,
+  capturedAt: 1,
+};
+function fixture() {
+  const values = new Map<string, string>();
+  const storage = {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
+  let offline = false;
+  let status = "running";
+  let messages: UIMessage[] = [];
+  let requestId = "";
+  let action: Record<string, unknown> | null = null;
+  let assistant: UIMessage | null = null;
+  const queue: Array<{ id: string; text: string; createdAt: number }> = [];
+  const requests: Array<{
+    path: string;
+    body?: Record<string, unknown>;
+    at: number;
+  }> = [];
+  const fetch = vi.fn(async (path: string, init?: RequestInit) => {
+    const body = init?.body
+      ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+      : undefined;
+    requests.push({ path, body, at: Date.now() });
+    if (path === "/api/auth/status")
+      return Response.json({ user: { id: "user-a" } });
+    if (path === "/api/remix/thread-a/queue") {
+      if (body?.text)
+        queue.push({
+          id: crypto.randomUUID(),
+          text: String(body.text),
+          createdAt: Date.now(),
+        });
+      return Response.json({
+        items: queue,
+        active:
+          Boolean(requestId) &&
+          !["completed", "failed", "canceled"].includes(status),
+      });
+    }
+    if (offline) throw new TypeError("Network unavailable");
+    if (path === "/api/remix/turns") {
+      requestId = String(body!.clientRequestId);
+      messages = body!.messages as UIMessage[];
+      return Response.json(
+        { turn: { id: "turn-a", status, clientRequestId: requestId } },
+        { status: 202 },
+      );
+    }
+    if (path.endsWith("/commands")) {
+      if (body!.type === "cancel") status = "canceled";
+      if (body!.type === "desktop_claim")
+        return Response.json({
+          action: { toolName: "Bash", input: { command: "pwd" } },
+        });
+      return Response.json({ receipt: { accepted: true } });
+    }
+    if (path === "/api/remix/thread/thread-a")
+      return Response.json({
+        thread: { id: "thread-a", messages },
+        activeTurn: requestId ? { id: "turn-a", status } : null,
+        pendingAction: action,
+      });
+    if (path === "/api/remix/turns/turn-a")
+      return Response.json({
+        turn: { id: "turn-a", status, clientRequestId: requestId },
+        checkpoint: { messages, context, assistant },
+      });
+    return Response.json({}, { status: 404 });
+  });
+  const onToolCall = vi.fn(async () => {});
+  const onFinish = vi.fn();
+  const onError = vi.fn();
+  const create = () =>
+    new RemixRecoveryController({
+      threadId: "thread-a",
+      messages: [],
+      fetch,
+      storage,
+      onToolCall,
+      onFinish,
+      onError,
+      requiresApproval: () => true,
+    });
+  return {
+    create,
+    requests,
+    onToolCall,
+    onFinish,
+    onError,
+    values,
+    offline: (value: boolean) => {
+      offline = value;
+    },
+    status: (value: string) => {
+      status = value;
+    },
+    approval: () => {
+      action = {
+        id: "action-a",
+        turnId: "turn-a",
+        kind: "desktop",
+        toolName: "Bash",
+        status: "pending",
+      };
+      assistant = {
+        id: "assistant-a",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "Bash",
+            toolCallId: "call-a",
+            state: "output-available",
+            input: { command: "pwd" },
+            output: { desktopAction: { actionId: "action-a" } },
+          },
+        ],
+      };
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+});
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe("durable Remix recovery", () => {
+  it("makes exactly five reconnects at 3/6/12/24/30 seconds and pauses", async () => {
+    const f = fixture();
+    const controller = f.create();
+    await controller.send("Hello", context);
+    f.offline(true);
+    await vi.advanceTimersByTimeAsync(1_000);
+    for (const delay of [3_000, 6_000, 12_000, 24_000, 30_000]) {
+      const before = f.requests.length;
+      await vi.advanceTimersByTimeAsync(delay - 1);
+      expect(f.requests).toHaveLength(before);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(f.requests).toHaveLength(before + 1);
+    }
+    expect(controller.getSnapshot().recovery).toEqual({
+      phase: "paused",
+      attempts: 5,
+    });
+    const count = f.requests.length;
+    await vi.advanceTimersByTimeAsync(100_000);
+    expect(f.requests).toHaveLength(count);
+    expect(
+      f.requests.filter((request) => request.path === "/api/remix/turns"),
+    ).toHaveLength(1);
+  });
+
+  it("retries immediately when clicked, cancels the old timer, and retains the receipt ID", async () => {
+    const f = fixture();
+    const controller = f.create();
+    f.offline(true);
+    await controller.send("Hello", context);
+    const id = f.requests.find((request) => request.body?.clientRequestId)?.body
+      ?.clientRequestId;
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.all([controller.retry(), controller.retry()]);
+    const submissions = f.requests.filter(
+      (request) => request.path === "/api/remix/turns",
+    );
+    expect(submissions).toHaveLength(2);
+    expect(submissions[1].body?.clientRequestId).toBe(id);
+    const count = f.requests.length;
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(f.requests).toHaveLength(count);
+    expect(controller.getSnapshot().recovery).toEqual({
+      phase: "reconnecting",
+      attempts: 1,
+      retryAt: 6_500,
+    });
+  });
+
+  it.each([
+    "completed",
+    "failed",
+    "canceled",
+  ])("stops recovery at the authoritative %s state", async (status) => {
+    const f = fixture();
+    const controller = f.create();
+    await controller.send("Hello", context);
+    f.offline(true);
+    await vi.advanceTimersByTimeAsync(1_000);
+    f.offline(false);
+    f.status(status);
+    await controller.retry();
+    expect(controller.getSnapshot().recovery.phase).toBe("idle");
+    expect(controller.getSnapshot().status).toBe("ready");
+    const count = f.requests.length;
+    await vi.advanceTimersByTimeAsync(100_000);
+    expect(f.requests).toHaveLength(count);
+    expect(f.onFinish).toHaveBeenCalledOnce();
+  });
+
+  it("retains offline Stop and queued follow-ups through a window restart", async () => {
+    const f = fixture();
+    const first = f.create();
+    await first.send("Hello", context);
+    await first.enqueue("Follow up", context);
+    f.offline(true);
+    await first.stop();
+    first.dispose();
+    expect(first.getSnapshot().queue[0].text).toBe("Follow up");
+    f.offline(false);
+    const second = f.create();
+    await second.start();
+    expect(f.requests.some((request) => request.body?.type === "cancel")).toBe(
+      true,
+    );
+    expect(second.getSnapshot().queue[0].text).toBe("Follow up");
+    expect(
+      f.requests.filter((request) => request.path === "/api/remix/turns"),
+    ).toHaveLength(1);
+  });
+
+  it("Resume submits the visible continuation as a new immutable turn", async () => {
+    const f = fixture();
+    const controller = f.create();
+    await controller.send("Hello", context);
+    f.offline(true);
+    await vi.advanceTimersByTimeAsync(76_000);
+    expect(controller.getSnapshot().recovery.phase).toBe("paused");
+    f.offline(false);
+    f.status("running");
+    await controller.resume(context);
+    const submissions = f.requests.filter(
+      (request) => request.path === "/api/remix/turns",
+    );
+    expect(submissions).toHaveLength(2);
+    expect(submissions[1].body?.clientRequestId).not.toBe(
+      submissions[0].body?.clientRequestId,
+    );
+    const messages = submissions[1].body?.messages as UIMessage[];
+    expect(messages.at(-1)?.parts).toEqual([
+      { type: "text", text: REMIX_CONTINUATION },
+    ]);
+  });
+
+  it("keeps approval unclaimed during handoff and claims only on a user decision", async () => {
+    const f = fixture();
+    f.approval();
+    const first = f.create();
+    await first.send("Hello", context);
+    expect(f.onToolCall).toHaveBeenCalledOnce();
+    expect(
+      f.requests.some((request) => request.body?.type === "desktop_claim"),
+    ).toBe(false);
+    first.dispose();
+    const second = f.create();
+    await second.start();
+    expect(f.onToolCall).toHaveBeenCalledTimes(2);
+    await second.authorizeTool("action-a");
+    f.offline(true);
+    await second.complete("action-a", { ok: true });
+    second.dispose();
+    f.offline(false);
+    const third = f.create();
+    await third.start();
+    const completions = f.requests.filter(
+      (request) => request.body?.type === "desktop_complete",
+    );
+    expect(completions.at(-1)?.body?.result).toEqual({ ok: true });
+    expect(
+      f.requests.filter((request) => request.body?.type === "desktop_claim"),
+    ).toHaveLength(1);
+  });
+
+  it("hands queued follow-ups to the durable server owner", async () => {
+    const f = fixture();
+    const controller = f.create();
+    await controller.send("Hello", context);
+    await controller.enqueue("Follow up", context);
+    expect(controller.getSnapshot().queue).toHaveLength(1);
+    f.status("completed");
+    await vi.advanceTimersByTimeAsync(1_001);
+    expect(controller.getSnapshot().queue).toHaveLength(1);
+    const submissions = f.requests.filter(
+      (request) => request.path === "/api/remix/turns",
+    );
+    expect(submissions).toHaveLength(1);
+    expect(
+      f.requests.some(
+        (request) =>
+          request.path === "/api/remix/thread-a/queue" &&
+          request.body?.text === "Follow up",
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/electron/src/renderer/src/lib/remix-recovery-controller.test.ts
+++ b/apps/electron/src/renderer/src/lib/remix-recovery-controller.test.ts
@@ -36,12 +36,12 @@ function fixture() {
       ? (JSON.parse(String(init.body)) as Record<string, unknown>)
       : undefined;
     requests.push({ path, body, at: Date.now() });
-    if (path === "/api/auth/status")
-      return Response.json({ user: { id: "user-a" } });
+    if (path === "/api/remix/identity")
+      return Response.json({ userId: "user-a", host: "https://cloud.test" });
     if (path === "/api/remix/thread-a/queue") {
       if (body?.text)
         queue.push({
-          id: crypto.randomUUID(),
+          id: String(body.requestId),
           text: String(body.text),
           createdAt: Date.now(),
         });

--- a/apps/electron/src/renderer/src/lib/remix-recovery-controller.test.ts
+++ b/apps/electron/src/renderer/src/lib/remix-recovery-controller.test.ts
@@ -53,6 +53,7 @@ function fixture() {
       });
     }
     if (offline) throw new TypeError("Network unavailable");
+    if (path.includes("/actions/")) return Response.json({ action });
     if (path === "/api/remix/turns") {
       requestId = String(body!.clientRequestId);
       messages = body!.messages as UIMessage[];

--- a/apps/electron/src/renderer/src/lib/remix-recovery-controller.ts
+++ b/apps/electron/src/renderer/src/lib/remix-recovery-controller.ts
@@ -160,20 +160,18 @@ export class RemixRecoveryController {
     body?: unknown,
     method = body === undefined ? "GET" : "POST",
   ): Promise<T> {
-    const response = await this.options.fetch(
-      path,
-      body === undefined && method === "GET"
-        ? undefined
-        : {
-            method,
-            headers: {
-              "Content-Type": "application/json",
-              "X-Remix-User": this.ownerId,
-              "X-Remix-Host": encodeURIComponent(this.ownerHost),
-            },
-            ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-          },
-    );
+    const response = await this.options.fetch(path, {
+      method,
+      // Reads are account-scoped too. A mounted observer can outlive a
+      // sign-out, so every request after identity discovery must carry the
+      // identity it was initialized under.
+      headers: {
+        "X-Remix-User": this.ownerId,
+        "X-Remix-Host": encodeURIComponent(this.ownerHost),
+        ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
     if (!response.ok)
       throw Object.assign(
         new Error(

--- a/apps/electron/src/renderer/src/lib/remix-recovery-controller.ts
+++ b/apps/electron/src/renderer/src/lib/remix-recovery-controller.ts
@@ -1,0 +1,586 @@
+import type { UIMessage } from "ai";
+import { nextRemixReconnect, type RemixReconnectState } from "./remix-recovery";
+import type { DurableThreadRuntime } from "./threads";
+
+export const REMIX_CONTINUATION = "Continue from where you left off.";
+type Turn = {
+  id: string;
+  status: string;
+  error?: string | null;
+  clientRequestId?: string;
+};
+type Admission = {
+  threadId: string;
+  clientRequestId: string;
+  messages: UIMessage[];
+  context: unknown;
+  firstTurn?: boolean;
+};
+type Receipt = {
+  turn: Turn;
+  checkpoint?: {
+    messages?: UIMessage[];
+    context?: unknown;
+    assistant?: UIMessage | null;
+  } | null;
+};
+export type RemixQueueItem = {
+  id: string;
+  text: string;
+  createdAt: number;
+  context?: unknown;
+};
+type Completion = {
+  turnId: string;
+  actionId: string;
+  clientId: string;
+  result: unknown;
+};
+type Saved = {
+  request?: Admission;
+  turn?: Turn;
+  cancels: Array<{ turn?: Turn; request?: Admission }>;
+  queue: RemixQueueItem[];
+  completions: Completion[];
+};
+export type RemixRecoverySnapshot = {
+  messages: UIMessage[];
+  status: "ready" | "submitted" | "streaming" | "error";
+  recovery: RemixReconnectState;
+  queue: RemixQueueItem[];
+  canonical: boolean;
+  runtime: DurableThreadRuntime | null;
+};
+type Options = {
+  threadId: string;
+  messages: UIMessage[];
+  fetch: (path: string, init?: RequestInit) => Promise<Response>;
+  storage?: Pick<Storage, "getItem" | "setItem">;
+  onToolCall: (call: {
+    toolName: string;
+    toolCallId: string;
+    input: unknown;
+  }) => Promise<void>;
+  requiresApproval?: (toolName: string) => boolean;
+  onFinish?: (messages: UIMessage[]) => void;
+  onError?: (error: Error) => void;
+};
+const terminal = new Set(["completed", "failed", "canceled"]);
+const emptySaved = (): Saved => ({ cancels: [], queue: [], completions: [] });
+
+/** Shared durable observer. Requests retain their admission ID across network
+ * retries; only explicit Send or Resume creates a new user turn. */
+export class RemixRecoveryController {
+  private saved = emptySaved();
+  private key = "";
+  private ownerId = "";
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private inFlight: Promise<void> | null = null;
+  private attempts = 0;
+  private disposed = false;
+  private generation = 0;
+  private readonly listeners = new Set<() => void>();
+  private readonly claims = new Map<string, Completion>();
+  private readonly seenActions = new Set<string>();
+  private readonly pendingApprovals = new Map<
+    string,
+    { turnId: string; toolName: string; input: unknown }
+  >();
+  private readonly clientId = crypto.randomUUID();
+  private initialized: Promise<void> | null = null;
+  private snapshot: RemixRecoverySnapshot;
+  constructor(private readonly options: Options) {
+    this.snapshot = {
+      messages: options.messages,
+      status: "ready",
+      recovery: { phase: "idle" },
+      queue: [],
+      canonical: false,
+      runtime: null,
+    };
+  }
+  getSnapshot = () => this.snapshot;
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+  private update(patch: Partial<RemixRecoverySnapshot>) {
+    if (this.disposed) return;
+    this.snapshot = { ...this.snapshot, ...patch };
+    for (const listener of this.listeners) listener();
+  }
+  private persist() {
+    if (this.key)
+      this.options.storage?.setItem(this.key, JSON.stringify(this.saved));
+  }
+  private async json<T>(
+    path: string,
+    body?: unknown,
+    method = body === undefined ? "GET" : "POST",
+  ): Promise<T> {
+    if (method !== "GET" && this.ownerId) {
+      const auth = await this.options.fetch("/api/auth/status");
+      const identity = auth.ok
+        ? ((await auth.json()) as { user?: { id: string } })
+        : null;
+      if (identity?.user?.id !== this.ownerId)
+        throw Object.assign(
+          new Error("Sign in with the account that started this conversation."),
+          { status: 401 },
+        );
+    }
+    const response = await this.options.fetch(
+      path,
+      body === undefined && method === "GET"
+        ? undefined
+        : {
+            method,
+            headers: { "Content-Type": "application/json" },
+            ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+          },
+    );
+    if (!response.ok)
+      throw Object.assign(
+        new Error(
+          response.status === 401
+            ? "Sign in to Freestyle Cloud to use Remix."
+            : response.status === 429
+              ? "You've hit this week's free limit."
+              : `Remix request failed (${response.status}).`,
+        ),
+        { status: response.status },
+      );
+    return (await response.json()) as T;
+  }
+  initialize = (): Promise<void> => {
+    this.initialized ??= (async () => {
+      const auth = await this.json<{ user?: { id: string } }>(
+        "/api/auth/status",
+      );
+      if (!auth.user?.id)
+        throw Object.assign(
+          new Error("Sign in to Freestyle Cloud to use Remix."),
+          { status: 401 },
+        );
+      this.key = `remix.recovery.${auth.user.id}.${this.options.threadId}`;
+      this.ownerId = auth.user.id;
+      const stored = this.options.storage?.getItem(this.key);
+      if (stored)
+        this.saved = { ...emptySaved(), ...(JSON.parse(stored) as Saved) };
+      this.update({ queue: this.saved.queue });
+    })().catch((error) => {
+      this.initialized = null;
+      throw error;
+    });
+    return this.initialized;
+  };
+  start = async () => {
+    this.disposed = false;
+    await this.observe();
+  };
+  dispose = () => {
+    this.disposed = true;
+    this.generation++;
+    clearTimeout(this.timer);
+  };
+  detach = () => {
+    this.generation++;
+    clearTimeout(this.timer);
+    this.update({ status: "ready" });
+  };
+  setMessages = (
+    messages: UIMessage[] | ((messages: UIMessage[]) => UIMessage[]),
+  ) => {
+    this.update({
+      messages:
+        typeof messages === "function"
+          ? messages(this.snapshot.messages)
+          : messages,
+    });
+  };
+  clearError = () => {
+    if (this.snapshot.status === "error") this.update({ status: "ready" });
+  };
+  private schedule(delay: number, action: () => void) {
+    clearTimeout(this.timer);
+    if (!this.disposed) this.timer = setTimeout(action, delay);
+  }
+  private failed(error: unknown) {
+    if (this.disposed) return;
+    const status = (error as { status?: number })?.status;
+    if (status && status >= 400 && status < 500 && status !== 408) {
+      clearTimeout(this.timer);
+      if (!this.saved.turn) {
+        this.saved.request = undefined;
+        this.persist();
+      }
+      this.update({ status: "error", recovery: { phase: "idle" } });
+      this.options.onError?.(error as Error);
+      return;
+    }
+    const recovery = nextRemixReconnect(this.attempts, Date.now());
+    this.update({ status: "error", recovery });
+    if (recovery.phase === "reconnecting")
+      this.schedule(recovery.retryAt - Date.now(), () => {
+        void this.retry();
+      });
+  }
+  retry = async () => {
+    if (
+      this.inFlight ||
+      this.disposed ||
+      this.snapshot.recovery.phase === "paused"
+    )
+      return;
+    clearTimeout(this.timer);
+    this.attempts++;
+    await this.observe();
+  };
+  private command(turnId: string, body: unknown) {
+    return this.json(
+      `/api/remix/turns/${encodeURIComponent(turnId)}/commands`,
+      body,
+    );
+  }
+  private async flush() {
+    for (const cancel of [...this.saved.cancels]) {
+      if (cancel.turn)
+        await this.command(cancel.turn.id, {
+          type: "cancel",
+          threadId: this.options.threadId,
+        });
+      else if (cancel.request)
+        await this.json("/api/remix/cancel", { request: cancel.request });
+      this.saved.cancels = this.saved.cancels.filter(
+        (entry) => entry !== cancel,
+      );
+      this.persist();
+    }
+    for (const completion of [...this.saved.completions]) {
+      await this.command(completion.turnId, {
+        type: "desktop_complete",
+        ...completion,
+      });
+      this.saved.completions = this.saved.completions.filter(
+        (entry) => entry !== completion,
+      );
+      this.persist();
+    }
+  }
+  private observe = (): Promise<void> => {
+    if (this.inFlight) return this.inFlight;
+    const generation = this.generation;
+    this.inFlight = (async () => {
+      await this.initialize();
+      await this.flush();
+      if (generation !== this.generation || this.disposed) return;
+      if (
+        this.saved.request &&
+        (!this.saved.turn ||
+          ["retryable", "queued"].includes(this.saved.turn.status))
+      ) {
+        const receipt = await this.json<Receipt>(
+          "/api/remix/turns",
+          this.saved.request,
+        );
+        if (generation !== this.generation || this.disposed) return;
+        this.saved.turn = receipt.turn;
+        this.persist();
+      }
+      let runtime: DurableThreadRuntime | null = null;
+      try {
+        runtime = await this.json<DurableThreadRuntime>(
+          `/api/remix/thread/${encodeURIComponent(this.options.threadId)}`,
+        );
+      } catch (error) {
+        if (
+          (error as { status?: number }).status !== 404 ||
+          this.saved.request ||
+          this.saved.turn
+        )
+          throw error;
+      }
+      if (generation !== this.generation || this.disposed) return;
+      this.saved.turn ??= runtime?.activeTurn ?? undefined;
+      let receipt: Receipt | null = null;
+      if (this.saved.turn) {
+        receipt = await this.json<Receipt>(
+          `/api/remix/turns/${this.saved.turn.id}`,
+        );
+        if (generation !== this.generation || this.disposed) return;
+        this.saved.turn = receipt.turn;
+        if (
+          !this.saved.request &&
+          receipt.turn.clientRequestId &&
+          receipt.checkpoint?.messages
+        )
+          this.saved.request = {
+            threadId: this.options.threadId,
+            clientRequestId: receipt.turn.clientRequestId,
+            messages: receipt.checkpoint.messages,
+            context: receipt.checkpoint.context,
+          };
+        this.persist();
+      }
+      const messages = runtime?.thread?.messages ?? this.snapshot.messages;
+      const assistant = receipt?.checkpoint?.assistant;
+      const hydrated = assistant
+        ? [
+            ...messages.filter((message) => message.id !== assistant.id),
+            assistant,
+          ]
+        : messages;
+      const turn = this.saved.turn;
+      const done = !turn || terminal.has(turn.status);
+      if (turn?.status === "retryable")
+        throw new Error("The saved turn needs to reconnect.");
+      const queue = await this.json<{
+        items: RemixQueueItem[];
+        active: boolean;
+      }>(this.queuePath());
+      this.saved.queue = queue.items;
+      this.update({
+        messages: hydrated,
+        status: done ? "ready" : "streaming",
+        recovery: { phase: "idle" },
+        canonical: Boolean(receipt?.checkpoint),
+        runtime,
+        queue: queue.items,
+      });
+      if (turn && done) {
+        this.attempts = 0;
+        this.saved.turn = undefined;
+        this.saved.request = undefined;
+        this.persist();
+        this.options.onFinish?.(hydrated);
+        if (turn.status === "failed")
+          this.options.onError?.(
+            new Error(turn.error || "Remix couldn't complete this turn."),
+          );
+      }
+      const action = runtime?.pendingAction;
+      if (
+        !done &&
+        receipt?.checkpoint &&
+        action?.kind === "desktop" &&
+        action.status === "pending" &&
+        !this.seenActions.has(action.id)
+      ) {
+        this.seenActions.add(action.id);
+        // Show the checkpointed input first. Claim only after the user makes
+        // a decision, so an unexecuted approval can move between windows.
+        if (this.options.requiresApproval?.(action.toolName)) {
+          const part = hydrated
+            .flatMap((message) => message.parts)
+            .find((part) => {
+              const output = (
+                part as { output?: { desktopAction?: { actionId?: string } } }
+              ).output;
+              return output?.desktopAction?.actionId === action.id;
+            }) as { input?: unknown } | undefined;
+          if (part) {
+            this.pendingApprovals.set(action.id, {
+              turnId: action.turnId,
+              toolName: action.toolName,
+              input: part.input,
+            });
+            await this.options.onToolCall({
+              toolName: action.toolName,
+              toolCallId: action.id,
+              input: part.input,
+            });
+          } else {
+            this.seenActions.delete(action.id);
+          }
+          this.schedule(1_000, () => {
+            void this.observe();
+          });
+          this.attempts = 0;
+          return;
+        }
+        let claim: { action: { toolName: string; input: unknown } };
+        try {
+          claim = (await this.command(action.turnId, {
+            type: "desktop_claim",
+            actionId: action.id,
+            clientId: this.clientId,
+          })) as typeof claim;
+        } catch (error) {
+          this.seenActions.delete(action.id);
+          if ((error as { status?: number }).status !== 409) throw error;
+          this.schedule(1_000, () => {
+            void this.observe();
+          });
+          return;
+        }
+        if (generation !== this.generation || this.disposed) return;
+        this.claims.set(action.id, {
+          turnId: action.turnId,
+          actionId: action.id,
+          clientId: this.clientId,
+          result: null,
+        });
+        await this.options.onToolCall({
+          toolName: claim.action.toolName,
+          toolCallId: action.id,
+          input: claim.action.input,
+        });
+      }
+      if (
+        !done ||
+        this.saved.cancels.length ||
+        queue.items.length ||
+        queue.active
+      )
+        this.schedule(1_000, () => {
+          void this.observe();
+        });
+      this.attempts = 0;
+    })()
+      .catch((error) => {
+        if (generation === this.generation) this.failed(error);
+      })
+      .finally(() => {
+        this.inFlight = null;
+      });
+    return this.inFlight;
+  };
+  send = async (text: string, context: unknown, messageId?: string) => {
+    await this.initialize();
+    if (this.saved.turn || this.saved.request) {
+      await this.enqueue(text, context);
+      return;
+    }
+    this.generation++;
+    clearTimeout(this.timer);
+    if (this.inFlight) await this.inFlight;
+    const index = messageId
+      ? this.snapshot.messages.findIndex((message) => message.id === messageId)
+      : -1;
+    const prior =
+      index >= 0
+        ? this.snapshot.messages.slice(0, index)
+        : this.snapshot.messages;
+    const messages: UIMessage[] = [
+      ...prior,
+      {
+        id: messageId ?? crypto.randomUUID(),
+        role: "user",
+        parts: [{ type: "text", text }],
+      },
+    ];
+    this.saved.request = {
+      threadId: this.options.threadId,
+      clientRequestId: crypto.randomUUID(),
+      messages,
+      context,
+      firstTurn: messages.length === 1,
+    };
+    this.attempts = 0;
+    this.persist();
+    this.update({
+      messages,
+      status: "submitted",
+      recovery: { phase: "idle" },
+      queue: [...this.saved.queue],
+    });
+    await this.observe();
+  };
+  stop = async () => {
+    await this.initialize();
+    this.generation++;
+    clearTimeout(this.timer);
+    if (this.saved.turn || this.saved.request)
+      this.saved.cancels.push({
+        turn: this.saved.turn,
+        request: this.saved.request,
+      });
+    this.saved.turn = undefined;
+    this.saved.request = undefined;
+    this.persist();
+    this.update({ status: "ready", recovery: { phase: "idle" } });
+    const flush = () => {
+      void this.flush().catch(() => this.schedule(3_000, flush));
+    };
+    flush();
+  };
+  resume = async (context: unknown) => {
+    await this.stop();
+    await this.send(REMIX_CONTINUATION, context);
+  };
+  complete = async (toolCallId: string, result: unknown) => {
+    const claim = this.claims.get(toolCallId);
+    if (!claim) return;
+    this.claims.delete(toolCallId);
+    this.saved.completions.push({ ...claim, result });
+    this.persist();
+    try {
+      await this.flush();
+      this.schedule(0, () => {
+        void this.observe();
+      });
+    } catch (error) {
+      this.failed(error);
+    }
+  };
+  authorizeTool = async (toolCallId: string) => {
+    const pending = this.pendingApprovals.get(toolCallId);
+    if (!pending) throw new Error("This approval is no longer available.");
+    const claim = (await this.command(pending.turnId, {
+      type: "desktop_claim",
+      actionId: toolCallId,
+      clientId: this.clientId,
+    })) as { action: { toolName: string; input: unknown } };
+    if (
+      claim.action.toolName !== pending.toolName ||
+      JSON.stringify(claim.action.input) !== JSON.stringify(pending.input)
+    )
+      throw new Error("The action changed. Review it again before continuing.");
+    this.pendingApprovals.delete(toolCallId);
+    this.claims.set(toolCallId, {
+      turnId: pending.turnId,
+      actionId: toolCallId,
+      clientId: this.clientId,
+      result: null,
+    });
+  };
+  private queuePath() {
+    return `/api/remix/${encodeURIComponent(this.options.threadId)}/queue`;
+  }
+  private async queueRequest(path: string, body?: unknown, method?: string) {
+    await this.initialize();
+    const queue = await this.json<{ items: RemixQueueItem[] }>(
+      path,
+      body,
+      method,
+    );
+    this.saved.queue = queue.items;
+    this.persist();
+    this.update({ queue: queue.items });
+  }
+  enqueue = async (text: string, context?: unknown) =>
+    this.queueRequest(this.queuePath(), { text, context });
+  updateQueued = async (id: string, text: string) =>
+    this.queueRequest(
+      `${this.queuePath()}/${encodeURIComponent(id)}`,
+      { text },
+      "PATCH",
+    );
+  removeQueued = async (id: string) =>
+    this.queueRequest(
+      `${this.queuePath()}/${encodeURIComponent(id)}`,
+      undefined,
+      "DELETE",
+    );
+  steer = async (id: string) => {
+    await this.queueRequest(
+      `${this.queuePath()}/${encodeURIComponent(id)}/steer`,
+      {},
+      "POST",
+    );
+    this.attempts = 0;
+    await this.observe();
+  };
+}

--- a/apps/electron/src/renderer/src/lib/remix-recovery-controller.ts
+++ b/apps/electron/src/renderer/src/lib/remix-recovery-controller.ts
@@ -22,6 +22,10 @@ type Receipt = {
     messages?: UIMessage[];
     context?: unknown;
     assistant?: UIMessage | null;
+    toolState?:
+      | { actionId?: string; status?: string }[]
+      | { actionId?: string; status?: string }
+      | null;
   } | null;
 };
 export type RemixQueueItem = {
@@ -36,12 +40,24 @@ type Completion = {
   clientId: string;
   result: unknown;
 };
+type ClaimIntent = {
+  turnId: string;
+  clientId: string;
+  toolName: string;
+  input: unknown;
+  phase: "claiming" | "executing";
+};
 type Saved = {
   request?: Admission;
   turn?: Turn;
   cancels: Array<{ turn?: Turn; request?: Admission }>;
   queue: RemixQueueItem[];
   completions: Completion[];
+  enqueues: Array<{ requestId: string; text: string; context?: unknown }>;
+  claimIntents: Record<string, ClaimIntent>;
+  desktopRetries: Record<string, string>;
+  retrySources: Record<string, string>;
+  confirmActions: string[];
 };
 export type RemixRecoverySnapshot = {
   messages: UIMessage[];
@@ -50,6 +66,7 @@ export type RemixRecoverySnapshot = {
   queue: RemixQueueItem[];
   canonical: boolean;
   runtime: DurableThreadRuntime | null;
+  desktopRecovery: { turnId: string; actionId: string } | null;
 };
 type Options = {
   threadId: string;
@@ -60,13 +77,25 @@ type Options = {
     toolName: string;
     toolCallId: string;
     input: unknown;
+    requiresConfirmation?: boolean;
   }) => Promise<void>;
   requiresApproval?: (toolName: string) => boolean;
   onFinish?: (messages: UIMessage[]) => void;
   onError?: (error: Error) => void;
+  onFork?: (thread: { id: string; messages: UIMessage[] }) => void;
+  onActionUnavailable?: (actionId: string) => void;
 };
 const terminal = new Set(["completed", "failed", "canceled"]);
-const emptySaved = (): Saved => ({ cancels: [], queue: [], completions: [] });
+const emptySaved = (): Saved => ({
+  cancels: [],
+  queue: [],
+  completions: [],
+  enqueues: [],
+  claimIntents: {},
+  desktopRetries: {},
+  retrySources: {},
+  confirmActions: [],
+});
 
 /** Shared durable observer. Requests retain their admission ID across network
  * retries; only explicit Send or Resume creates a new user turn. */
@@ -74,6 +103,7 @@ export class RemixRecoveryController {
   private saved = emptySaved();
   private key = "";
   private ownerId = "";
+  private ownerHost = "";
   private timer: ReturnType<typeof setTimeout> | undefined;
   private inFlight: Promise<void> | null = null;
   private attempts = 0;
@@ -86,7 +116,6 @@ export class RemixRecoveryController {
     string,
     { turnId: string; toolName: string; input: unknown }
   >();
-  private readonly clientId = crypto.randomUUID();
   private initialized: Promise<void> | null = null;
   private snapshot: RemixRecoverySnapshot;
   constructor(private readonly options: Options) {
@@ -97,6 +126,7 @@ export class RemixRecoveryController {
       queue: [],
       canonical: false,
       runtime: null,
+      desktopRecovery: null,
     };
   }
   getSnapshot = () => this.snapshot;
@@ -120,24 +150,17 @@ export class RemixRecoveryController {
     body?: unknown,
     method = body === undefined ? "GET" : "POST",
   ): Promise<T> {
-    if (method !== "GET" && this.ownerId) {
-      const auth = await this.options.fetch("/api/auth/status");
-      const identity = auth.ok
-        ? ((await auth.json()) as { user?: { id: string } })
-        : null;
-      if (identity?.user?.id !== this.ownerId)
-        throw Object.assign(
-          new Error("Sign in with the account that started this conversation."),
-          { status: 401 },
-        );
-    }
     const response = await this.options.fetch(
       path,
       body === undefined && method === "GET"
         ? undefined
         : {
             method,
-            headers: { "Content-Type": "application/json" },
+            headers: {
+              "Content-Type": "application/json",
+              "X-Remix-User": this.ownerId,
+              "X-Remix-Host": encodeURIComponent(this.ownerHost),
+            },
             ...(body === undefined ? {} : { body: JSON.stringify(body) }),
           },
     );
@@ -156,16 +179,17 @@ export class RemixRecoveryController {
   }
   initialize = (): Promise<void> => {
     this.initialized ??= (async () => {
-      const auth = await this.json<{ user?: { id: string } }>(
-        "/api/auth/status",
+      const auth = await this.json<{ userId: string; host: string }>(
+        "/api/remix/identity",
       );
-      if (!auth.user?.id)
+      if (!auth.userId || !auth.host)
         throw Object.assign(
           new Error("Sign in to Freestyle Cloud to use Remix."),
           { status: 401 },
         );
-      this.key = `remix.recovery.${auth.user.id}.${this.options.threadId}`;
-      this.ownerId = auth.user.id;
+      this.key = `remix.recovery.${encodeURIComponent(auth.host)}.${auth.userId}.${this.options.threadId}`;
+      this.ownerId = auth.userId;
+      this.ownerHost = auth.host;
       const stored = this.options.storage?.getItem(this.key);
       if (stored)
         this.saved = { ...emptySaved(), ...(JSON.parse(stored) as Saved) };
@@ -259,12 +283,66 @@ export class RemixRecoveryController {
       this.persist();
     }
     for (const completion of [...this.saved.completions]) {
-      await this.command(completion.turnId, {
-        type: "desktop_complete",
-        ...completion,
-      });
+      try {
+        await this.command(completion.turnId, {
+          type: "desktop_complete",
+          ...completion,
+        });
+      } catch (error) {
+        const status = (error as { status?: number }).status;
+        if (status !== 409 && status !== 404) throw error;
+        // A canceled/settled turn can no longer accept first completion.
+        // Retire that output only after authoritative reconciliation; network
+        // uncertainty remains replayable and never causes local reexecution.
+        const receipt = await this.json<Receipt>(
+          `/api/remix/turns/${completion.turnId}`,
+        );
+        const tools = Array.isArray(receipt.checkpoint?.toolState)
+          ? receipt.checkpoint.toolState
+          : [receipt.checkpoint?.toolState];
+        const settledAction = tools.some(
+          (action) =>
+            action?.actionId === completion.actionId &&
+            ["expired", "declined", "completed", "failed"].includes(
+              action.status ?? "",
+            ),
+        );
+        if (!terminal.has(receipt.turn.status) && !settledAction) {
+          const runtime = await this.json<DurableThreadRuntime>(
+            `/api/remix/thread/${encodeURIComponent(this.options.threadId)}`,
+          );
+          if (
+            runtime.pendingAction?.id !== completion.actionId ||
+            !["expired", "declined", "completed", "failed"].includes(
+              runtime.pendingAction.status,
+            )
+          )
+            throw error;
+        }
+      }
       this.saved.completions = this.saved.completions.filter(
         (entry) => entry !== completion,
+      );
+      const retired = new Set<string>();
+      let actionId: string | undefined = completion.actionId;
+      while (actionId && !retired.has(actionId)) {
+        retired.add(actionId);
+        delete this.saved.claimIntents[actionId];
+        const predecessor: string | undefined =
+          this.saved.retrySources[actionId];
+        if (predecessor) delete this.saved.desktopRetries[predecessor];
+        delete this.saved.retrySources[actionId];
+        actionId = predecessor;
+      }
+      this.saved.confirmActions = this.saved.confirmActions.filter(
+        (id) => !retired.has(id),
+      );
+      this.persist();
+    }
+    for (const pending of [...this.saved.enqueues]) {
+      await this.queueRequest(this.queuePath(), pending);
+      this.saved.enqueues = this.saved.enqueues.filter(
+        (item) => item.requestId !== pending.requestId,
       );
       this.persist();
     }
@@ -276,6 +354,20 @@ export class RemixRecoveryController {
       await this.initialize();
       await this.flush();
       if (generation !== this.generation || this.disposed) return;
+      if (this.saved.turn?.status === "retryable") {
+        const queue = await this.json<{
+          items: RemixQueueItem[];
+          recoveryPaused?: boolean;
+        }>(this.queuePath());
+        if (queue.recoveryPaused) {
+          this.update({
+            queue: queue.items,
+            status: "error",
+            recovery: { phase: "paused", attempts: 5 },
+          });
+          return;
+        }
+      }
       if (
         this.saved.request &&
         (!this.saved.turn ||
@@ -334,17 +426,20 @@ export class RemixRecoveryController {
         : messages;
       const turn = this.saved.turn;
       const done = !turn || terminal.has(turn.status);
-      if (turn?.status === "retryable")
-        throw new Error("The saved turn needs to reconnect.");
       const queue = await this.json<{
         items: RemixQueueItem[];
         active: boolean;
+        recoveryPaused?: boolean;
       }>(this.queuePath());
+      if (turn?.status === "retryable" && !queue.recoveryPaused)
+        throw new Error("The saved turn needs to reconnect.");
       this.saved.queue = queue.items;
       this.update({
         messages: hydrated,
         status: done ? "ready" : "streaming",
-        recovery: { phase: "idle" },
+        recovery: queue.recoveryPaused
+          ? { phase: "paused", attempts: 5 }
+          : { phase: "idle" },
         canonical: Boolean(receipt?.checkpoint),
         runtime,
         queue: queue.items,
@@ -361,25 +456,68 @@ export class RemixRecoveryController {
           );
       }
       const action = runtime?.pendingAction;
+      for (const actionId of this.pendingApprovals.keys()) {
+        if (action?.id === actionId && !done) continue;
+        this.pendingApprovals.delete(actionId);
+        this.options.onActionUnavailable?.(actionId);
+      }
+      const checkpointActions = (assistant?.parts ?? []).flatMap((part) => {
+        const id = (
+          part as { output?: { desktopAction?: { actionId?: string } } }
+        ).output?.desktopAction?.actionId;
+        return id ? [id] : [];
+      });
+      const tools = Array.isArray(receipt?.checkpoint?.toolState)
+        ? receipt.checkpoint.toolState
+        : [receipt?.checkpoint?.toolState];
+      const interruptedActionId =
+        tools.find((tool) => tool?.status === "expired")?.actionId ??
+        checkpointActions.at(-1);
+      this.update({
+        desktopRecovery:
+          turn?.status === "needs_desktop" && interruptedActionId
+            ? { turnId: turn.id, actionId: interruptedActionId }
+            : null,
+      });
       if (
         !done &&
         receipt?.checkpoint &&
         action?.kind === "desktop" &&
-        action.status === "pending" &&
+        (action.status === "pending" ||
+          this.saved.claimIntents[action.id]?.phase === "claiming") &&
         !this.seenActions.has(action.id)
       ) {
         this.seenActions.add(action.id);
         // Show the checkpointed input first. Claim only after the user makes
         // a decision, so an unexecuted approval can move between windows.
-        if (this.options.requiresApproval?.(action.toolName)) {
-          const part = hydrated
-            .flatMap((message) => message.parts)
-            .find((part) => {
-              const output = (
-                part as { output?: { desktopAction?: { actionId?: string } } }
-              ).output;
-              return output?.desktopAction?.actionId === action.id;
-            }) as { input?: unknown } | undefined;
+        const retrySource =
+          this.saved.retrySources[action.id] ??
+          Object.keys(this.saved.desktopRetries)
+            .reverse()
+            .find(
+              (id) =>
+                this.saved.claimIntents[id]?.turnId === action.turnId ||
+                checkpointActions.includes(id),
+            );
+        const explicitRetry =
+          this.saved.confirmActions.includes(action.id) || Boolean(retrySource);
+        if (retrySource) {
+          // Recover the replacement relationship even if retry_desktop committed
+          // but its response was lost, so completion retires the retry intent.
+          this.saved.retrySources[action.id] = retrySource;
+          this.persist();
+        }
+        if (this.options.requiresApproval?.(action.toolName) || explicitRetry) {
+          const part = (assistant?.parts ?? []).find((part) => {
+            const output = (
+              part as { output?: { desktopAction?: { actionId?: string } } }
+            ).output;
+            const id = output?.desktopAction?.actionId;
+            return (
+              id === action.id ||
+              (explicitRetry && Boolean(id && this.saved.desktopRetries[id]))
+            );
+          }) as { input?: unknown } | undefined;
           if (part) {
             this.pendingApprovals.set(action.id, {
               turnId: action.turnId,
@@ -390,6 +528,7 @@ export class RemixRecoveryController {
               toolName: action.toolName,
               toolCallId: action.id,
               input: part.input,
+              requiresConfirmation: explicitRetry,
             });
           } else {
             this.seenActions.delete(action.id);
@@ -400,13 +539,12 @@ export class RemixRecoveryController {
           this.attempts = 0;
           return;
         }
-        let claim: { action: { toolName: string; input: unknown } };
+        let claim: { toolName: string; input: unknown };
         try {
-          claim = (await this.command(action.turnId, {
-            type: "desktop_claim",
-            actionId: action.id,
-            clientId: this.clientId,
-          })) as typeof claim;
+          claim = await this.claimAction(action.id, {
+            turnId: action.turnId,
+            toolName: action.toolName,
+          });
         } catch (error) {
           this.seenActions.delete(action.id);
           if ((error as { status?: number }).status !== 409) throw error;
@@ -416,23 +554,18 @@ export class RemixRecoveryController {
           return;
         }
         if (generation !== this.generation || this.disposed) return;
-        this.claims.set(action.id, {
-          turnId: action.turnId,
-          actionId: action.id,
-          clientId: this.clientId,
-          result: null,
-        });
         await this.options.onToolCall({
-          toolName: claim.action.toolName,
+          toolName: claim.toolName,
           toolCallId: action.id,
-          input: claim.action.input,
+          input: claim.input,
         });
       }
       if (
-        !done ||
-        this.saved.cancels.length ||
-        queue.items.length ||
-        queue.active
+        !queue.recoveryPaused &&
+        (!done ||
+          this.saved.cancels.length ||
+          queue.items.length ||
+          queue.active)
       )
         this.schedule(1_000, () => {
           void this.observe();
@@ -449,6 +582,39 @@ export class RemixRecoveryController {
   };
   send = async (text: string, context: unknown, messageId?: string) => {
     await this.initialize();
+    if (messageId) {
+      if (!this.options.onFork) throw new Error("Editing requires a new chat.");
+      const index = this.snapshot.messages.findIndex(
+        (message) => message.id === messageId && message.role === "user",
+      );
+      if (index < 0)
+        throw new Error("The original message is no longer available.");
+      const id = crypto.randomUUID();
+      const messages: UIMessage[] = [
+        ...this.snapshot.messages.slice(0, index),
+        {
+          id: crypto.randomUUID(),
+          role: "user" as const,
+          parts: [{ type: "text" as const, text }],
+        },
+      ].map((message) => ({ ...message, id: crypto.randomUUID() }));
+      const saved: Saved = {
+        ...emptySaved(),
+        request: {
+          threadId: id,
+          clientRequestId: crypto.randomUUID(),
+          messages,
+          context,
+          firstTurn: true,
+        },
+      };
+      this.options.storage?.setItem(
+        `remix.recovery.${encodeURIComponent(this.ownerHost)}.${this.ownerId}.${id}`,
+        JSON.stringify(saved),
+      );
+      this.options.onFork({ id, messages });
+      return;
+    }
     if (this.saved.turn || this.saved.request) {
       await this.enqueue(text, context);
       return;
@@ -456,17 +622,10 @@ export class RemixRecoveryController {
     this.generation++;
     clearTimeout(this.timer);
     if (this.inFlight) await this.inFlight;
-    const index = messageId
-      ? this.snapshot.messages.findIndex((message) => message.id === messageId)
-      : -1;
-    const prior =
-      index >= 0
-        ? this.snapshot.messages.slice(0, index)
-        : this.snapshot.messages;
     const messages: UIMessage[] = [
-      ...prior,
+      ...this.snapshot.messages,
       {
-        id: messageId ?? crypto.randomUUID(),
+        id: crypto.randomUUID(),
         role: "user",
         parts: [{ type: "text", text }],
       },
@@ -528,23 +687,65 @@ export class RemixRecoveryController {
   authorizeTool = async (toolCallId: string) => {
     const pending = this.pendingApprovals.get(toolCallId);
     if (!pending) throw new Error("This approval is no longer available.");
+    await this.claimAction(toolCallId, pending);
+    this.pendingApprovals.delete(toolCallId);
+  };
+  private async claimAction(
+    toolCallId: string,
+    pending: { turnId: string; toolName: string; input?: unknown },
+  ) {
+    let intent = this.saved.claimIntents[toolCallId];
+    if (intent?.phase === "executing")
+      throw new Error(
+        "This action may already have run. Wait for recovery before retrying.",
+      );
+    intent ??= {
+      ...pending,
+      input: pending.input,
+      clientId: crypto.randomUUID(),
+      phase: "claiming",
+    };
+    this.saved.claimIntents[toolCallId] = intent;
+    this.persist();
+    // Cloud must replay the SAME live claim for this claimant, without a new
+    // lease, when the original successful claim response was lost.
     const claim = (await this.command(pending.turnId, {
       type: "desktop_claim",
       actionId: toolCallId,
-      clientId: this.clientId,
+      clientId: intent.clientId,
     })) as { action: { toolName: string; input: unknown } };
     if (
       claim.action.toolName !== pending.toolName ||
-      JSON.stringify(claim.action.input) !== JSON.stringify(pending.input)
+      (pending.input !== undefined &&
+        JSON.stringify(claim.action.input) !== JSON.stringify(pending.input))
     )
       throw new Error("The action changed. Review it again before continuing.");
-    this.pendingApprovals.delete(toolCallId);
+    intent.phase = "executing";
+    intent.input = claim.action.input;
+    this.persist();
     this.claims.set(toolCallId, {
       turnId: pending.turnId,
       actionId: toolCallId,
-      clientId: this.clientId,
+      clientId: intent.clientId,
       result: null,
     });
+    return claim.action;
+  }
+  retryDesktop = async () => {
+    const action = this.snapshot.desktopRecovery;
+    if (!action) return;
+    this.saved.desktopRetries[action.actionId] ??= crypto.randomUUID();
+    this.persist();
+    const result = (await this.command(action.turnId, {
+      type: "retry_desktop",
+      actionId: action.actionId,
+      clientRequestId: this.saved.desktopRetries[action.actionId],
+    })) as { action: { id: string } };
+    this.saved.confirmActions.push(result.action.id);
+    this.saved.retrySources[result.action.id] = action.actionId;
+    this.persist();
+    this.update({ desktopRecovery: null });
+    await this.observe();
   };
   private queuePath() {
     return `/api/remix/${encodeURIComponent(this.options.threadId)}/queue`;
@@ -560,8 +761,42 @@ export class RemixRecoveryController {
     this.persist();
     this.update({ queue: queue.items });
   }
-  enqueue = async (text: string, context?: unknown) =>
-    this.queueRequest(this.queuePath(), { text, context });
+  enqueue = async (text: string, context?: unknown) => {
+    await this.initialize();
+    const pending = { requestId: crypto.randomUUID(), text, context };
+    this.saved.enqueues.push(pending);
+    this.persist();
+    this.update({
+      queue: [
+        ...this.snapshot.queue,
+        { id: pending.requestId, text, context, createdAt: Date.now() },
+      ],
+    });
+    try {
+      await this.queueRequest(this.queuePath(), pending);
+      this.saved.enqueues = this.saved.enqueues.filter(
+        (item) => item.requestId !== pending.requestId,
+      );
+      this.persist();
+    } catch (error) {
+      const status = (error as { status?: number }).status;
+      if (status && status >= 400 && status < 500 && status !== 408) {
+        this.saved.enqueues = this.saved.enqueues.filter(
+          (item) => item.requestId !== pending.requestId,
+        );
+        this.persist();
+        this.update({
+          queue: this.snapshot.queue.filter(
+            (item) => item.id !== pending.requestId,
+          ),
+        });
+        throw error;
+      }
+      // The local enqueue receipt may already exist. Retain the intent, don't
+      // restore a draft that would become a second independent user send.
+      this.failed(error);
+    }
+  };
   updateQueued = async (id: string, text: string) =>
     this.queueRequest(
       `${this.queuePath()}/${encodeURIComponent(id)}`,

--- a/apps/electron/src/renderer/src/lib/remix-recovery-controller.ts
+++ b/apps/electron/src/renderer/src/lib/remix-recovery-controller.ts
@@ -40,6 +40,14 @@ type Completion = {
   clientId: string;
   result: unknown;
 };
+type ActionReceipt = {
+  id: string;
+  turnId: string;
+  status: string;
+  toolName: string;
+  invocationId?: string | null;
+  retryOfActionId?: string | null;
+};
 type ClaimIntent = {
   turnId: string;
   clientId: string;
@@ -116,6 +124,8 @@ export class RemixRecoveryController {
     string,
     { turnId: string; toolName: string; input: unknown }
   >();
+  private readonly observerId = crypto.randomUUID();
+  private readonly authorizing = new Set<string>();
   private initialized: Promise<void> | null = null;
   private snapshot: RemixRecoverySnapshot;
   constructor(private readonly options: Options) {
@@ -268,6 +278,18 @@ export class RemixRecoveryController {
       body,
     );
   }
+  private async actionReceipt(turnId: string, actionId: string) {
+    const { action } = await this.json<{ action: ActionReceipt }>(
+      `/api/remix/turns/${encodeURIComponent(turnId)}/actions/${encodeURIComponent(actionId)}`,
+    );
+    if (
+      action?.id !== actionId ||
+      action.turnId !== turnId ||
+      typeof action.status !== "string"
+    )
+      throw new Error("Could not verify this desktop action.");
+    return action;
+  }
   private async flush() {
     for (const cancel of [...this.saved.cancels]) {
       if (cancel.turn)
@@ -308,14 +330,20 @@ export class RemixRecoveryController {
             ),
         );
         if (!terminal.has(receipt.turn.status) && !settledAction) {
-          const runtime = await this.json<DurableThreadRuntime>(
-            `/api/remix/thread/${encodeURIComponent(this.options.threadId)}`,
+          // Check the predecessor itself: the checkpoint intentionally replaces
+          // its ID with the retry successor for the same invocation.
+          const action = await this.actionReceipt(
+            completion.turnId,
+            completion.actionId,
           );
           if (
-            runtime.pendingAction?.id !== completion.actionId ||
-            !["expired", "declined", "completed", "failed"].includes(
-              runtime.pendingAction.status,
-            )
+            ![
+              "expired",
+              "declined",
+              "completed",
+              "failed",
+              "canceled",
+            ].includes(action.status)
           )
             throw error;
         }
@@ -487,6 +515,20 @@ export class RemixRecoveryController {
           this.saved.claimIntents[action.id]?.phase === "claiming") &&
         !this.seenActions.has(action.id)
       ) {
+        const ownedAction = await this.actionReceipt(action.turnId, action.id);
+        const lineage = new Set([action.id]);
+        let ancestor = ownedAction;
+        while (
+          ancestor.retryOfActionId &&
+          !lineage.has(ancestor.retryOfActionId)
+        ) {
+          const predecessor = ancestor.retryOfActionId;
+          lineage.add(predecessor);
+          this.saved.retrySources[ancestor.id] = predecessor;
+          if (checkpointActions.includes(predecessor)) break;
+          ancestor = await this.actionReceipt(action.turnId, predecessor);
+        }
+        if (generation !== this.generation || this.disposed) return;
         this.seenActions.add(action.id);
         // Show the checkpointed input first. Claim only after the user makes
         // a decision, so an unexecuted approval can move between windows.
@@ -500,7 +542,9 @@ export class RemixRecoveryController {
                 checkpointActions.includes(id),
             );
         const explicitRetry =
-          this.saved.confirmActions.includes(action.id) || Boolean(retrySource);
+          Boolean(ownedAction.retryOfActionId) ||
+          this.saved.confirmActions.includes(action.id) ||
+          Boolean(retrySource);
         if (retrySource) {
           // Recover the replacement relationship even if retry_desktop committed
           // but its response was lost, so completion retires the retry intent.
@@ -515,6 +559,7 @@ export class RemixRecoveryController {
             const id = output?.desktopAction?.actionId;
             return (
               id === action.id ||
+              (explicitRetry && Boolean(id && lineage.has(id))) ||
               (explicitRetry && Boolean(id && this.saved.desktopRetries[id]))
             );
           }) as { input?: unknown } | undefined;
@@ -694,6 +739,19 @@ export class RemixRecoveryController {
     toolCallId: string,
     pending: { turnId: string; toolName: string; input?: unknown },
   ) {
+    if (this.authorizing.has(toolCallId))
+      throw new Error("This action is already being confirmed.");
+    this.authorizing.add(toolCallId);
+    try {
+      return await this.claimActionOnce(toolCallId, pending);
+    } finally {
+      this.authorizing.delete(toolCallId);
+    }
+  }
+  private async claimActionOnce(
+    toolCallId: string,
+    pending: { turnId: string; toolName: string; input?: unknown },
+  ) {
     let intent = this.saved.claimIntents[toolCallId];
     if (intent?.phase === "executing")
       throw new Error(
@@ -713,6 +771,7 @@ export class RemixRecoveryController {
       type: "desktop_claim",
       actionId: toolCallId,
       clientId: intent.clientId,
+      observerId: this.observerId,
     })) as { action: { toolName: string; input: unknown } };
     if (
       claim.action.toolName !== pending.toolName ||

--- a/apps/electron/src/renderer/src/lib/remix-recovery-transitions.test.ts
+++ b/apps/electron/src/renderer/src/lib/remix-recovery-transitions.test.ts
@@ -39,15 +39,39 @@ function harness() {
   let loseRetry = false;
   let checkpointActionId = "";
   let replacements = 0;
-  let action: {
+  type Action = {
     id: string;
     turnId: string;
     kind: "desktop";
     toolName: string;
     status: string;
     claimedBy?: string;
-  } | null = null;
-  const onToolCall = vi.fn(async () => {});
+    retryOfActionId?: string;
+  };
+  let action: Action | null = null;
+  const predecessors = new Map<string, Action>();
+  const executionOwners = new Map<string, string>();
+  const replace = () => {
+    const original = action!;
+    predecessors.set(original.id, original);
+    replacements++;
+    action = {
+      ...original,
+      id: replacements === 1 ? "replacement" : `replacement-${replacements}`,
+      status: "pending",
+      claimedBy: undefined,
+      retryOfActionId: original.id,
+    };
+    turns.get(action.turnId)!.status = "waiting_desktop";
+  };
+  const onToolCall = vi.fn(
+    async (_call: {
+      toolName: string;
+      toolCallId: string;
+      input: unknown;
+      requiresConfirmation?: boolean;
+    }) => {},
+  );
   const onFork = vi.fn();
   const fetch = async (path: string, init?: RequestInit) => {
     const body = init?.body ? JSON.parse(String(init.body)) : undefined;
@@ -107,13 +131,22 @@ function harness() {
     }
     const turnId = path.split("/")[4];
     const turn = turns.get(turnId);
+    if (path.includes("/actions/")) {
+      const id = path.split("/").at(-1)!;
+      return Response.json({
+        action: action?.id === id ? action : predecessors.get(id),
+      });
+    }
     if (path.endsWith("/commands")) {
       if (body.type === "cancel") {
         turn!.status = "canceled";
         return Response.json({ receipt: { canceled: true } });
       }
       if (body.type === "desktop_complete") {
-        if (["canceled", "completed", "failed"].includes(turn!.status))
+        if (
+          predecessors.has(body.actionId) ||
+          ["canceled", "completed", "failed"].includes(turn!.status)
+        )
           return Response.json({}, { status: 409 });
         action = null;
         return Response.json({ receipt: { accepted: true } });
@@ -131,31 +164,28 @@ function harness() {
           loseClaim = false;
           throw new Error("claim committed, response lost");
         }
+        if (body.observerId) {
+          const owner = executionOwners.get(action.id);
+          if (owner && owner !== body.observerId)
+            return Response.json({}, { status: 409 });
+          executionOwners.set(action.id, body.observerId);
+        }
         return Response.json({
           action: {
             id: action.id,
-            toolName: "Bash",
+            toolName: action.toolName,
             input: { command: "pwd" },
           },
           receipt: { claimed: true },
         });
       }
       if (body.type === "retry_desktop") {
-        replacements++;
-        action = {
-          id:
-            replacements === 1 ? "replacement" : `replacement-${replacements}`,
-          turnId,
-          kind: "desktop",
-          status: "pending",
-          toolName: "Bash",
-        };
-        turn!.status = "waiting_desktop";
+        replace();
         if (loseRetry) {
           loseRetry = false;
           throw new Error("replacement committed, response lost");
         }
-        return Response.json({ action: { id: action.id } });
+        return Response.json({ action: { id: action!.id } });
       }
     }
     if (path.startsWith("/api/remix/thread/")) {
@@ -200,7 +230,11 @@ function harness() {
       });
     return Response.json({}, { status: 404 });
   };
-  const create = (threadId = "thread-a", messages: UIMessage[] = []) =>
+  const create = (
+    threadId = "thread-a",
+    messages: UIMessage[] = [],
+    requiresApproval = true,
+  ) =>
     new RemixRecoveryController({
       threadId,
       messages,
@@ -212,7 +246,7 @@ function harness() {
         },
       },
       onToolCall,
-      requiresApproval: () => true,
+      requiresApproval: () => requiresApproval,
       onFork,
     });
   return {
@@ -239,14 +273,15 @@ function harness() {
     loseRetry: () => {
       loseRetry = true;
     },
-    approval: () => {
+    replace,
+    approval: (toolName = "Bash") => {
       const turn = [...turns.values()][0];
       action = {
         id: "action-a",
         turnId: turn.id,
         kind: "desktop",
         status: "pending",
-        toolName: "Bash",
+        toolName,
       };
       checkpointActionId = action.id;
     },
@@ -266,6 +301,99 @@ afterEach(() => {
 });
 
 describe("durable persistence-boundary regressions", () => {
+  it("serializes simultaneous confirmations within the same observer", async () => {
+    const h = harness();
+    const controller = h.create();
+    await controller.send("Run", context);
+    h.approval();
+    await controller.start();
+    const confirmations = await Promise.allSettled([
+      controller.authorizeTool("action-a"),
+      controller.authorizeTool("action-a"),
+    ]);
+    expect(confirmations.map((result) => result.status).sort()).toEqual([
+      "fulfilled",
+      "rejected",
+    ]);
+    expect(
+      h.calls.filter((call) => call.body?.type === "desktop_claim"),
+    ).toHaveLength(1);
+  });
+  it.each([
+    false,
+    true,
+  ])("allows only one reattached observer to execute a shared uncertain claim (concurrent: %s)", async (concurrent) => {
+    const h = harness();
+    const first = h.create();
+    await first.send("Run", context);
+    h.approval();
+    await first.start();
+    h.loseClaim();
+    await expect(first.authorizeTool("action-a")).rejects.toThrow();
+    first.dispose();
+    const compact = h.create();
+    const workspace = h.create();
+    await Promise.all([compact.start(), workspace.start()]);
+    const executed: string[] = [];
+    const allow = (controller: RemixRecoveryController, label: string) =>
+      controller.authorizeTool("action-a").then(() => executed.push(label));
+    if (concurrent)
+      await Promise.allSettled([
+        allow(compact, "compact"),
+        allow(workspace, "workspace"),
+      ]);
+    else {
+      await allow(compact, "compact");
+      await expect(allow(workspace, "workspace")).rejects.toThrow();
+    }
+    expect(executed).toHaveLength(1);
+  });
+  it("does not let a stale second observer execute a reviewed replacement before confirmation", async () => {
+    const h = harness();
+    const compact = h.create("thread-a", [], false);
+    await compact.send("Run", context);
+    h.approval("paste");
+    h.expire();
+    await compact.start();
+    const workspace = h.create("thread-a", [], false);
+    await workspace.start();
+    await compact.retryDesktop();
+    await workspace.start();
+    expect(
+      h.calls.filter((call) => call.body?.type === "desktop_claim"),
+    ).toHaveLength(0);
+    expect(h.onToolCall.mock.calls).toHaveLength(2);
+    for (const [call] of h.onToolCall.mock.calls)
+      expect(call).toMatchObject({
+        toolCallId: "replacement",
+        requiresConfirmation: true,
+      });
+  });
+  it("retires an offline expired completion and presents a replacement created by another observer", async () => {
+    const h = harness();
+    const first = h.create();
+    await first.send("Run", context);
+    h.approval();
+    await first.start();
+    await first.authorizeTool("action-a");
+    h.offline(true);
+    await first.complete("action-a", { ok: true });
+    first.dispose();
+    h.expire();
+    h.replace();
+    h.offline(false);
+    h.onToolCall.mockClear();
+    const reopened = h.create();
+    await reopened.start();
+    expect(reopened.getSnapshot().status).toBe("streaming");
+    expect(h.onToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCallId: "replacement",
+        requiresConfirmation: true,
+      }),
+    );
+    expect(JSON.parse([...h.storage.values()][0]).completions).toEqual([]);
+  });
   it("binds the initialized owner to the admission even when the backing account changes", async () => {
     const h = harness();
     h.switchOwner();

--- a/apps/electron/src/renderer/src/lib/remix-recovery-transitions.test.ts
+++ b/apps/electron/src/renderer/src/lib/remix-recovery-transitions.test.ts
@@ -1,0 +1,464 @@
+import type { UIMessage } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RemixRecoveryController } from "./remix-recovery-controller";
+
+const context = {
+  selection: null,
+  appName: null,
+  windowTitle: null,
+  capturedAt: 1,
+};
+function harness() {
+  const storage = new Map<string, string>();
+  const threads = new Map<string, UIMessage[]>();
+  const turns = new Map<
+    string,
+    {
+      id: string;
+      threadId: string;
+      clientRequestId: string;
+      status: string;
+      messages: UIMessage[];
+      context: unknown;
+    }
+  >();
+  const queued = new Map<
+    string,
+    { id: string; text: string; createdAt: number }
+  >();
+  const calls: Array<{
+    path: string;
+    body?: Record<string, unknown>;
+    headers: Headers;
+  }> = [];
+  let owner = "a";
+  let switchAfterIdentity = false;
+  let offline = false;
+  let loseClaim = false;
+  let loseEnqueue = false;
+  let loseRetry = false;
+  let checkpointActionId = "";
+  let replacements = 0;
+  let action: {
+    id: string;
+    turnId: string;
+    kind: "desktop";
+    toolName: string;
+    status: string;
+    claimedBy?: string;
+  } | null = null;
+  const onToolCall = vi.fn(async () => {});
+  const onFork = vi.fn();
+  const fetch = async (path: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    const headers = new Headers(init?.headers);
+    calls.push({ path, body, headers });
+    if (path === "/api/remix/identity") {
+      const response = Response.json({
+        userId: owner,
+        host: "https://cloud.test",
+      });
+      if (switchAfterIdentity) owner = "b";
+      return response;
+    }
+    if (
+      init?.method &&
+      init.method !== "GET" &&
+      (headers.get("X-Remix-User") !== owner ||
+        headers.get("X-Remix-Host") !==
+          encodeURIComponent("https://cloud.test"))
+    )
+      return Response.json({}, { status: 401 });
+    if (path.endsWith("/queue")) {
+      if (body?.requestId) {
+        queued.set(
+          body.requestId,
+          queued.get(body.requestId) ?? {
+            id: body.requestId,
+            text: body.text,
+            createdAt: Date.now(),
+          },
+        );
+        if (loseEnqueue) {
+          loseEnqueue = false;
+          throw new Error("enqueue committed, response lost");
+        }
+      }
+      return Response.json({ items: [...queued.values()], active: false });
+    }
+    if (offline) throw new Error("offline");
+    if (path === "/api/remix/turns") {
+      let turn = [...turns.values()].find(
+        (turn) =>
+          turn.threadId === body.threadId &&
+          turn.clientRequestId === body.clientRequestId,
+      );
+      if (!turn) {
+        turn = { ...body, id: crypto.randomUUID(), status: "running" };
+        const messages = threads.get(body.threadId) ?? [];
+        // Match Cloud's append-only, unseen-message-ID ingestion.
+        for (const message of body.messages)
+          if (!messages.some((saved) => saved.id === message.id))
+            messages.push(message);
+        threads.set(body.threadId, messages);
+        turns.set(turn!.id, turn!);
+      }
+      return Response.json({ turn });
+    }
+    const turnId = path.split("/")[4];
+    const turn = turns.get(turnId);
+    if (path.endsWith("/commands")) {
+      if (body.type === "cancel") {
+        turn!.status = "canceled";
+        return Response.json({ receipt: { canceled: true } });
+      }
+      if (body.type === "desktop_complete") {
+        if (["canceled", "completed", "failed"].includes(turn!.status))
+          return Response.json({}, { status: 409 });
+        action = null;
+        return Response.json({ receipt: { accepted: true } });
+      }
+      if (body.type === "desktop_claim") {
+        if (
+          !action ||
+          (action.status !== "pending" &&
+            (action.status !== "claimed" || action.claimedBy !== body.clientId))
+        )
+          return Response.json({}, { status: 409 });
+        action.status = "claimed";
+        action.claimedBy = body.clientId;
+        if (loseClaim) {
+          loseClaim = false;
+          throw new Error("claim committed, response lost");
+        }
+        return Response.json({
+          action: {
+            id: action.id,
+            toolName: "Bash",
+            input: { command: "pwd" },
+          },
+          receipt: { claimed: true },
+        });
+      }
+      if (body.type === "retry_desktop") {
+        replacements++;
+        action = {
+          id:
+            replacements === 1 ? "replacement" : `replacement-${replacements}`,
+          turnId,
+          kind: "desktop",
+          status: "pending",
+          toolName: "Bash",
+        };
+        turn!.status = "waiting_desktop";
+        if (loseRetry) {
+          loseRetry = false;
+          throw new Error("replacement committed, response lost");
+        }
+        return Response.json({ action: { id: action.id } });
+      }
+    }
+    if (path.startsWith("/api/remix/thread/")) {
+      const id = path.split("/").at(-1)!;
+      return Response.json({
+        thread: { id, messages: threads.get(id) ?? [] },
+        activeTurn:
+          [...turns.values()].find(
+            (turn) =>
+              turn.threadId === id &&
+              !["canceled", "completed", "failed"].includes(turn.status),
+          ) ?? null,
+        pendingAction: action?.status === "expired" ? null : action,
+      });
+    }
+    if (turn)
+      return Response.json({
+        turn,
+        checkpoint: {
+          messages: turn.messages,
+          context: turn.context,
+          toolState: action
+            ? [{ actionId: action.id, status: action.status }]
+            : [],
+          assistant: action
+            ? {
+                id: "assistant-action",
+                role: "assistant",
+                parts: [
+                  {
+                    type: "dynamic-tool",
+                    toolName: "Bash",
+                    toolCallId: "invocation",
+                    state: "output-available",
+                    input: { command: "pwd" },
+                    output: { desktopAction: { actionId: checkpointActionId } },
+                  },
+                ],
+              }
+            : null,
+        },
+      });
+    return Response.json({}, { status: 404 });
+  };
+  const create = (threadId = "thread-a", messages: UIMessage[] = []) =>
+    new RemixRecoveryController({
+      threadId,
+      messages,
+      fetch,
+      storage: {
+        getItem: (key) => storage.get(key) ?? null,
+        setItem: (key, value) => {
+          storage.set(key, value);
+        },
+      },
+      onToolCall,
+      requiresApproval: () => true,
+      onFork,
+    });
+  return {
+    create,
+    calls,
+    threads,
+    turns,
+    queued,
+    storage,
+    onToolCall,
+    onFork,
+    offline: (value: boolean) => {
+      offline = value;
+    },
+    switchOwner: () => {
+      switchAfterIdentity = true;
+    },
+    loseEnqueue: () => {
+      loseEnqueue = true;
+    },
+    loseClaim: () => {
+      loseClaim = true;
+    },
+    loseRetry: () => {
+      loseRetry = true;
+    },
+    approval: () => {
+      const turn = [...turns.values()][0];
+      action = {
+        id: "action-a",
+        turnId: turn.id,
+        kind: "desktop",
+        status: "pending",
+        toolName: "Bash",
+      };
+      checkpointActionId = action.id;
+    },
+    expire: () => {
+      action!.status = "expired";
+      turns.get(action!.turnId)!.status = "needs_desktop";
+    },
+  };
+}
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+});
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe("durable persistence-boundary regressions", () => {
+  it("binds the initialized owner to the admission even when the backing account changes", async () => {
+    const h = harness();
+    h.switchOwner();
+    const controller = h.create();
+    await controller.send("Private A", context);
+    expect(h.turns.size).toBe(0);
+    expect(
+      h.calls
+        .find((call) => call.path === "/api/remix/turns")!
+        .headers.get("X-Remix-User"),
+    ).toBe("a");
+    expect(controller.getSnapshot().status).toBe("error");
+  });
+  it("retires offline completion after Stop and can send again after observer restart", async () => {
+    const h = harness();
+    const first = h.create();
+    await first.send("Run", context);
+    h.approval();
+    await first.start();
+    await first.authorizeTool("action-a");
+    h.offline(true);
+    await first.complete("action-a", { ok: true });
+    await first.stop();
+    first.dispose();
+    h.offline(false);
+    const second = h.create();
+    await second.start();
+    await second.send("A new request", context);
+    expect(h.turns.size).toBe(2);
+    expect(
+      [...h.storage.values()].every(
+        (saved) => JSON.parse(saved).completions.length === 0,
+      ),
+    ).toBe(true);
+  });
+  it("recovers a committed claim with the same claimant across an observer restart", async () => {
+    const h = harness();
+    const first = h.create();
+    await first.send("Run", context);
+    h.approval();
+    await first.start();
+    h.loseClaim();
+    await expect(first.authorizeTool("action-a")).rejects.toThrow(
+      "response lost",
+    );
+    first.dispose();
+    const second = h.create();
+    await second.start();
+    await second.authorizeTool("action-a");
+    const claims = h.calls.filter(
+      (call) => call.body?.type === "desktop_claim",
+    );
+    expect(claims).toHaveLength(2);
+    expect(claims[1].body!.clientId).toBe(claims[0].body!.clientId);
+    await second.complete("action-a", { ok: true });
+    expect(
+      h.calls.filter((call) => call.body?.type === "desktop_complete"),
+    ).toHaveLength(1);
+  });
+  it("requires a fresh user decision after an expired claim replacement", async () => {
+    const h = harness();
+    const first = h.create();
+    await first.send("Run", context);
+    h.approval();
+    await first.start();
+    h.loseClaim();
+    await expect(first.authorizeTool("action-a")).rejects.toThrow();
+    h.expire();
+    await first.start();
+    expect(first.getSnapshot().desktopRecovery?.actionId).toBe("action-a");
+    await first.retryDesktop();
+    expect(
+      h.calls.filter((call) => call.body?.type === "desktop_claim"),
+    ).toHaveLength(1);
+    expect(h.onToolCall).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        toolCallId: "replacement",
+        requiresConfirmation: true,
+      }),
+    );
+    await first.authorizeTool("replacement");
+    expect(
+      h.calls.filter((call) => call.body?.type === "desktop_claim"),
+    ).toHaveLength(2);
+  });
+  it("recovers an uncertain replacement without executing it and retires its retry intent", async () => {
+    const h = harness();
+    const first = h.create();
+    await first.send("Run", context);
+    h.approval();
+    await first.start();
+    h.loseClaim();
+    await expect(first.authorizeTool("action-a")).rejects.toThrow();
+    h.expire();
+    await first.start();
+    h.loseRetry();
+    await expect(first.retryDesktop()).rejects.toThrow();
+    first.dispose();
+    const second = h.create();
+    await second.start();
+    expect(
+      h.calls.filter((call) => call.body?.type === "desktop_claim"),
+    ).toHaveLength(1);
+    expect(h.onToolCall).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        toolCallId: "replacement",
+        requiresConfirmation: true,
+      }),
+    );
+    await second.authorizeTool("replacement");
+    await second.complete("replacement", { ok: true });
+    const saved = JSON.parse([...h.storage.values()][0]);
+    expect(saved.desktopRetries).toEqual({});
+    expect(saved.retrySources).toEqual({});
+    expect(saved.confirmActions).toEqual([]);
+  });
+  it("reviews the latest expired replacement even while assistant output names the original action", async () => {
+    const h = harness();
+    const controller = h.create();
+    await controller.send("Run", context);
+    h.approval();
+    await controller.start();
+    h.expire();
+    await controller.start();
+    await controller.retryDesktop();
+    h.expire();
+    await controller.start();
+    expect(controller.getSnapshot().desktopRecovery?.actionId).toBe(
+      "replacement",
+    );
+    await controller.retryDesktop();
+    expect(h.onToolCall).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        toolCallId: "replacement-2",
+        requiresConfirmation: true,
+      }),
+    );
+    await controller.authorizeTool("replacement-2");
+    await controller.complete("replacement-2", { ok: true });
+    const saved = JSON.parse([...h.storage.values()][0]);
+    expect(saved.desktopRetries).toEqual({});
+    expect(saved.retrySources).toEqual({});
+  });
+  it.each([
+    "Edited question",
+    "Old question",
+  ])("branches edit/regenerate input '%s' without rewriting append-only history", async (text) => {
+    const h = harness();
+    const original: UIMessage[] = [
+      {
+        id: "old-user",
+        role: "user",
+        parts: [{ type: "text", text: "Old question" }],
+      },
+      {
+        id: "old-answer",
+        role: "assistant",
+        parts: [{ type: "text", text: "Old answer" }],
+      },
+      {
+        id: "later-user",
+        role: "user",
+        parts: [{ type: "text", text: "Later question" }],
+      },
+    ];
+    h.threads.set("thread-a", original);
+    const first = h.create("thread-a", original);
+    await first.send(text, context, "old-user");
+    const fork = h.onFork.mock.calls[0][0];
+    const second = h.create(fork.id, fork.messages);
+    await second.start();
+    expect(h.threads.get("thread-a")).toEqual(original);
+    expect(h.threads.get(fork.id)).toHaveLength(1);
+    expect(h.threads.get(fork.id)![0]).toMatchObject({
+      parts: [{ type: "text", text }],
+    });
+    expect(h.threads.get(fork.id)![0].id).not.toBe("old-user");
+  });
+  it("replays a committed enqueue receipt after restart while keeping repeated sends distinct", async () => {
+    const h = harness();
+    const first = h.create();
+    await first.send("Run", context);
+    h.loseEnqueue();
+    await first.enqueue("Follow up", context);
+    expect(h.queued.size).toBe(1);
+    first.dispose();
+    const second = h.create();
+    await second.start();
+    expect(h.queued.size).toBe(1);
+    const writes = h.calls.filter((call) => call.body?.requestId);
+    expect(writes).toHaveLength(2);
+    expect(writes[1].body!.requestId).toBe(writes[0].body!.requestId);
+    await second.enqueue("Follow up", context);
+    expect(h.queued.size).toBe(2);
+  });
+});

--- a/apps/electron/src/renderer/src/lib/remix-recovery.test.ts
+++ b/apps/electron/src/renderer/src/lib/remix-recovery.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  nextRemixReconnect,
+  REMIX_RECONNECT_DELAYS_MS,
+  remixReconnectLabel,
+} from "./remix-recovery";
+
+describe("Remix reconnect policy", () => {
+  it("uses the approved capped exponential retry schedule", () => {
+    expect(REMIX_RECONNECT_DELAYS_MS).toEqual([
+      3_000, 6_000, 12_000, 24_000, 30_000,
+    ]);
+  });
+
+  it("pauses after the fifth failed reconnect", () => {
+    expect(nextRemixReconnect(5, 0)).toEqual({ phase: "paused", attempts: 5 });
+  });
+
+  it("formats a clickable countdown label", () => {
+    expect(
+      remixReconnectLabel(
+        { phase: "reconnecting", attempts: 1, retryAt: 3_000 },
+        1_001,
+      ),
+    ).toBe("Reconnecting — retry in 2 seconds");
+  });
+});

--- a/apps/electron/src/renderer/src/lib/remix-recovery.ts
+++ b/apps/electron/src/renderer/src/lib/remix-recovery.ts
@@ -1,0 +1,32 @@
+export const REMIX_RECONNECT_DELAYS_MS = [
+  3_000, 6_000, 12_000, 24_000, 30_000,
+] as const;
+
+export type RemixReconnectState =
+  | { phase: "idle" }
+  | { phase: "paused"; attempts: number }
+  | { phase: "reconnecting"; attempts: number; retryAt: number };
+
+/** Schedule at most five reconnects. `attempts` counts requests already made. */
+export function nextRemixReconnect(
+  attempts: number,
+  now: number,
+): RemixReconnectState {
+  if (attempts >= REMIX_RECONNECT_DELAYS_MS.length)
+    return { phase: "paused", attempts };
+  return {
+    phase: "reconnecting",
+    attempts,
+    retryAt: now + REMIX_RECONNECT_DELAYS_MS[attempts],
+  };
+}
+
+export function remixReconnectLabel(
+  state: RemixReconnectState,
+  now: number,
+): string | null {
+  if (state.phase === "paused") return "Connection paused — Resume";
+  if (state.phase !== "reconnecting") return null;
+  const seconds = Math.max(0, Math.ceil((state.retryAt - now) / 1_000));
+  return `Reconnecting — retry in ${seconds} second${seconds === 1 ? "" : "s"}`;
+}

--- a/apps/electron/src/renderer/src/lib/remix-thread.test.ts
+++ b/apps/electron/src/renderer/src/lib/remix-thread.test.ts
@@ -12,9 +12,9 @@ describe("Remix pill agent contract", () => {
       "utf8",
     );
 
-    expect(chat).toContain('api: "/api/agent"');
-    expect(chat).toContain('apiFetch("/api/agent"');
-    expect(chat).toContain("threadId: thread.id");
+    expect(chat).toContain("} = useRemixRecovery({");
+    expect(chat).not.toContain('apiFetch("/api/agent"');
+    expect(chat).toContain("id: thread.id");
     expect(chat).toContain("onOpenWorkspace(thread.id)");
     expect(chat).toContain("executeRemixTool(call");
     expect(chat).not.toContain('"/api/remix/thread');

--- a/apps/electron/src/renderer/src/lib/remix-tool-executor.test.ts
+++ b/apps/electron/src/renderer/src/lib/remix-tool-executor.test.ts
@@ -5,7 +5,10 @@ const { executeMcpToolCall } = vi.hoisted(() => ({
 }));
 vi.mock("@renderer/lib/mcp", () => ({ executeMcpToolCall }));
 
-import { executeRemixTool } from "./remix-tool-executor";
+import {
+  executeApprovedRemixTool,
+  executeRemixTool,
+} from "./remix-tool-executor";
 
 describe("canonical Remix tool executor", () => {
   const remixGetContext = vi.fn();
@@ -33,6 +36,50 @@ describe("canonical Remix tool executor", () => {
       query: "roadmap",
     });
   });
+  it("allows a confirmed cursor replacement through the cursor executor", async () => {
+    const remixPasteClipboard = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal("window", { api: { remixPasteClipboard } });
+    expect(
+      await executeApprovedRemixTool({
+        toolName: "paste",
+        toolCallId: "replacement",
+        input: {},
+      }),
+    ).toEqual({ ok: true });
+    expect(remixPasteClipboard).toHaveBeenCalledTimes(1);
+  });
+  it("allows a confirmed MCP replacement through its local MCP executor", async () => {
+    executeMcpToolCall.mockResolvedValue({ ok: true, content: [] });
+    expect(
+      await executeApprovedRemixTool({
+        toolName: "mcp_1_search",
+        toolCallId: "replacement",
+        input: { query: "roadmap" },
+      }),
+    ).toEqual({ ok: true, content: [] });
+    expect(executeMcpToolCall).toHaveBeenCalledWith("mcp_1_search", {
+      query: "roadmap",
+    });
+  });
+  it("preserves a declined save-file grant without executing the approved action", async () => {
+    const requestAgentFileSaveGrant = vi.fn(async () => ({
+      ok: false,
+      reason: "canceled",
+    }));
+    vi.stubGlobal("window", { api: { requestAgentFileSaveGrant } });
+    expect(
+      await executeApprovedRemixTool({
+        toolName: "save_file",
+        toolCallId: "replacement",
+        input: { filename: "test.txt", content: "content" },
+      }),
+    ).toEqual({ ok: false, reason: "canceled" });
+    expect(requestAgentFileSaveGrant).toHaveBeenCalledWith({
+      toolCallId: "replacement",
+      filename: "test.txt",
+      content: "content",
+    });
+  });
 
   it("returns a live cursor capture to the active renderer surface", async () => {
     remixGetContext.mockResolvedValue({
@@ -47,7 +94,7 @@ describe("canonical Remix tool executor", () => {
     const onContext = vi.fn();
 
     await expect(
-      executeRemixTool(
+      executeApprovedRemixTool(
         { toolName: "get_context", toolCallId: "call-1", input: {} },
         { onContext },
       ),

--- a/apps/electron/src/renderer/src/lib/remix-tool-executor.ts
+++ b/apps/electron/src/renderer/src/lib/remix-tool-executor.ts
@@ -1,10 +1,34 @@
 import type { RemixSelectionPayload } from "@shared/remix";
-import type { AgentToolCall } from "./agent-tools";
+import {
+  type AgentToolCall,
+  agentToolTier,
+  executeAgentTool,
+  requestAgentFileSaveGrant,
+} from "./agent-tools";
 import { executeMcpToolCall } from "./mcp";
 
 export interface RemixToolExecutionOptions {
   /** Keep the pill's next request grounded in a fresh live capture. */
   onContext?: (context: RemixSelectionPayload) => void;
+}
+
+/** Approval changes permission, not dispatch. Recovered cursor/MCP actions
+ * still use the same executor and context callback as their ordinary calls. */
+export async function executeApprovedRemixTool(
+  call: AgentToolCall,
+  options: RemixToolExecutionOptions = {},
+): Promise<Record<string, unknown>> {
+  if ((await agentToolTier(call)) === null)
+    return executeRemixTool(call, options);
+  const grant =
+    call.toolName === "save_file"
+      ? await requestAgentFileSaveGrant(call)
+      : null;
+  if (grant && grant.ok !== true) return grant;
+  return executeAgentTool(call, {
+    saveFileGrant:
+      grant && typeof grant.grant === "string" ? grant.grant : undefined,
+  });
 }
 
 const str = (input: Record<string, unknown>, key: string): string =>
@@ -27,8 +51,8 @@ const badArgs = (
 });
 
 /**
- * The canonical `/api/agent` thread can be rendered by either the compact
- * pill or the full workspace. Keep non-approved local tool dispatch here so
+ * The canonical `/api/remix` thread can be rendered by either the compact
+ * pill or the full workspace. Keep cursor/MCP local tool dispatch here so
  * the two surfaces cannot drift in MCP or cursor behavior.
  */
 export async function executeRemixTool(

--- a/apps/electron/src/renderer/src/lib/use-remix-recovery.ts
+++ b/apps/electron/src/renderer/src/lib/use-remix-recovery.ts
@@ -14,10 +14,17 @@ type Options = {
   messages: UIMessage[];
   context?: () => unknown;
   onToolCall: (event: {
-    toolCall: { toolName: string; toolCallId: string; input: unknown };
+    toolCall: {
+      toolName: string;
+      toolCallId: string;
+      input: unknown;
+      requiresConfirmation?: boolean;
+    };
   }) => Promise<void>;
   onFinish?: (event: { messages: UIMessage[] }) => void;
   onError?: (error: Error) => void;
+  onFork?: (thread: { id: string; messages: UIMessage[] }) => void;
+  onActionUnavailable?: (actionId: string) => void;
 };
 const defaultContext = () => ({
   selection: null,
@@ -53,6 +60,9 @@ export function useRemixRecovery(options: Options) {
           ].includes(name),
         onFinish: (messages) => ref.current.onFinish?.({ messages }),
         onError: (error) => ref.current.onError?.(error),
+        onFork: (thread) => ref.current.onFork?.(thread),
+        onActionUnavailable: (actionId) =>
+          ref.current.onActionUnavailable?.(actionId),
       }),
     [options.id],
   );
@@ -136,6 +146,8 @@ export function useRemixRecovery(options: Options) {
         attempt: controller.retry,
         resume: () =>
           controller.resume((ref.current.context ?? defaultContext)()),
+        desktop: snapshot.desktopRecovery,
+        retryDesktop: controller.retryDesktop,
       },
       queue: {
         items: snapshot.queue,

--- a/apps/electron/src/renderer/src/lib/use-remix-recovery.ts
+++ b/apps/electron/src/renderer/src/lib/use-remix-recovery.ts
@@ -1,0 +1,152 @@
+import { apiFetch, initApiBase } from "@renderer/lib/api";
+import type { UIMessage } from "ai";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { RemixRecoveryController } from "./remix-recovery-controller";
+
+type Options = {
+  id: string;
+  messages: UIMessage[];
+  context?: () => unknown;
+  onToolCall: (event: {
+    toolCall: { toolName: string; toolCallId: string; input: unknown };
+  }) => Promise<void>;
+  onFinish?: (event: { messages: UIMessage[] }) => void;
+  onError?: (error: Error) => void;
+};
+const defaultContext = () => ({
+  selection: null,
+  appName: null,
+  windowTitle: null,
+  capturedAt: Date.now(),
+});
+
+/** Both surfaces use the same receipt lifecycle and existing approval cards. */
+export function useRemixRecovery(options: Options) {
+  const ref = useRef(options);
+  ref.current = options;
+  const controller = useMemo(
+    () =>
+      new RemixRecoveryController({
+        threadId: options.id,
+        messages: ref.current.messages,
+        storage: localStorage,
+        fetch: async (path, init) => {
+          await initApiBase();
+          return apiFetch(path, init);
+        },
+        onToolCall: (toolCall) => ref.current.onToolCall({ toolCall }),
+        requiresApproval: (name) =>
+          [
+            "Bash",
+            "Read",
+            "Write",
+            "Edit",
+            "Glob",
+            "Grep",
+            "save_file",
+          ].includes(name),
+        onFinish: (messages) => ref.current.onFinish?.({ messages }),
+        onError: (error) => ref.current.onError?.(error),
+      }),
+    [options.id],
+  );
+  const snapshot = useSyncExternalStore(
+    controller.subscribe,
+    controller.getSnapshot,
+  );
+  const [now, setNow] = useState(Date.now);
+  useEffect(() => {
+    void controller.start();
+    return controller.dispose;
+  }, [controller]);
+  useEffect(() => {
+    if (snapshot.recovery.phase !== "reconnecting") return;
+    const timer = setInterval(() => setNow(Date.now()), 250);
+    return () => clearInterval(timer);
+  }, [snapshot.recovery.phase]);
+  return useMemo(
+    () => ({
+      messages: snapshot.messages,
+      status: snapshot.status,
+      canonical: snapshot.canonical,
+      durableRuntime: {
+        data: snapshot.runtime,
+        refetch: async () => {
+          await controller.start();
+          return { data: controller.getSnapshot().runtime };
+        },
+      },
+      setMessages: controller.setMessages,
+      clearError: controller.clearError,
+      sendMessage: (
+        { text, messageId }: { text: string; messageId?: string },
+        _options?: unknown,
+      ) =>
+        controller.send(
+          text,
+          (ref.current.context ?? defaultContext)(),
+          messageId,
+        ),
+      regenerate: async ({ messageId }: { messageId: string }) => {
+        const messages = controller.getSnapshot().messages;
+        const index = messages.findIndex((message) => message.id === messageId);
+        const user = messages
+          .slice(0, index)
+          .reverse()
+          .find((message) => message.role === "user");
+        if (user)
+          await controller.send(
+            user.parts
+              .filter((part) => part.type === "text")
+              .map((part) => part.text)
+              .join("\n"),
+            (ref.current.context ?? defaultContext)(),
+            user.id,
+          );
+      },
+      addToolResult: ({
+        toolCallId,
+        output,
+      }: {
+        tool?: string;
+        toolCallId: string;
+        output: unknown;
+      }) => controller.complete(toolCallId, output),
+      addToolOutput: ({
+        toolCallId,
+        output,
+      }: {
+        tool?: string;
+        toolCallId: string;
+        output: unknown;
+      }) => controller.complete(toolCallId, output),
+      stop: controller.detach,
+      cancel: controller.stop,
+      authorizeTool: controller.authorizeTool,
+      resumeStream: controller.start,
+      recovery: {
+        state: snapshot.recovery,
+        now,
+        attempt: controller.retry,
+        resume: () =>
+          controller.resume((ref.current.context ?? defaultContext)()),
+      },
+      queue: {
+        items: snapshot.queue,
+        active:
+          snapshot.status === "streaming" || snapshot.status === "submitted",
+        enqueue: controller.enqueue,
+        update: controller.updateQueued,
+        remove: controller.removeQueued,
+        steer: controller.steer,
+      },
+    }),
+    [controller, snapshot, now],
+  );
+}

--- a/apps/electron/src/renderer/src/remix-chat-polish.test.ts
+++ b/apps/electron/src/renderer/src/remix-chat-polish.test.ts
@@ -243,7 +243,6 @@ describe("Remix chat polish", () => {
     );
     expect(chat).toContain('className="remix-chat-approval"');
     expect(chat).toContain("Remix wants to act locally");
-    expect(chat).toContain("requestAgentFileSaveGrant(call)");
     expect(chat).toContain("DECLINED_OUTPUT");
     expect(chat).toContain('"Waiting for your approval"');
     expect(chat).toContain(

--- a/apps/electron/src/renderer/src/remix-chat-polish.test.ts
+++ b/apps/electron/src/renderer/src/remix-chat-polish.test.ts
@@ -238,7 +238,9 @@ describe("Remix chat polish", () => {
       readFile(resolve(rendererRoot, "pages/app.tsx"), "utf8"),
     ]);
 
-    expect(chat).toContain('if (tier === "confirmed")');
+    expect(chat).toContain(
+      'if (tier === "confirmed" || toolCall.requiresConfirmation)',
+    );
     expect(chat).toContain('className="remix-chat-approval"');
     expect(chat).toContain("Remix wants to act locally");
     expect(chat).toContain("requestAgentFileSaveGrant(call)");

--- a/apps/electron/src/renderer/src/remix-chat-polish.test.ts
+++ b/apps/electron/src/renderer/src/remix-chat-polish.test.ts
@@ -94,31 +94,44 @@ describe("Remix chat polish", () => {
     expect(sessions).toContain("current?.id === threadId ? loaded : current");
   });
 
-  it("reconnects either Remix surface to the local server-owned stream", async () => {
+  it("reconnects either Remix surface through the shared durable observer", async () => {
     const [chat, panel] = await Promise.all([
       readFile(resolve(rendererRoot, "components/remix-chat.tsx"), "utf8"),
       readFile(resolve(rendererRoot, "components/panel.tsx"), "utf8"),
     ]);
 
-    expect(chat).toContain("resume: true");
-    expect(panel).toContain("resume: true");
+    expect(chat).toContain("} = useRemixRecovery({");
+    expect(panel).toContain("} = useRemixRecovery({");
+  });
+
+  it("shows a shared retry countdown after a transient Remix stream failure", async () => {
+    const [chat, panel] = await Promise.all([
+      readFile(resolve(rendererRoot, "components/remix-chat.tsx"), "utf8"),
+      readFile(resolve(rendererRoot, "components/panel.tsx"), "utf8"),
+    ]);
+
+    expect(chat).toContain("useRemixRecovery");
+    expect(panel).toContain("useRemixRecovery");
   });
 
   it("keeps queued follow-ups in the shared local queue across both Remix surfaces", async () => {
     const [chat, panel, queue] = await Promise.all([
       readFile(resolve(rendererRoot, "components/remix-chat.tsx"), "utf8"),
       readFile(resolve(rendererRoot, "components/panel.tsx"), "utf8"),
-      readFile(resolve(rendererRoot, "lib/agent-message-queue.ts"), "utf8"),
+      readFile(
+        resolve(rendererRoot, "lib/remix-recovery-controller.ts"),
+        "utf8",
+      ),
     ]);
 
     expect(chat).toContain("AgentMessageQueueControls");
     expect(panel).toContain("AgentMessageQueueControls");
     expect(chat).toContain('capture("remix_message_queued"');
     expect(panel).toContain('capture("remix_message_queued"');
-    expect(chat).toContain("return resumeStream()");
-    expect(panel).toContain("return resumeStream()");
-    expect(queue).toContain('method: "POST"');
-    expect(queue).toContain("/steer");
+    expect(chat).toContain("queue,");
+    expect(panel).toContain("queue,");
+    expect(queue).toContain('method = body === undefined ? "GET" : "POST"');
+    expect(queue).toContain("steer = async");
   });
 
   it("uses the shared activity stream instead of periodic Remix polling", async () => {
@@ -391,8 +404,7 @@ describe("Remix chat polish", () => {
     );
 
     expect(chat).toContain("onCancelActive");
-    expect(chat).toContain("getThreadRuntime(thread.id)");
-    expect(chat).toContain("cancelDurableTurn(runtime.activeTurn.id)");
+    expect(chat).toContain("void cancel()");
     expect(chat).toContain("cancellationRequestedRef.current = false");
   });
 });

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1666,6 +1666,33 @@ button.tavern-notice {
   cursor: pointer;
 }
 
+button.tavern-recovery-notice {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  min-height: 30px;
+  margin: 8px 0 0;
+  padding: 5px 10px;
+  border: 1px solid color-mix(in srgb, var(--tavern-rust) 44%, var(--tavern-rule));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tavern-rust) 9%, transparent);
+  color: var(--tavern-rust);
+  font-weight: 650;
+  line-height: 1.25;
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+}
+
+button.tavern-recovery-notice:hover {
+  border-color: var(--tavern-rust);
+  background: color-mix(in srgb, var(--tavern-rust) 16%, transparent);
+  color: var(--tavern-ink);
+}
+
+button.tavern-recovery-notice:focus-visible {
+  outline: 2px solid var(--tavern-rust);
+  outline-offset: 2px;
+}
+
 .tavern-head-btn {
   font: inherit;
   font-size: 11px;

--- a/apps/electron/src/renderer/src/tavern.css
+++ b/apps/electron/src/renderer/src/tavern.css
@@ -1656,6 +1656,16 @@
   color: var(--tavern-rust);
 }
 
+button.tavern-notice {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
 .tavern-head-btn {
   font: inherit;
   font-size: 11px;

--- a/apps/electron/tests/remix-recovery.test.ts
+++ b/apps/electron/tests/remix-recovery.test.ts
@@ -94,6 +94,11 @@ async function installFixtures(page: Page) {
         turnId = backend.turnId;
       }
       const json = (body: unknown) => Response.json(body);
+      if (path === "/api/mcp/calls")
+        return json({
+          ok: true,
+          content: [{ type: "text", text: "Safe MCP test result" }],
+        });
       if (path === "/api/remix/identity")
         return json({ userId: "e2e", host: "https://cloud.test" });
       if (/\/api\/remix\/[^/]+\/queue$/.test(path)) {
@@ -268,18 +273,28 @@ type MainFixture = {
   claims: string[];
   completions: number;
   checkpointActionId?: string;
-  action: {
-    id: string;
-    turnId: string;
-    kind: string;
-    toolName: string;
-    status: string;
-    claimedBy?: string;
-  } | null;
+  toolName: string;
+  startExpired: boolean;
+  loseCompletion: boolean;
+  actions: Record<string, CloudAction>;
+  outputs: unknown[];
+  holdExecution: boolean;
+  action: CloudAction | null;
+};
+type CloudAction = {
+  id: string;
+  turnId: string;
+  kind: string;
+  toolName: string;
+  status: string;
+  claimedBy?: string;
+  retryOfActionId?: string;
 };
 type MainFixtureGlobal = {
   __recoveryCloud: MainFixture;
   __originalRecoveryFetch?: typeof fetch;
+  __safeExecutions?: string[];
+  __releaseSafeExecution?: () => void;
 };
 function readPersisted(owner: string, kind: "queue" | "cancel") {
   const db = new DatabaseSync(join(userData, "freestyle.db"));
@@ -316,6 +331,9 @@ async function mainState() {
       admissionCount: state.admissionCount,
       claims: state.claims,
       completions: state.completions,
+      outputs: state.outputs,
+      executions:
+        (globalThis as unknown as MainFixtureGlobal).__safeExecutions ?? [],
     };
   });
 }
@@ -333,7 +351,7 @@ async function installMainCloudFixture(owner: string) {
     Date.now(),
   );
   db.close();
-  await app.evaluate((_, owner) => {
+  await app.evaluate(({ ipcMain }, owner) => {
     const g = globalThis as unknown as MainFixtureGlobal;
     g.__originalRecoveryFetch ??= globalThis.fetch;
     const state: MainFixture = {
@@ -348,8 +366,25 @@ async function installMainCloudFixture(owner: string) {
       claims: [],
       completions: 0,
       action: null,
+      actions: {},
+      outputs: [],
+      toolName: "Bash",
+      startExpired: false,
+      loseCompletion: false,
+      holdExecution: false,
     };
     g.__recoveryCloud = state;
+    g.__safeExecutions = [];
+    // Exercise real renderer dispatch/IPC without touching the actual clipboard.
+    ipcMain.removeHandler("remix:paste-clipboard");
+    ipcMain.handle("remix:paste-clipboard", async () => {
+      g.__safeExecutions!.push("paste");
+      if (state.holdExecution)
+        await new Promise<void>((resolve) => {
+          g.__releaseSafeExecution = resolve;
+        });
+      return { ok: true };
+    });
     globalThis.fetch = async (input, init) => {
       const url = new URL(
         typeof input === "string"
@@ -386,7 +421,9 @@ async function installMainCloudFixture(owner: string) {
                 ? "retryable"
                 : "completed"
               : state.approval
-                ? "waiting_desktop"
+                ? state.startExpired
+                  ? "needs_desktop"
+                  : "waiting_desktop"
                 : "running",
           };
           state.turns.push(turn!);
@@ -400,10 +437,11 @@ async function installMainCloudFixture(owner: string) {
               id: crypto.randomUUID(),
               turnId: turn!.id,
               kind: "desktop",
-              toolName: "Bash",
-              status: "pending",
+              toolName: state.toolName,
+              status: state.startExpired ? "expired" : "pending",
             };
             state.checkpointActionId = state.action.id;
+            state.actions[state.action.id] = state.action;
           }
           if (state.loseAdmission) {
             state.loseAdmission = false;
@@ -422,6 +460,23 @@ async function installMainCloudFixture(owner: string) {
       }
       const turnId = path.split("/")[4];
       const turn = state.turns.find((turn) => turn.id === turnId);
+      if (path.includes("/actions/")) {
+        const action = state.actions[path.split("/").at(-1)!];
+        if (!action || action.turnId !== turnId)
+          return Response.json({}, { status: 404 });
+        return Response.json({
+          action: {
+            id: action.id,
+            turnId,
+            status: action.status,
+            toolName: action.toolName,
+            invocationId: "invocation",
+            ...(action.retryOfActionId
+              ? { retryOfActionId: action.retryOfActionId }
+              : {}),
+          },
+        });
+      }
       if (path.endsWith("/commands")) {
         if (body.type === "cancel") {
           turn!.status = "canceled";
@@ -447,26 +502,43 @@ async function installMainCloudFixture(owner: string) {
             action: {
               id: action.id,
               toolName: action.toolName,
-              input: { command: "pwd" },
+              input:
+                action.toolName === "Bash"
+                  ? { command: "pwd" }
+                  : action.toolName.startsWith("mcp_")
+                    ? { query: "roadmap" }
+                    : {},
             },
           });
         }
         if (body.type === "desktop_complete") {
-          if (turn!.status === "canceled")
+          if (state.loseCompletion) {
+            state.loseCompletion = false;
+            throw new Error("Completion offline");
+          }
+          if (
+            turn!.status === "canceled" ||
+            state.actions[body.actionId]?.status === "expired"
+          )
             return Response.json({}, { status: 409 });
           state.completions++;
+          state.outputs.push(body.result);
+          state.actions[body.actionId].status = "completed";
           state.action = null;
           turn!.status = "completed";
           return Response.json({ receipt: { accepted: true } });
         }
         if (body.type === "retry_desktop") {
+          const previous = state.action!;
           state.action = {
             id: crypto.randomUUID(),
             turnId: turn!.id,
             kind: "desktop",
-            toolName: "Bash",
+            toolName: previous.toolName,
             status: "pending",
+            retryOfActionId: previous.id,
           };
+          state.actions[state.action.id] = state.action;
           turn!.status = "waiting_desktop";
           return Response.json({ action: { id: state.action.id } });
         }
@@ -487,10 +559,15 @@ async function installMainCloudFixture(owner: string) {
                   parts: [
                     {
                       type: "dynamic-tool",
-                      toolName: "Bash",
+                      toolName: state.action.toolName,
                       toolCallId: "invocation",
                       state: "output-available",
-                      input: { command: "pwd" },
+                      input:
+                        state.action.toolName === "Bash"
+                          ? { command: "pwd" }
+                          : state.action.toolName.startsWith("mcp_")
+                            ? { query: "roadmap" }
+                            : {},
                       output: {
                         desktopAction: { actionId: state.checkpointActionId },
                       },
@@ -527,13 +604,46 @@ async function installMainCloudFixture(owner: string) {
   }, owner);
 }
 
+async function reattachSurface(surface: "compact" | "workspace") {
+  const page = surface === "compact" ? pill : workspace;
+  await page.goto(
+    `app://renderer/${surface === "compact" ? "pill.html" : "index.html"}?real-remix=1&recovery-resume=observer${surface === "workspace" ? "#/remix" : ""}`,
+  );
+  if (surface === "compact") {
+    await app.evaluate(({ BrowserWindow }) => {
+      const window = BrowserWindow.getAllWindows().find((window) =>
+        window.webContents.getURL().includes("pill.html"),
+      )!;
+      window.show();
+      window.setIgnoreMouseEvents(false);
+      window.webContents.send("remix:open-chat");
+    });
+  }
+  return page;
+}
+const reviewAction = (page: Page) =>
+  page.getByRole("button", {
+    name: "Desktop action interrupted — Review before retrying",
+    exact: true,
+  });
+const allowAction = (page: Page) =>
+  page.getByRole("button", { name: "Allow", exact: true });
+const savedCompletions = (page: Page) =>
+  page.evaluate(() =>
+    Object.keys(localStorage)
+      .filter((key) => key.startsWith("remix.recovery."))
+      .flatMap(
+        (key) => JSON.parse(localStorage.getItem(key)!).completions ?? [],
+      ),
+  );
+
 for (const surface of ["compact", "workspace"] as const) {
-  async function openSurface(real = false) {
-    const page = surface === "compact" ? pill : workspace;
+  async function openSurface(real = false, targetSurface = surface) {
+    const page = targetSurface === "compact" ? pill : workspace;
     await page.goto(
-      `app://renderer/${surface === "compact" ? "pill.html" : "index.html"}?${real ? "real-remix=1&" : ""}recovery=${Date.now()}${surface === "workspace" ? "#/remix" : ""}`,
+      `app://renderer/${targetSurface === "compact" ? "pill.html" : "index.html"}?${real ? "real-remix=1&" : ""}recovery=${Date.now()}${targetSurface === "workspace" ? "#/remix" : ""}`,
     );
-    if (surface === "compact") {
+    if (targetSurface === "compact") {
       await page.evaluate(() => window.api.getServerPort());
       await app.evaluate(({ BrowserWindow }) => {
         const window = BrowserWindow.getAllWindows().find((window) =>
@@ -545,7 +655,7 @@ for (const surface of ["compact", "workspace"] as const) {
       });
     }
     const input =
-      surface === "compact"
+      targetSurface === "compact"
         ? page.getByLabel("Message Remix")
         : page.locator("#panel-composer");
     await expect(input).toBeVisible();
@@ -554,7 +664,7 @@ for (const surface of ["compact", "workspace"] as const) {
     await page.getByRole("button", { name: "Send", exact: true }).click();
     await expect(
       page.getByRole("button", {
-        name: surface === "compact" ? "Stop" : "Stop generating",
+        name: targetSurface === "compact" ? "Stop" : "Stop generating",
         exact: true,
       }),
     ).toBeVisible();
@@ -569,6 +679,139 @@ for (const surface of ["compact", "workspace"] as const) {
         )
         .toBe(true);
     return { page, input };
+  }
+
+  for (const toolName of ["paste", "mcp_1_search"]) {
+    test(`${surface}: Allow executes a reviewed ${toolName} replacement once while another observer is attached`, async () => {
+      await closeObservers();
+      await installMainCloudFixture(`allow-${surface}-${toolName}`);
+      await app.evaluate((_, toolName) => {
+        const state = (globalThis as unknown as MainFixtureGlobal)
+          .__recoveryCloud;
+        state.approval = true;
+        state.startExpired = true;
+        state.toolName = toolName;
+      }, toolName);
+      await openSurface(true, "compact");
+      await expect(reviewAction(pill)).toBeVisible();
+      await reattachSurface("workspace");
+      await expect(reviewAction(workspace)).toBeVisible();
+      const page = surface === "compact" ? pill : workspace;
+      const other = surface === "compact" ? workspace : pill;
+      await reviewAction(page).click();
+      await expect(allowAction(page)).toBeVisible();
+      await expect(allowAction(other)).toBeVisible();
+      expect((await mainState()).claims).toHaveLength(0);
+      expect((await mainState()).executions).toHaveLength(0);
+      await allowAction(page).dispatchEvent("click");
+      await expect.poll(mainState).toMatchObject({ completions: 1 });
+      expect((await mainState()).outputs).toEqual([
+        expect.objectContaining({ ok: true }),
+      ]);
+      if (toolName === "paste")
+        expect((await mainState()).executions).toEqual(["paste"]);
+      else {
+        const mcpCalls = await page.evaluate(() =>
+          (window as unknown as FixtureWindow).__remixRecovery.calls.filter(
+            (call) => call.path === "/api/mcp/calls",
+          ),
+        );
+        expect(mcpCalls).toEqual([
+          {
+            path: "/api/mcp/calls",
+            body: { toolName: "mcp_1_search", input: { query: "roadmap" } },
+          },
+        ]);
+      }
+      await closeObservers();
+    });
+  }
+
+  if (surface === "workspace") {
+    test("attached compact and reattached workspace cannot both execute the same uncertain claim", async () => {
+      await closeObservers();
+      await installMainCloudFixture("two-observers");
+      await app.evaluate(() => {
+        const state = (globalThis as unknown as MainFixtureGlobal)
+          .__recoveryCloud;
+        Object.assign(state, {
+          approval: true,
+          startExpired: true,
+          toolName: "paste",
+          loseClaim: true,
+          holdExecution: true,
+        });
+      });
+      const { page } = await openSurface(true, "compact");
+      await reviewAction(page).click();
+      await expect(allowAction(page)).toBeVisible();
+      // Exercise confirmation, not the transparent pill's native hitbox.
+      await allowAction(page).dispatchEvent("click");
+      await expect.poll(async () => (await mainState()).claims.length).toBe(1);
+      expect((await mainState()).executions).toEqual([]);
+      await reattachSurface("workspace");
+      await expect(allowAction(pill)).toBeVisible();
+      await expect(allowAction(workspace)).toBeVisible();
+      await Promise.all([
+        allowAction(pill).dispatchEvent("click"),
+        allowAction(workspace).dispatchEvent("click"),
+      ]);
+      await expect.poll(async () => (await mainState()).claims.length).toBe(3);
+      expect(new Set((await mainState()).claims).size).toBe(1);
+      expect((await mainState()).executions).toEqual(["paste"]);
+      await app.evaluate(() => {
+        (globalThis as unknown as MainFixtureGlobal).__releaseSafeExecution?.();
+      });
+      await expect.poll(mainState).toMatchObject({ completions: 1 });
+      await closeObservers();
+    });
+    test("offline completion expiry observes another device's replacement after reattachment", async () => {
+      await closeObservers();
+      await installMainCloudFixture("expired-output");
+      await app.evaluate(() => {
+        Object.assign(
+          (globalThis as unknown as MainFixtureGlobal).__recoveryCloud,
+          {
+            approval: true,
+            startExpired: true,
+            toolName: "paste",
+            loseCompletion: true,
+          },
+        );
+      });
+      const { page } = await openSurface(true);
+      await reviewAction(page).click();
+      await allowAction(page).click();
+      await expect.poll(() => savedCompletions(page)).toHaveLength(1);
+      expect((await mainState()).executions).toEqual(["paste"]);
+      await closeObservers();
+      await app.evaluate(() => {
+        const state = (globalThis as unknown as MainFixtureGlobal)
+          .__recoveryCloud;
+        const previous = state.action!;
+        previous.status = "expired";
+        state.action = {
+          ...previous,
+          id: crypto.randomUUID(),
+          status: "pending",
+          claimedBy: undefined,
+          retryOfActionId: previous.id,
+        };
+        state.actions[state.action.id] = state.action;
+        state.turns.find((turn) => turn.id === previous.turnId)!.status =
+          "waiting_desktop";
+      });
+      await reattachSurface("workspace");
+      await expect(allowAction(workspace)).toBeVisible();
+      await expect.poll(() => savedCompletions(workspace)).toHaveLength(0);
+      expect((await mainState()).executions).toEqual(["paste"]);
+      await workspace
+        .getByRole("button", { name: "Don't allow", exact: true })
+        .click();
+      await expect.poll(mainState).toMatchObject({ completions: 1 });
+      expect((await mainState()).executions).toEqual(["paste"]);
+      await closeObservers();
+    });
   }
 
   test(`${surface}: real Hono and SQLite drain and cancel after both observers close`, async () => {

--- a/apps/electron/tests/remix-recovery.test.ts
+++ b/apps/electron/tests/remix-recovery.test.ts
@@ -1,0 +1,392 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  type ElectronApplication,
+  expect,
+  type Page,
+  test,
+} from "@playwright/test";
+import { _electron as electron } from "playwright";
+
+type Fixture = {
+  offline: boolean;
+  status: string;
+  calls: Array<{ path: string; body?: Record<string, unknown> }>;
+};
+type FixtureWindow = Window & { __remixRecovery: Fixture };
+let app: ElectronApplication;
+let pill: Page;
+let workspace: Page;
+
+async function installFixtures(page: Page) {
+  await page.addInitScript(() => {
+    if (!location.search.includes("recovery-resume")) localStorage.clear();
+    const f: Fixture = { offline: false, status: "running", calls: [] };
+    (window as unknown as FixtureWindow).__remixRecovery = f;
+    let messages: unknown[] = [];
+    let threadId = "";
+    let clientRequestId = "";
+    let queue: Array<{ id: string; text: string; createdAt: number }> = [];
+    const save = () =>
+      localStorage.setItem(
+        "e2e.remix.backend",
+        JSON.stringify({
+          messages,
+          threadId,
+          clientRequestId,
+          queue,
+          status: f.status,
+        }),
+      );
+    const turnId = "00000000-0000-4000-8000-000000000001";
+    const original = window.fetch.bind(window);
+    window.fetch = async (input, init) => {
+      const path = new URL(
+        typeof input === "string"
+          ? input
+          : input instanceof Request
+            ? input.url
+            : input.href,
+      ).pathname;
+      if (!path.startsWith("/api/")) return original(input, init);
+      const body = init?.body
+        ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+        : undefined;
+      f.calls.push({ path, body });
+      const stored = localStorage.getItem("e2e.remix.backend");
+      if (stored) {
+        const backend = JSON.parse(stored);
+        if (!threadId) f.status = backend.status;
+        messages = backend.messages;
+        threadId = backend.threadId;
+        clientRequestId = backend.clientRequestId;
+        queue = backend.queue;
+      }
+      const json = (body: unknown) => Response.json(body);
+      if (/\/api\/remix\/[^/]+\/queue$/.test(path)) {
+        if (body?.text) {
+          queue.push({
+            id: crypto.randomUUID(),
+            text: String(body.text),
+            createdAt: Date.now(),
+          });
+          save();
+        }
+        return json({
+          items: queue,
+          active:
+            Boolean(threadId) &&
+            !["completed", "failed", "canceled"].includes(f.status),
+        });
+      }
+      if (path.startsWith("/api/remix/") && f.offline)
+        throw new TypeError("offline");
+      if (path === "/api/auth/status")
+        return json({
+          authenticated: true,
+          verified: true,
+          user: { id: "e2e", email: "e2e@example.test", name: "Remix test" },
+        });
+      if (path === "/api/settings")
+        return json({ onboarding: JSON.stringify({ v: 2, done: true }) });
+      if (path === "/api/health")
+        return json({ name: "freestyle", status: "ok" });
+      if (path === "/api/remix/turns") {
+        if (clientRequestId !== body!.clientRequestId) f.status = "running";
+        clientRequestId = String(body!.clientRequestId);
+        threadId = String(body!.threadId);
+        messages = body!.messages as unknown[];
+        save();
+        return json({
+          turn: { id: turnId, status: f.status, clientRequestId },
+        });
+      }
+      if (path.startsWith("/api/remix/turns/") && path.endsWith("/commands")) {
+        if (body?.type === "cancel") f.status = "canceled";
+        save();
+        return json({ receipt: { accepted: true } });
+      }
+      if (path === `/api/remix/turns/${turnId}`)
+        return json({
+          turn: { id: turnId, status: f.status, clientRequestId },
+          checkpoint: { messages, assistant: null },
+        });
+      if (
+        path.startsWith("/api/remix/thread/") ||
+        path.startsWith("/api/agent/thread/")
+      ) {
+        if (path.endsWith("/latest"))
+          return json({ thread: threadId ? { id: threadId, messages } : null });
+        if (path.endsWith("/list"))
+          return json({ threads: [], nextCursor: null });
+        if (path.endsWith("/runs")) return json({ runs: [] });
+        return json({
+          thread: threadId ? { id: threadId, messages } : null,
+          activeTurn:
+            threadId && !["completed", "failed", "canceled"].includes(f.status)
+              ? { id: turnId, status: f.status }
+              : null,
+          pendingAction: null,
+        });
+      }
+      if (path === "/api/agent/activity/stream")
+        return new Response(
+          'event: activity\ndata: {"threads":[],"changedThreadId":null}\n\n',
+          { headers: { "Content-Type": "text/event-stream" } },
+        );
+      if (path === "/api/agent/activity") return json({ threads: [] });
+      if (path === "/api/usage")
+        return json({
+          remaining: 2400,
+          limit: 3000,
+          totalConsumed: 600,
+          plan: "free",
+        });
+      if (path === "/api/notifications/token")
+        return json({ token: null, userId: null });
+      if (path === "/api/connectors/connections")
+        return json({ connections: [] });
+      if (path.startsWith("/api/connectors/")) return json({ connectors: [] });
+      if (
+        [
+          "/api/keys",
+          "/api/models/available",
+          "/api/models/configured",
+          "/api/plugins",
+          "/api/brain/files",
+          "/api/dismissed-notifications",
+        ].includes(path)
+      )
+        return json([]);
+      return json({ items: [], threads: [], total: 0 });
+    };
+  });
+}
+
+test.beforeAll(async () => {
+  app = await electron.launch({
+    args: [resolve(__dirname, "../out/main/index.js")],
+    env: {
+      ...process.env,
+      NODE_ENV: "development",
+      FREESTYLE_E2E: "1",
+      FREESTYLE_USER_DATA: mkdtempSync(
+        join(tmpdir(), "freestyle-remix-recovery-"),
+      ),
+      ELECTRON_DISABLE_SECURITY_WARNINGS: "true",
+    },
+  });
+  pill = await app.firstWindow();
+  await pill.evaluate(() => window.api.getServerPort());
+  await pill.evaluate(() =>
+    window.electron.ipcRenderer.send("e2e:open-dashboard"),
+  );
+  workspace = await expect
+    .poll(() => app.windows().find((page) => page.url().includes("index.html")))
+    .toBeTruthy()
+    .then(
+      () => app.windows().find((page) => page.url().includes("index.html"))!,
+    );
+  await installFixtures(pill);
+  await installFixtures(workspace);
+});
+test.afterAll(async () => {
+  await app?.close();
+});
+
+for (const surface of ["compact", "workspace"] as const) {
+  async function openSurface() {
+    const page = surface === "compact" ? pill : workspace;
+    await page.goto(
+      `app://renderer/${surface === "compact" ? "pill.html" : "index.html"}?recovery=${Date.now()}${surface === "workspace" ? "#/remix" : ""}`,
+    );
+    if (surface === "compact") {
+      await page.evaluate(() => window.api.getServerPort());
+      await app.evaluate(({ BrowserWindow }) => {
+        const window = BrowserWindow.getAllWindows().find((window) =>
+          window.webContents.getURL().includes("pill.html"),
+        )!;
+        window.show();
+        window.setIgnoreMouseEvents(false);
+        window.webContents.send("remix:open-chat");
+      });
+    }
+    const input =
+      surface === "compact"
+        ? page.getByLabel("Message Remix")
+        : page.locator("#panel-composer");
+    await expect(input).toBeVisible();
+    await page.clock.install();
+    await input.fill("Start the recovery test");
+    await page.getByRole("button", { name: "Send", exact: true }).click();
+    await expect(
+      page.getByRole("button", {
+        name: surface === "compact" ? "Stop" : "Stop generating",
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (window as unknown as FixtureWindow).__remixRecovery.calls.some(
+            (call) => call.path.startsWith("/api/remix/turns/"),
+          ),
+        ),
+      )
+      .toBe(true);
+    return { page, input };
+  }
+
+  test(`${surface}: offline Stop retains follow-ups and retries cancellation`, async () => {
+    const { page, input } = await openSurface();
+    await page.evaluate(() => {
+      (window as unknown as FixtureWindow).__remixRecovery.offline = true;
+    });
+    await page.clock.runFor(1_000);
+    await expect(
+      page.getByRole("button", { name: /Reconnecting/ }),
+    ).toBeVisible();
+    await input.fill("Keep this follow-up");
+    await page.getByRole("button", { name: "Send", exact: true }).click();
+    await expect(page.locator(".agent-message-queue-text")).toHaveText(
+      "Keep this follow-up",
+    );
+    await page
+      .getByRole("button", {
+        name: surface === "compact" ? "Stop" : "Stop generating",
+        exact: true,
+      })
+      .click();
+    await expect(
+      page.getByRole("button", { name: /Reconnecting/ }),
+    ).toBeHidden();
+    await page.evaluate(() => {
+      (window as unknown as FixtureWindow).__remixRecovery.offline = false;
+    });
+    await page.clock.runFor(3_000);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (window as unknown as FixtureWindow).__remixRecovery.calls.some(
+            (call) => call.body?.type === "cancel",
+          ),
+        ),
+      )
+      .toBe(true);
+    await expect(page.locator(".agent-message-queue-text")).toHaveText(
+      "Keep this follow-up",
+    );
+  });
+
+  test(`${surface}: manual retry is immediate and paused Resume creates a visible new turn`, async () => {
+    const { page } = await openSurface();
+    await page.evaluate(() => {
+      (window as unknown as FixtureWindow).__remixRecovery.offline = true;
+    });
+    await page.clock.runFor(1_000);
+    const count = await page.evaluate(
+      () =>
+        (window as unknown as FixtureWindow).__remixRecovery.calls.filter(
+          (call) => call.path.startsWith("/api/remix/"),
+        ).length,
+    );
+    await page.getByRole("button", { name: /Reconnecting/ }).click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as FixtureWindow).__remixRecovery.calls.filter(
+              (call) => call.path.startsWith("/api/remix/"),
+            ).length,
+        ),
+      )
+      .toBe(count + 1);
+    for (const delay of [6_000, 12_000, 24_000, 30_000])
+      await page.clock.runFor(delay);
+    await expect(
+      page.getByRole("button", { name: "Connection paused — Resume" }),
+    ).toBeVisible();
+    await page.evaluate(() => {
+      (window as unknown as FixtureWindow).__remixRecovery.offline = false;
+    });
+    await page
+      .getByRole("button", { name: "Connection paused — Resume" })
+      .click();
+    await expect(
+      page.getByText("Continue from where you left off.", { exact: true }),
+    ).toBeVisible();
+    await expect
+      .poll(
+        async () =>
+          new Set(
+            await page.evaluate(() =>
+              (window as unknown as FixtureWindow).__remixRecovery.calls
+                .filter((call) => call.path === "/api/remix/turns")
+                .map((call) => call.body?.clientRequestId),
+            ),
+          ).size,
+      )
+      .toBe(2);
+  });
+
+  test(`${surface}: terminal snapshots settle without reconnecting`, async () => {
+    for (const status of ["completed", "failed", "canceled"]) {
+      const { page } = await openSurface();
+      await page.evaluate((status) => {
+        (window as unknown as FixtureWindow).__remixRecovery.status = status;
+      }, status);
+      await page.clock.runFor(1_000);
+      await expect(
+        page.getByRole("button", {
+          name: surface === "compact" ? "Stop" : "Stop generating",
+          exact: true,
+        }),
+      ).toBeHidden();
+      await expect(
+        page.getByRole("button", { name: /Reconnecting|Connection paused/ }),
+      ).toBeHidden();
+    }
+  });
+
+  if (surface === "compact")
+    test("keeps the queue through compact-to-workspace handoff and a closed observer", async () => {
+      // Prepare the destination before opening the compact window: focusing
+      // the dashboard after that would collapse the native compact surface.
+      await workspace.goto(
+        "app://renderer/index.html?recovery-resume=handoff#/remix",
+      );
+      await expect(workspace.locator("#panel-composer")).toBeVisible();
+      const { page, input } = await openSurface();
+      await input.fill("Survive a handoff");
+      await page.getByRole("button", { name: "Send", exact: true }).click();
+      await expect(page.locator(".agent-message-queue-text")).toHaveText(
+        "Survive a handoff",
+      );
+      // Exercise the real renderer -> main -> workspace handoff. The frozen
+      // renderer clock can leave the transparent native pill hitbox behind
+      // its DOM layout, so this lifecycle test dispatches the button event.
+      await page
+        .getByRole("button", { name: "Open Remix workspace", exact: true })
+        .dispatchEvent("click");
+      await expect(workspace.locator(".agent-message-queue-text")).toHaveText(
+        "Survive a handoff",
+      );
+      await page.goto("app://renderer/pill.html?recovery-resume=closed");
+      await workspace.goto(
+        "app://renderer/index.html?recovery-resume=closed#/today",
+      );
+      await workspace.goto(
+        "app://renderer/index.html?recovery-resume=reopen#/remix",
+      );
+      await expect(workspace.locator(".agent-message-queue-text")).toHaveText(
+        "Survive a handoff",
+      );
+      const submissions = await workspace.evaluate(() =>
+        (window as unknown as FixtureWindow).__remixRecovery.calls.filter(
+          (call) => call.path === "/api/remix/turns",
+        ),
+      );
+      expect(submissions).toHaveLength(0);
+    });
+}

--- a/apps/electron/tests/remix-recovery.test.ts
+++ b/apps/electron/tests/remix-recovery.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import {
   type ElectronApplication,
   expect,
@@ -13,16 +14,25 @@ type Fixture = {
   offline: boolean;
   status: string;
   calls: Array<{ path: string; body?: Record<string, unknown> }>;
+  successfulCancels: number;
+  loseEnqueue: boolean;
 };
 type FixtureWindow = Window & { __remixRecovery: Fixture };
 let app: ElectronApplication;
 let pill: Page;
 let workspace: Page;
+let userData: string;
 
 async function installFixtures(page: Page) {
   await page.addInitScript(() => {
     if (!location.search.includes("recovery-resume")) localStorage.clear();
-    const f: Fixture = { offline: false, status: "running", calls: [] };
+    const f: Fixture = {
+      offline: false,
+      status: "running",
+      calls: [],
+      successfulCancels: 0,
+      loseEnqueue: false,
+    };
     (window as unknown as FixtureWindow).__remixRecovery = f;
     let messages: unknown[] = [];
     let threadId = "";
@@ -37,9 +47,10 @@ async function installFixtures(page: Page) {
           clientRequestId,
           queue,
           status: f.status,
+          turnId,
         }),
       );
-    const turnId = "00000000-0000-4000-8000-000000000001";
+    let turnId = "00000000-0000-4000-8000-000000000001";
     const original = window.fetch.bind(window);
     window.fetch = async (input, init) => {
       const path = new URL(
@@ -50,6 +61,24 @@ async function installFixtures(page: Page) {
             : input.href,
       ).pathname;
       if (!path.startsWith("/api/")) return original(input, init);
+      if (
+        location.search.includes("real-remix") &&
+        (path.startsWith("/api/remix/") ||
+          path.startsWith("/api/agent/thread/") ||
+          path.startsWith("/api/agent/turn/"))
+      ) {
+        if (
+          f.loseEnqueue &&
+          init?.method === "POST" &&
+          /\/api\/remix\/[^/]+\/queue$/.test(path)
+        ) {
+          f.loseEnqueue = false;
+          const response = await original(input, init);
+          if (response.ok) throw new Error("Enqueue committed; response lost");
+          return response;
+        }
+        return original(input, init);
+      }
       const body = init?.body
         ? (JSON.parse(String(init.body)) as Record<string, unknown>)
         : undefined;
@@ -62,12 +91,15 @@ async function installFixtures(page: Page) {
         threadId = backend.threadId;
         clientRequestId = backend.clientRequestId;
         queue = backend.queue;
+        turnId = backend.turnId;
       }
       const json = (body: unknown) => Response.json(body);
+      if (path === "/api/remix/identity")
+        return json({ userId: "e2e", host: "https://cloud.test" });
       if (/\/api\/remix\/[^/]+\/queue$/.test(path)) {
-        if (body?.text) {
+        if (body?.text && !queue.some((item) => item.id === body.requestId)) {
           queue.push({
-            id: crypto.randomUUID(),
+            id: String(body.requestId),
             text: String(body.text),
             createdAt: Date.now(),
           });
@@ -93,17 +125,32 @@ async function installFixtures(page: Page) {
       if (path === "/api/health")
         return json({ name: "freestyle", status: "ok" });
       if (path === "/api/remix/turns") {
-        if (clientRequestId !== body!.clientRequestId) f.status = "running";
+        if (clientRequestId !== body!.clientRequestId) {
+          f.status = "running";
+          turnId = crypto.randomUUID();
+        }
         clientRequestId = String(body!.clientRequestId);
         threadId = String(body!.threadId);
-        messages = body!.messages as unknown[];
+        const incoming = body!.messages as Array<{ id: string }>;
+        messages = [
+          ...messages,
+          ...incoming.filter(
+            (message) =>
+              !(messages as Array<{ id: string }>).some(
+                (saved) => saved.id === message.id,
+              ),
+          ),
+        ];
         save();
         return json({
           turn: { id: turnId, status: f.status, clientRequestId },
         });
       }
       if (path.startsWith("/api/remix/turns/") && path.endsWith("/commands")) {
-        if (body?.type === "cancel") f.status = "canceled";
+        if (body?.type === "cancel") {
+          f.status = "canceled";
+          f.successfulCancels++;
+        }
         save();
         return json({ receipt: { accepted: true } });
       }
@@ -136,6 +183,8 @@ async function installFixtures(page: Page) {
           { headers: { "Content-Type": "text/event-stream" } },
         );
       if (path === "/api/agent/activity") return json({ threads: [] });
+      if (path.startsWith("/api/agent/turn/") && path.endsWith("/events"))
+        return json({ events: [] });
       if (path === "/api/usage")
         return json({
           remaining: 2400,
@@ -165,15 +214,15 @@ async function installFixtures(page: Page) {
 }
 
 test.beforeAll(async () => {
+  userData = mkdtempSync(join(tmpdir(), "freestyle-remix-recovery-"));
   app = await electron.launch({
     args: [resolve(__dirname, "../out/main/index.js")],
     env: {
       ...process.env,
       NODE_ENV: "development",
       FREESTYLE_E2E: "1",
-      FREESTYLE_USER_DATA: mkdtempSync(
-        join(tmpdir(), "freestyle-remix-recovery-"),
-      ),
+      FREESTYLE_USER_DATA: userData,
+      FREESTYLE_CLOUD_URL: "https://cloud.test",
       ELECTRON_DISABLE_SECURITY_WARNINGS: "true",
     },
   });
@@ -190,16 +239,299 @@ test.beforeAll(async () => {
     );
   await installFixtures(pill);
   await installFixtures(workspace);
+  workspace.on("console", (message) => {
+    if (message.type() === "error") console.error(message.text());
+  });
 });
 test.afterAll(async () => {
   await app?.close();
 });
 
+type CloudTurn = {
+  id: string;
+  threadId: string;
+  clientRequestId: string;
+  status: string;
+  messages: Array<{ id: string; role: string; parts: unknown[] }>;
+  context: unknown;
+  retryReceiptSeen?: boolean;
+};
+type MainFixture = {
+  turns: CloudTurn[];
+  messages: Record<string, CloudTurn["messages"]>;
+  offline: boolean;
+  headless: boolean;
+  loseAdmission: boolean;
+  admissionCount: number;
+  approval: boolean;
+  loseClaim: boolean;
+  claims: string[];
+  completions: number;
+  checkpointActionId?: string;
+  action: {
+    id: string;
+    turnId: string;
+    kind: string;
+    toolName: string;
+    status: string;
+    claimedBy?: string;
+  } | null;
+};
+type MainFixtureGlobal = {
+  __recoveryCloud: MainFixture;
+  __originalRecoveryFetch?: typeof fetch;
+};
+function readPersisted(owner: string, kind: "queue" | "cancel") {
+  const db = new DatabaseSync(join(userData, "freestyle.db"));
+  try {
+    const row = db
+      .prepare("SELECT value FROM settings WHERE key = ?")
+      .get(
+        `remix.${kind}.${encodeURIComponent("https://cloud.test")}.${owner}`,
+      ) as { value: string } | undefined;
+    if (!row) return [];
+    const value = JSON.parse(row.value);
+    return kind === "queue" ? Object.values(value) : value;
+  } finally {
+    db.close();
+  }
+}
+async function closeObservers() {
+  await pill.goto(
+    "app://renderer/pill.html?real-remix=1&recovery-resume=closed",
+  );
+  await workspace.goto(
+    "app://renderer/index.html?real-remix=1&recovery-resume=closed#/today",
+  );
+}
+async function mainState() {
+  return app.evaluate(() => {
+    const state = (globalThis as unknown as MainFixtureGlobal).__recoveryCloud;
+    return {
+      turnCount: state.turns.length,
+      completedCount: state.turns.filter((turn) => turn.status === "completed")
+        .length,
+      canceledCount: state.turns.filter((turn) => turn.status === "canceled")
+        .length,
+      admissionCount: state.admissionCount,
+      claims: state.claims,
+      completions: state.completions,
+    };
+  });
+}
+async function installMainCloudFixture(owner: string) {
+  // Seed only the disposable app database. All recovery HTTP handlers, local
+  // queue writes, and background workers remain the production implementation.
+  const db = new DatabaseSync(join(userData, "freestyle.db"));
+  db.prepare(
+    "INSERT INTO sessions (id, host, token, user_id, email, updated_at) VALUES (NULL, ?, ?, ?, ?, ?) ON CONFLICT(host) DO UPDATE SET token=excluded.token, user_id=excluded.user_id, email=excluded.email, updated_at=excluded.updated_at",
+  ).run(
+    "https://cloud.test",
+    "e2e-token",
+    owner,
+    "e2e@example.test",
+    Date.now(),
+  );
+  db.close();
+  await app.evaluate((_, owner) => {
+    const g = globalThis as unknown as MainFixtureGlobal;
+    g.__originalRecoveryFetch ??= globalThis.fetch;
+    const state: MainFixture = {
+      turns: [],
+      messages: {},
+      offline: false,
+      headless: false,
+      loseAdmission: false,
+      admissionCount: 0,
+      approval: false,
+      loseClaim: false,
+      claims: [],
+      completions: 0,
+      action: null,
+    };
+    g.__recoveryCloud = state;
+    globalThis.fetch = async (input, init) => {
+      const url = new URL(
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url,
+      );
+      if (url.origin !== "https://cloud.test")
+        return g.__originalRecoveryFetch!(input, init);
+      const path = url.pathname;
+      if (state.offline) throw new Error("Cloud is offline");
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      if (path === "/api/auth/get-session")
+        return Response.json({
+          user: { id: owner, email: "e2e@example.test" },
+          session: {},
+        });
+      if (path.startsWith("/v2/turns/") && path.endsWith("/events"))
+        return Response.json({ events: [] });
+      if (path === "/v2/remix/turns") {
+        state.admissionCount++;
+        let turn = state.turns.find(
+          (turn) =>
+            turn.threadId === body.threadId &&
+            turn.clientRequestId === body.clientRequestId,
+        );
+        if (!turn) {
+          turn = {
+            ...body,
+            id: crypto.randomUUID(),
+            status: state.headless
+              ? state.loseAdmission
+                ? "retryable"
+                : "completed"
+              : state.approval
+                ? "waiting_desktop"
+                : "running",
+          };
+          state.turns.push(turn!);
+          state.messages[body.threadId] ??= [];
+          const messages = state.messages[body.threadId];
+          for (const message of body.messages)
+            if (!messages.some((saved) => saved.id === message.id))
+              messages.push(message);
+          if (state.approval) {
+            state.action = {
+              id: crypto.randomUUID(),
+              turnId: turn!.id,
+              kind: "desktop",
+              toolName: "Bash",
+              status: "pending",
+            };
+            state.checkpointActionId = state.action.id;
+          }
+          if (state.loseAdmission) {
+            state.loseAdmission = false;
+            throw new Error("Admission committed; response lost");
+          }
+        } else if (state.headless && turn.status === "retryable") {
+          // Recover the lost admission first, then require a separate replay
+          // after that accepted turn is observed as retryable by the worker.
+          if (turn.retryReceiptSeen) turn.status = "completed";
+          turn.retryReceiptSeen = true;
+        }
+        return Response.json(
+          { turn, receipt: { duplicate: true } },
+          { status: 202 },
+        );
+      }
+      const turnId = path.split("/")[4];
+      const turn = state.turns.find((turn) => turn.id === turnId);
+      if (path.endsWith("/commands")) {
+        if (body.type === "cancel") {
+          turn!.status = "canceled";
+          return Response.json({ receipt: { canceled: true } });
+        }
+        if (body.type === "desktop_claim") {
+          const action = state.action;
+          state.claims.push(body.clientId);
+          if (
+            !action ||
+            (action.status !== "pending" &&
+              (action.status !== "claimed" ||
+                action.claimedBy !== body.clientId))
+          )
+            return Response.json({}, { status: 409 });
+          action.status = "claimed";
+          action.claimedBy = body.clientId;
+          if (state.loseClaim) {
+            state.loseClaim = false;
+            throw new Error("Claim committed; response lost");
+          }
+          return Response.json({
+            action: {
+              id: action.id,
+              toolName: action.toolName,
+              input: { command: "pwd" },
+            },
+          });
+        }
+        if (body.type === "desktop_complete") {
+          if (turn!.status === "canceled")
+            return Response.json({}, { status: 409 });
+          state.completions++;
+          state.action = null;
+          turn!.status = "completed";
+          return Response.json({ receipt: { accepted: true } });
+        }
+        if (body.type === "retry_desktop") {
+          state.action = {
+            id: crypto.randomUUID(),
+            turnId: turn!.id,
+            kind: "desktop",
+            toolName: "Bash",
+            status: "pending",
+          };
+          turn!.status = "waiting_desktop";
+          return Response.json({ action: { id: state.action.id } });
+        }
+      }
+      if (path.startsWith("/v2/remix/turns/") && turn)
+        return Response.json({
+          turn,
+          checkpoint: {
+            messages: turn.messages,
+            context: turn.context,
+            toolState: state.action
+              ? [{ actionId: state.action.id, status: state.action.status }]
+              : [],
+            assistant: state.action
+              ? {
+                  id: `assistant-${turn.id}`,
+                  role: "assistant",
+                  parts: [
+                    {
+                      type: "dynamic-tool",
+                      toolName: "Bash",
+                      toolCallId: "invocation",
+                      state: "output-available",
+                      input: { command: "pwd" },
+                      output: {
+                        desktopAction: { actionId: state.checkpointActionId },
+                      },
+                    },
+                  ],
+                }
+              : null,
+          },
+        });
+      if (path.startsWith("/v2/threads")) {
+        if (path === "/v2/threads" || path.endsWith("/list"))
+          return Response.json({ threads: [], nextCursor: null });
+        if (path.endsWith("/runs")) return Response.json({ runs: [] });
+        const id = path.endsWith("/latest")
+          ? state.turns.at(-1)?.threadId
+          : path.split("/")[3];
+        return Response.json({
+          thread:
+            id && state.messages[id]
+              ? { id, messages: state.messages[id] }
+              : null,
+          activeTurn:
+            state.turns.find(
+              (turn) =>
+                turn.threadId === id &&
+                !["completed", "canceled", "failed"].includes(turn.status),
+            ) ?? null,
+          pendingAction:
+            state.action?.status === "expired" ? null : state.action,
+        });
+      }
+      return Response.json({});
+    };
+  }, owner);
+}
+
 for (const surface of ["compact", "workspace"] as const) {
-  async function openSurface() {
+  async function openSurface(real = false) {
     const page = surface === "compact" ? pill : workspace;
     await page.goto(
-      `app://renderer/${surface === "compact" ? "pill.html" : "index.html"}?recovery=${Date.now()}${surface === "workspace" ? "#/remix" : ""}`,
+      `app://renderer/${surface === "compact" ? "pill.html" : "index.html"}?${real ? "real-remix=1&" : ""}recovery=${Date.now()}${surface === "workspace" ? "#/remix" : ""}`,
     );
     if (surface === "compact") {
       await page.evaluate(() => window.api.getServerPort());
@@ -217,7 +549,7 @@ for (const surface of ["compact", "workspace"] as const) {
         ? page.getByLabel("Message Remix")
         : page.locator("#panel-composer");
     await expect(input).toBeVisible();
-    await page.clock.install();
+    if (!real) await page.clock.install();
     await input.fill("Start the recovery test");
     await page.getByRole("button", { name: "Send", exact: true }).click();
     await expect(
@@ -226,17 +558,211 @@ for (const surface of ["compact", "workspace"] as const) {
         exact: true,
       }),
     ).toBeVisible();
-    await expect
-      .poll(() =>
-        page.evaluate(() =>
-          (window as unknown as FixtureWindow).__remixRecovery.calls.some(
-            (call) => call.path.startsWith("/api/remix/turns/"),
+    if (!real)
+      await expect
+        .poll(() =>
+          page.evaluate(() =>
+            (window as unknown as FixtureWindow).__remixRecovery.calls.some(
+              (call) => call.path.startsWith("/api/remix/turns/"),
+            ),
           ),
-        ),
-      )
-      .toBe(true);
+        )
+        .toBe(true);
     return { page, input };
   }
+
+  test(`${surface}: real Hono and SQLite drain and cancel after both observers close`, async () => {
+    const owner = `live-${surface}`;
+    await installMainCloudFixture(owner);
+    const { page, input } = await openSurface(true);
+    await expect.poll(() => mainState()).toMatchObject({ turnCount: 1 });
+    await page.evaluate(() => {
+      (window as unknown as FixtureWindow).__remixRecovery.loseEnqueue = true;
+    });
+    for (const text of ["Headless follow-up one", "Headless follow-up two"]) {
+      await input.fill(text);
+      await page.getByRole("button", { name: "Send", exact: true }).click();
+      await expect
+        .poll(() =>
+          readPersisted(owner, "queue").flatMap(
+            (state: { items: Array<{ text: string }> }) =>
+              state.items.map((item) => item.text),
+          ),
+        )
+        .toContain(text);
+      await expect
+        .poll(() =>
+          page.evaluate(() =>
+            Object.keys(localStorage)
+              .filter((key) => key.startsWith("remix.recovery."))
+              .flatMap(
+                (key) => JSON.parse(localStorage.getItem(key)!).enqueues ?? [],
+              ),
+          ),
+        )
+        .toHaveLength(0);
+    }
+    expect(
+      readPersisted(owner, "queue").flatMap(
+        (state: { items: unknown[] }) => state.items,
+      ),
+    ).toHaveLength(2);
+    await expect(page.locator(".agent-message-queue-text")).toContainText(
+      "Headless follow-up one",
+    );
+    await closeObservers();
+    await app.evaluate(() => {
+      const state = (globalThis as unknown as MainFixtureGlobal)
+        .__recoveryCloud;
+      state.turns[0].status = "completed";
+      state.loseAdmission = true;
+      state.headless = true;
+    });
+    await expect
+      .poll(mainState, { timeout: 15_000 })
+      .toMatchObject({ turnCount: 3, completedCount: 3 });
+    expect(
+      readPersisted(owner, "queue").flatMap(
+        (state: { items: unknown[] }) => state.items,
+      ),
+    ).toHaveLength(0);
+    const admitted = await mainState();
+    expect(admitted.admissionCount).toBe(5); // Lost receipt + retryable replay, not duplicate turns.
+    await workspace.goto(
+      "app://renderer/index.html?real-remix=1&recovery-resume=headless#/remix",
+    );
+    await expect(
+      workspace.getByText("Headless follow-up two", { exact: true }),
+    ).toBeVisible();
+    await expect.poll(mainState).toMatchObject({ turnCount: 3 });
+    await app.evaluate(() => {
+      (globalThis as unknown as MainFixtureGlobal).__recoveryCloud.headless =
+        false;
+    });
+    await workspace
+      .locator("#panel-composer")
+      .fill("Cancel through the real outbox");
+    await workspace.getByRole("button", { name: "Send", exact: true }).click();
+    await expect.poll(mainState).toMatchObject({ turnCount: 4 });
+    await app.evaluate(() => {
+      (globalThis as unknown as MainFixtureGlobal).__recoveryCloud.offline =
+        true;
+    });
+    await workspace
+      .getByRole("button", { name: "Stop generating", exact: true })
+      .click();
+    await expect
+      .poll(() => readPersisted(owner, "cancel").flat())
+      .toHaveLength(1);
+    await closeObservers();
+    await app.evaluate(() => {
+      (globalThis as unknown as MainFixtureGlobal).__recoveryCloud.offline =
+        false;
+    });
+    await expect
+      .poll(mainState, { timeout: 15_000 })
+      .toMatchObject({ canceledCount: 1 });
+    await expect
+      .poll(() => readPersisted(owner, "cancel").flat())
+      .toHaveLength(0);
+  });
+
+  if (surface === "workspace")
+    test("workspace: real proxy recovers lost claims and explicitly reviews expired replacements", async () => {
+      await installMainCloudFixture("live-claims");
+      await app.evaluate(() => {
+        const state = (globalThis as unknown as MainFixtureGlobal)
+          .__recoveryCloud;
+        state.approval = true;
+        state.loseClaim = true;
+      });
+      const { page } = await openSurface(true);
+      await page
+        .getByRole("button", { name: "Don't allow", exact: true })
+        .click();
+      await expect.poll(mainState).toMatchObject({ completions: 0 });
+      await expect.poll(async () => (await mainState()).claims.length).toBe(1);
+      await page.goto(
+        "app://renderer/index.html?real-remix=1&recovery-resume=claim#/remix",
+      );
+      await page
+        .getByRole("button", { name: "Don't allow", exact: true })
+        .click();
+      await expect.poll(mainState).toMatchObject({ completions: 1 });
+      const first = await mainState();
+      expect(first.claims).toHaveLength(2);
+      expect(first.claims[1]).toBe(first.claims[0]);
+      await app.evaluate(() => {
+        (globalThis as unknown as MainFixtureGlobal).__recoveryCloud.loseClaim =
+          true;
+      });
+      await page.locator("#panel-composer").fill("A second approval");
+      await page.getByRole("button", { name: "Send", exact: true }).click();
+      await page
+        .getByRole("button", { name: "Don't allow", exact: true })
+        .click();
+      await expect.poll(async () => (await mainState()).claims.length).toBe(3);
+      await app.evaluate(() => {
+        const state = (globalThis as unknown as MainFixtureGlobal)
+          .__recoveryCloud;
+        state.action!.status = "expired";
+        state.turns.find((turn) => turn.id === state.action!.turnId)!.status =
+          "needs_desktop";
+      });
+      await page
+        .getByRole("button", {
+          name: "Desktop action interrupted — Review before retrying",
+          exact: true,
+        })
+        .click();
+      expect((await mainState()).claims).toHaveLength(3);
+      await page
+        .getByRole("button", { name: "Don't allow", exact: true })
+        .last()
+        .click();
+      await expect.poll(mainState).toMatchObject({ completions: 2 });
+      expect((await mainState()).claims).toHaveLength(4);
+    });
+
+  if (surface === "workspace")
+    test("workspace: editing branches append-only history instead of losing the revision", async () => {
+      await installMainCloudFixture("live-edit");
+      const { page } = await openSurface(true);
+      await app.evaluate(() => {
+        (
+          globalThis as unknown as MainFixtureGlobal
+        ).__recoveryCloud.turns[0].status = "completed";
+      });
+      await expect(
+        page.getByRole("button", { name: "Stop generating", exact: true }),
+      ).toBeHidden();
+      await page.locator(".tavern-msg-user-wrap").first().hover();
+      await page
+        .getByRole("button", { name: "Edit in new chat", exact: true })
+        .first()
+        .click();
+      await page
+        .getByLabel("Edit message", { exact: true })
+        .fill("The revised question");
+      await page
+        .getByRole("button", { name: "Send in new chat", exact: true })
+        .click();
+      await expect.poll(mainState).toMatchObject({ turnCount: 2 });
+      await expect(
+        page.getByText("The revised question", { exact: true }),
+      ).toBeVisible();
+      const history = await app.evaluate(
+        () =>
+          (globalThis as unknown as MainFixtureGlobal).__recoveryCloud.messages,
+      );
+      expect(Object.keys(history)).toHaveLength(2);
+      expect(
+        Object.values(history).map((messages) => messages[0].parts),
+      ).toEqual([
+        [{ type: "text", text: "Start the recovery test" }],
+        [{ type: "text", text: "The revised question" }],
+      ]);
+    });
 
   test(`${surface}: offline Stop retains follow-ups and retries cancellation`, async () => {
     const { page, input } = await openSurface();
@@ -267,10 +793,15 @@ for (const surface of ["compact", "workspace"] as const) {
     await page.clock.runFor(3_000);
     await expect
       .poll(() =>
-        page.evaluate(() =>
-          (window as unknown as FixtureWindow).__remixRecovery.calls.some(
-            (call) => call.body?.type === "cancel",
-          ),
+        page.evaluate(
+          () =>
+            (window as unknown as FixtureWindow).__remixRecovery
+              .successfulCancels > 0 &&
+            (window as unknown as FixtureWindow).__remixRecovery.status ===
+              "canceled" &&
+            Object.entries(localStorage)
+              .filter(([key]) => key.startsWith("remix.recovery."))
+              .every(([, value]) => JSON.parse(value).cancels.length === 0),
         ),
       )
       .toBe(true);
@@ -346,6 +877,10 @@ for (const surface of ["compact", "workspace"] as const) {
       await expect(
         page.getByRole("button", { name: /Reconnecting|Connection paused/ }),
       ).toBeHidden();
+      if (status === "failed")
+        await expect(
+          page.getByText("Remix couldn't complete this turn.", { exact: true }),
+        ).toBeVisible();
     }
   });
 

--- a/apps/server/src/lib/remix-cancel-outbox.ts
+++ b/apps/server/src/lib/remix-cancel-outbox.ts
@@ -1,0 +1,119 @@
+import { deleteSetting, readSetting, writeSetting } from "./db.js";
+import { freestyleCloudUrl } from "./freestyle-cloud.js";
+import { getSession } from "./sessions.js";
+
+// Scope pending cancellation to the host and signed-in user. An admission
+// whose response was lost also retains its immutable request, so the local
+// server can recover its receipt and stop it after the renderer closes.
+function key() {
+  const session = getSession();
+  return session
+    ? `remix.cancel.${encodeURIComponent(session.host)}.${session.user.id}`
+    : null;
+}
+
+export function pendingRemixCancels(): string[] {
+  return pendingEntries().flatMap((entry) =>
+    entry.turnId ? [entry.turnId] : [],
+  );
+}
+
+type CancelEntry = {
+  turnId?: string;
+  request?: Record<string, unknown> & { clientRequestId: string };
+};
+function pendingEntries(): CancelEntry[] {
+  const scopedKey = key();
+  if (!scopedKey) return [];
+  return (
+    JSON.parse(readSetting(scopedKey) ?? "[]") as Array<string | CancelEntry>
+  ).map((entry) => (typeof entry === "string" ? { turnId: entry } : entry));
+}
+
+export function deferRemixCancel(turnId: string): void {
+  deferEntry({ turnId });
+}
+
+export function deferRemixRequestCancel(
+  request: NonNullable<CancelEntry["request"]>,
+): void {
+  deferEntry({ request });
+}
+
+function entryId(entry: CancelEntry) {
+  return entry.turnId ?? entry.request?.clientRequestId;
+}
+function deferEntry(entry: CancelEntry): void {
+  const scopedKey = key();
+  if (!scopedKey) throw new Error("cloud_auth_required");
+  writeSetting(
+    scopedKey,
+    JSON.stringify([
+      ...pendingEntries().filter((saved) => entryId(saved) !== entryId(entry)),
+      entry,
+    ]),
+  );
+}
+
+let flushing: Promise<void> | null = null;
+export function flushRemixCancels(): Promise<void> {
+  if (flushing) return flushing;
+  flushing = (async () => {
+    const session = getSession();
+    const scopedKey = key();
+    if (!session || !scopedKey) return;
+    for (const entry of pendingEntries()) {
+      try {
+        let turnId = entry.turnId;
+        if (!turnId && entry.request) {
+          const admission = await fetch(
+            `${freestyleCloudUrl()}/v2/remix/turns`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${session.token}`,
+              },
+              body: JSON.stringify(entry.request),
+              signal: AbortSignal.timeout(15_000),
+            },
+          );
+          if (!admission.ok || key() !== scopedKey) continue;
+          turnId = ((await admission.json()) as { turn: { id: string } }).turn
+            .id;
+        }
+        if (!turnId || key() !== scopedKey) continue;
+        const response = await fetch(
+          `${freestyleCloudUrl()}/v2/remix/turns/${encodeURIComponent(turnId)}/commands`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${session.token}`,
+            },
+            body: JSON.stringify({ type: "cancel" }),
+            signal: AbortSignal.timeout(15_000),
+          },
+        );
+        if (key() !== scopedKey) return;
+        if (!response.ok && response.status !== 404) continue;
+        const remaining = pendingEntries().filter(
+          (saved) => entryId(saved) !== entryId(entry),
+        );
+        if (remaining.length)
+          writeSetting(scopedKey, JSON.stringify(remaining));
+        else deleteSetting(scopedKey);
+      } catch {
+        // Retain the intent through offline periods and process restarts.
+      }
+    }
+  })().finally(() => {
+    flushing = null;
+  });
+  return flushing;
+}
+
+// This belongs to the server, so closing the pill does not abandon Stop.
+setInterval(() => {
+  void flushRemixCancels().catch(() => {});
+}, 10_000).unref();

--- a/apps/server/src/lib/remix-cancel-outbox.ts
+++ b/apps/server/src/lib/remix-cancel-outbox.ts
@@ -22,6 +22,15 @@ type CancelEntry = {
   turnId?: string;
   request?: Record<string, unknown> & { clientRequestId: string };
 };
+const settledListeners = new Set<
+  (receipt: { turnId: string; clientRequestId?: string }) => void
+>();
+export function onRemixCancellationSettled(
+  listener: (receipt: { turnId: string; clientRequestId?: string }) => void,
+) {
+  settledListeners.add(listener);
+  return () => settledListeners.delete(listener);
+}
 function pendingEntries(): CancelEntry[] {
   const scopedKey = key();
   if (!scopedKey) return [];
@@ -97,6 +106,8 @@ export function flushRemixCancels(): Promise<void> {
         );
         if (key() !== scopedKey) return;
         if (!response.ok && response.status !== 404) continue;
+        for (const listener of settledListeners)
+          listener({ turnId, clientRequestId: entry.request?.clientRequestId });
         const remaining = pendingEntries().filter(
           (saved) => entryId(saved) !== entryId(entry),
         );

--- a/apps/server/src/lib/remix-durable-queue.ts
+++ b/apps/server/src/lib/remix-durable-queue.ts
@@ -6,6 +6,7 @@ import {
   deferRemixCancel,
   deferRemixRequestCancel,
   flushRemixCancels,
+  onRemixCancellationSettled,
 } from "./remix-cancel-outbox.js";
 import { getSession } from "./sessions.js";
 
@@ -18,9 +19,14 @@ export type RemixQueuedMessage = {
 };
 type QueueState = {
   items: RemixQueuedMessage[];
+  enqueueIds?: string[];
   activeTurnId?: string;
   steer?: boolean;
   paused?: boolean;
+  activeRequest?: Record<string, unknown>;
+  retryAttempts?: number;
+  retryAt?: number;
+  recoveryPaused?: boolean;
 };
 type Registry = Record<string, QueueState>;
 function scope() {
@@ -40,7 +46,8 @@ function write(threadId: string, state: QueueState) {
   const key = scope();
   if (!key) throw new Error("cloud_auth_required");
   const all = registry();
-  if (!state.activeTurnId && !state.items.length) delete all[threadId];
+  if (!state.activeTurnId && !state.items.length && !state.enqueueIds?.length)
+    delete all[threadId];
   else all[threadId] = state;
   writeSetting(key, JSON.stringify(all));
   agentActivityEvents.publish(threadId);
@@ -49,16 +56,26 @@ export function remixQueueSnapshot(threadId: string) {
   const state = read(threadId);
   return {
     items: state.items.map(({ request: _request, ...item }) => item),
-    active: Boolean(state.activeTurnId) && !state.paused,
+    active:
+      Boolean(state.activeTurnId) && !state.paused && !state.recoveryPaused,
     activeTurnId: state.activeTurnId ?? null,
+    recoveryPaused: Boolean(state.recoveryPaused),
   };
 }
-export function registerRemixTurn(threadId: string, turnId: string) {
+export function registerRemixTurn(
+  threadId: string,
+  turnId: string,
+  request?: Record<string, unknown>,
+) {
   write(threadId, {
     ...read(threadId),
     activeTurnId: turnId,
     steer: false,
     paused: false,
+    activeRequest: request,
+    retryAttempts: 0,
+    retryAt: undefined,
+    recoveryPaused: false,
   });
 }
 export function pauseRemixQueue(threadId: string) {
@@ -75,8 +92,10 @@ export function pauseRemixQueue(threadId: string) {
 export function remixQueueActivity() {
   return Object.entries(registry()).map(([threadId, state]) => ({
     threadId,
-    active: Boolean(state.activeTurnId) && !state.paused,
+    active:
+      Boolean(state.activeTurnId) && !state.paused && !state.recoveryPaused,
     queuedCount: state.items.length,
+    recoveryPaused: Boolean(state.recoveryPaused),
   }));
 }
 export function settleRemixTurn(turnId: string, status: string) {
@@ -84,18 +103,24 @@ export function settleRemixTurn(turnId: string, status: string) {
   for (const [threadId, state] of Object.entries(registry())) {
     if (state.activeTurnId !== turnId) continue;
     state.activeTurnId = undefined;
+    state.activeRequest = undefined;
+    state.recoveryPaused = false;
     state.steer = Boolean(state.steer || status === "completed");
     write(threadId, state);
   }
 }
 export function enqueueRemixMessage(
   threadId: string,
-  input: { text: string; context?: unknown },
+  input: { requestId?: string; text: string; context?: unknown },
 ) {
   const state = read(threadId);
+  const { requestId = crypto.randomUUID(), ...message } = input;
+  if (state.enqueueIds?.includes(requestId))
+    return remixQueueSnapshot(threadId);
+  state.enqueueIds = [...(state.enqueueIds ?? []), requestId];
   state.items.push({
-    ...input,
-    id: crypto.randomUUID(),
+    ...message,
+    id: requestId,
     createdAt: Date.now(),
   });
   write(threadId, state);
@@ -130,6 +155,9 @@ export function steerRemixQueuedMessage(threadId: string, id: string) {
   state.items = [item, ...state.items.filter((item) => item.id !== id)];
   state.steer = true;
   state.paused = false;
+  state.recoveryPaused = false;
+  state.retryAttempts = 0;
+  state.retryAt = undefined;
   if (state.activeTurnId) {
     deferRemixCancel(state.activeTurnId);
     void flushRemixCancels();
@@ -139,6 +167,28 @@ export function steerRemixQueuedMessage(threadId: string, id: string) {
   return true;
 }
 const draining = new Set<string>();
+const RETRY_DELAYS = [3_000, 6_000, 12_000, 24_000, 30_000];
+onRemixCancellationSettled(({ turnId, clientRequestId }) => {
+  for (const [threadId, state] of Object.entries(registry())) {
+    let changed = false;
+    for (const item of state.items) {
+      if (!clientRequestId || item.request?.clientRequestId !== clientRequestId)
+        continue;
+      // The old admission is definitively canceled. Preserve the draft, but
+      // detach it from that immutable receipt so edit/remove/steer work again.
+      item.id = crypto.randomUUID();
+      item.request = undefined;
+      changed = true;
+    }
+    if (state.activeTurnId === turnId) {
+      state.activeTurnId = undefined;
+      state.activeRequest = undefined;
+      state.recoveryPaused = false;
+      changed = true;
+    }
+    if (changed) write(threadId, state);
+  }
+});
 async function drainThread(threadId: string) {
   const session = getSession();
   const key = scope();
@@ -163,17 +213,60 @@ async function drainThread(threadId: string) {
       return payload;
     };
     let state = read(threadId);
-    if (state.paused) return;
+    if (state.paused || state.recoveryPaused) return;
     if (state.activeTurnId) {
       const observedTurn = state.activeTurnId;
       const receipt = (await cloud(`remix/turns/${observedTurn}`)) as {
-        turn: { status: string };
+        turn: { status: string; clientRequestId?: string };
+        checkpoint?: { messages: unknown[]; context: unknown };
       };
       state = read(threadId);
-      if (state.activeTurnId !== observedTurn) return;
+      if (
+        state.activeTurnId !== observedTurn ||
+        state.paused ||
+        state.recoveryPaused
+      )
+        return;
+      if (["retryable", "queued"].includes(receipt.turn.status)) {
+        const attempts = state.retryAttempts ?? 0;
+        if (attempts >= RETRY_DELAYS.length) {
+          state.recoveryPaused = true;
+          write(threadId, state);
+          return;
+        }
+        state.activeRequest ??=
+          receipt.checkpoint && receipt.turn.clientRequestId
+            ? {
+                threadId,
+                clientRequestId: receipt.turn.clientRequestId,
+                messages: receipt.checkpoint.messages,
+                context: receipt.checkpoint.context,
+                ...trustedDesktopAgentFields(),
+              }
+            : undefined;
+        if (!state.activeRequest) {
+          state.recoveryPaused = true;
+          write(threadId, state);
+          return;
+        }
+        if (!state.retryAt) {
+          state.retryAt = Date.now() + RETRY_DELAYS[attempts];
+          write(threadId, state);
+          return;
+        }
+        if (Date.now() < state.retryAt) return;
+        state.retryAttempts = attempts + 1;
+        state.retryAt = undefined;
+        write(threadId, state);
+        await cloud("remix/turns", state.activeRequest);
+        return;
+      }
+      state.retryAttempts = 0;
+      state.retryAt = undefined;
       if (!["completed", "failed", "canceled"].includes(receipt.turn.status))
         return;
       state.activeTurnId = undefined;
+      state.activeRequest = undefined;
       // Failure/Stop preserve the queue until the user sends or steers again.
       if (receipt.turn.status !== "completed" && !state.steer) {
         write(threadId, state);
@@ -216,9 +309,15 @@ async function drainThread(threadId: string) {
       turn: { id: string };
     };
     state = read(threadId);
+    if (!state.items.some((entry) => entry.id === item.id)) return;
+    state.activeRequest = state.items.find(
+      (entry) => entry.id === item.id,
+    )!.request;
     state.items = state.items.filter((entry) => entry.id !== item.id);
     state.activeTurnId = receipt.turn.id;
     state.steer = false;
+    state.retryAttempts = 0;
+    state.retryAt = undefined;
     write(threadId, state);
     if (state.paused) {
       deferRemixCancel(receipt.turn.id);
@@ -237,6 +336,7 @@ export async function drainRemixQueues() {
       .filter(
         ([, state]) =>
           !state.paused &&
+          !state.recoveryPaused &&
           (state.activeTurnId || (state.items.length > 0 && state.steer)),
       )
       .map(([threadId]) => drainThread(threadId)),

--- a/apps/server/src/lib/remix-durable-queue.ts
+++ b/apps/server/src/lib/remix-durable-queue.ts
@@ -1,0 +1,247 @@
+import { agentActivityEvents } from "./agent-activity-events.js";
+import { trustedDesktopAgentFields } from "./agent-request.js";
+import { readSetting, writeSetting } from "./db.js";
+import { freestyleCloudUrl } from "./freestyle-cloud.js";
+import {
+  deferRemixCancel,
+  deferRemixRequestCancel,
+  flushRemixCancels,
+} from "./remix-cancel-outbox.js";
+import { getSession } from "./sessions.js";
+
+export type RemixQueuedMessage = {
+  id: string;
+  text: string;
+  context?: unknown;
+  createdAt: number;
+  request?: Record<string, unknown>;
+};
+type QueueState = {
+  items: RemixQueuedMessage[];
+  activeTurnId?: string;
+  steer?: boolean;
+  paused?: boolean;
+};
+type Registry = Record<string, QueueState>;
+function scope() {
+  const session = getSession();
+  return session
+    ? `remix.queue.${encodeURIComponent(session.host)}.${session.user.id}`
+    : null;
+}
+function registry(): Registry {
+  const key = scope();
+  return key ? (JSON.parse(readSetting(key) ?? "{}") as Registry) : {};
+}
+function read(threadId: string): QueueState {
+  return registry()[threadId] ?? { items: [] };
+}
+function write(threadId: string, state: QueueState) {
+  const key = scope();
+  if (!key) throw new Error("cloud_auth_required");
+  const all = registry();
+  if (!state.activeTurnId && !state.items.length) delete all[threadId];
+  else all[threadId] = state;
+  writeSetting(key, JSON.stringify(all));
+  agentActivityEvents.publish(threadId);
+}
+export function remixQueueSnapshot(threadId: string) {
+  const state = read(threadId);
+  return {
+    items: state.items.map(({ request: _request, ...item }) => item),
+    active: Boolean(state.activeTurnId) && !state.paused,
+    activeTurnId: state.activeTurnId ?? null,
+  };
+}
+export function registerRemixTurn(threadId: string, turnId: string) {
+  write(threadId, {
+    ...read(threadId),
+    activeTurnId: turnId,
+    steer: false,
+    paused: false,
+  });
+}
+export function pauseRemixQueue(threadId: string) {
+  const state = read(threadId);
+  state.paused = true;
+  state.steer = false;
+  for (const item of state.items) {
+    if (item.request)
+      deferRemixRequestCancel({ ...item.request, clientRequestId: item.id });
+  }
+  write(threadId, state);
+  return state.activeTurnId;
+}
+export function remixQueueActivity() {
+  return Object.entries(registry()).map(([threadId, state]) => ({
+    threadId,
+    active: Boolean(state.activeTurnId) && !state.paused,
+    queuedCount: state.items.length,
+  }));
+}
+export function settleRemixTurn(turnId: string, status: string) {
+  if (!["completed", "failed", "canceled"].includes(status)) return;
+  for (const [threadId, state] of Object.entries(registry())) {
+    if (state.activeTurnId !== turnId) continue;
+    state.activeTurnId = undefined;
+    state.steer = Boolean(state.steer || status === "completed");
+    write(threadId, state);
+  }
+}
+export function enqueueRemixMessage(
+  threadId: string,
+  input: { text: string; context?: unknown },
+) {
+  const state = read(threadId);
+  state.items.push({
+    ...input,
+    id: crypto.randomUUID(),
+    createdAt: Date.now(),
+  });
+  write(threadId, state);
+  return remixQueueSnapshot(threadId);
+}
+export function updateRemixQueuedMessage(
+  threadId: string,
+  id: string,
+  text: string,
+) {
+  const state = read(threadId);
+  const item = state.items.find((item) => item.id === id);
+  // A submitted receipt's request must remain immutable even if the network
+  // dropped the response. Wait for that receipt before editing/removing it.
+  if (!item || item.request) return false;
+  item.text = text;
+  write(threadId, state);
+  return true;
+}
+export function removeRemixQueuedMessage(threadId: string, id: string) {
+  const state = read(threadId);
+  const item = state.items.find((item) => item.id === id);
+  if (!item || item.request) return false;
+  state.items = state.items.filter((item) => item.id !== id);
+  write(threadId, state);
+  return true;
+}
+export function steerRemixQueuedMessage(threadId: string, id: string) {
+  const state = read(threadId);
+  const item = state.items.find((item) => item.id === id);
+  if (!item || item.request) return false;
+  state.items = [item, ...state.items.filter((item) => item.id !== id)];
+  state.steer = true;
+  state.paused = false;
+  if (state.activeTurnId) {
+    deferRemixCancel(state.activeTurnId);
+    void flushRemixCancels();
+  }
+  write(threadId, state);
+  void drainRemixQueues();
+  return true;
+}
+const draining = new Set<string>();
+async function drainThread(threadId: string) {
+  const session = getSession();
+  const key = scope();
+  if (!session || !key) return;
+  const lock = `${key}.${threadId}`;
+  if (draining.has(lock)) return;
+  draining.add(lock);
+  try {
+    const cloud = async (path: string, body?: unknown) => {
+      const response = await fetch(`${freestyleCloudUrl()}/v2/${path}`, {
+        method: body === undefined ? "GET" : "POST",
+        headers: {
+          Authorization: `Bearer ${session.token}`,
+          ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!response.ok) throw new Error("remix_queue_unavailable");
+      const payload = await response.json();
+      if (scope() !== key) throw new Error("remix_queue_account_changed");
+      return payload;
+    };
+    let state = read(threadId);
+    if (state.paused) return;
+    if (state.activeTurnId) {
+      const observedTurn = state.activeTurnId;
+      const receipt = (await cloud(`remix/turns/${observedTurn}`)) as {
+        turn: { status: string };
+      };
+      state = read(threadId);
+      if (state.activeTurnId !== observedTurn) return;
+      if (!["completed", "failed", "canceled"].includes(receipt.turn.status))
+        return;
+      state.activeTurnId = undefined;
+      // Failure/Stop preserve the queue until the user sends or steers again.
+      if (receipt.turn.status !== "completed" && !state.steer) {
+        write(threadId, state);
+        return;
+      }
+      state.steer = true;
+      write(threadId, state);
+    }
+    if (state.paused || !state.steer || !state.items.length) return;
+    const item = state.items[0];
+    if (!item.request) {
+      const runtime = (await cloud(
+        `threads/${encodeURIComponent(threadId)}`,
+      )) as { thread: { messages: unknown[] } };
+      state = read(threadId);
+      if (state.paused || state.activeTurnId || state.items[0]?.id !== item.id)
+        return;
+      state.items[0].request = {
+        threadId,
+        clientRequestId: item.id,
+        messages: [
+          ...runtime.thread.messages,
+          {
+            id: item.id,
+            role: "user",
+            parts: [{ type: "text", text: item.text }],
+          },
+        ],
+        context: item.context ?? {
+          selection: null,
+          appName: null,
+          windowTitle: null,
+          capturedAt: Date.now(),
+        },
+        ...trustedDesktopAgentFields(),
+      };
+      write(threadId, state);
+    }
+    const receipt = (await cloud("remix/turns", state.items[0].request)) as {
+      turn: { id: string };
+    };
+    state = read(threadId);
+    state.items = state.items.filter((entry) => entry.id !== item.id);
+    state.activeTurnId = receipt.turn.id;
+    state.steer = false;
+    write(threadId, state);
+    if (state.paused) {
+      deferRemixCancel(receipt.turn.id);
+      void flushRemixCancels();
+    }
+  } catch {
+    // Retain the original request and queue item until an idempotent admission
+    // succeeds. This worker runs independently of every renderer lifecycle.
+  } finally {
+    draining.delete(lock);
+  }
+}
+export async function drainRemixQueues() {
+  await Promise.all(
+    Object.entries(registry())
+      .filter(
+        ([, state]) =>
+          !state.paused &&
+          (state.activeTurnId || (state.items.length > 0 && state.steer)),
+      )
+      .map(([threadId]) => drainThread(threadId)),
+  );
+}
+setInterval(() => {
+  void drainRemixQueues().catch(() => {});
+}, 1_000).unref();

--- a/apps/server/src/lib/remix-durable-queue.ts
+++ b/apps/server/src/lib/remix-durable-queue.ts
@@ -26,6 +26,8 @@ type QueueState = {
   activeRequest?: Record<string, unknown>;
   retryAttempts?: number;
   retryAt?: number;
+  transportRetryAttempts?: number;
+  transportRetryAt?: number;
   recoveryPaused?: boolean;
 };
 type Registry = Record<string, QueueState>;
@@ -75,6 +77,8 @@ export function registerRemixTurn(
     activeRequest: request,
     retryAttempts: 0,
     retryAt: undefined,
+    transportRetryAttempts: undefined,
+    transportRetryAt: undefined,
     recoveryPaused: false,
   });
 }
@@ -158,6 +162,8 @@ export function steerRemixQueuedMessage(threadId: string, id: string) {
   state.recoveryPaused = false;
   state.retryAttempts = 0;
   state.retryAt = undefined;
+  state.transportRetryAttempts = undefined;
+  state.transportRetryAt = undefined;
   if (state.activeTurnId) {
     deferRemixCancel(state.activeTurnId);
     void flushRemixCancels();
@@ -168,6 +174,48 @@ export function steerRemixQueuedMessage(threadId: string, id: string) {
 }
 const draining = new Set<string>();
 const RETRY_DELAYS = [3_000, 6_000, 12_000, 24_000, 30_000];
+
+function resetTransportRetry(threadId: string) {
+  const state = read(threadId);
+  if (
+    state.transportRetryAttempts === undefined &&
+    state.transportRetryAt === undefined
+  )
+    return;
+  state.transportRetryAttempts = undefined;
+  state.transportRetryAt = undefined;
+  write(threadId, state);
+}
+
+function deferTransportRetry(threadId: string, key: string, error: unknown) {
+  if (scope() !== key) return;
+  const state = read(threadId);
+  if (state.paused || state.recoveryPaused) return;
+  const status = (error as { status?: number })?.status;
+  // Authorization and malformed requests will not recover through a retry;
+  // retain the queue for the visible Resume affordance instead of polling.
+  if (
+    status &&
+    status >= 400 &&
+    status < 500 &&
+    status !== 408 &&
+    status !== 429
+  ) {
+    state.recoveryPaused = true;
+    state.transportRetryAt = undefined;
+    write(threadId, state);
+    return;
+  }
+  const attempts = (state.transportRetryAttempts ?? 0) + 1;
+  state.transportRetryAttempts = attempts;
+  if (attempts >= RETRY_DELAYS.length) {
+    state.recoveryPaused = true;
+    state.transportRetryAt = undefined;
+  } else {
+    state.transportRetryAt = Date.now() + RETRY_DELAYS[attempts - 1];
+  }
+  write(threadId, state);
+}
 onRemixCancellationSettled(({ turnId, clientRequestId }) => {
   for (const [threadId, state] of Object.entries(registry())) {
     let changed = false;
@@ -207,13 +255,22 @@ async function drainThread(threadId: string) {
         ...(body === undefined ? {} : { body: JSON.stringify(body) }),
         signal: AbortSignal.timeout(15_000),
       });
-      if (!response.ok) throw new Error("remix_queue_unavailable");
+      if (!response.ok)
+        throw Object.assign(new Error("remix_queue_unavailable"), {
+          status: response.status,
+        });
       const payload = await response.json();
       if (scope() !== key) throw new Error("remix_queue_account_changed");
+      resetTransportRetry(threadId);
       return payload;
     };
     let state = read(threadId);
     if (state.paused || state.recoveryPaused) return;
+    if (state.transportRetryAt) {
+      if (Date.now() < state.transportRetryAt) return;
+      state.transportRetryAt = undefined;
+      write(threadId, state);
+    }
     if (state.activeTurnId) {
       const observedTurn = state.activeTurnId;
       const receipt = (await cloud(`remix/turns/${observedTurn}`)) as {
@@ -323,9 +380,10 @@ async function drainThread(threadId: string) {
       deferRemixCancel(receipt.turn.id);
       void flushRemixCancels();
     }
-  } catch {
+  } catch (error) {
     // Retain the original request and queue item until an idempotent admission
     // succeeds. This worker runs independently of every renderer lifecycle.
+    deferTransportRetry(threadId, key, error);
   } finally {
     draining.delete(lock);
   }

--- a/apps/server/src/lib/remix-durable-queue.ts
+++ b/apps/server/src/lib/remix-durable-queue.ts
@@ -206,13 +206,12 @@ function deferTransportRetry(threadId: string, key: string, error: unknown) {
     write(threadId, state);
     return;
   }
-  const attempts = (state.transportRetryAttempts ?? 0) + 1;
-  state.transportRetryAttempts = attempts;
+  const attempts = state.transportRetryAttempts ?? 0;
   if (attempts >= RETRY_DELAYS.length) {
     state.recoveryPaused = true;
     state.transportRetryAt = undefined;
   } else {
-    state.transportRetryAt = Date.now() + RETRY_DELAYS[attempts - 1];
+    state.transportRetryAt = Date.now() + RETRY_DELAYS[attempts];
   }
   write(threadId, state);
 }
@@ -269,6 +268,7 @@ async function drainThread(threadId: string) {
     if (state.transportRetryAt) {
       if (Date.now() < state.transportRetryAt) return;
       state.transportRetryAt = undefined;
+      state.transportRetryAttempts = (state.transportRetryAttempts ?? 0) + 1;
       write(threadId, state);
     }
     if (state.activeTurnId) {

--- a/apps/server/src/lib/remix-execution-reservations.ts
+++ b/apps/server/src/lib/remix-execution-reservations.ts
@@ -1,0 +1,23 @@
+import { prepareCached } from "./db.js";
+import { getSession } from "./sessions.js";
+
+/** A Cloud claim receipt may be replayed, but local execution has one owner.
+ * Never expire/reassign this reservation: a crashed observer may already have
+ * performed the side effect. Explicit Cloud retry creates a new action ID. */
+export function reserveRemixExecution(
+  actionId: string,
+  clientId: string,
+  observerId: string,
+): boolean {
+  const session = getSession();
+  if (!session) return false;
+  const key = `remix.execution.${encodeURIComponent(session.host)}.${session.user.id}.${actionId}`;
+  const value = JSON.stringify({ clientId, observerId });
+  prepareCached(
+    "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO NOTHING",
+  ).run(key, value);
+  const saved = prepareCached("SELECT value FROM settings WHERE key = ?").get(
+    key,
+  ) as { value: string } | undefined;
+  return saved?.value === value;
+}

--- a/apps/server/src/routes/agent.ts
+++ b/apps/server/src/routes/agent.ts
@@ -11,6 +11,7 @@ import {
 import { trustedDesktopAgentFields } from "../lib/agent-request.js";
 import { agentStreamStore } from "../lib/agent-stream-store.js";
 import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
+import { remixQueueActivity } from "../lib/remix-durable-queue.js";
 import { getSessionToken, invalidateSession } from "../lib/sessions.js";
 
 const log = createAppLogger("agent");
@@ -176,11 +177,14 @@ function activitySnapshot() {
     ...agentMessageQueue.threadIds(),
   ]);
   return {
-    threads: [...threadIds].map((threadId) => ({
-      threadId,
-      active: agentStreamStore.isActive(threadId),
-      queuedCount: agentMessageQueue.list(threadId).length,
-    })),
+    threads: [
+      ...remixQueueActivity(),
+      ...[...threadIds].map((threadId) => ({
+        threadId,
+        active: agentStreamStore.isActive(threadId),
+        queuedCount: agentMessageQueue.list(threadId).length,
+      })),
+    ],
   };
 }
 

--- a/apps/server/src/routes/remix-durable.ts
+++ b/apps/server/src/routes/remix-durable.ts
@@ -1,0 +1,205 @@
+import { remixAgentRequestSchema } from "@freestyle-voice/validations";
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { z } from "zod/v3";
+import { trustedDesktopAgentFields } from "../lib/agent-request.js";
+import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
+import {
+  deferRemixCancel,
+  deferRemixRequestCancel,
+  flushRemixCancels,
+} from "../lib/remix-cancel-outbox.js";
+import {
+  enqueueRemixMessage,
+  pauseRemixQueue,
+  registerRemixTurn,
+  remixQueueSnapshot,
+  removeRemixQueuedMessage,
+  settleRemixTurn,
+  steerRemixQueuedMessage,
+  updateRemixQueuedMessage,
+} from "../lib/remix-durable-queue.js";
+import {
+  getSession,
+  getSessionToken,
+  invalidateSession,
+} from "../lib/sessions.js";
+
+const submitSchema = remixAgentRequestSchema.extend({
+  threadId: z.string().min(1).max(100),
+  clientRequestId: z.string().min(8).max(160),
+});
+const turnParam = z.object({ turnId: z.string().uuid() });
+const threadParam = z.object({ threadId: z.string().min(1).max(100) });
+const queueInput = z.object({
+  text: z.string().trim().min(1).max(10_000),
+  context: remixAgentRequestSchema.shape.context.optional(),
+});
+const commandSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("cancel"),
+    threadId: z.string().min(1).max(100).optional(),
+  }),
+  z.object({
+    type: z.literal("desktop_claim"),
+    actionId: z.string().uuid(),
+    clientId: z.string().min(8).max(160),
+  }),
+  z.object({
+    type: z.literal("desktop_complete"),
+    actionId: z.string().uuid(),
+    clientId: z.string().min(8).max(160),
+    result: z.unknown(),
+  }),
+  z.object({
+    type: z.literal("retry_desktop"),
+    actionId: z.string().uuid(),
+    clientRequestId: z.string().min(8).max(160),
+  }),
+]);
+
+async function proxy(path: string, body?: unknown): Promise<Response> {
+  const session = getSession();
+  const token = getSessionToken();
+  if (!token || !session)
+    return Response.json({ error: "cloud_auth_required" }, { status: 401 });
+  try {
+    const response = await fetch(`${freestyleCloudUrl()}/v2/${path}`, {
+      method: body === undefined ? "GET" : "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      // The receipt is independent of the renderer's observer lifetime.
+      signal: AbortSignal.timeout(15_000),
+    });
+    const payload = await response.text();
+    const current = getSession();
+    if (current?.host !== session.host || current?.user.id !== session.user.id)
+      return Response.json({ error: "remix_account_changed" }, { status: 401 });
+    if (response.status === 401) invalidateSession();
+    return new Response(payload, {
+      status: response.status,
+      headers: {
+        "Content-Type":
+          response.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch {
+    return Response.json({ error: "remix_unavailable" }, { status: 502 });
+  }
+}
+
+export const remixDurableRoute = new Hono()
+  .use("*", async (c, next) => {
+    if (!getSessionToken())
+      return c.json({ error: "cloud_auth_required" }, 401);
+    await next();
+  })
+  .get("/:threadId/queue", zValidator("param", threadParam), (c) =>
+    c.json(remixQueueSnapshot(c.req.valid("param").threadId)),
+  )
+  .post(
+    "/:threadId/queue",
+    zValidator("param", threadParam),
+    zValidator("json", queueInput),
+    (c) =>
+      c.json(
+        enqueueRemixMessage(c.req.valid("param").threadId, c.req.valid("json")),
+        201,
+      ),
+  )
+  .patch(
+    "/:threadId/queue/:id",
+    zValidator("json", queueInput.pick({ text: true })),
+    (c) =>
+      updateRemixQueuedMessage(
+        c.req.param("threadId"),
+        c.req.param("id"),
+        c.req.valid("json").text,
+      )
+        ? c.json(remixQueueSnapshot(c.req.param("threadId")))
+        : c.json({ error: "queue_item_unavailable" }, 409),
+  )
+  .delete("/:threadId/queue/:id", (c) =>
+    removeRemixQueuedMessage(c.req.param("threadId"), c.req.param("id"))
+      ? c.json(remixQueueSnapshot(c.req.param("threadId")))
+      : c.json({ error: "queue_item_unavailable" }, 409),
+  )
+  .post("/:threadId/queue/:id/steer", (c) =>
+    steerRemixQueuedMessage(c.req.param("threadId"), c.req.param("id"))
+      ? c.json(remixQueueSnapshot(c.req.param("threadId")))
+      : c.json({ error: "queue_item_unavailable" }, 409),
+  )
+  .post(
+    "/cancel",
+    zValidator("json", z.object({ request: submitSchema })),
+    (c) => {
+      if (!getSessionToken())
+        return c.json({ error: "cloud_auth_required" }, 401);
+      pauseRemixQueue(c.req.valid("json").request.threadId);
+      deferRemixRequestCancel({
+        ...c.req.valid("json").request,
+        ...trustedDesktopAgentFields(),
+      });
+      void flushRemixCancels();
+      return c.json({ receipt: { cancelQueued: true } }, 202);
+    },
+  )
+  .post("/turns", zValidator("json", submitSchema), async (c) => {
+    const response = await proxy("remix/turns", {
+      ...c.req.valid("json"),
+      ...trustedDesktopAgentFields(),
+    });
+    if (response.ok) {
+      const receipt = (await response.clone().json()) as {
+        turn: { id: string };
+      };
+      registerRemixTurn(c.req.valid("json").threadId, receipt.turn.id);
+    }
+    return response;
+  })
+  .get("/turns/:turnId", zValidator("param", turnParam), async (c) => {
+    const response = await proxy(`remix/turns/${c.req.valid("param").turnId}`);
+    if (response.ok) {
+      const receipt = (await response.clone().json()) as {
+        turn: { id: string; status: string };
+      };
+      settleRemixTurn(receipt.turn.id, receipt.turn.status);
+    }
+    return response;
+  })
+  .get("/turns/:turnId/events", zValidator("param", turnParam), (c) =>
+    proxy(`remix/turns/${c.req.valid("param").turnId}/events`),
+  )
+  .post(
+    "/turns/:turnId/commands",
+    zValidator("param", turnParam),
+    zValidator("json", commandSchema),
+    (c) => {
+      const command = c.req.valid("json");
+      const { turnId } = c.req.valid("param");
+      if (command.type !== "cancel")
+        return proxy(`remix/turns/${turnId}/commands`, command);
+      if (!getSessionToken())
+        return c.json({ error: "cloud_auth_required" }, 401);
+      if (command.threadId) {
+        const queuedTurn = pauseRemixQueue(command.threadId);
+        if (queuedTurn && queuedTurn !== turnId) deferRemixCancel(queuedTurn);
+      }
+      deferRemixCancel(turnId);
+      void flushRemixCancels();
+      return c.json({ receipt: { cancelQueued: true } }, 202);
+    },
+  )
+  .get(
+    "/thread/:threadId",
+    zValidator("param", z.object({ threadId: z.string().min(1).max(100) })),
+    (c) => {
+      void flushRemixCancels();
+      return proxy(
+        `threads/${encodeURIComponent(c.req.valid("param").threadId)}`,
+      );
+    },
+  );

--- a/apps/server/src/routes/remix-durable.ts
+++ b/apps/server/src/routes/remix-durable.ts
@@ -1,6 +1,6 @@
 import { remixAgentRequestSchema } from "@freestyle-voice/validations";
 import { zValidator } from "@hono/zod-validator";
-import { Hono } from "hono";
+import { type Context, Hono, type MiddlewareHandler } from "hono";
 import { z } from "zod/v3";
 import { trustedDesktopAgentFields } from "../lib/agent-request.js";
 import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
@@ -32,9 +32,24 @@ const submitSchema = remixAgentRequestSchema.extend({
 const turnParam = z.object({ turnId: z.string().uuid() });
 const threadParam = z.object({ threadId: z.string().min(1).max(100) });
 const queueInput = z.object({
+  requestId: z.string().uuid(),
   text: z.string().trim().min(1).max(10_000),
   context: remixAgentRequestSchema.shape.context.optional(),
 });
+// Run after body validation, immediately before the synchronous queue write or
+// proxy session capture. A separate auth preflight cannot bind this mutation.
+function matchesOwner(c: Context) {
+  const session = getSession();
+  return Boolean(
+    session &&
+      c.req.header("X-Remix-User") === session.user.id &&
+      c.req.header("X-Remix-Host") === encodeURIComponent(session.host),
+  );
+}
+const boundOwner: MiddlewareHandler = async (c, next) => {
+  if (!matchesOwner(c)) return c.json({ error: "remix_account_changed" }, 401);
+  await next();
+};
 const commandSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("cancel"),
@@ -97,6 +112,10 @@ export const remixDurableRoute = new Hono()
       return c.json({ error: "cloud_auth_required" }, 401);
     await next();
   })
+  .get("/identity", (c) => {
+    const session = getSession()!;
+    return c.json({ userId: session.user.id, host: session.host });
+  })
   .get("/:threadId/queue", zValidator("param", threadParam), (c) =>
     c.json(remixQueueSnapshot(c.req.valid("param").threadId)),
   )
@@ -104,6 +123,7 @@ export const remixDurableRoute = new Hono()
     "/:threadId/queue",
     zValidator("param", threadParam),
     zValidator("json", queueInput),
+    boundOwner,
     (c) =>
       c.json(
         enqueueRemixMessage(c.req.valid("param").threadId, c.req.valid("json")),
@@ -113,6 +133,7 @@ export const remixDurableRoute = new Hono()
   .patch(
     "/:threadId/queue/:id",
     zValidator("json", queueInput.pick({ text: true })),
+    boundOwner,
     (c) =>
       updateRemixQueuedMessage(
         c.req.param("threadId"),
@@ -122,12 +143,12 @@ export const remixDurableRoute = new Hono()
         ? c.json(remixQueueSnapshot(c.req.param("threadId")))
         : c.json({ error: "queue_item_unavailable" }, 409),
   )
-  .delete("/:threadId/queue/:id", (c) =>
+  .delete("/:threadId/queue/:id", boundOwner, (c) =>
     removeRemixQueuedMessage(c.req.param("threadId"), c.req.param("id"))
       ? c.json(remixQueueSnapshot(c.req.param("threadId")))
       : c.json({ error: "queue_item_unavailable" }, 409),
   )
-  .post("/:threadId/queue/:id/steer", (c) =>
+  .post("/:threadId/queue/:id/steer", boundOwner, (c) =>
     steerRemixQueuedMessage(c.req.param("threadId"), c.req.param("id"))
       ? c.json(remixQueueSnapshot(c.req.param("threadId")))
       : c.json({ error: "queue_item_unavailable" }, 409),
@@ -135,6 +156,7 @@ export const remixDurableRoute = new Hono()
   .post(
     "/cancel",
     zValidator("json", z.object({ request: submitSchema })),
+    boundOwner,
     (c) => {
       if (!getSessionToken())
         return c.json({ error: "cloud_auth_required" }, 401);
@@ -147,16 +169,19 @@ export const remixDurableRoute = new Hono()
       return c.json({ receipt: { cancelQueued: true } }, 202);
     },
   )
-  .post("/turns", zValidator("json", submitSchema), async (c) => {
-    const response = await proxy("remix/turns", {
+  .post("/turns", zValidator("json", submitSchema), boundOwner, async (c) => {
+    const request = {
       ...c.req.valid("json"),
       ...trustedDesktopAgentFields(),
-    });
+    };
+    const response = await proxy("remix/turns", request);
     if (response.ok) {
       const receipt = (await response.clone().json()) as {
         turn: { id: string };
       };
-      registerRemixTurn(c.req.valid("json").threadId, receipt.turn.id);
+      if (!matchesOwner(c))
+        return c.json({ error: "remix_account_changed" }, 401);
+      registerRemixTurn(c.req.valid("json").threadId, receipt.turn.id, request);
     }
     return response;
   })
@@ -177,6 +202,7 @@ export const remixDurableRoute = new Hono()
     "/turns/:turnId/commands",
     zValidator("param", turnParam),
     zValidator("json", commandSchema),
+    boundOwner,
     (c) => {
       const command = c.req.valid("json");
       const { turnId } = c.req.valid("param");

--- a/apps/server/src/routes/remix-durable.ts
+++ b/apps/server/src/routes/remix-durable.ts
@@ -19,6 +19,7 @@ import {
   steerRemixQueuedMessage,
   updateRemixQueuedMessage,
 } from "../lib/remix-durable-queue.js";
+import { reserveRemixExecution } from "../lib/remix-execution-reservations.js";
 import {
   getSession,
   getSessionToken,
@@ -59,6 +60,7 @@ const commandSchema = z.discriminatedUnion("type", [
     type: z.literal("desktop_claim"),
     actionId: z.string().uuid(),
     clientId: z.string().min(8).max(160),
+    observerId: z.string().uuid(),
   }),
   z.object({
     type: z.literal("desktop_complete"),
@@ -198,14 +200,34 @@ export const remixDurableRoute = new Hono()
   .get("/turns/:turnId/events", zValidator("param", turnParam), (c) =>
     proxy(`remix/turns/${c.req.valid("param").turnId}/events`),
   )
+  .get(
+    "/turns/:turnId/actions/:actionId",
+    zValidator("param", turnParam.extend({ actionId: z.string().uuid() })),
+    (c) => {
+      const { turnId, actionId } = c.req.valid("param");
+      return proxy(`remix/turns/${turnId}/actions/${actionId}`);
+    },
+  )
   .post(
     "/turns/:turnId/commands",
     zValidator("param", turnParam),
     zValidator("json", commandSchema),
     boundOwner,
-    (c) => {
+    async (c) => {
       const command = c.req.valid("json");
       const { turnId } = c.req.valid("param");
+      if (command.type === "desktop_claim") {
+        const { observerId, ...claim } = command;
+        const response = await proxy(`remix/turns/${turnId}/commands`, claim);
+        if (!response.ok) return response;
+        if (!matchesOwner(c))
+          return c.json({ error: "remix_account_changed" }, 401);
+        if (
+          !reserveRemixExecution(command.actionId, command.clientId, observerId)
+        )
+          return c.json({ error: "remix_execution_reserved" }, 409);
+        return response;
+      }
       if (command.type !== "cancel")
         return proxy(`remix/turns/${turnId}/commands`, command);
       if (!getSessionToken())

--- a/apps/server/src/routes/remix-durable.ts
+++ b/apps/server/src/routes/remix-durable.ts
@@ -118,7 +118,7 @@ export const remixDurableRoute = new Hono()
     const session = getSession()!;
     return c.json({ userId: session.user.id, host: session.host });
   })
-  .get("/:threadId/queue", zValidator("param", threadParam), (c) =>
+  .get("/:threadId/queue", zValidator("param", threadParam), boundOwner, (c) =>
     c.json(remixQueueSnapshot(c.req.valid("param").threadId)),
   )
   .post(
@@ -187,22 +187,33 @@ export const remixDurableRoute = new Hono()
     }
     return response;
   })
-  .get("/turns/:turnId", zValidator("param", turnParam), async (c) => {
-    const response = await proxy(`remix/turns/${c.req.valid("param").turnId}`);
-    if (response.ok) {
-      const receipt = (await response.clone().json()) as {
-        turn: { id: string; status: string };
-      };
-      settleRemixTurn(receipt.turn.id, receipt.turn.status);
-    }
-    return response;
-  })
-  .get("/turns/:turnId/events", zValidator("param", turnParam), (c) =>
-    proxy(`remix/turns/${c.req.valid("param").turnId}/events`),
+  .get(
+    "/turns/:turnId",
+    zValidator("param", turnParam),
+    boundOwner,
+    async (c) => {
+      const response = await proxy(
+        `remix/turns/${c.req.valid("param").turnId}`,
+      );
+      if (response.ok) {
+        const receipt = (await response.clone().json()) as {
+          turn: { id: string; status: string };
+        };
+        settleRemixTurn(receipt.turn.id, receipt.turn.status);
+      }
+      return response;
+    },
+  )
+  .get(
+    "/turns/:turnId/events",
+    zValidator("param", turnParam),
+    boundOwner,
+    (c) => proxy(`remix/turns/${c.req.valid("param").turnId}/events`),
   )
   .get(
     "/turns/:turnId/actions/:actionId",
     zValidator("param", turnParam.extend({ actionId: z.string().uuid() })),
+    boundOwner,
     (c) => {
       const { turnId, actionId } = c.req.valid("param");
       return proxy(`remix/turns/${turnId}/actions/${actionId}`);
@@ -244,6 +255,7 @@ export const remixDurableRoute = new Hono()
   .get(
     "/thread/:threadId",
     zValidator("param", z.object({ threadId: z.string().min(1).max(100) })),
+    boundOwner,
     (c) => {
       void flushRemixCancels();
       return proxy(

--- a/apps/server/src/routes/remix.ts
+++ b/apps/server/src/routes/remix.ts
@@ -10,6 +10,7 @@ import { Hono } from "hono";
 import { freestyleCloudUrl } from "../lib/freestyle-cloud.js";
 import { createMcpStore } from "../lib/mcp/store.js";
 import { getSessionToken, invalidateSession } from "../lib/sessions.js";
+import { remixDurableRoute } from "./remix-durable.js";
 
 const log = createAppLogger("remix");
 
@@ -18,10 +19,9 @@ const log = createAppLogger("remix");
  * local server, while preserving the captured desktop context and AI SDK
  * stream for the pill renderer.
  */
-const remixRoute = new Hono().post(
-  "/",
-  zValidator("json", remixAgentRequestSchema),
-  async (c) => {
+const remixRoute = new Hono()
+  .route("/", remixDurableRoute)
+  .post("/", zValidator("json", remixAgentRequestSchema), async (c) => {
     const token = getSessionToken();
     if (!token) return c.json({ error: "cloud_auth_required" }, 401);
 
@@ -87,7 +87,6 @@ const remixRoute = new Hono().post(
           : {}),
       },
     });
-  },
-);
+  });
 
 export default remixRoute;

--- a/apps/server/tests/remix-durable-proxy.test.ts
+++ b/apps/server/tests/remix-durable-proxy.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import createApp from "../src/index.js";
+import { closeDb } from "../src/lib/db.js";
 import { freestyleCloudUrl } from "../src/lib/freestyle-cloud.js";
 import {
   deferRemixCancel,
@@ -29,6 +30,71 @@ afterEach(async () => {
 });
 
 describe("additive durable Remix proxy", () => {
+  it("grants a replayed Cloud claim to only one local execution observer", async () => {
+    const actionId = crypto.randomUUID();
+    const observers = [crypto.randomUUID(), crypto.randomUUID()];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          action: { id: actionId, toolName: "paste", input: {} },
+        }),
+      ),
+    );
+    const claim = (observerId: string) =>
+      app.request(`/api/remix/turns/${turnId}/commands`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Remix-User": "user-a",
+          "X-Remix-Host": encodeURIComponent(freestyleCloudUrl()),
+        },
+        body: JSON.stringify({
+          type: "desktop_claim",
+          actionId,
+          clientId: "same-cloud-claimant",
+          observerId,
+        }),
+      });
+    const responses = await Promise.all(observers.map(claim));
+    expect(responses.map((response) => response.status).sort()).toEqual([
+      200, 409,
+    ]);
+    const winner = responses.findIndex((response) => response.ok);
+    closeDb();
+    expect((await claim(observers[1 - winner])).status).toBe(409);
+    // Only the same still-live observer may recover a lost local response.
+    expect((await claim(observers[winner])).status).toBe(200);
+  });
+  it("proxies an owned predecessor receipt after the checkpoint advances", async () => {
+    const actionId = crypto.randomUUID();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          action: {
+            id: actionId,
+            turnId,
+            status: "expired",
+            toolName: "paste",
+            invocationId: "invocation",
+            retryOfActionId: null,
+          },
+        }),
+      ),
+    );
+    const response = await app.request(
+      `/api/remix/turns/${turnId}/actions/${actionId}`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      action: { id: actionId, status: "expired" },
+    });
+    expect(
+      (await app.request(`/api/remix/turns/${turnId}/actions/not-a-uuid`))
+        .status,
+    ).toBe(400);
+  });
   it("rejects an old owner's mutation after identity lookup but before the POST", async () => {
     const identity = (await (
       await app.request("/api/remix/identity")

--- a/apps/server/tests/remix-durable-proxy.test.ts
+++ b/apps/server/tests/remix-durable-proxy.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import createApp from "../src/index.js";
+import { freestyleCloudUrl } from "../src/lib/freestyle-cloud.js";
+import {
+  deferRemixCancel,
+  flushRemixCancels,
+  pendingRemixCancels,
+} from "../src/lib/remix-cancel-outbox.js";
+import { remixQueueSnapshot } from "../src/lib/remix-durable-queue.js";
+import { clearSession, setSession } from "../src/lib/sessions.js";
+
+const app = createApp();
+const turnId = "00000000-0000-4000-8000-000000000001";
+const signIn = (id = "user-a") =>
+  setSession({
+    token: "cloud-token",
+    user: { id, email: "test@example.test" },
+    host: freestyleCloudUrl(),
+  });
+beforeEach(() => signIn());
+afterEach(async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => Response.json({})),
+  );
+  await flushRemixCancels();
+  clearSession();
+  vi.unstubAllGlobals();
+});
+
+describe("additive durable Remix proxy", () => {
+  it("discards an admission response if the signed-in account changed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        signIn("user-b");
+        return Response.json({ turn: { id: turnId } }, { status: 202 });
+      }),
+    );
+    const response = await app.request("/api/remix/turns", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        threadId: "switched-thread",
+        clientRequestId: "request-a",
+        messages: [{ role: "user", parts: [{ type: "text", text: "Hello" }] }],
+        context: {
+          selection: null,
+          appName: null,
+          windowTitle: null,
+          capturedAt: 1,
+        },
+      }),
+    });
+    expect(response.status).toBe(401);
+    expect(remixQueueSnapshot("switched-thread").activeTurnId).toBeNull();
+  });
+  it("passes immutable admission through the server-owned capability boundary", async () => {
+    const fetch = vi.fn(async () =>
+      Response.json(
+        { turn: { id: turnId }, receipt: { duplicate: false } },
+        { status: 202 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetch);
+    const response = await app.request("/api/remix/turns", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        threadId: "thread-a",
+        clientRequestId: "request-a",
+        messages: [{ role: "user", parts: [{ type: "text", text: "Hello" }] }],
+        context: {
+          selection: null,
+          appName: null,
+          windowTitle: null,
+          capturedAt: 1,
+        },
+        client: { platform: "android", localTools: [] },
+      }),
+    });
+    expect(response.status).toBe(202);
+    const [url, init] = fetch.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`${freestyleCloudUrl()}/v2/remix/turns`);
+    const payload = JSON.parse(String(init.body));
+    expect(payload.clientRequestId).toBe("request-a");
+    expect(payload.client.platform).toBe(process.platform);
+    expect(payload.client.localTools).toContain("Bash");
+    expect(init.headers).toMatchObject({ Authorization: "Bearer cloud-token" });
+  });
+  it("preserves terminal receipt responses and validates IDs", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          turn: { id: turnId, status: "canceled" },
+          receipt: { terminal: true, retryable: false },
+        }),
+      ),
+    );
+    const response = await app.request(`/api/remix/turns/${turnId}`);
+    expect(await response.json()).toMatchObject({
+      receipt: { terminal: true, retryable: false },
+    });
+    expect((await app.request("/api/remix/turns/not-a-uuid")).status).toBe(400);
+  });
+  it("persists offline cancellation and flushes it after connectivity returns", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("offline");
+      }),
+    );
+    const response = await app.request(`/api/remix/turns/${turnId}/commands`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "cancel" }),
+    });
+    expect(response.status).toBe(202);
+    await flushRemixCancels();
+    expect(pendingRemixCancels()).toEqual([turnId]);
+    const fetch = vi.fn(async () =>
+      Response.json({ receipt: { canceled: true } }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    await flushRemixCancels();
+    expect(pendingRemixCancels()).toEqual([]);
+    expect(fetch).toHaveBeenCalledWith(
+      `${freestyleCloudUrl()}/v2/remix/turns/${turnId}/commands`,
+      expect.objectContaining({ body: JSON.stringify({ type: "cancel" }) }),
+    );
+  });
+  it("does not send another account's cancellation outbox", async () => {
+    deferRemixCancel(turnId);
+    signIn("user-b");
+    const fetch = vi.fn(async () => Response.json({}));
+    vi.stubGlobal("fetch", fetch);
+    await flushRemixCancels();
+    expect(fetch).not.toHaveBeenCalled();
+    signIn();
+    await flushRemixCancels();
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("recovers and cancels an unknown receipt after the submitting renderer closes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+    const request = {
+      threadId: "thread-a",
+      clientRequestId: "lost-request-a",
+      messages: [{ role: "user", parts: [{ type: "text", text: "Hello" }] }],
+      context: {
+        selection: null,
+        appName: null,
+        windowTitle: null,
+        capturedAt: 1,
+      },
+    };
+    const response = await app.request("/api/remix/cancel", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ request }),
+    });
+    expect(response.status).toBe(202);
+    await flushRemixCancels();
+    const fetch = vi.fn(async (url: string) =>
+      url.endsWith("/turns")
+        ? Response.json({ turn: { id: turnId } })
+        : Response.json({ receipt: { canceled: true } }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    await flushRemixCancels();
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch.mock.calls[0][0]).toBe(
+      `${freestyleCloudUrl()}/v2/remix/turns`,
+    );
+    expect(fetch.mock.calls[1][0]).toBe(
+      `${freestyleCloudUrl()}/v2/remix/turns/${turnId}/commands`,
+    );
+  });
+});

--- a/apps/server/tests/remix-durable-proxy.test.ts
+++ b/apps/server/tests/remix-durable-proxy.test.ts
@@ -29,6 +29,69 @@ afterEach(async () => {
 });
 
 describe("additive durable Remix proxy", () => {
+  it("rejects an old owner's mutation after identity lookup but before the POST", async () => {
+    const identity = (await (
+      await app.request("/api/remix/identity")
+    ).json()) as { userId: string; host: string };
+    signIn("user-b");
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const headers = {
+      "Content-Type": "application/json",
+      "X-Remix-User": identity.userId,
+      "X-Remix-Host": encodeURIComponent(identity.host),
+    };
+    for (const [path, body] of [
+      [
+        "/api/remix/turns",
+        {
+          threadId: "private-a",
+          clientRequestId: "private-request-a",
+          messages: [
+            { role: "user", parts: [{ type: "text", text: "Private A" }] },
+          ],
+          context: {
+            selection: null,
+            appName: null,
+            windowTitle: null,
+            capturedAt: 1,
+          },
+        },
+      ],
+      [
+        "/api/remix/private-a/queue",
+        { requestId: crypto.randomUUID(), text: "Private A queue" },
+      ],
+    ] as const) {
+      expect(
+        (
+          await app.request(path, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(body),
+          })
+        ).status,
+      ).toBe(401);
+    }
+    expect(fetch).not.toHaveBeenCalled();
+    expect(remixQueueSnapshot("private-a").items).toEqual([]);
+    expect(
+      (
+        await app.request("/api/remix/private-a/queue", {
+          method: "POST",
+          headers: {
+            ...headers,
+            "X-Remix-User": "user-b",
+            "X-Remix-Host": encodeURIComponent("https://different-host.test"),
+          },
+          body: JSON.stringify({
+            requestId: crypto.randomUUID(),
+            text: "Private host A",
+          }),
+        })
+      ).status,
+    ).toBe(401);
+  });
   it("discards an admission response if the signed-in account changed", async () => {
     vi.stubGlobal(
       "fetch",
@@ -39,7 +102,11 @@ describe("additive durable Remix proxy", () => {
     );
     const response = await app.request("/api/remix/turns", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Remix-User": "user-a",
+        "X-Remix-Host": encodeURIComponent(freestyleCloudUrl()),
+      },
       body: JSON.stringify({
         threadId: "switched-thread",
         clientRequestId: "request-a",
@@ -65,7 +132,11 @@ describe("additive durable Remix proxy", () => {
     vi.stubGlobal("fetch", fetch);
     const response = await app.request("/api/remix/turns", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Remix-User": "user-a",
+        "X-Remix-Host": encodeURIComponent(freestyleCloudUrl()),
+      },
       body: JSON.stringify({
         threadId: "thread-a",
         clientRequestId: "request-a",
@@ -113,7 +184,11 @@ describe("additive durable Remix proxy", () => {
     );
     const response = await app.request(`/api/remix/turns/${turnId}/commands`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Remix-User": "user-a",
+        "X-Remix-Host": encodeURIComponent(freestyleCloudUrl()),
+      },
       body: JSON.stringify({ type: "cancel" }),
     });
     expect(response.status).toBe(202);
@@ -162,7 +237,11 @@ describe("additive durable Remix proxy", () => {
     };
     const response = await app.request("/api/remix/cancel", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Remix-User": "user-a",
+        "X-Remix-Host": encodeURIComponent(freestyleCloudUrl()),
+      },
       body: JSON.stringify({ request }),
     });
     expect(response.status).toBe(202);

--- a/apps/server/tests/remix-durable-proxy.test.ts
+++ b/apps/server/tests/remix-durable-proxy.test.ts
@@ -18,6 +18,10 @@ const signIn = (id = "user-a") =>
     user: { id, email: "test@example.test" },
     host: freestyleCloudUrl(),
   });
+const ownerHeaders = (id = "user-a", host = freestyleCloudUrl()) => ({
+  "X-Remix-User": id,
+  "X-Remix-Host": encodeURIComponent(host),
+});
 beforeEach(() => signIn());
 afterEach(async () => {
   vi.stubGlobal(
@@ -85,14 +89,18 @@ describe("additive durable Remix proxy", () => {
     );
     const response = await app.request(
       `/api/remix/turns/${turnId}/actions/${actionId}`,
+      { headers: ownerHeaders() },
     );
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
       action: { id: actionId, status: "expired" },
     });
     expect(
-      (await app.request(`/api/remix/turns/${turnId}/actions/not-a-uuid`))
-        .status,
+      (
+        await app.request(`/api/remix/turns/${turnId}/actions/not-a-uuid`, {
+          headers: ownerHeaders(),
+        })
+      ).status,
     ).toBe(400);
   });
   it("rejects an old owner's mutation after identity lookup but before the POST", async () => {
@@ -157,6 +165,23 @@ describe("additive durable Remix proxy", () => {
         })
       ).status,
     ).toBe(401);
+  });
+  it("rejects an old owner's durable reads after the account changes", async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({ turn: { id: turnId, status: "running" } }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    const oldOwner = ownerHeaders();
+    expect(
+      (await app.request(`/api/remix/turns/${turnId}`, { headers: oldOwner }))
+        .status,
+    ).toBe(200);
+    signIn("user-b");
+    expect(
+      (await app.request(`/api/remix/turns/${turnId}`, { headers: oldOwner }))
+        .status,
+    ).toBe(401);
+    expect(fetch).toHaveBeenCalledOnce();
   });
   it("discards an admission response if the signed-in account changed", async () => {
     vi.stubGlobal(
@@ -235,11 +260,19 @@ describe("additive durable Remix proxy", () => {
         }),
       ),
     );
-    const response = await app.request(`/api/remix/turns/${turnId}`);
+    const response = await app.request(`/api/remix/turns/${turnId}`, {
+      headers: ownerHeaders(),
+    });
     expect(await response.json()).toMatchObject({
       receipt: { terminal: true, retryable: false },
     });
-    expect((await app.request("/api/remix/turns/not-a-uuid")).status).toBe(400);
+    expect(
+      (
+        await app.request("/api/remix/turns/not-a-uuid", {
+          headers: ownerHeaders(),
+        })
+      ).status,
+    ).toBe(400);
   });
   it("persists offline cancellation and flushes it after connectivity returns", async () => {
     vi.stubGlobal(

--- a/apps/server/tests/remix-durable-queue.test.ts
+++ b/apps/server/tests/remix-durable-queue.test.ts
@@ -72,7 +72,7 @@ describe("server-owned durable Remix follow-ups", () => {
     expect(posts).toHaveLength(5);
     expect(remixQueueSnapshot("thread-a").items[0].text).toBe("Next");
   });
-  it("backs off ordinary transport failures and pauses after five attempts", async () => {
+  it("backs off ordinary transport failures and pauses after five reconnects", async () => {
     registerRemixTurn("thread-a", "turn-a", {
       threadId: "thread-a",
       clientRequestId: "request-a",
@@ -86,19 +86,19 @@ describe("server-owned durable Remix follow-ups", () => {
     await drainRemixQueues();
     await drainRemixQueues();
     expect(fetch).toHaveBeenCalledOnce();
-    for (const delay of [3_000, 6_000, 12_000, 24_000]) {
+    for (const delay of [3_000, 6_000, 12_000, 24_000, 30_000]) {
       vi.setSystemTime(Date.now() + delay);
       await drainRemixQueues();
     }
-    expect(fetch).toHaveBeenCalledTimes(5);
+    expect(fetch).toHaveBeenCalledTimes(6);
     expect(remixQueueSnapshot("thread-a").recoveryPaused).toBe(true);
     vi.setSystemTime(Date.now() + 30_000);
     await drainRemixQueues();
-    expect(fetch).toHaveBeenCalledTimes(5);
+    expect(fetch).toHaveBeenCalledTimes(6);
     // A fresh visible Resume/new turn receives its own retry budget.
     registerRemixTurn("thread-a", "turn-b");
     await drainRemixQueues();
-    expect(fetch).toHaveBeenCalledTimes(6);
+    expect(fetch).toHaveBeenCalledTimes(7);
     expect(remixQueueSnapshot("thread-a").recoveryPaused).toBe(false);
   });
   it("continues the next follow-up after headless retryable recovery succeeds", async () => {

--- a/apps/server/tests/remix-durable-queue.test.ts
+++ b/apps/server/tests/remix-durable-queue.test.ts
@@ -8,7 +8,10 @@ import {
   pauseRemixQueue,
   registerRemixTurn,
   remixQueueSnapshot,
+  removeRemixQueuedMessage,
   settleRemixTurn,
+  steerRemixQueuedMessage,
+  updateRemixQueuedMessage,
 } from "../src/lib/remix-durable-queue.js";
 import { clearSession, setSession } from "../src/lib/sessions.js";
 
@@ -24,6 +27,116 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 describe("server-owned durable Remix follow-ups", () => {
+  it("deduplicates local enqueue receipts, including after the item left the queue", () => {
+    const requestId = crypto.randomUUID();
+    enqueueRemixMessage("thread-a", { requestId, text: "Once" });
+    closeDb();
+    enqueueRemixMessage("thread-a", { requestId, text: "Once" });
+    expect(remixQueueSnapshot("thread-a").items).toHaveLength(1);
+    removeRemixQueuedMessage("thread-a", requestId);
+    enqueueRemixMessage("thread-a", { requestId, text: "Once" });
+    expect(remixQueueSnapshot("thread-a").items).toHaveLength(0);
+    enqueueRemixMessage("thread-a", {
+      requestId: crypto.randomUUID(),
+      text: "Once",
+    });
+    expect(remixQueueSnapshot("thread-a").items).toHaveLength(1);
+  });
+  it("replays headless retryable admissions with a bounded persisted budget", async () => {
+    const request = {
+      threadId: "thread-a",
+      clientRequestId: "request-a",
+      messages: [],
+      context: {},
+    };
+    registerRemixTurn("thread-a", "turn-a", request);
+    enqueueRemixMessage("thread-a", { text: "Next" });
+    const posts: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        if (init?.body) posts.push(String(init.body));
+        return Response.json({ turn: { id: "turn-a", status: "retryable" } });
+      }),
+    );
+    await drainRemixQueues();
+    for (const delay of [3_000, 6_000, 12_000, 24_000, 30_000]) {
+      closeDb();
+      vi.setSystemTime(Date.now() + delay);
+      await drainRemixQueues();
+      await drainRemixQueues();
+    }
+    expect(posts).toEqual(Array(5).fill(JSON.stringify(request)));
+    expect(remixQueueSnapshot("thread-a").recoveryPaused).toBe(true);
+    await drainRemixQueues();
+    expect(posts).toHaveLength(5);
+    expect(remixQueueSnapshot("thread-a").items[0].text).toBe("Next");
+  });
+  it("continues the next follow-up after headless retryable recovery succeeds", async () => {
+    const request = {
+      threadId: "thread-a",
+      clientRequestId: "request-a",
+      messages: [],
+      context: {},
+    };
+    registerRemixTurn("thread-a", "turn-a", request);
+    enqueueRemixMessage("thread-a", { text: "Next" });
+    let status = "retryable";
+    const posts: Record<string, unknown>[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (init?.body) {
+          const body = JSON.parse(String(init.body));
+          posts.push(body);
+          if (body.clientRequestId === "request-a") status = "completed";
+          return Response.json({
+            turn: {
+              id: body.clientRequestId === "request-a" ? "turn-a" : "turn-b",
+            },
+          });
+        }
+        return url.includes("/threads/")
+          ? Response.json({ thread: { messages: [] } })
+          : Response.json({ turn: { status } });
+      }),
+    );
+    await drainRemixQueues();
+    vi.setSystemTime(Date.now() + 3_000);
+    await drainRemixQueues();
+    closeDb();
+    await drainRemixQueues();
+    expect(posts[0]).toEqual(request);
+    expect(posts).toHaveLength(2);
+    expect(remixQueueSnapshot("thread-a")).toMatchObject({
+      items: [],
+      activeTurnId: "turn-b",
+    });
+  });
+  it("does not replay a retryable receipt when Stop pauses during observation", async () => {
+    registerRemixTurn("thread-a", "turn-a", {
+      threadId: "thread-a",
+      clientRequestId: "request-a",
+      messages: [],
+      context: {},
+    });
+    let stopDuringRead = false;
+    const posts: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        if (init?.body) posts.push(init.body);
+        else if (stopDuringRead) pauseRemixQueue("thread-a");
+        return Response.json({ turn: { id: "turn-a", status: "retryable" } });
+      }),
+    );
+    await drainRemixQueues();
+    vi.setSystemTime(Date.now() + 3_000);
+    stopDuringRead = true;
+    await drainRemixQueues();
+    expect(posts).toEqual([]);
+    expect(remixQueueSnapshot("thread-a").active).toBe(false);
+  });
   it("recovers a lost queued receipt to honor Stop after both renderers close", async () => {
     registerRemixTurn("thread-a", "turn-a");
     enqueueRemixMessage("thread-a", { text: "Follow up" });
@@ -52,6 +165,12 @@ describe("server-owned durable Remix follow-ups", () => {
       `${freestyleCloudUrl()}/v2/remix/turns/turn-b/commands`,
     ]);
     expect(remixQueueSnapshot("thread-a").items[0].text).toBe("Follow up");
+    const draft = remixQueueSnapshot("thread-a").items[0];
+    expect(
+      updateRemixQueuedMessage("thread-a", draft.id, "Edited follow-up"),
+    ).toBe(true);
+    expect(steerRemixQueuedMessage("thread-a", draft.id)).toBe(true);
+    expect(removeRemixQueuedMessage("thread-a", draft.id)).toBe(true);
   });
   it("drains a follow-up after both renderers close and after a database reopen", async () => {
     registerRemixTurn("thread-a", "turn-a");

--- a/apps/server/tests/remix-durable-queue.test.ts
+++ b/apps/server/tests/remix-durable-queue.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeDb } from "../src/lib/db.js";
+import { freestyleCloudUrl } from "../src/lib/freestyle-cloud.js";
+import { flushRemixCancels } from "../src/lib/remix-cancel-outbox.js";
+import {
+  drainRemixQueues,
+  enqueueRemixMessage,
+  pauseRemixQueue,
+  registerRemixTurn,
+  remixQueueSnapshot,
+  settleRemixTurn,
+} from "../src/lib/remix-durable-queue.js";
+import { clearSession, setSession } from "../src/lib/sessions.js";
+
+beforeEach(() =>
+  setSession({
+    token: "test-token",
+    user: { id: crypto.randomUUID(), email: "test@example.test" },
+    host: freestyleCloudUrl(),
+  }),
+);
+afterEach(() => {
+  clearSession();
+  vi.unstubAllGlobals();
+});
+describe("server-owned durable Remix follow-ups", () => {
+  it("recovers a lost queued receipt to honor Stop after both renderers close", async () => {
+    registerRemixTurn("thread-a", "turn-a");
+    enqueueRemixMessage("thread-a", { text: "Follow up" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.endsWith("turn-a"))
+          return Response.json({ turn: { status: "completed" } });
+        if (url.endsWith("threads/thread-a"))
+          return Response.json({ thread: { messages: [] } });
+        throw new Error("lost queued receipt");
+      }),
+    );
+    await drainRemixQueues();
+    pauseRemixQueue("thread-a");
+    closeDb();
+    const fetch = vi.fn(async (url: string) =>
+      url.endsWith("remix/turns")
+        ? Response.json({ turn: { id: "turn-b" } })
+        : Response.json({ receipt: { canceled: true } }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    await flushRemixCancels();
+    expect(fetch.mock.calls.map(([url]) => url)).toEqual([
+      `${freestyleCloudUrl()}/v2/remix/turns`,
+      `${freestyleCloudUrl()}/v2/remix/turns/turn-b/commands`,
+    ]);
+    expect(remixQueueSnapshot("thread-a").items[0].text).toBe("Follow up");
+  });
+  it("drains a follow-up after both renderers close and after a database reopen", async () => {
+    registerRemixTurn("thread-a", "turn-a");
+    enqueueRemixMessage("thread-a", { text: "Follow up" });
+    closeDb();
+    const requests: Array<{ url: string; body?: Record<string, unknown> }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+        requests.push({ url, body });
+        if (url.endsWith("turn-a"))
+          return Response.json({ turn: { status: "completed" } });
+        if (url.endsWith("threads/thread-a"))
+          return Response.json({
+            thread: {
+              messages: [
+                {
+                  id: "assistant-a",
+                  role: "assistant",
+                  parts: [{ type: "text", text: "Done" }],
+                },
+              ],
+            },
+          });
+        return Response.json({ turn: { id: "turn-b" } });
+      }),
+    );
+    await drainRemixQueues();
+    expect(remixQueueSnapshot("thread-a")).toMatchObject({
+      items: [],
+      activeTurnId: "turn-b",
+    });
+    const admitted = requests.find((request) =>
+      request.url.endsWith("remix/turns"),
+    )!.body!;
+    expect(
+      (admitted.messages as Array<{ parts: unknown }>).at(-1)?.parts,
+    ).toEqual([{ type: "text", text: "Follow up" }]);
+    expect(admitted.clientRequestId).toBeTruthy();
+  });
+  it("replays the same queued admission after its receipt response is lost", async () => {
+    registerRemixTurn("thread-a", "turn-a");
+    enqueueRemixMessage("thread-a", { text: "Follow up" });
+    const bodies: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.endsWith("turn-a"))
+          return Response.json({ turn: { status: "completed" } });
+        if (url.endsWith("threads/thread-a"))
+          return Response.json({ thread: { messages: [] } });
+        bodies.push(String(init?.body));
+        if (bodies.length === 1) throw new Error("lost receipt");
+        return Response.json({ turn: { id: "turn-b" } });
+      }),
+    );
+    await drainRemixQueues();
+    expect(remixQueueSnapshot("thread-a").items).toHaveLength(1);
+    closeDb();
+    await drainRemixQueues();
+    expect(bodies).toHaveLength(2);
+    expect(bodies[1]).toBe(bodies[0]);
+    expect(remixQueueSnapshot("thread-a").items).toHaveLength(0);
+  });
+  it.each([
+    "failed",
+    "canceled",
+  ])("preserves queued follow-ups after %s", async (status) => {
+    registerRemixTurn("thread-a", "turn-a");
+    enqueueRemixMessage("thread-a", { text: "Follow up" });
+    settleRemixTurn("turn-a", status);
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    await drainRemixQueues();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(remixQueueSnapshot("thread-a").items[0].text).toBe("Follow up");
+  });
+});

--- a/apps/server/tests/remix-durable-queue.test.ts
+++ b/apps/server/tests/remix-durable-queue.test.ts
@@ -72,6 +72,35 @@ describe("server-owned durable Remix follow-ups", () => {
     expect(posts).toHaveLength(5);
     expect(remixQueueSnapshot("thread-a").items[0].text).toBe("Next");
   });
+  it("backs off ordinary transport failures and pauses after five attempts", async () => {
+    registerRemixTurn("thread-a", "turn-a", {
+      threadId: "thread-a",
+      clientRequestId: "request-a",
+      messages: [],
+      context: {},
+    });
+    const fetch = vi.fn(async () => {
+      throw new TypeError("offline");
+    });
+    vi.stubGlobal("fetch", fetch);
+    await drainRemixQueues();
+    await drainRemixQueues();
+    expect(fetch).toHaveBeenCalledOnce();
+    for (const delay of [3_000, 6_000, 12_000, 24_000]) {
+      vi.setSystemTime(Date.now() + delay);
+      await drainRemixQueues();
+    }
+    expect(fetch).toHaveBeenCalledTimes(5);
+    expect(remixQueueSnapshot("thread-a").recoveryPaused).toBe(true);
+    vi.setSystemTime(Date.now() + 30_000);
+    await drainRemixQueues();
+    expect(fetch).toHaveBeenCalledTimes(5);
+    // A fresh visible Resume/new turn receives its own retry budget.
+    registerRemixTurn("thread-a", "turn-b");
+    await drainRemixQueues();
+    expect(fetch).toHaveBeenCalledTimes(6);
+    expect(remixQueueSnapshot("thread-a").recoveryPaused).toBe(false);
+  });
   it("continues the next follow-up after headless retryable recovery succeeds", async () => {
     const request = {
       threadId: "thread-a",
@@ -231,6 +260,7 @@ describe("server-owned durable Remix follow-ups", () => {
     await drainRemixQueues();
     expect(remixQueueSnapshot("thread-a").items).toHaveLength(1);
     closeDb();
+    vi.setSystemTime(Date.now() + 3_000);
     await drainRemixQueues();
     expect(bodies).toHaveLength(2);
     expect(bodies[1]).toBe(bodies[0]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,9 +37,6 @@ importers:
 
   apps/electron:
     dependencies:
-      '@ai-sdk/react':
-        specifier: ^3.0.44
-        version: 3.0.242(react@19.2.6)(zod@4.5.4)
       '@electron-toolkit/preload':
         specifier: ^3.0.2
         version: 3.0.2(electron@39.8.10)
@@ -714,12 +711,6 @@ packages:
   '@ai-sdk/provider@3.0.15':
     resolution: {integrity: sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==}
     engines: {node: '>=18'}
-
-  '@ai-sdk/react@3.0.242':
-    resolution: {integrity: sha512-fuYQg/nO8zptYmBoN1OpoxpGSeXjzCUwf4xLJFObI6ywuONql1oxmd3OLNi91tZSVUJi8sgppB8K5CPFdHUN9A==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@alcalzone/ansi-tokenize@0.2.5':
     resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
@@ -10371,11 +10362,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  swr@2.4.2:
-    resolution: {integrity: sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   systeminformation@5.33.4:
     resolution: {integrity: sha512-poXpX8M9NBll1NDMW1ho6qRFkjrlttfm8E/YtPmn5x0TQ1z8LoJUHg9kwr/sRDmCjktqfnFRxqsoUNpaRakeMQ==}
     engines: {node: '>=10.0.0'}
@@ -10452,10 +10438,6 @@ packages:
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
-
-  throttleit@2.1.0:
-    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
-    engines: {node: '>=18'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -11266,16 +11248,6 @@ snapshots:
   '@ai-sdk/provider@3.0.15':
     dependencies:
       json-schema: 0.4.0
-
-  '@ai-sdk/react@3.0.242(react@19.2.6)(zod@4.5.4)':
-    dependencies:
-      '@ai-sdk/provider-utils': 4.0.41(zod@4.5.4)
-      ai: 6.0.240(zod@4.5.4)
-      react: 19.2.6
-      swr: 2.4.2(react@19.2.6)
-      throttleit: 2.1.0
-    transitivePeerDependencies:
-      - zod
 
   '@alcalzone/ansi-tokenize@0.2.5':
     dependencies:
@@ -15307,9 +15279,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 
@@ -22910,12 +22880,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swr@2.4.2(react@19.2.6):
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.6
-      use-sync-external-store: 1.6.0(react@19.2.6)
-
   systeminformation@5.33.4: {}
 
   tagged-tag@1.0.0: {}
@@ -23047,8 +23011,6 @@ snapshots:
       any-promise: 1.3.0
 
   throat@5.0.0: {}
-
-  throttleit@2.1.0: {}
 
   through@2.3.8: {}
 


### PR DESCRIPTION
## Summary
- route both Remix surfaces through durable turn receipts, replayable observation, and the local deferred-cancel outbox
- add shared reconnect, Stop, Resume, queued follow-up, and cross-observer action recovery controls
- bind recovery reads to the observed account and apply the 3/6/12/24/30-second retry policy to renderer and headless recovery

## Dependency
Depends on https://github.com/freestyle-voice/cloud/pull/227. Merge the Cloud PR before this Desktop PR.

## Verification
- Cloud durable lifecycle suite: 60 tests
- Desktop server and recovery policy suites: 46 tests
- Native Electron recovery E2E: 7 tests across compact and workspace
- Desktop typecheck, server build, Biome, and diff checks