### PR TITLE
fix(electron): limit custom chrome to macOS

### DIFF
--- a/apps/electron/src/renderer/src/shell-titlebar.test.ts
+++ b/apps/electron/src/renderer/src/shell-titlebar.test.ts
@@ -22,4 +22,16 @@ describe("desktop content titlebar", () => {
     expect(styles).toContain("height: 8px");
     expect(styles).not.toContain("flex: 0 0 24px");
   });
+
+  it("reserves custom chrome only for macOS", async () => {
+    const shell = await readFile(resolve(sourceDir, "shell.tsx"), "utf8");
+
+    expect(shell).toContain(
+      'import { IS_MAC, MOD_LABEL } from "@renderer/lib/platform"',
+    );
+    expect(shell).toContain('IS_MAC && !isFullscreen ? "h-8" : "h-0"');
+    expect(shell).toContain("{IS_MAC ? (");
+    expect(shell).toContain('className="sidebar-reveal-trigger"');
+    expect(shell).not.toContain("if (!IS_MAC) return null;");
+  });
 });

--- a/apps/electron/src/renderer/src/shell-workspace-switcher.test.ts
+++ b/apps/electron/src/renderer/src/shell-workspace-switcher.test.ts
@@ -27,7 +27,7 @@ describe("workspace switcher", () => {
     expect(shell).toContain('className="remix-sidebar-titlebar"');
     expect(shell).toContain('aria-label="Switch workspace"');
     expect(shell).toContain("onFullscreenChanged(setIsFullscreen)");
-    expect(shell).toContain('isFullscreen ? "h-0" : "h-8"');
+    expect(shell).toContain('IS_MAC && !isFullscreen ? "h-8" : "h-0"');
     expect(shell).toContain("WORKSPACE_STORAGE_KEY");
     expect(shell).toContain('from "@renderer/lib/workspace"');
     expect(shell).toContain("const isSettingsRoute =");

--- a/apps/electron/src/renderer/src/shell.tsx
+++ b/apps/electron/src/renderer/src/shell.tsx
@@ -20,7 +20,7 @@ import {
 import { UpdateBanner } from "@renderer/components/update-banner";
 import { usePersistentState } from "@renderer/hooks/use-persistent-state";
 import { useCloudAuth } from "@renderer/lib/auth-context";
-import { MOD_LABEL } from "@renderer/lib/platform";
+import { IS_MAC, MOD_LABEL } from "@renderer/lib/platform";
 import { listPlugins } from "@renderer/lib/plugins-api";
 import { queryKeys } from "@renderer/lib/query";
 import {
@@ -815,7 +815,7 @@ export default function AppShell(): React.JSX.Element {
             <div
               className={cn(
                 "shrink-0 transition-[height] duration-150",
-                isFullscreen ? "h-0" : "h-8",
+                IS_MAC && !isFullscreen ? "h-8" : "h-0",
               )}
             />
             {isSettingsRoute ? (
@@ -948,9 +948,10 @@ function SignedOutShell(): React.JSX.Element {
 }
 
 /**
- * A dedicated, transparent titlebar for the content pane. Keeping it as a
- * sibling of every route gives Remix and ordinary pages one reliable place to
- * drag the window, without putting a drag region over buttons inside a page.
+ * macOS needs a dedicated transparent titlebar for the content pane because
+ * its native controls share the renderer's top edge. Windows and Linux keep
+ * their system titlebars, while the sidebar restore control remains available
+ * on every platform.
  */
 function ContentTitlebar({
   sidebarHidden = false,
@@ -963,11 +964,13 @@ function ContentTitlebar({
 }): React.JSX.Element {
   return (
     <>
-      <div
-        className="glass-content-titlebar"
-        aria-hidden="true"
-        style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
-      />
+      {IS_MAC ? (
+        <div
+          className="glass-content-titlebar"
+          aria-hidden="true"
+          style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+        />
+      ) : null}
       {sidebarHidden && onShowSidebar ? (
         <button
           type="button"


### PR DESCRIPTION
Windows and Linux now use their native titlebars without the desktop sidebar's macOS-only top spacer or transparent content drag strip. The sidebar restore control remains available on every platform, so hiding the sidebar is still reversible outside macOS.